### PR TITLE
 Community Docker build pipeline

### DIFF
--- a/pipelines/docker-build-community/README.md
+++ b/pipelines/docker-build-community/README.md
@@ -1,0 +1,226 @@
+# "docker-build pipeline"
+## Parameters
+|name|description|default value|used in (taskname:taskrefversion:taskparam)|
+|---|---|---|---|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.1:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.1:BUILD_ARGS_FILE|
+|build-source-image| Build a source image.| false| |
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.1:DOCKERFILE|
+|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|hermetic| Execute the build with network isolation| false| build-container:0.1:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.1:IMAGE_EXPIRES_AFTER|
+|java| Java build| false| |
+|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.1:PREFETCH_INPUT|
+|rebuild| Force rebuild image| false| init:0.2:rebuild|
+|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
+## Available params from tasks
+### apply-tags:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
+### buildah:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|BUILDER_IMAGE| Deprecated. Has no effect. Will be removed in the future.| | |
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
+|COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|
+|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
+|DOCKER_AUTH| unused, should be removed in next task version| | |
+|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
+|HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
+|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
+|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
+|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
+|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
+|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
+|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
+### clair-scan:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|docker-auth| unused, should be removed in next task version.| | |
+|image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|
+### clamav-scan:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|docker-auth| unused| | |
+|image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|
+### deprecated-image-check:0.4 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|BASE_IMAGES_DIGESTS| Digests of base build images.| | '$(tasks.build-container.results.BASE_IMAGES_DIGESTS)'|
+|IMAGE_DIGEST| Image digest.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
+|IMAGE_URL| Fully qualified image name.| None| '$(tasks.build-container.results.IMAGE_URL)'|
+|POLICY_DIR| Path to directory containing Conftest policies.| /project/repository/| |
+|POLICY_NAMESPACE| Namespace for Conftest policy.| required_checks| |
+### ecosystem-cert-preflight-checks:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|image-url| Image url to scan.| None| '$(tasks.build-container.results.IMAGE_URL)'|
+### git-clone:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|deleteExisting| Clean out the contents of the destination directory if it already exists before cloning.| true| |
+|depth| Perform a shallow clone, fetching only the most recent N commits.| 1| |
+|enableSymlinkCheck| Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. | true| |
+|fetchTags| Fetch all tags for the repo.| false| |
+|gitInitImage| Deprecated. Has no effect. Will be removed in the future.| | |
+|httpProxy| HTTP proxy server for non-SSL requests.| | |
+|httpsProxy| HTTPS proxy server for SSL requests.| | |
+|noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
+|refspec| Refspec to fetch before checking out revision.| | |
+|revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
+|sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
+|subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
+|submodules| Initialize and fetch git submodules.| true| |
+|url| Repository URL to clone from.| None| '$(params.git-url)'|
+|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
+|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
+### init:0.2 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
+|rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
+|skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
+### prefetch-dependencies:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
+|input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
+|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+### sast-snyk-check:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ARGS| Append arguments.| --all-projects --exclude=test*,vendor,deps| |
+|SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |
+### sbom-json-check:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|IMAGE_DIGEST| Image digest.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
+|IMAGE_URL| Fully qualified image name to verify.| None| '$(tasks.build-container.results.IMAGE_URL)'|
+### show-sbom:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|IMAGE_URL| Fully qualified image name to show SBOM for.| None| '$(tasks.build-container.results.IMAGE_URL)'|
+|PLATFORM| Specific architecture to display the SBOM for. An example arch would be "linux/amd64". If IMAGE_URL refers to a multi-arch image and this parameter is empty, the task will default to use "linux/amd64".| linux/amd64| |
+### source-build:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|BASE_IMAGES| Base images used to build the binary image. Each image per line in the same order of FROM instructions specified in a multistage Dockerfile. Default to an empty string, which means to skip handling a base image.| | '$(tasks.build-container.results.BASE_IMAGES_DIGESTS)'|
+|BINARY_IMAGE| Binary image name from which to generate the source image name.| None| '$(params.output-image)'|
+### summary:0.2 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|build-task-status| State of build task in pipelineRun| Succeeded| '$(tasks.build-container.status)'|
+|git-url| Git URL| None| '$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)'|
+|image-url| Image URL| None| '$(params.output-image)'|
+|pipelinerun-name| pipeline-run to annotate| None| '$(context.pipelineRun.name)'|
+
+## Results
+|name|description|value|
+|---|---|---|
+|CHAINS-GIT_COMMIT| |$(tasks.clone-repository.results.commit)|
+|CHAINS-GIT_URL| |$(tasks.clone-repository.results.url)|
+|IMAGE_DIGEST| |$(tasks.build-container.results.IMAGE_DIGEST)|
+|IMAGE_URL| |$(tasks.build-container.results.IMAGE_URL)|
+|JAVA_COMMUNITY_DEPENDENCIES| |$(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)|
+## Available results from tasks
+### buildah:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|BASE_IMAGES_DIGESTS| Digests of the base images used for build| build-source-image:0.1:BASE_IMAGES ; deprecated-base-image-check:0.4:BASE_IMAGES_DIGESTS|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.1:image-digest ; clamav-scan:0.1:image-digest ; sbom-json-check:0.1:IMAGE_DIGEST|
+|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE|
+|JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
+|SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
+### clair-scan:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|CLAIR_SCAN_RESULT| Clair scan result.| |
+|IMAGES_PROCESSED| Images processed in the task.| |
+|TEST_OUTPUT| Tekton task test output.| |
+### clamav-scan:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGES_PROCESSED| Images processed in the task.| |
+|TEST_OUTPUT| Tekton task test output.| |
+### deprecated-image-check:0.4 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|TEST_OUTPUT| Tekton task test output.| |
+### ecosystem-cert-preflight-checks:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|TEST_OUTPUT| Preflight pass or fail outcome.| |
+### git-clone:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA|
+|url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
+### init:0.2 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|build| Defines if the image in param image-url should be built| |
+### sast-snyk-check:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|TEST_OUTPUT| Tekton task test output.| |
+### sbom-json-check:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGES_PROCESSED| Images processed in the task.| |
+|TEST_OUTPUT| Tekton task test output.| |
+### source-build:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|BUILD_RESULT| Build result.| |
+|SOURCE_IMAGE_DIGEST| The source image digest.| |
+|SOURCE_IMAGE_URL| The source image url.| |
+
+## Workspaces
+|name|description|optional|used in tasks
+|---|---|---|---|
+|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.1:source ; build-source-image:0.1:workspace ; sast-snyk-check:0.1:workspace|
+## Available workspaces from tasks
+### buildah:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|source| Workspace containing the source code to build.| False| workspace|
+### git-clone:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|output| The git repo will be cloned onto the volume backing this Workspace.| False| workspace|
+|ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
+### prefetch-dependencies:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|source| Workspace with the source code, cachi2 artifacts will be stored on the workspace as well| False| workspace|
+### sast-snyk-check:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| | False| workspace|
+### source-build:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| The workspace where source code is included.| False| workspace|
+### summary:0.2 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|workspace| The workspace where source code is included.| True| workspace|

--- a/pipelines/docker-build-community/kustomization.yaml
+++ b/pipelines/docker-build-community/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../docker-build
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Pipeline

--- a/pipelines/docker-build-community/patch.yaml
+++ b/pipelines/docker-build-community/patch.yaml
@@ -1,0 +1,16 @@
+---
+- op: replace
+  path: /metadata/name
+  value: docker-build-community
+
+- op: replace
+  path: /spec/tasks/0/taskRef
+  value:
+    name: init-community
+    version: "0.2"
+
+- op: replace
+  path: /spec/tasks/1/taskRef
+  value:
+    name: git-clone-community
+    version: "0.1"

--- a/task/git-clone-community/0.1/README.md
+++ b/task/git-clone-community/0.1/README.md
@@ -1,0 +1,37 @@
+# git-clone task
+
+The git-clone Task will clone a repo from the provided url into the output Workspace. By default the repo will be cloned into the root of your Workspace.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|url|Repository URL to clone from.||true|
+|revision|Revision to checkout. (branch, tag, sha, ref, etc...)|""|false|
+|refspec|Refspec to fetch before checking out revision.|""|false|
+|submodules|Initialize and fetch git submodules.|true|false|
+|depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
+|sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
+|subdirectory|Subdirectory inside the `output` Workspace to clone the repo into.|""|false|
+|sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
+|deleteExisting|Clean out the contents of the destination directory if it already exists before cloning.|true|false|
+|httpProxy|HTTP proxy server for non-SSL requests.|""|false|
+|httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
+|verbose|Log the commands that are executed during `git-clone`'s operation.|true|false|
+|gitInitImage|Deprecated. Has no effect. Will be removed in the future.|""|false|
+|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden the gitInitImage param with an image containing custom user configuration. |/tekton/home|false|
+|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.|true|false|
+|fetchTags|Fetch all tags for the repo.|false|false|
+
+## Results
+|name|description|
+|---|---|
+|commit|The precise commit SHA that was fetched by this Task.|
+|url|The precise URL that was fetched by this Task.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|output|The git repo will be cloned onto the volume backing this Workspace.|false|
+|ssh-directory|A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. |true|
+|basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. |true|

--- a/task/git-clone-community/0.1/git-clone.yaml
+++ b/task/git-clone-community/0.1/git-clone.yaml
@@ -1,0 +1,305 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/displayName: git clone
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: git
+  name: git-clone
+spec:
+  description: |-
+    The git-clone Task will clone a repo from the provided url into the output Workspace. By default the repo will be cloned into the root of your Workspace.
+  params:
+  - description: Repository URL to clone from.
+    name: url
+    type: string
+  - default: ""
+    description: Revision to checkout. (branch, tag, sha, ref, etc...)
+    name: revision
+    type: string
+  - default: ""
+    description: Refspec to fetch before checking out revision.
+    name: refspec
+    type: string
+  - default: "true"
+    description: Initialize and fetch git submodules.
+    name: submodules
+    type: string
+  - default: "1"
+    description: Perform a shallow clone, fetching only the most recent N commits.
+    name: depth
+    type: string
+  - default: "true"
+    description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
+    name: sslVerify
+    type: string
+  - default: "source"
+    description: Subdirectory inside the `output` Workspace to clone the repo into.
+    name: subdirectory
+    type: string
+  - default: ""
+    description: Define the directory patterns to match or exclude when performing a sparse checkout.
+    name: sparseCheckoutDirectories
+    type: string
+  - default: "true"
+    description: Clean out the contents of the destination directory if it already exists before cloning.
+    name: deleteExisting
+    type: string
+  - default: ""
+    description: HTTP proxy server for non-SSL requests.
+    name: httpProxy
+    type: string
+  - default: ""
+    description: HTTPS proxy server for SSL requests.
+    name: httpsProxy
+    type: string
+  - default: ""
+    description: Opt out of proxying HTTP/HTTPS requests.
+    name: noProxy
+    type: string
+  - default: "false"
+    description: Log the commands that are executed during `git-clone`'s operation.
+    name: verbose
+    type: string
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
+    name: gitInitImage
+    type: string
+  - default: /tekton/home
+    description: |
+      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
+    name: userHome
+    type: string
+  - default: "true"
+    description: |
+      Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
+    name: enableSymlinkCheck
+    type: string
+  - default: "false"
+    description: Fetch all tags for the repo.
+    name: fetchTags
+    type: string
+  - name: caTrustConfigMapName
+    type: string
+    description: The name of the ConfigMap to read CA bundle data from.
+    default: trusted-ca
+  - name: caTrustConfigMapKey
+    type: string
+    description: The name of the key in the ConfigMap that contains the CA bundle data.
+    default: ca-bundle.crt
+  results:
+  - description: The precise commit SHA that was fetched by this Task.
+    name: commit
+  - description: The precise URL that was fetched by this Task.
+    name: url
+  steps:
+  - name: clone
+    env:
+    - name: HOME
+      value: $(params.userHome)
+    - name: PARAM_URL
+      value: $(params.url)
+    - name: PARAM_REVISION
+      value: $(params.revision)
+    - name: PARAM_REFSPEC
+      value: $(params.refspec)
+    - name: PARAM_SUBMODULES
+      value: $(params.submodules)
+    - name: PARAM_DEPTH
+      value: $(params.depth)
+    - name: PARAM_SSL_VERIFY
+      value: $(params.sslVerify)
+    - name: PARAM_SUBDIRECTORY
+      value: $(params.subdirectory)
+    - name: PARAM_DELETE_EXISTING
+      value: $(params.deleteExisting)
+    - name: PARAM_HTTP_PROXY
+      value: $(params.httpProxy)
+    - name: PARAM_HTTPS_PROXY
+      value: $(params.httpsProxy)
+    - name: PARAM_NO_PROXY
+      value: $(params.noProxy)
+    - name: PARAM_VERBOSE
+      value: $(params.verbose)
+    - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+      value: $(params.sparseCheckoutDirectories)
+    - name: PARAM_USER_HOME
+      value: $(params.userHome)
+    - name: PARAM_FETCH_TAGS
+      value: $(params.fetchTags)
+    - name: PARAM_GIT_INIT_IMAGE
+      value: $(params.gitInitImage)
+    - name: WORKSPACE_OUTPUT_PATH
+      value: $(workspaces.output.path)
+    - name: WORKSPACE_SSH_DIRECTORY_BOUND
+      value: $(workspaces.ssh-directory.bound)
+    - name: WORKSPACE_SSH_DIRECTORY_PATH
+      value: $(workspaces.ssh-directory.path)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+      value: $(workspaces.basic-auth.bound)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+      value: $(workspaces.basic-auth.path)
+    image: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8
+    computeResources: {}
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    script: |
+      #!/usr/bin/env sh
+      set -eu
+
+      if [ "${PARAM_VERBOSE}" = "true" ] ; then
+        set -x
+      fi
+
+      if [ -n "${PARAM_GIT_INIT_IMAGE}" ]; then
+        echo "WARNING: provided deprecated gitInitImage parameter has no effect."
+      fi
+
+      if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+        if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+        # Compatibility with kubernetes.io/basic-auth secrets
+        elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
+          HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
+          echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" > "${PARAM_USER_HOME}/.git-credentials"
+          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${PARAM_USER_HOME}/.gitconfig"
+        else
+          echo "Unknown basic-auth workspace format"
+          exit 1
+        fi
+        chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+        chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+      fi
+
+      # Should be called after the gitconfig is copied from the repository secret
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        git config --global http.sslCAInfo "$ca_bundle"
+      fi
+
+      if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+        cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+        chmod 700 "${PARAM_USER_HOME}"/.ssh
+        chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+      fi
+
+      CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+
+      cleandir() {
+        # Delete any existing contents of the repo directory if it exists.
+        #
+        # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
+        # or the root of a mounted volume.
+        if [ -d "${CHECKOUT_DIR}" ] ; then
+          # Delete non-hidden files and directories
+          rm -rf "${CHECKOUT_DIR:?}"/*
+          # Delete files and directories starting with . but excluding ..
+          rm -rf "${CHECKOUT_DIR}"/.[!.]*
+          # Delete files and directories starting with .. plus any other character
+          rm -rf "${CHECKOUT_DIR}"/..?*
+        fi
+      }
+
+      if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
+        cleandir
+      fi
+
+      test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+      test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+      test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+      /ko-app/git-init \
+        -url="${PARAM_URL}" \
+        -revision="${PARAM_REVISION}" \
+        -refspec="${PARAM_REFSPEC}" \
+        -path="${CHECKOUT_DIR}" \
+        -sslVerify="${PARAM_SSL_VERIFY}" \
+        -submodules="${PARAM_SUBMODULES}" \
+        -depth="${PARAM_DEPTH}" \
+        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+      cd "${CHECKOUT_DIR}"
+      RESULT_SHA="$(git rev-parse HEAD)"
+      EXIT_CODE="$?"
+      if [ "${EXIT_CODE}" != 0 ] ; then
+        exit "${EXIT_CODE}"
+      fi
+      printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+      printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+
+      if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
+        echo "Fetching tags"
+        git fetch --tags
+      fi
+
+  - name: symlink-check
+    image: registry.redhat.io/ubi9:9.2-696@sha256:089bd3b82a78ac45c0eed231bb58bfb43bfcd0560d9bba240fc6355502c92976
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    env:
+    - name: PARAM_ENABLE_SYMLINK_CHECK
+      value: $(params.enableSymlinkCheck)
+    - name: PARAM_SUBDIRECTORY
+      value: $(params.subdirectory)
+    - name: WORKSPACE_OUTPUT_PATH
+      value: $(workspaces.output.path)
+    computeResources: {}
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+      check_symlinks() {
+        FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
+        while read symlink
+        do
+          target=$(readlink -f "$symlink")
+          if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
+            echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
+            FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
+          fi
+        done < <(find $CHECKOUT_DIR -type l -print)
+        if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ] ; then
+          return 1
+        fi
+      }
+
+      if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ] ; then
+        echo "Running symlink check"
+        check_symlinks
+      fi
+  workspaces:
+  - description: The git repo will be cloned onto the volume backing this Workspace.
+    name: output
+  - description: |
+      A .ssh directory with private key, known_hosts, config, etc. Copied to
+      the user's home before git commands are executed. Used to authenticate
+      with the git remote when performing the clone. Binding a Secret to this
+      Workspace is strongly recommended over other volume types.
+    name: ssh-directory
+    optional: true
+  - description: |
+      A Workspace containing a .gitconfig and .git-credentials file or username and password.
+      These will be copied to the user's home before any git commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to use ssh-directory over basic-auth whenever possible and to bind a
+      Secret to this Workspace over other volume types.
+    name: basic-auth
+    optional: true
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true

--- a/task/git-clone-community/0.1/kustomization.yaml
+++ b/task/git-clone-community/0.1/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- git-clone.yaml
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Task

--- a/task/git-clone-community/0.1/patch.yaml
+++ b/task/git-clone-community/0.1/patch.yaml
@@ -1,0 +1,8 @@
+---
+- op: replace
+  path: /metadata/name
+  value: git-clone-community
+
+- op: replace
+  path: /spec/steps/0/image
+  value: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2

--- a/task/git-clone-community/OWNERS
+++ b/task/git-clone-community/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Build Team

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -25,7 +25,7 @@ spec:
 
   steps:
     - name: init
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
+      image: quay.io/openshift/origin-cli@sha256:086156148c5ef531223b959c3636f0cdb556272eb5a181a3a2fe43d822f41b4f
       env:
         - name: IMAGE_URL
           value: $(params.image-url)


### PR DESCRIPTION
Author: gbenhaim <gbenhaim@redhat.com>
Date:   Wed May 22 11:18:42 2024 +0300

    Add docker-build community pipeline
    
    It has the same logic has the docker-build pipeline,
    but it uses only tasks that use public images.
    
    Signed-off-by: gbenhaim <gbenhaim@redhat.com>

commit 04d9148e2cda4a4d8eb0a48f0fab652920e61f04
Author: gbenhaim <gbenhaim@redhat.com>
Date:   Wed May 22 11:15:34 2024 +0300

    Add git-clone community task
    
    It has the same logic such as the git-clone task, but it's
    using an image which is publicly available.
    
    Signed-off-by: gbenhaim <gbenhaim@redhat.com>

commit ff790de061e19df89505236522a86f8f4e9a9384
Author: gbenhaim <gbenhaim@redhat.com>
Date:   Wed May 22 11:11:47 2024 +0300

    Add init community task
    
    It has the same logic such as the init task, but it's
    using an image which is publicly available.
    
    Signed-off-by: gbenhaim <gbenhaim@redhat.com>
