### PR TITLE
fix: add golang in the image

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -13,6 +13,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     git \
     skopeo \
     make \
+    golang \
     && dnf clean all
 
 COPY util-scripts /appstudio-utils/util-scripts


### PR DESCRIPTION
Will be using this image in prepare-e2e-tasks task in integration tests of build-task-dockerfiles repo
Part of the story: https://issues.redhat.com/browse/STONEBLD-2353
