### PR TITLE
prefetch: parameterized option to commit changes

### DIFF
--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -80,6 +80,8 @@ spec:
       value: $(params.HERMETIC)
     - name: PREFETCH_INPUT
       value: $(params.PREFETCH_INPUT)
+    - name: PREFETCH_COMMIT
+      value: $(params.PREFETCH_COMMIT)
     - name: CONTEXT
       value: $(params.CONTEXT)
     - name: DOCKERFILE

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -47,6 +47,10 @@ spec:
     name: PREFETCH_INPUT
     type: string
   - default: ""
+    description: In case it is not empty, the prefetch modifications to the containerfile will be applied to the source repository with a git commit
+    name: PREFETCH_COMMIT
+    type: string
+  - default: ""
     description: Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
@@ -149,6 +153,10 @@ spec:
         chmod -R go+rwX /tmp/cachi2
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
         sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        if [ -n "${PREFETCH_COMMIT}" ]; then
+          git add "$dockerfile_path"
+          git commit -m "RHTAP: inject cachi2 environment"
+        fi
         echo "Prefetched content will be made available"
       fi
 


### PR DESCRIPTION
When cachi2 updates the Dockerfile this makes the git tree dirty and may affect scripts or other build processes that use git commit tree information for things like version numbers and other metadata. When the git tree has been modified, the version is indicated as being "dirty".

This change allows projects who use this information to inject a `git commit` in the workflow with the cachi2 changes applied so that and git version information includes a non-dirty hash.

Note that this does not push that commit back to the origin repository. I'm not sure if that's problematic or not. It doesn't seem like it should be.