### PR TITLE
chore: convert init to use a public image

### DIFF
--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -25,7 +25,7 @@ spec:
 
   steps:
     - name: init
-      image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
+      image: registry.access.redhat.com/ubi9/skopeo:9.4@sha256:23557ecf3de07618968affb59adfb3db80336b976501032b5da9e4e92b943776
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -41,7 +41,7 @@ spec:
         echo "Determine if Image Already Exists"
         # Build the image when rebuild is set to true or image does not exist
         # The image check comes last to avoid unnecessary, slow API calls
-        if [ "$REBUILD" == "true" ] || [ "$SKIP_CHECKS" == "false" ] || ! oc image info $IMAGE_URL &>/dev/null; then
+        if [ "$REBUILD" == "true" ] || [ "$SKIP_CHECKS" == "false" ] || ! skopeo inspect --raw docker://$IMAGE_URL &>/dev/null; then
           echo -n "true" > $(results.build.path)
         else
           echo -n "false" > $(results.build.path)


### PR DESCRIPTION
The init task is using an image hosted in registry.redhat.io in order to make use of the oc command. This change, instead, makes it use skopeo which can be found on an image in registry.access.redhat.com which does not require login.
