### PR TITLE
buildah: Add an ADD_CAPABILITIES parameter

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -86,6 +86,11 @@ spec:
     description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
     name: BUILD_ARGS_FILE
     type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -135,6 +140,8 @@ spec:
       value: $(params.ENTITLEMENT_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
     - name: BUILDER_IMAGE
       value: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
   steps:
@@ -252,6 +259,10 @@ spec:
         BUILDAH_ARGS+=("--build-arg=$build_arg")
       done
 
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -342,6 +353,7 @@ spec:
        -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
+       -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -79,6 +79,10 @@ spec:
     description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
     type: string
     default: ""
+  - name: ADD_CAPABILITIES
+    description: Comma separated list of extra capabilities to add when running 'buildah build'
+    type: string
+    default: ""
 
   results:
   - description: Digest of the image just built
@@ -124,6 +128,8 @@ spec:
       value: $(params.ENTITLEMENT_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
 
   steps:
   - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
@@ -204,6 +210,10 @@ spec:
       for build_arg in "$@"; do
         BUILDAH_ARGS+=("--build-arg=$build_arg")
       done
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
 
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/


### PR DESCRIPTION
This corresponds to 'buildah build --cap-add=<value>'

One use case is when we want to do nested sandboxing within the build, and need to set up a new mount namespace - in this case we need ADD_CAPABILITIES=SYS_ADMIN. (Since we are running buildah using --isolation=chroot.)

Related: #1014
