### PR TITLE
Enable trusted_artifacts policy package for Tasks

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -10,6 +10,7 @@ sources:
       include:
         - kind
         - step_image_registries
+        - trusted_artifacts
       exclude:
         # https://issues.redhat.com/browse/KFLUXBUGS-1111
         - step_image_registries.step_images_permitted:generate-odcs-compose/noversion


### PR DESCRIPTION
This enables the policy rules from the newly added `trusted_artifacts`[1] policy package to ensure the Tasks in this repo that use Trusted Artifacts follow the expects parameter and result naming convention.

[1] https://enterprisecontract.dev/docs/ec-policies/task_policy.html#trusted_artifacts_package

Ref: [EC-371](https://issues.redhat.com//browse/EC-371)
