### PR TITLE
Start pushing all images to quay.io/konflux-ci

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -151,7 +151,7 @@ spec:
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
-                MY_QUAY_USER=redhat-appstudio-tekton-catalog \
+                QUAY_NAMESPACE=redhat-appstudio-tekton-catalog \
                 TEST_REPO_NAME=pull-request-builds \
                 BUILD_TAG=$(params.revision) \
                 SKIP_BUILD=1 \

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -79,8 +79,6 @@ spec:
           steps:
             - name: check-task-structure
               image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -89,8 +87,6 @@ spec:
                 cat partner-tasks.out
             - name: create-comment
               image: quay.io/redhat-appstudio/github-app-token@sha256:b4f2af12e9beea68055995ccdbdb86cfe1be97688c618117e5da2243dc1da18e
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
               volumeMounts:
                 - name: infra-deployments-pr-creator
                   mountPath: /secrets/deploy-key
@@ -146,8 +142,6 @@ spec:
           steps:
             - name: build-bundles
               image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -183,8 +177,6 @@ spec:
           steps:
             - name: fail-when-repo-is-missed
               image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12@sha256:2098dc35cf999984ffb2a0aebd4f8bb1b52f1e2c308efef90831a3660c75c358
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -209,8 +201,6 @@ spec:
           steps:
             - name: check-task-migration-md
               image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12@sha256:9deda623e4768ecbaa6f1c6204077d9a151d55f9569bfe414e793fcb36cc391e
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -243,8 +233,6 @@ spec:
           steps:
             - name: e2e-cleanup
               image: registry.redhat.io/openshift4/ose-cli:v4.12@sha256:0d21299d2adfa3cb74562c4dffbedd3b107fffac3a2a537f14770088abd4671f
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
               script: |
                 #!/usr/bin/env bash
                 # Perform cleanup of resources created by gitops service

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -176,7 +176,7 @@ spec:
         taskSpec:
           steps:
             - name: fail-when-repo-is-missed
-              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12@sha256:2098dc35cf999984ffb2a0aebd4f8bb1b52f1e2c308efef90831a3660c75c358
+              image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -64,7 +64,7 @@ spec:
           - yaml-lint-check
         params:
           - name: IMAGE
-            value: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+            value: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
           - name: CONTEXT
             value: appstudio-utils
         taskRef:
@@ -78,7 +78,7 @@ spec:
         taskSpec:
           steps:
             - name: check-task-structure
-              image: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+              image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
               # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
               # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source
@@ -145,7 +145,7 @@ spec:
               type: string
           steps:
             - name: build-bundles
-              image: quay.io/redhat-appstudio/pull-request-builds:build-definitions-utils-{{revision}}
+              image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
               # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
               # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -151,21 +151,13 @@ spec:
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
-                QUAY_NAMESPACE=redhat-appstudio-tekton-catalog \
+                QUAY_NAMESPACE=konflux-ci \
                 TEST_REPO_NAME=pull-request-builds \
                 BUILD_TAG=$(params.revision) \
                 SKIP_BUILD=1 \
                 INSTALL_BUNDLE_NS=$(params.e2e_test_namespace) \
                 ENABLE_SOURCE_BUILD=1 \
                 hack/build-and-push.sh
-              volumeMounts:
-                - mountPath: /root/.docker/config.json
-                  subPath: .dockerconfigjson
-                  name: quay-secret
-          volumes:
-          - name: quay-secret
-            secret:
-              secretName: redhat-appstudio-tekton-catalog-build-definitions-pull-secret
           workspaces:
             - name: source
       - name: e2e-tests

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -52,7 +52,7 @@ spec:
       - name: build-container
         params:
           - name: IMAGE
-            value: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
+            value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
           - name: CONTEXT
             value: appstudio-utils
         runAfter:
@@ -77,7 +77,7 @@ spec:
               type: string
           steps:
             - name: build-bundles
-              image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
+              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
               # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
               # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source
@@ -134,7 +134,7 @@ spec:
               secretName: redhat-appstudio-tekton-catalog-build-definitions-pull-secret
           steps:
             - name: build-bundles
-              image: quay.io/redhat-appstudio/appstudio-utils:{{ revision }}
+              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
               workingDir: $(workspaces.artifacts.path)/source
               env:
               - name: REVISION

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -83,7 +83,7 @@ spec:
               workingDir: $(workspaces.source.path)/source
               command: ["./hack/build-and-push.sh"]
               env:
-                - name: MY_QUAY_USER
+                - name: QUAY_NAMESPACE
                   value: redhat-appstudio-tekton-catalog
                 - name: BUILD_TAG
                   value: "$(params.revision)"

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -41,6 +41,21 @@ spec:
         workspaces:
           - name: output
             workspace: workspace
+
+      - name: clone-repository-to-redhat-appstudio-workspace
+        params:
+          - name: url
+            value: $(params.git-url)
+          - name: revision
+            value: "$(params.revision)"
+          - name: depth
+            value: "0"
+        taskRef:
+          name: git-clone
+        workspaces:
+          - name: output
+            workspace: workspace-redhat-appstudio
+
       - name: ec-task-checks
         runAfter:
           - clone-repository
@@ -62,15 +77,17 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
-      - name: build-bundles
+
+      - name: build-bundles-redhat-appstudio
         params:
           - name: revision
             value: "$(params.revision)"
         runAfter:
           - build-container
+          - clone-repository-to-redhat-appstudio-workspace
         workspaces:
           - name: source
-            workspace: workspace
+            workspace: workspace-redhat-appstudio
         taskSpec:
           params:
             - name: revision
@@ -105,9 +122,47 @@ spec:
               secretName: redhat-appstudio-tekton-catalog-build-definitions-pull-secret
           workspaces:
             - name: source
+
+      - name: build-bundles-konflux-ci
+        params:
+          - name: revision
+            value: "$(params.revision)"
+        runAfter:
+          - build-container
+        workspaces:
+          - name: source
+            workspace: workspace
+        taskSpec:
+          params:
+            - name: revision
+              type: string
+          steps:
+            - name: build-bundles
+              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+              # the cluster will set imagePullPolicy to IfNotPresent
+              workingDir: $(workspaces.source.path)/source
+              command: ["./hack/build-and-push.sh"]
+              env:
+                - name: QUAY_NAMESPACE
+                  value: konflux-ci/tekton-catalog
+                - name: BUILD_TAG
+                  value: "$(params.revision)"
+                - name: SKIP_BUILD
+                  value: "1"
+                - name: SKIP_INSTALL
+                  value: "1"
+                - name: OUTPUT_TASK_BUNDLE_LIST
+                  value: $(workspaces.source.path)/task-bundle-list
+                - name: OUTPUT_PIPELINE_BUNDLE_LIST
+                  value: $(workspaces.source.path)/pipeline-bundle-list
+          workspaces:
+            - name: source
+
       - name: update-infra-repo
         runAfter:
-          - build-bundles
+          - build-bundles-redhat-appstudio
+          - build-bundles-konflux-ci
         params:
           - name: ORIGIN_REPO
             value: $(params.git-url)
@@ -118,16 +173,24 @@ spec:
               sed -i -E 's/[0-9a-f]{40}/$(params.revision)/g' components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
         taskRef:
           name: update-infra-deployments
-      - name: build-acceptable-bundles
+
+      # Note: pushes to redhat-appstudio-tekton-catalog, but contains the bundles
+      # from both redhat-appstudio-tekton-catalog and konflux-ci/tekton-catalog
+      - name: build-acceptable-bundles-redhat-appstudio
         runAfter:
-          - build-bundles
+          - build-bundles-redhat-appstudio
+          - build-bundles-konflux-ci
         workspaces:
           - name: artifacts
             workspace: workspace
+          - name: artifacts-redhat-appstudio
+            workspace: workspace-redhat-appstudio
         taskSpec:
           workspaces:
             - name: artifacts
               description: Workspace containing arbitrary artifacts used during the task run.
+            - name: artifacts-redhat-appstudio
+              description: Same as 'artifacts', but for tasks that push to the old redhat-appstudio location.
           volumes:
           - name: quay-secret
             secret:
@@ -141,25 +204,21 @@ spec:
                 value: "$(params.revision)"
               - name: GIT_URL
                 value: "$(params.git-url)"
-              - name: TASK_BUNDLE_LIST
-                value: $(workspaces.artifacts.path)/task-bundle-list
-              - name: PIPELINE_BUNDLE_LIST
-                value: $(workspaces.artifacts.path)/pipeline-bundle-list
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
-              script: |-
-                #!/usr/bin/env bash
-                set -o errexit
-                set -o nounset
-                set -o pipefail
-
-                .tekton/scripts/build-acceptable-bundles.sh "${TASK_BUNDLE_LIST}"  "${PIPELINE_BUNDLE_LIST}"
+              command: [".tekton/scripts/build-acceptable-bundles.sh"]
+              args:
+                - $(workspaces.artifacts.path)/task-bundle-list
+                - $(workspaces.artifacts.path)/pipeline-bundle-list
+                - $(workspaces.artifacts-redhat-appstudio.path)/task-bundle-list
+                - $(workspaces.artifacts-redhat-appstudio.path)/pipeline-bundle-list
               volumeMounts:
                 - mountPath: /root/.docker/config.json
                   subPath: .dockerconfigjson
                   name: quay-secret
     workspaces:
       - name: workspace
+        description: Workspace containing arbitrary artifacts used during the pipeline run.
+      - name: workspace-redhat-appstudio
+        description: Same as 'workspace', but for tasks that push to the old redhat-appstudio location.
     finally:
       - name: slack-webhook-notification
         taskRef:
@@ -178,6 +237,14 @@ spec:
           value: $(params.slack-webhook-notification-team)
   workspaces:
     - name: workspace
+      volumeClaimTemplate:
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 1Gi
+    - name: workspace-redhat-appstudio
       volumeClaimTemplate:
         spec:
           accessModes:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -95,8 +95,6 @@ spec:
           steps:
             - name: build-bundles
               image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source
               command: ["./hack/build-and-push.sh"]
               env:
@@ -139,8 +137,6 @@ spec:
           steps:
             - name: build-bundles
               image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
-              # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-              # the cluster will set imagePullPolicy to IfNotPresent
               workingDir: $(workspaces.source.path)/source
               command: ["./hack/build-and-push.sh"]
               env:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -195,6 +195,9 @@ spec:
           - name: quay-secret
             secret:
               secretName: redhat-appstudio-tekton-catalog-build-definitions-pull-secret
+          results:
+          - name: DATA_BUNDLE_REPO
+          - name: DATA_BUNDLE_TAG
           steps:
             - name: build-bundles
               image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
@@ -204,7 +207,18 @@ spec:
                 value: "$(params.revision)"
               - name: GIT_URL
                 value: "$(params.git-url)"
-              command: [".tekton/scripts/build-acceptable-bundles.sh"]
+              script: |
+                #!/bin/bash
+                set -euo pipefail
+
+                DATA_BUNDLE_REPO=quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles
+                DATA_BUNDLE_TAG=$(date '+%s')
+                export DATA_BUNDLE_REPO DATA_BUNDLE_TAG
+
+                .tekton/scripts/build-acceptable-bundles.sh "$@"
+
+                echo -n "$DATA_BUNDLE_REPO" > "$(results.DATA_BUNDLE_REPO.path)"
+                echo -n "$DATA_BUNDLE_TAG" > "$(results.DATA_BUNDLE_TAG.path)"
               args:
                 - $(workspaces.artifacts.path)/task-bundle-list
                 - $(workspaces.artifacts.path)/pipeline-bundle-list
@@ -214,6 +228,34 @@ spec:
                 - mountPath: /root/.docker/config.json
                   subPath: .dockerconfigjson
                   name: quay-secret
+
+      # Note: copies the redhat-appstudio-tekton-catalog data-acceptable-bundles image
+      - name: build-acceptable-bundles-konflux-ci
+        runAfter:
+          - build-acceptable-bundles-redhat-appstudio
+        taskSpec:
+          steps:
+            - name: copy-bundles
+              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              env:
+              - name: DATA_BUNDLE_RH_APPSTUDIO
+                value: $(tasks.build-acceptable-bundles-redhat-appstudio.results.DATA_BUNDLE_REPO)
+              - name: DATA_BUNDLE_TAG
+                value: $(tasks.build-acceptable-bundles-redhat-appstudio.results.DATA_BUNDLE_TAG)
+              script: |
+                #!/bin/bash
+                set -euo pipefail
+                set -x
+
+                DATA_BUNDLE_KONFLUX_CI=quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles
+
+                skopeo copy \
+                  "docker://$DATA_BUNDLE_RH_APPSTUDIO:$DATA_BUNDLE_TAG" \
+                  "docker://$DATA_BUNDLE_KONFLUX_CI:$DATA_BUNDLE_TAG"
+
+                skopeo copy \
+                  "docker://$DATA_BUNDLE_KONFLUX_CI:$DATA_BUNDLE_TAG" \
+                  "docker://$DATA_BUNDLE_KONFLUX_CI:latest"
     workspaces:
       - name: workspace
         description: Workspace containing arbitrary artifacts used during the pipeline run.

--- a/.tekton/scripts/build-acceptable-bundles.sh
+++ b/.tekton/scripts/build-acceptable-bundles.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 
 # helps with debugging
-DATA_BUNDLE_REPO="${DATA_BUNDLE_REPO:-quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles}"
+DATA_BUNDLE_REPO="${DATA_BUNDLE_REPO:-quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles}"
 mapfile -t BUNDLES < <(cat "$@")
 
 # store a list of changed task files
@@ -34,7 +34,7 @@ printf '%s\n' "${BUNDLES[@]}"
 # advantages. First, it prevents the image from accidentally not having any tags,
 # and getting garbage collected. Second, it helps us create a timeline of the
 # changes done to the data over time.
-TAG="$(date '+%s')"
+DATA_BUNDLE_TAG=${DATA_BUNDLE_TAG:-$(date '+%s')}
 
 # task_records can be empty if a task wasn't changed
 TASK_PARAM=()
@@ -47,11 +47,11 @@ PARAMS=("${TASK_PARAM[@]}" "${BUNDLES_PARAM[@]}")
 
 ec track bundle --debug \
     --input "oci:${DATA_BUNDLE_REPO}:latest" \
-    --output "oci:${DATA_BUNDLE_REPO}:${TAG}" \
+    --output "oci:${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" \
     --timeout "15m0s" \
     --freshen \
     --prune \
     "${PARAMS[@]}"
 
 # To facilitate usage in some contexts, tag the image with the floating "latest" tag.
-skopeo copy "docker://${DATA_BUNDLE_REPO}:${TAG}" "docker://${DATA_BUNDLE_REPO}:latest"
+skopeo copy "docker://${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" "docker://${DATA_BUNDLE_REPO}:latest"

--- a/.tekton/scripts/check-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/check-task-pipeline-bundle-repos.sh
@@ -7,13 +7,34 @@ set -o nounset
 SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPTDIR/../.."
 
-QUAY_ORG=redhat-appstudio-tekton-catalog
+CATALOG_NAMESPACES=(
+    redhat-appstudio-tekton-catalog
+    konflux-ci/tekton-catalog
+)
 
 locate_bundle_repo() {
+    local -r quay_namespace="$1"
+    local -r type="$2"
+    local -r object="$3"
+
+    curl -I -s -L -w "%{http_code}\n" -o /dev/null "https://quay.io/v2/${quay_namespace}/${type}-${object}/tags/list"
+}
+
+locate_in_all_namespaces() {
     local -r type="$1"
     local -r object="$2"
 
-    curl -I -s -L -w "%{http_code}\n" -o /dev/null "https://quay.io/v2/${QUAY_ORG}/${type}-${object}/tags/list"
+    local rc=0
+
+    for quay_namespace in "${CATALOG_NAMESPACES[@]}"; do
+        found=$(locate_bundle_repo "$quay_namespace" "$type" "$object")
+        if [ "$found" != "200" ]; then
+            echo "Missing $type bundle repo: ${quay_namespace}/${type}-${object}"
+            rc=1
+        fi
+    done
+
+    return "$rc"
 }
 
 has_missing_repo=
@@ -27,9 +48,8 @@ for task_dir in $(find task/*/*/ -maxdepth 0 -type d); do
     else
       task_name=$(oc apply --dry-run=client -k "$task_dir" -o jsonpath='{.metadata.name}')
     fi
-    found=$(locate_bundle_repo task "$task_name")
-    if [ "$found" != "200" ]; then
-        echo "Missing task bundle repo: task-$task_name"
+
+    if ! locate_in_all_namespaces task "$task_name"; then
         has_missing_repo=yes
     fi
 done
@@ -39,15 +59,15 @@ pl_names=($(oc kustomize pipelines/ | oc apply --dry-run=client -f - -o jsonpath
 # Currently, only one pipeline for core services CI
 pl_names+=($(oc kustomize pipelines/core-services/ | oc apply --dry-run=client -f - -o jsonpath='{"core-services-"}{.metadata.name}'))
 for pl_name in ${pl_names[@]}; do
-    found=$(locate_bundle_repo pipeline "$pl_name")
-    if [ "$found" != "200" ]; then
-        echo "Missing pipeline bundle repo: pipeline-$pl_name"
+    if ! locate_in_all_namespaces pipeline "$pl_name"; then
         has_missing_repo=yes
     fi
 done
 
 if [ -n "$has_missing_repo" ]; then
-    echo "Please contact Build team - #forum-stonesoup-build that the missing repos should be created in https://quay.io/organization/redhat-appstudio-tekton-catalog"
+    echo "Please contact Build team - #forum-stonesoup-build that the missing repos should be created in:"
+    echo "- https://quay.io/organization/redhat-appstudio-tekton-catalog"
+    echo "- https://quay.io/organization/konflux-ci"
     exit 1
 else
     echo "Done"

--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -51,7 +51,7 @@ spec:
       - name: QUAY_TOKEN
         valueFrom:
           secretKeyRef:
-            name: quay-push-secret
+            name: quay-push-secret-konflux-ci
             key: .dockerconfigjson
       - name: MY_GITHUB_ORG
         value: redhat-appstudio-appdata

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Currently a set of utilities are bundled with App Studio in `quay.io/konflux-ci/
 
 ## Building
 
-Script `hack/build-and-push.sh` creates bundles for pipelines, tasks and create appstudio-utils image. Images are pushed into your quay.io repository. You will need to set `MY_QUAY_USER` to use this feature and be logged into quay.io on your workstation.
+Script `hack/build-and-push.sh` creates bundles for pipelines, tasks and create appstudio-utils image. Images are pushed into your quay.io repository. You will need to set `QUAY_NAMESPACE` to use this feature and be logged into quay.io on your workstation.
 Once you run the `hack/build-and-push.sh` all pipelines will come from your bundle instead of from the default installed by gitops into the cluster.
 
 > **Note**
@@ -43,7 +43,7 @@ Shellspec tests can be run by invoking `hack/test-shellspec.sh`.
 
 ## Release
 
-Release is done by setting env variable `MY_QUAY_USER=redhat-appstudio-tekton-catalog`, `BUILD_TAG=$(git rev-parse HEAD)` and running `hack/build-and-push.sh`.
+Release is done by setting env variable `QUAY_NAMESPACE=redhat-appstudio-tekton-catalog`, `BUILD_TAG=$(git rev-parse HEAD)` and running `hack/build-and-push.sh`.
 
 ### Versioning
 
@@ -55,7 +55,7 @@ Task version increase must be approved by Project Manager.
 
 ## Testing
 
-Script `./hack/test-builds.sh` creates pipelines and tasks directly in current namespace and executes there test builds. By setting the environment variable `MY_QUAY_USER` the images will be pushed into user's quay repository, in that case creation of secret named `redhat-appstudio-staginguser-pull-secret` is required.
+Script `./hack/test-builds.sh` creates pipelines and tasks directly in current namespace and executes there test builds. By setting the environment variable `QUAY_NAMESPACE` the images will be pushed into user's quay repository, in that case creation of secret named `redhat-appstudio-staginguser-pull-secret` is required.
 
 Script `./hack/test-build.sh` provides way to test on custom git repository and pipeline. Usage example: `./hack/test-build.sh https://github.com/jduimovich/spring-petclinic java-builder`.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Pipelines and Tasks are delivered into App Studio via quay organization `redhat-
 Pipelines are bundled and pushed into repositories prefixed with `pipeline-` and tagged with `$GIT_SHA` (tag will be updated with every change).
 Tasks are bundled and pushed into repositories prefixed with `task-` and tagged with `$VERSION` where `VERSION` is the task version (tag is updated when the task file contains any change in the PR)
 
-Currently a set of utilities are bundled with App Studio in `quay.io/redhat-appstudio/appstudio-utils:$GIT_SHA` as a convenience but tasks may be run from different per-task containers.
+Currently a set of utilities are bundled with App Studio in `quay.io/konflux-ci/appstudio-utils:$GIT_SHA` as a convenience but tasks may be run from different per-task containers.
 
 
 ## Building
@@ -37,7 +37,7 @@ The pipelines can be found in the `pipelines` directory.
 The tasks can be found in the `tasks` directories. Tasks are bundled and used by bundled pipelines. Tasks are not stored in the Cluster.
 For quick local innerloop style task development, you may install new Tasks in your local namespace manually and create your pipelines as well as the base task image to test new function. Tasks can be installed into local namespace using `oc apply -k tasks/appstudio-utils/util-tasks`.
 
-There is a container which is used to support multiple set of tasks called `quay.io/redhat-appstudio/appstudio-utils:GIT_SHA` , which is a single container which is used by multiple tasks. Tasks may also be in their own container as well however many simple tasks are utilities and will be packaged for app studio in a single container. Tasks can rely on other tasks in the system which are co-packed in a container allowing combined tasks (build-only vs build-deploy) which use the same core implementations.
+There is a container which is used to support multiple set of tasks called `quay.io/konflux-ci/appstudio-utils:GIT_SHA` , which is a single container which is used by multiple tasks. Tasks may also be in their own container as well however many simple tasks are utilities and will be packaged for app studio in a single container. Tasks can rely on other tasks in the system which are co-packed in a container allowing combined tasks (build-only vs build-deploy) which use the same core implementations.
 
 Shellspec tests can be run by invoking `hack/test-shellspec.sh`.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains components that are installed or managed by the managed
 
 This includes default Pipelines and Tasks. You need to have bootstrapped a working appstudio configuration from (see `https://github.com/redhat-appstudio/infra-deployments`) for the dev of pipelines or new tasks.
 
-Pipelines and Tasks are delivered into App Studio via quay organization `redhat-appstudio-tekton-catalog`.
+Pipelines and Tasks are delivered into App Studio via quay organization `konflux-ci/tekton-catalog`.
 Pipelines are bundled and pushed into repositories prefixed with `pipeline-` and tagged with `$GIT_SHA` (tag will be updated with every change).
 Tasks are bundled and pushed into repositories prefixed with `task-` and tagged with `$VERSION` where `VERSION` is the task version (tag is updated when the task file contains any change in the PR)
 
@@ -43,7 +43,13 @@ Shellspec tests can be run by invoking `hack/test-shellspec.sh`.
 
 ## Release
 
-Release is done by setting env variable `QUAY_NAMESPACE=redhat-appstudio-tekton-catalog`, `BUILD_TAG=$(git rev-parse HEAD)` and running `hack/build-and-push.sh`.
+Release is done by (better leave it to the [push pipeline](.tekton/push.yaml)):
+
+```bash
+for quay_namespace in redhat-appstudio-tekton-catalog konflux-ci/tekton-catalog; do
+  QUAY_NAMESPACE=$quay_namespace BUILD_TAG=$(git rev-parse HEAD) hack/build-and-push.sh
+done
+```
 
 ### Versioning
 

--- a/appstudio-utils/README.md
+++ b/appstudio-utils/README.md
@@ -1,4 +1,4 @@
-# Source for quay.io/redhat-appstudio/appstudio-utils:$GIT_SHA
+# Source for quay.io/konflux-ci/appstudio-utils:$GIT_SHA
 
 This component provides an image which contains a suite of app-studio specific utilies.
 

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -67,7 +67,7 @@ fi
 # (This method is used in PR testing)
 : "${TEST_REPO_NAME:=}"
 
-APPSTUDIO_UTILS_IMG="quay.io/$MY_QUAY_USER/${TEST_REPO_NAME:-appstudio-utils}:${TEST_REPO_NAME:+build-definitions-utils-}$BUILD_TAG"
+APPSTUDIO_UTILS_IMG="quay.io/$MY_QUAY_USER/${TEST_REPO_NAME:-appstudio-utils}:${TEST_REPO_NAME:+appstudio-utils-}$BUILD_TAG"
 
 OUTPUT_TASK_BUNDLE_LIST="${OUTPUT_TASK_BUNDLE_LIST-${SCRIPTDIR}/../task-bundle-list}"
 OUTPUT_PIPELINE_BUNDLE_LIST="${OUTPUT_PIPELINE_BUNDLE_LIST-${SCRIPTDIR}/../pipeline-bundle-list}"

--- a/hack/check-partner-tasks.sh
+++ b/hack/check-partner-tasks.sh
@@ -136,6 +136,9 @@ if check_dir_structure; then
     if ! oc whoami >/dev/null 2>&1; then
         echo "warning: haven't logged in an OpenShift instance. Task definition can't be validated on server side."
         check_task_schema_status=Ignored
+    elif ! oc auth can-i get task >/dev/null; then
+        echo "warning: don't have permission to get Task objects. Task definition can't be validated on server side."
+        check_task_schema_status=Ignored
     else
         if check_task_schema; then
             check_task_schema_status=Pass

--- a/hack/test-build.sh
+++ b/hack/test-build.sh
@@ -25,9 +25,9 @@ IMAGE_SHORT_TAG=${IMAGE_FULL_TAG:position:7}
 BUILD_TAG=$(date +"%Y-%m-%d-%H%M%S")
 NS=$(oc config view --minify -o "jsonpath={..namespace}")
 
-if [ -z "$MY_QUAY_USER" ]; then
+if [ -z "$QUAY_NAMESPACE" ]; then
   IMG=image-registry.openshift-image-registry.svc:5000/$NS/$APPNAME:$IMAGE_SHORT_TAG
-  echo MY_QUAY_USER env variable is not set, pushing to $IMG
+  echo QUAY_NAMESPACE env variable is not set, pushing to $IMG
 else
   if oc get secret redhat-appstudio-staginguser-pull-secret &>/dev/null; then
      # Ensure that the appstudio-pipeline service account has access to the secret. Although the
@@ -45,7 +45,7 @@ else
      echo "  oc secrets link appstudio-pipeline redhat-appstudio-staginguser-pull-secret"
      echo ""
   fi
-  IMG=quay.io/$MY_QUAY_USER/$APPNAME:$IMAGE_SHORT_TAG
+  IMG=quay.io/$QUAY_NAMESPACE/$APPNAME:$IMAGE_SHORT_TAG
   echo Building $IMG
 fi
 

--- a/hack/trusted-tasks-update.sh
+++ b/hack/trusted-tasks-update.sh
@@ -1,34 +1,56 @@
 #!/usr/bin/env bash
 # Resolves all tasks from the `/task` directory of this repository and any Task
-# bundles in the `$QUAY_NAMESPACE` quay.io namespace (defaults to
-# `redhat-appstudio-tekton-catalog`) and runs `ec track bundle` with those git
-# and image references in order to catalogue the latest versions in the trusted
-# tasks list in `$INPUT_IMAGE` written to `$OUTPUT_IMAGE` (both default to
-# `quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest`).
+# bundles in the `$QUAY_NAMESPACES` quay.io namespaces. Runs `ec track bundle`
+# with those git and image references in order to catalogue the latest versions
+# in the trusted tasks list in `$INPUT_IMAGE` written to `$OUTPUT_IMAGE` (both
+# default to `quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest`).
 #
 # By default both git and image references are collected, what is collected can
 # be controlled by `$COLLECT` which can be set to `git` or `oci`
 #
 # Parameters via environment variables:
-# COLLECT        - can be set to `oci` or `git` (defaults to both), what to
-#                  resolve
-# INPUT_IMAGE    - Conftest OCI bundle containing the trusted tasks list, defaults
-#                  to:
-#                  `quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest`
-# OUTPUT_IMAGE   - Conftest OCI bundle to write the trusted task list to, defaults
-#                  to `$INPUT_IMAGE`
-# QUAY_NAMESPACE - Quay namespace to query for Task bundles (defaults to
-#                  `redhat-appstudio-tekton-catalog`)
+# COLLECT         - can be set to `oci` or `git` (defaults to both), what to
+#                   resolve
+# INPUT_IMAGE     - Conftest OCI bundle containing the trusted tasks list, defaults
+#                   to:
+#                   `quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest`
+# OUTPUT_IMAGE    - Conftest OCI bundle to write the trusted task list to, defaults
+#                   to `$INPUT_IMAGE`
+# QUAY_NAMESPACES - Quay namespaces to query for Task bundles (defaults to
+#                   `redhat-appstudio-tekton-catalog konflux-ci/tekton-catalog`)
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
 mapfile -td ' ' COLLECT < <(echo -n "${COLLECT:-git oci}")
-INPUT_IMAGE=${INPUT_IMAGE:-quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest}
+mapfile -td ' ' QUAY_NAMESPACES < <(
+    echo -n "${QUAY_NAMESPACES:-'redhat-appstudio-tekton-catalog konflux-ci/tekton-catalog'}"
+)
+
+INPUT_IMAGE=${INPUT_IMAGE:-quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest}
 OUTPUT_IMAGE=${OUTPUT_IMAGE:-$INPUT_IMAGE}
 GIT_REPOSITORY=git+https://github.com/konflux-ci/build-definitions.git
-QUAY_NAMESPACE=${QUAY_NAMESPACE:-redhat-appstudio-tekton-catalog}
+
+function list_tasks() {
+    local full_namespace=$1
+    # The Quay API only supports filtering by e.g. "konflux-ci", not by "konflux-ci/tekton-catalog"
+    local toplevel_namespace=${full_namespace%%/*}
+
+    curl -sSL "https://quay.io/api/v1/repository?namespace=${toplevel_namespace}&public=true" -H 'Accept: application/json' |
+        jq --arg full_namespace "$full_namespace" -r '
+            .repositories[]
+            | "\(.namespace)/\(.name)"
+            | select(test("^\($full_namespace)/task-[^/]*$"))
+            | "quay.io/\(.)"
+        '
+}
+
+function list_tasks_in_all_namespaces() {
+    for namespace in "${QUAY_NAMESPACES[@]}"; do
+        list_tasks "$namespace"
+    done
+}
 
 HACK_DIR="$(dirname "${BASH_SOURCE[0]}")"
 
@@ -55,10 +77,7 @@ for c in "${COLLECT[@]}"; do
       ;;
     oci)
       echo -n Resolving OCI Tasks bundles
-      for repository in $(
-        curl -sSL "https://quay.io/api/v1/repository?namespace=${QUAY_NAMESPACE}&public=true" -H 'Accept: application/json' |
-          jq -r '.repositories.[].name | select(startswith("task-")) | "quay.io/'"${QUAY_NAMESPACE}"'/\(.)"'
-      ); do
+      for repository in $(list_tasks_in_all_namespaces); do
         mapfile -t refs < <(
           skopeo list-tags docker://"${repository}" |
             jq --arg repository "${repository}" -r '.Tags[] | select(test("^(\\d+)(\\.\\d)*$")) | "\($repository):\(.)"'


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

All the images published from this repo will now be pushed to `quay.io/konflux-ci/*`. Some will continue getting pushed to their old location.

| Old (continues getting updates?) | New |
| --- | --- |
| ✅ `redhat-appstudio-tekton-catalog/task-*` | `konflux-ci/tekton-catalog/task-*` |
| ✅ `redhat-appstudio-tekton-catalog/pipeline-*` | `konflux-ci/tekton-catalog/pipeline-*` |
| ✅ `redhat-appstudio-tekton-catalog/data-acceptable-bundles` | `konflux-ci/tekton-catalog/data-acceptable-bundles` |
| ❌ `redhat-appstudio-tekton-catalog/pull-request-builds` | `konflux-ci/pull-request-builds:(task\|pipeline)-*` |
| ❌ `redhat-appstudio/appstudio-utils` | `konflux-ci/appstudio-utils` |
| ❌ `redhat-appstudio/pull-request-builds:build-definitions-utils-*` | `konflux-ci/pull-request-builds:appstudio-utils-*` |

Also, `data-acceptable-bundles` will now contain bundle references for both `redhat-appstudio-tekton-catalog/task-*` and `konflux-ci/tekton-catalog/task-*`.

The full list of repos that we need created in <https://quay.io/konflux-ci>:

<details>
<summary>click me</summary>

```
tekton-catalog/task-acs-deploy-check
tekton-catalog/task-acs-image-check
tekton-catalog/task-acs-image-scan
tekton-catalog/task-apply-tags
tekton-catalog/task-buildah
tekton-catalog/task-buildah-10gb
tekton-catalog/task-buildah-20gb
tekton-catalog/task-buildah-24gb
tekton-catalog/task-buildah-6gb
tekton-catalog/task-buildah-8gb
tekton-catalog/task-buildah-oci-ta
tekton-catalog/task-buildah-remote
tekton-catalog/task-buildah-rhtap
tekton-catalog/task-build-image-manifest
tekton-catalog/task-clair-scan
tekton-catalog/task-clamav-scan
tekton-catalog/task-deprecated-image-check
tekton-catalog/task-download-sbom-from-url-in-attestation
tekton-catalog/task-ecosystem-cert-preflight-checks
tekton-catalog/task-fbc-related-image-check
tekton-catalog/task-fbc-validation
tekton-catalog/task-gather-deploy-images
tekton-catalog/task-generate-odcs-compose
tekton-catalog/task-git-clone
tekton-catalog/task-git-clone-oci-ta
tekton-catalog/task-init
tekton-catalog/task-inspect-image
tekton-catalog/task-prefetch-dependencies
tekton-catalog/task-prefetch-dependencies-oci-ta
tekton-catalog/task-provision-env-with-ephemeral-namespace
tekton-catalog/task-rpm-ostree
tekton-catalog/task-s2i-java
tekton-catalog/task-s2i-nodejs
tekton-catalog/task-sast-snyk-check
tekton-catalog/task-sast-snyk-check-oci-ta
tekton-catalog/task-sbom-json-check
tekton-catalog/task-show-sbom
tekton-catalog/task-show-sbom-rhdh
tekton-catalog/task-slack-webhook-notification
tekton-catalog/task-source-build
tekton-catalog/task-source-build-oci-ta
tekton-catalog/task-summary
tekton-catalog/task-tkn-bundle
tekton-catalog/task-update-deployment
tekton-catalog/task-update-infra-deployments
tekton-catalog/task-upload-sbom-to-trustification
tekton-catalog/task-verify-enterprise-contract
tekton-catalog/task-verify-signed-rpms

tekton-catalog/pipeline-docker-build
tekton-catalog/pipeline-docker-build-oci-ta
tekton-catalog/pipeline-enterprise-contract
tekton-catalog/pipeline-enterprise-contract-everything
tekton-catalog/pipeline-enterprise-contract-slsa3
tekton-catalog/pipeline-fbc-builder
tekton-catalog/pipeline-java-builder
tekton-catalog/pipeline-nodejs-builder
tekton-catalog/pipeline-tekton-bundle-builder
tekton-catalog/pipeline-core-services-docker-build

tekton-catalog/data-acceptable-bundles

appstudio-utils

pull-request-builds

```

</details>

See the individual commits for more details.