### PR TITLE
buildah: support passing build args as Tekton parameter list

### DIFF
--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -79,10 +79,17 @@ spec:
     name: ENTITLEMENT_SECRET
     type: string
   - default: ""
-    description: Path to a file with build arguments which will be passed to podman
-      during build
+    description: |
+      Path to a file with build arguments which will be passed to buildah during build.
+      The path is relative to the repository root.
     name: BUILD_ARGS_FILE
     type: string
+  - default: []
+    description: |
+      List of arguments that will be passed to buildah during build. Each item in the list should be in the format
+      expected for `--build-arg` command-line option: `name=value`, e.g. `foo=bar`, `some_name=here is some value`.
+    name: BUILD_ARGS_LIST
+    type: array
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -132,9 +139,44 @@ spec:
       value: $(params.ENTITLEMENT_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
+    - name: BUILD_ARGS_UNIFIED_FILE
+      value: /build-args/build-args-unified
     - name: BUILDER_IMAGE
       value: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
   steps:
+  - args:
+    - $(params.BUILD_ARGS_LIST[*])
+    computeResources: {}
+    image: registry.access.redhat.com/ubi9/ubi-minimal:9@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3
+    name: prepare-build-args
+    script: |
+      # This step concatenates BUILD_ARGS_FILE and BUILD_ARGS_LIST into BUILD_ARGS_UNIFIED_FILE file that can be later
+      # passed to buildah.
+
+      set -euo pipefail
+
+      SOURCE_CODE_DIR=source
+
+      if [[ -n "${BUILD_ARGS_FILE}" ]]; then
+        echo "BUILD_ARGS_FILE provided, copying it to ${BUILD_ARGS_UNIFIED_FILE}..."
+        cp -v "$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}" "${BUILD_ARGS_UNIFIED_FILE}"
+      fi
+
+      BUILD_ARGS_LIST=( "$@" )
+
+      if [[ "${#BUILD_ARGS_LIST[@]}" -gt 0 ]]; then
+        echo "BUILD_ARGS_LIST provided, saving it to ${BUILD_ARGS_UNIFIED_FILE}..."
+        printf '%s\n' "${BUILD_ARGS_LIST[@]}" >> "${BUILD_ARGS_UNIFIED_FILE}"
+      fi
+
+      if [[ -s "${BUILD_ARGS_UNIFIED_FILE}" ]]; then
+        echo -n "Arguments (lines) count: "
+        wc -l "${BUILD_ARGS_UNIFIED_FILE}"
+      fi
+    volumeMounts:
+    - mountPath: /build-args
+      name: build-args-volume
+    workingDir: $(workspaces.source.path)
   - computeResources:
       limits:
         memory: 4Gi
@@ -239,8 +281,8 @@ spec:
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
       fi
 
-      if [ -n "${BUILD_ARGS_FILE}" ]; then
-        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
+      if [ -f "${BUILD_ARGS_UNIFIED_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=${BUILD_ARGS_UNIFIED_FILE}")
       fi
 
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
@@ -333,6 +375,7 @@ spec:
        -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
+       -e BUILD_ARGS_UNIFIED_FILE="$BUILD_ARGS_UNIFIED_FILE" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
@@ -356,6 +399,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
+    - mountPath: /build-args
+      name: build-args-volume
     - mountPath: /ssh
       name: ssh
       readOnly: true
@@ -528,6 +573,9 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
+  - emptyDir:
+      sizeLimit: 64Mi
+    name: build-args-volume
   - name: ssh
     secret:
       optional: false

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -72,9 +72,17 @@ spec:
     type: string
     default: "etc-pki-entitlement"
   - name: BUILD_ARGS_FILE
-    description: Path to a file with build arguments which will be passed to podman during build
+    description: |
+      Path to a file with build arguments which will be passed to buildah during build.
+      The path is relative to the repository root.
     type: string
     default: ""
+  - name: BUILD_ARGS_LIST
+    description: |
+      List of arguments that will be passed to buildah during build. Each item in the list should be in the format
+      expected for `--build-arg` command-line option: `name=value`, e.g. `foo=bar`, `some_name=here is some value`.
+    type: array
+    default: [ ]
 
   results:
   - description: Digest of the image just built
@@ -120,8 +128,43 @@ spec:
       value: $(params.ENTITLEMENT_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
+    - name: BUILD_ARGS_UNIFIED_FILE
+      value: /build-args/build-args-unified
 
   steps:
+  - name: prepare-build-args
+    image: registry.access.redhat.com/ubi9/ubi-minimal:9@sha256:2636170dc55a0931d013014a72ae26c0c2521d4b61a28354b3e2e5369fa335a3
+    args: [ "$(params.BUILD_ARGS_LIST[*])" ]
+    script: |
+      # This step concatenates BUILD_ARGS_FILE and BUILD_ARGS_LIST into BUILD_ARGS_UNIFIED_FILE file that can be later
+      # passed to buildah.
+
+      set -euo pipefail
+
+      SOURCE_CODE_DIR=source
+
+      if [[ -n "${BUILD_ARGS_FILE}" ]]; then
+        echo "BUILD_ARGS_FILE provided, copying it to ${BUILD_ARGS_UNIFIED_FILE}..."
+        cp -v "$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}" "${BUILD_ARGS_UNIFIED_FILE}"
+      fi
+
+      BUILD_ARGS_LIST=( "$@" )
+
+      if [[ "${#BUILD_ARGS_LIST[@]}" -gt 0 ]]; then
+        echo "BUILD_ARGS_LIST provided, saving it to ${BUILD_ARGS_UNIFIED_FILE}..."
+        printf '%s\n' "${BUILD_ARGS_LIST[@]}" >> "${BUILD_ARGS_UNIFIED_FILE}"
+      fi
+
+      if [[ -s "${BUILD_ARGS_UNIFIED_FILE}" ]]; then
+        echo -n "Arguments (lines) count: "
+        wc -l "${BUILD_ARGS_UNIFIED_FILE}"
+      fi
+
+    volumeMounts:
+      - mountPath: "/build-args"
+        name: build-args-volume
+    workingDir: $(workspaces.source.path)
+
   - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
     name: build
     computeResources:
@@ -191,8 +234,8 @@ spec:
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
       fi
 
-      if [ -n "${BUILD_ARGS_FILE}" ]; then
-        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
+      if [ -f "${BUILD_ARGS_UNIFIED_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=${BUILD_ARGS_UNIFIED_FILE}")
       fi
 
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
@@ -274,6 +317,8 @@ spec:
       name: varlibcontainers
     - mountPath: "/entitlement"
       name: etc-pki-entitlement
+    - mountPath: "/build-args"
+      name: build-args-volume
     workingDir: $(workspaces.source.path)
 
   - name: sbom-syft-generate
@@ -447,6 +492,9 @@ spec:
     secret:
       secretName: $(params.ENTITLEMENT_SECRET)
       optional: true
+  - name: build-args-volume
+    emptyDir:
+      sizeLimit: 64Mi
   workspaces:
   - name: source
     description: Workspace containing the source code to build.


### PR DESCRIPTION
## Description

For building ACS containers, we need to pass the same parameter to multiple tasks, one of them is `buildah`.

While there is `BUILD_ARGS_FILE` parameter (added in https://github.com/redhat-appstudio/build-definitions/pull/935), it requires us _writing_ a file in a workspace which, well, requires creating a custom task which will be a pain to get rid of in order to conform with EC.

Here I introduce an additional parameter of Tekton's type `list` - `BUILD_ARGS_LIST`.

## Notes on testing

I developed it in a toy task and also verified how it runs in a pipeline: <https://github.com/stackrox/scanner/pull/1512>. ([Example runs](https://console.redhat.com/preview/application-pipeline/workspaces/rh-acs/applications/acs/commit/2b810bde1582d0bbf51268b38b277c16193b3825), if you have access to the ACS tenant.)

A thing I'm concerned about is that now `--build-arg-file` option will point to a file that's outside of `buildah` Context directory (`/build-args/build-args-unified`). I think it should be fine but I was not able to test whether `buildah` will object (the latest version I get on my machine is 1.28 and it does not have that command-line option).

More broadly, I don't know how to test this change on real pipelines before it's merged so I'll appreciate some guidance. Also, leaving the template text :point_down: as a reminder.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
