### PR TITLE
Add docker-build-oci-ta Pipeline

### DIFF
--- a/pipelines/docker-build-oci-ta/kustomization.yaml
+++ b/pipelines/docker-build-oci-ta/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../docker-build
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Pipeline

--- a/pipelines/docker-build-oci-ta/patch.yaml
+++ b/pipelines/docker-build-oci-ta/patch.yaml
@@ -1,0 +1,126 @@
+---
+- op: replace
+  path: /metadata/name
+  value: docker-build-oci-ta
+- op: replace
+  path: /metadata/labels
+  value:
+    "pipelines.openshift.io/used-by": "build-cloud"
+    "pipelines.openshift.io/runtime": "generic"
+    "pipelines.openshift.io/strategy": "docker"
+- op: remove
+  path: /spec/workspaces/0
+# Order of Tasks from the base docker-build Pipeline:
+# $ kustomize build pipelines/docker-build | yq .spec.tasks.[].name | nl -v 0
+#  0  init
+#  1  clone-repository
+#  2  prefetch-dependencies
+#  3  build-container
+#  4  build-source-image
+#  5  deprecated-base-image-check
+#  6  clair-scan
+#  7  ecosystem-cert-preflight-checks
+#  8  sast-snyk-check
+#  9  clamav-scan
+# 10  sbom-json-check
+# 11  apply-tags
+
+# clone-repository Task
+- op: replace
+  path: /spec/tasks/1/taskRef/name
+  value: git-clone-oci-ta
+- op: add
+  path: /spec/tasks/1/params/-
+  value:
+    name: ociStorage
+    value: $(params.output-image).git
+- op: add
+  path: /spec/tasks/1/params/-
+  value:
+    name: ociArtifactExpiresAfter
+    value: $(params.image-expires-after)
+- op: remove
+  path: /spec/tasks/1/workspaces/0
+
+# prefetch-dependencies Task
+- op: replace
+  path: /spec/tasks/2/taskRef/name
+  value: prefetch-dependencies-oci-ta
+- op: add
+  path: /spec/tasks/2/params/-
+  value:
+    name: SOURCE_ARTIFACT
+    value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+- op: add
+  path: /spec/tasks/2/params/-
+  value:
+    name: ociStorage
+    value: $(params.output-image).prefetch
+- op: add
+  path: /spec/tasks/2/params/-
+  value:
+    name: ociArtifactExpiresAfter
+    value: $(params.image-expires-after)
+- op: remove
+  path: /spec/tasks/2/workspaces/0
+
+# build-container
+- op: replace
+  path: /spec/tasks/3/taskRef/name
+  value: buildah-oci-ta
+- op: add
+  path: /spec/tasks/3/params/-
+  value:
+    name: SOURCE_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+- op: add
+  path: /spec/tasks/3/params/-
+  value:
+    name: CACHI2_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+- op: remove
+  path: /spec/tasks/3/workspaces/0
+
+# build-source-image
+- op: replace
+  path: /spec/tasks/4/taskRef/name
+  value: source-build-oci-ta
+- op: add
+  path: /spec/tasks/4/params/-
+  value:
+    name: SOURCE_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+- op: add
+  path: /spec/tasks/4/params/-
+  value:
+    name: CACHI2_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+- op: remove
+  path: /spec/tasks/4/workspaces/0
+
+# sast-snyk-check
+- op: replace
+  path: /spec/tasks/8/taskRef/name
+  value: sast-snyk-check-oci-ta
+- op: add
+  # In the docker-build Pipeline, the snyk Task does not receive any parameters, so we cannot
+  # append to it.
+  path: /spec/tasks/8/params
+  value:
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+- op: remove
+  path: /spec/tasks/8/workspaces/0
+
+# Order of finally Tasks from the base docker-build Pipeline:
+# $ kustomize build pipelines/docker-build | yq .spec.finally.[].name | nl -v 0
+#  0  show-sbom
+#  1  show-summary
+
+# show-summary
+# This Task relies on a shared workspace for some of its functionality. Although optional, it raises
+# the question of how valuable this Task actually is. Rather than add Trusted Artifacts support for
+# this Task, we are taking the approach of just removing it altogether. Additional context on this
+# decision can be found in https://issues.redhat.com/browse/EC-643.
+- op: remove
+  path: /spec/finally/1

--- a/pipelines/kustomization.yaml
+++ b/pipelines/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - docker-build
+- docker-build-oci-ta
 - java-builder
 - nodejs-builder
 - enterprise-contract.yaml


### PR DESCRIPTION
This Pipeline, based on the docker-build Pipeline, uses Trusted Artifacts stored in an OCI registry to share data between Tasks. No PVC is needed.

Ref: [EC-555](https://issues.redhat.com//browse/EC-555)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
