### PR TITLE
Use Konflux git-clone image

### DIFF
--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -143,7 +143,7 @@ spec:
       value: $(workspaces.basic-auth.bound)
     - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
       value: $(workspaces.basic-auth.path)
-    image: registry.redhat.io/openshift-pipelines/pipelines-git-init-rhel8:v1.8.2-8@sha256:a538c423e7a11aae6ae582a411fdb090936458075f99af4ce5add038bb6983e8
+    image: quay.io/konflux-ci/git-clone@sha256:005487d3967e7a90490f96b2ff3b0c6d0463b647d212cd809683b494e20146a8
     computeResources: {}
     securityContext:
       runAsUser: 0
@@ -242,7 +242,7 @@ spec:
       fi
 
   - name: symlink-check
-    image: registry.redhat.io/ubi9:9.2-696@sha256:089bd3b82a78ac45c0eed231bb58bfb43bfcd0560d9bba240fc6355502c92976
+    image: quay.io/konflux-ci/git-clone@sha256:005487d3967e7a90490f96b2ff3b0c6d0463b647d212cd809683b494e20146a8
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     env:


### PR DESCRIPTION
A git-clone image built by Konflux to be used in the git-clone task.
