### PR TITLE
Fix GH app installation ID for commenting on PRs

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -96,8 +96,9 @@ spec:
                   value: /secrets/deploy-key/private-key
                 - name: GITHUBAPP_APP_ID
                   value: "305606"
+                # https://github.com/apps/rh-tap-build-team in https://github.com/konflux-ci
                 - name: GITHUBAPP_INSTALLATION_ID
-                  value: "35269675"
+                  value: "51073377"
                 - name: GITHUB_API_URL
                   value: https://api.github.com
                 - name: REPO_OWNER


### PR DESCRIPTION
STONEBLD-2339

The build-definitions repo has moved to the konflux-ci org. The
https://github.com/apps/rh-tap-build-team app had to be reinstalled in
the new org, thus changing the installation ID.

Update the installation ID for the create-comment task, which may try to
comment on build-definitions pull requests.

NOTE: do not update the default installation ID in the
update-infra-deployments task - infra-deployments is staying in the
redhat-appstudio org.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
