### PR TITLE
prefetch-dependencies: Make the task fail if the input is empty

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -80,13 +80,6 @@ spec:
         mountPath: /mnt/trusted-ca
         readOnly: true
     script: |
-      if [ -z "${INPUT}" ]
-      then
-        # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
-        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
-        exit 0
-      fi
-
       if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
         dev_pacman_flag=--dev-package-managers
       else

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -51,13 +51,6 @@ spec:
         mountPath: /mnt/trusted-ca
         readOnly: true
     script: |
-      if [ -z "${INPUT}" ]
-      then
-        # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
-        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
-        exit 0
-      fi
-
       if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
         dev_pacman_flag=--dev-package-managers
       else


### PR DESCRIPTION
This change aims to make it clear that a successful execution of the prefetch-dependencies task means that Cachi2 was executed successfully, as opposed to the task being executed as a no-op.

Accepting an empty input was initially allowed because, previously, the task execution was tied to hermetic builds, and we wanted to allow use cases in which there could be a hermetic build but no prefetch. Since this behavior is now changed, allowing the task to be a no-op is no longer necessary.
