### PR TITLE
Bigger resources for git clone: 250m/512Mi

### DIFF
--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -129,7 +129,14 @@ spec:
     - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
       value: $(workspaces.basic-auth.path)
     image: $(params.gitInitImage)
-    resources: {}
+    resources:
+      limits:
+        memory: 4Gi
+        cpu: 2
+      requests:
+        memory: 512Mi
+        cpu: 250m
+
     securityContext:
       runAsUser: 0
     script: |


### PR DESCRIPTION
OCP creates a PV for a first TaskRun in PipelineRun that needs it. Once created, all the other tasks in the PipelineRun needs to run on the same OCP node, as PV is tied to that node.

By setting substitutional requests for that first task (git-init) we make sure OCP scheduler will have a chance to schedule it on node that has enough capacity.

Also git-init is usually very short when compared with buildah, so the resources should not be blocked for too long.

This was discussed on this mtg: https://docs.google.com/document/d/1UXjkG7NUwrPJMba7FSQjT57ICDH0nBT3gWujhNX-p1c/edit#heading=h.jyt53srvyj4h 