### PR TITLE
chore(stoneintg-571): update fbc-validation documentation

### DIFF
--- a/task/fbc-validation/0.1/README.md
+++ b/task/fbc-validation/0.1/README.md
@@ -3,7 +3,9 @@
 ## Description:
 The fbc-validation task will ensure FBC (File based catalog) components uniquely linted to ensure they're properly
 constructed as part of the build pipeline. To validate the image in build pipeline, Skopeo is used to extract
-information and then contents are checked using the OpenShift Operator Framework.
+information from the image itself and then contents are checked using the OpenShift Operator Framework.  The binary
+used to run the validation is extracted from the base image for the component being tested.  Because of this, the
+base image must come from a trusted source.  Trusted sources are declared in `ALLOWED_BASE_IMAGES` in fbc-validation.yaml.
 
 ## Params:
 

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -11,6 +11,7 @@ spec:
   description: >-
     Ensures file-based catalog (FBC) components are uniquely linted for proper construction as part of build pipeline.
     The manifest data of container images obtained previously (via Skopeo) from inspect-image task is checked using OpenShift Operator Framework's opm CLI tool.
+    The opm binary is extracted from the container's base image, which must come from a trusted source.
   params:
     - name: IMAGE_URL
       description: Fully qualified image name.


### PR DESCRIPTION
Update fbc-validation README and description to include information on the use of a trusted opm binary to run the validation.