### PR TITLE
fix(STONEBLD-2496, KFLUXBUGS-1317) Ensure that the base image digest result is present

### DIFF
--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -272,6 +272,7 @@ spec:
       fi
 
       # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
       for image in $BASE_IMAGES; do
         if [ "${image}" != "scratch" ]; then
           buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -322,6 +322,7 @@ spec:
       fi
 
       # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
       for image in $BASE_IMAGES; do
         if [ "${image}" != "scratch" ]; then
           buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -329,6 +329,7 @@ spec:
       fi
 
       # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
       for image in $BASE_IMAGES; do
         if [ "${image}" != "scratch" ]; then
           buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -281,6 +281,7 @@ spec:
       fi
 
       # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
       for image in $BASE_IMAGES; do
         if [ "${image}" != "scratch" ]; then
           buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)


### PR DESCRIPTION
If there is no base image (i.e. if the image is only FROM scratch), then the file will not be present and therefore step-create-base-images-sbom will fail.

Resolves: https://issues.redhat.com/browse/STONEBLD-2496
Resolves: https://issues.redhat.com/browse/KFLUXBUGS-1317
