### PR TITLE
Migrate build-definitions redhat-appstudio images

### DIFF
--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -13,7 +13,7 @@ spec:
     This task can be used to run enterprise contract checks
   steps:
   - name: gather-tasks
-    image: quay.io/redhat-appstudio/appstudio-utils:512cca38316355d6dbfc9c23ed3c5afabb943d24
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     workingDir: $(workspaces.source.path)/source

--- a/.tekton/tasks/yaml-lint.yaml
+++ b/.tekton/tasks/yaml-lint.yaml
@@ -32,7 +32,7 @@ spec:
       args:
         - $(params.args)
     - name: ensure-params-not-in-script
-      image: quay.io/redhat-appstudio/appstudio-utils:d8a93bf5650424a4f20ee065578609792d70af1c
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       script: |

--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -4,7 +4,7 @@ sources:
   - policy:
       - oci::quay.io/enterprise-contract/ec-task-policy:latest
     data:
-      - oci::quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles:latest
+      - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
     config:
       include:

--- a/renovate.json
+++ b/renovate.json
@@ -11,9 +11,9 @@
   "packageRules": [
     {
       "matchPackageNames": [
-        "quay.io/redhat-appstudio/pull-request-builds",
+        "quay.io/konflux-ci/pull-request-builds",
         "quay.io/redhat-appstudio/github-app-token",
-        "quay.io/redhat-appstudio/appstudio-utils",
+        "quay.io/konflux-ci/appstudio-utils",
         "quay.io/redhat-appstudio/e2e-tests",
         "quay.io/redhat-appstudio/buildah",
         "quay.io/redhat-appstudio/syft",

--- a/task/acs-deploy-check/0.1/acs-deploy-check.yaml
+++ b/task/acs-deploy-check/0.1/acs-deploy-check.yaml
@@ -49,7 +49,7 @@ spec:
         oc annotate taskrun $(context.taskRun.name) task.output.location=logs
 
     - name: rox-deploy-check
-      image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       volumeMounts:
         - name: repository
           mountPath: /workspace/repository

--- a/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
+++ b/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
@@ -95,7 +95,7 @@ spec:
       value: /tekton/home
   steps:
   - name: download-attestations
-    image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     script: |
       #!/usr/bin/env bash
       set -o errexit -o nounset -o pipefail
@@ -130,7 +130,7 @@ spec:
       done
 
   - name: download-sboms
-    image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     script: |
       #!/usr/bin/env bash
       set -o errexit -o nounset -o pipefail

--- a/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
@@ -22,7 +22,7 @@ spec:
         - name: pfltoutputdir
           mountPath: /artifacts
     - name: gather-pflt-results
-      image: quay.io/redhat-appstudio/appstudio-utils@sha256:586149e3f18d966f681d956ab074b4e1d8433663d615ed86e19a3804ba952dfe
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       volumeMounts:
         - name: pfltoutputdir
           mountPath: /artifacts

--- a/task/gather-deploy-images/0.1/gather-deploy-images.yaml
+++ b/task/gather-deploy-images/0.1/gather-deploy-images.yaml
@@ -28,7 +28,7 @@ spec:
         When there are no images to verify, this is an empty string.
   steps:
   - name: get-images-per-env
-    image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     workingDir: $(workspaces.source.path)/source
     env:
       - name: TARGET_BRANCH

--- a/task/show-sbom/0.1/show-sbom.yaml
+++ b/task/show-sbom/0.1/show-sbom.yaml
@@ -22,7 +22,7 @@ spec:
       default: "linux/amd64"
   steps:
   - name: show-sbom
-    image: quay.io/redhat-appstudio/appstudio-utils:3e548a38b3ad183262a25bc2a4eb6b5367b83fb5
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     env:

--- a/task/summary/0.2/summary.yaml
+++ b/task/summary/0.2/summary.yaml
@@ -27,7 +27,7 @@ spec:
       optional: true
   steps:
     - name: appstudio-summary
-      image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -23,7 +23,7 @@ spec:
         optional: true
   steps:
     - name: patch-gitops
-      image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       volumeMounts:
         - name: gitops-auth-secret
           mountPath: /gitops-auth-secret

--- a/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
+++ b/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
@@ -77,7 +77,7 @@ spec:
       mountPath: /run/secrets/trustification
   steps:
   - name: gather-sboms
-    image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     script: |
       #!/usr/bin/env bash
       set -o errexit -o nounset -o pipefail
@@ -162,7 +162,7 @@ spec:
       done
 
   - name: upload-sboms
-    image: quay.io/redhat-appstudio/appstudio-utils:5bd7d6cb0b17f9f2eab043a8ad16ba3d90551bc2@sha256:8c7fcf86af40c71aeb58e4279625c8308af5144e2f6b8e28b0ec7e795260e5f7
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     script: |
       #!/usr/bin/env bash
       set -o errexit -o nounset -o pipefail


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

All the images built in build-definitions CI now get released to the
quay.io/konflux-ci organization.

Replace the relevant redhat-appstudio[-tekton-catalog] references in
this repo with konflux-ci[/tekton-catalog] references.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
