### PR TITLE
fix(clamav): inform users that scan started

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -63,7 +63,7 @@ spec:
           echo "Unable to extract image. Skipping ClamAV scan!"
           exit 0
         fi
-        echo Extraction done.
+        echo "Scanning image. This operation may take a while."
         clamscan -ri --max-scansize=250M | tee /tekton/home/clamscan-result.log
         echo "Executed-on: Scan was executed on version - $(clamscan --version)" | tee -a /tekton/home/clamscan-result.log
       volumeMounts:


### PR DESCRIPTION
Instead of telling users that extraction is done and let them to look at empty screen, tell them that scan is in progress and may take a while