### PR TITLE
Configurable public key path for EC pipelines

### DIFF
--- a/pipelines/enterprise-contract-everything.yaml
+++ b/pipelines/enterprise-contract-everything.yaml
@@ -39,6 +39,13 @@ spec:
         "/var/run/secrets/kubernetes.io/serviceaccount" is a good value. Multiple
         paths can be provided by using the ":" separator.
       default: ""
+    - name: PUBLIC_KEY
+      type: string
+      default: "k8s://openshift-pipelines/public-key"
+      description: |
+        Public key used to verify signatures. Must be a valid k8s cosign
+        reference, e.g. k8s://my-space/my-secret where my-secret contains
+        the expected cosign.pub attribute.
   results:
     - name: TEST_OUTPUT
       value: "$(tasks.verify.results.TEST_OUTPUT)"
@@ -58,7 +65,7 @@ spec:
         - name: STRICT
           value: "true"
         - name: PUBLIC_KEY
-          value: "k8s://openshift-pipelines/public-key"
+          value: "$(params.PUBLIC_KEY)"
         - name: IGNORE_REKOR
           value: "true"
       taskRef:

--- a/pipelines/enterprise-contract-redhat-no-hermetic.yaml
+++ b/pipelines/enterprise-contract-redhat-no-hermetic.yaml
@@ -39,6 +39,13 @@ spec:
         "/var/run/secrets/kubernetes.io/serviceaccount" is a good value. Multiple
         paths can be provided by using the ":" separator.
       default: ""
+    - name: PUBLIC_KEY
+      type: string
+      default: "k8s://openshift-pipelines/public-key"
+      description: |
+        Public key used to verify signatures. Must be a valid k8s cosign
+        reference, e.g. k8s://my-space/my-secret where my-secret contains
+        the expected cosign.pub attribute.
   results:
     - name: TEST_OUTPUT
       value: "$(tasks.verify.results.TEST_OUTPUT)"
@@ -58,7 +65,7 @@ spec:
         - name: STRICT
           value: "true"
         - name: PUBLIC_KEY
-          value: "k8s://openshift-pipelines/public-key"
+          value: "$(params.PUBLIC_KEY)"
         - name: IGNORE_REKOR
           value: "true"
       taskRef:

--- a/pipelines/enterprise-contract-redhat.yaml
+++ b/pipelines/enterprise-contract-redhat.yaml
@@ -39,6 +39,13 @@ spec:
         "/var/run/secrets/kubernetes.io/serviceaccount" is a good value. Multiple
         paths can be provided by using the ":" separator.
       default: ""
+    - name: PUBLIC_KEY
+      type: string
+      default: "k8s://openshift-pipelines/public-key"
+      description: |
+        Public key used to verify signatures. Must be a valid k8s cosign
+        reference, e.g. k8s://my-space/my-secret where my-secret contains
+        the expected cosign.pub attribute.
   results:
     - name: TEST_OUTPUT
       value: "$(tasks.verify.results.TEST_OUTPUT)"
@@ -58,7 +65,7 @@ spec:
         - name: STRICT
           value: "true"
         - name: PUBLIC_KEY
-          value: "k8s://openshift-pipelines/public-key"
+          value: "$(params.PUBLIC_KEY)"
         - name: IGNORE_REKOR
           value: "true"
       taskRef:

--- a/pipelines/enterprise-contract-slsa3.yaml
+++ b/pipelines/enterprise-contract-slsa3.yaml
@@ -39,6 +39,13 @@ spec:
         "/var/run/secrets/kubernetes.io/serviceaccount" is a good value. Multiple
         paths can be provided by using the ":" separator.
       default: ""
+    - name: PUBLIC_KEY
+      type: string
+      default: "k8s://openshift-pipelines/public-key"
+      description: |
+        Public key used to verify signatures. Must be a valid k8s cosign
+        reference, e.g. k8s://my-space/my-secret where my-secret contains
+        the expected cosign.pub attribute.
   results:
     - name: TEST_OUTPUT
       value: "$(tasks.verify.results.TEST_OUTPUT)"
@@ -58,7 +65,7 @@ spec:
         - name: STRICT
           value: "true"
         - name: PUBLIC_KEY
-          value: "k8s://openshift-pipelines/public-key"
+          value: "$(params.PUBLIC_KEY)"
         - name: IGNORE_REKOR
           value: "true"
       taskRef:

--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -40,6 +40,13 @@ spec:
         "/var/run/secrets/kubernetes.io/serviceaccount" is a good value. Multiple
         paths can be provided by using the ":" separator.
       default: ""
+    - name: PUBLIC_KEY
+      type: string
+      default: "k8s://openshift-pipelines/public-key"
+      description: |
+        Public key used to verify signatures. Must be a valid k8s cosign
+        reference, e.g. k8s://my-space/my-secret where my-secret contains
+        the expected cosign.pub attribute.
   results:
     - name: TEST_OUTPUT
       value: "$(tasks.verify.results.TEST_OUTPUT)"
@@ -59,7 +66,7 @@ spec:
         - name: STRICT
           value: "true"
         - name: PUBLIC_KEY
-          value: "k8s://openshift-pipelines/public-key"
+          value: "$(params.PUBLIC_KEY)"
         - name: IGNORE_REKOR
           value: "true"
       taskRef:


### PR DESCRIPTION
Allow to mention the path to the public key in the enterprise-contract pipelines. This is needed when running on non OCP k8s cluster.
