### PR TITLE
DO NOT MERGE: Generate OCI Image Indexes by default

### DIFF
--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -80,7 +80,7 @@ spec:
           TOADD="$(echo $i | cut -d: -f1)@sha256:$(echo $i | cut -d: -f3)"
         fi
         echo "Adding $TOADD"
-        buildah manifest add $IMAGE "docker://$TOADD"
+        buildah manifest add $IMAGE "docker://$TOADD" --all
       done
 
       status=-1

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -19,6 +19,12 @@ spec:
   - description: Reference of the image buildah will produce.
     name: IMAGE
     type: string
+  - default: ""
+    description: Disable the generation of an OCI Image Index. Empty means that params.IMAGE
+      will be an Image Index. Any content will result in params.IMAGE being an OCI
+      Image Manifest.
+    name: DISABLE_IMAGE_INDEX
+    type: string
   - default: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
     description: The location of the buildah builder image.
     name: BUILDER_IMAGE
@@ -102,6 +108,8 @@ spec:
       value: $(params.DOCKERFILE)
     - name: IMAGE
       value: $(params.IMAGE)
+    - name: DISABLE_IMAGE_INDEX
+      value: $(params.DISABLE_IMAGE_INDEX)
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
     - name: IMAGE_EXPIRES_AFTER
@@ -269,6 +277,7 @@ spec:
        -e CONTEXT="$CONTEXT" \
        -e DOCKERFILE="$DOCKERFILE" \
        -e IMAGE="$IMAGE" \
+       -e DISABLE_IMAGE_INDEX="$DISABLE_IMAGE_INDEX" \
        -e TLSVERIFY="$TLSVERIFY" \
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
@@ -400,7 +409,16 @@ spec:
       container=$(buildah from --pull-never $IMAGE)
       buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
       buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
-      buildah commit $container $IMAGE
+      
+      IMAGE_PUSH="$IMAGE"
+      if [ -n "${DISABLE_IMAGE_INDEX}" ]; then
+        echo "Skipping production of OCI Image Index"
+        buildah commit $container $IMAGE
+      else
+        echo "Generating OCI Image Index"
+        IMAGE_PUSH="$IMAGE-index"
+        buildah commit --manifest $IMAGE_PUSH $container $IMAGE
+      fi
 
       status=-1
       max_run=5
@@ -409,10 +427,17 @@ spec:
         status=0
         [ "$run" -gt 1 ] && sleep $sleep_sec
         echo "Pushing sbom image to registry"
-        buildah push \
+        if [ -n "${DISABLE_IMAGE_INDEX}" ]; then
+          buildah push \
           --tls-verify=$TLSVERIFY \
-          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE_PUSH \
           docker://$IMAGE && break || status=$?
+        else
+          buildah manifest push --all \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE_PUSH \
+          docker://$IMAGE && break || status=$?
+        fi
       done
       if [ "$status" -ne 0 ]; then
           echo "Failed to push sbom image to registry after ${max_run} tries"

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -18,6 +18,10 @@ spec:
   - description: Reference of the image buildah will produce.
     name: IMAGE
     type: string
+  - default: ""
+    description: Disable the generation of an OCI Image Index. Empty means that params.IMAGE will be an Image Index. Any content will result in params.IMAGE being an OCI Image Manifest.
+    name: DISABLE_IMAGE_INDEX
+    type: string
   - default: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
@@ -94,6 +98,8 @@ spec:
       value: $(params.DOCKERFILE)
     - name: IMAGE
       value: $(params.IMAGE)
+    - name: DISABLE_IMAGE_INDEX
+      value: $(params.DISABLE_IMAGE_INDEX)
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
     - name: IMAGE_EXPIRES_AFTER
@@ -339,7 +345,16 @@ spec:
       container=$(buildah from --pull-never $IMAGE)
       buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
       buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
-      buildah commit $container $IMAGE
+      
+      IMAGE_PUSH="$IMAGE"
+      if [ -n "${DISABLE_IMAGE_INDEX}" ]; then
+        echo "Skipping production of OCI Image Index"
+        buildah commit $container $IMAGE
+      else
+        echo "Generating OCI Image Index"
+        IMAGE_PUSH="$IMAGE-index"
+        buildah commit --manifest $IMAGE_PUSH $container $IMAGE
+      fi
 
       status=-1
       max_run=5
@@ -348,10 +363,17 @@ spec:
         status=0
         [ "$run" -gt 1 ] && sleep $sleep_sec
         echo "Pushing sbom image to registry"
-        buildah push \
+        if [ -n "${DISABLE_IMAGE_INDEX}" ]; then
+          buildah push \
           --tls-verify=$TLSVERIFY \
-          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE_PUSH \
           docker://$IMAGE && break || status=$?
+        else
+          buildah manifest push --all \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE_PUSH \
+          docker://$IMAGE && break || status=$?
+        fi
       done
       if [ "$status" -ne 0 ]; then
           echo "Failed to push sbom image to registry after ${max_run} tries"


### PR DESCRIPTION
While this PR is a small change, we need to effectively support multi-arch test and release before it can be merged. Therefore, work needs to happen for https://issues.redhat.com/browse/KONFLUX-387 first.

In order to better support the mix of single-architecture and multi-architecture container images, we should put OCI Image Manifests within OCI Image Indexes by default.

Acknowledging that some use cases might not want an Image Index, it is possible to disable their generation.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
