### PR TITLE
Create a skip markerfile in no-op case

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -78,6 +78,22 @@ spec:
       - mountPath: /var/workdir
         name: workdir
   steps:
+    - name: skip-ta
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.3-1612@sha256:119ac25920c8bb50c8b5fd75dcbca369bf7d1f702b82f3d39663307890f0bf26
+      env:
+        - name: INPUT
+          value: $(params.input)
+        - name: SOURCE_ARTIFACT
+          value: $(params.SOURCE_ARTIFACT)
+      script: |
+        if [ -z "${INPUT}" ]; then
+          mkdir -p /var/workdir/source
+          mkdir -p /var/workdir/cachi2
+          echo "true" >/var/workdir/source/.skip-trusted-artifacts
+          echo "true" >/var/workdir/cachi2/.skip-trusted-artifacts
+          echo -n "${SOURCE_ARTIFACT}" >$( results.SOURCE_ARTIFACT.path)
+          echo -n "" >$( results.CACHI2_ARTIFACT.path)
+        fi
     - name: use-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
       args:

--- a/task/prefetch-dependencies-oci-ta/0.1/recipe.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/recipe.yaml
@@ -4,6 +4,24 @@ add:
   - use-source
   - create-source
   - create-cachi2
+additionalSteps:
+  - at: 0
+    name: skip-ta
+    image: registry.access.redhat.com/ubi9/ubi-minimal:9.3-1612@sha256:119ac25920c8bb50c8b5fd75dcbca369bf7d1f702b82f3d39663307890f0bf26
+    env:
+    - name: INPUT
+      value: $(params.input)
+    - name: SOURCE_ARTIFACT
+      value: $(params.SOURCE_ARTIFACT)
+    script: |
+      if [ -z "${INPUT}" ]; then
+        mkdir -p /var/workdir/source
+        mkdir -p /var/workdir/cachi2
+        echo "true" > /var/workdir/source/.skip-trusted-artifacts
+        echo "true" > /var/workdir/cachi2/.skip-trusted-artifacts
+        echo -n "${SOURCE_ARTIFACT}" > $(results.SOURCE_ARTIFACT.path)
+        echo -n "" > $(results.CACHI2_ARTIFACT.path)
+      fi
 description: |-
     Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
     application source code are stored as a trusted artifact in the provided OCI repository.


### PR DESCRIPTION
When prefetch-dependencies will not do anything we don't need to restore or create Trusted Artifacts, so this adds a step before those to create a marker file so that TA will not do anything. This optimizes the no-op case of prefetch-dependencies.

Reference: https://issues.redhat.com/browse/EC-480