### PR TITLE
Buildah: Add SKIP_UNUSED_STAGES parameter

### DIFF
--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -22,6 +22,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
 |STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -77,6 +77,11 @@ spec:
         be made available to the build.
       type: string
       default: ""
+    - name: SKIP_UNUSED_STAGES
+      description: Whether to skip stages in Containerfile that seem unused
+        by subsequent stages
+      type: string
+      default: "true"
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -178,6 +183,8 @@ spec:
         value: $(params.IMAGE)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.IMAGE_EXPIRES_AFTER)
+      - name: SKIP_UNUSED_STAGES
+        value: $(params.SKIP_UNUSED_STAGES)
       - name: SQUASH
         value: $(params.SQUASH)
       - name: STORAGE_DRIVER
@@ -297,6 +304,10 @@ spec:
 
         if [ "${SQUASH}" == "true" ]; then
           BUILDAH_ARGS+=("--squash")
+        fi
+
+        if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
+          BUILDAH_ARGS+=("--skip-unused-stages=false")
         fi
 
         if [ -f "/var/workdir/cachi2/cachi2.env" ]; then

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -77,6 +77,11 @@ spec:
       to the build.
     name: PREFETCH_INPUT
     type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
   - description: The Trusted Artifact URI pointing to the artifact with the application
       source code.
     name: SOURCE_ARTIFACT
@@ -158,6 +163,8 @@ spec:
       value: $(params.IMAGE)
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
     - name: SQUASH
       value: $(params.SQUASH)
     - name: STORAGE_DRIVER
@@ -316,6 +323,10 @@ spec:
         BUILDAH_ARGS+=("--squash")
       fi
 
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
       if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
         cp -r "/var/workdir/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -412,6 +423,7 @@ spec:
        -e HERMETIC="$HERMETIC" \
        -e IMAGE="$IMAGE" \
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+       -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
        -e SQUASH="$SQUASH" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -114,6 +114,11 @@ spec:
     description: Storage driver to configure for buildah
     name: STORAGE_DRIVER
     type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -169,6 +174,8 @@ spec:
       value: $(params.ADD_CAPABILITIES)
     - name: SQUASH
       value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     volumeMounts:
@@ -308,6 +315,10 @@ spec:
         BUILDAH_ARGS+=("--squash")
       fi
 
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -412,6 +423,7 @@ spec:
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e SQUASH="$SQUASH" \
+       -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -103,6 +103,10 @@ spec:
     description: Storage driver to configure for buildah
     type: string
     default: vfs
+  - name: SKIP_UNUSED_STAGES
+    description: Whether to skip stages in Containerfile that seem unused by subsequent stages
+    type: string
+    default: "true"
 
   results:
   - description: Digest of the image just built
@@ -157,6 +161,8 @@ spec:
       value: $(params.ADD_CAPABILITIES)
     - name: SQUASH
       value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
 
   steps:
   - image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
@@ -251,6 +257,10 @@ spec:
 
       if [ "${SQUASH}" == "true" ]; then
         BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
       fi
 
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then


### PR DESCRIPTION
Expose the --skip-unused-stages argument to Buildah as a parameter. This is needed to handle certain Containerfiles where stages have hidden side-effects like writing things to the context directory.

See https://github.com/containers/buildah/issues/5529 for details.
