### PR TITLE
Allow certain workspaces in TA tasks

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -6,6 +6,11 @@ sources:
     data:
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data
+    ruleData:
+      allowed_trusted_artifacts_workspaces:
+        - git-basic-auth
+        - basic-auth
+        - ssh-directory
     config:
       include:
         - kind


### PR DESCRIPTION
The `trusted_artifacts` package now has a new polcy rule, `workspace`[1]` that aims to restrict the workspaces used by Tasks that implement the Trusted Artifacts pattern. By default, it does not allow any. This commit adds a list of allow workspaces which are meant for providing authentication details.

Ref: [EC-258](https://issues.redhat.com/browse/EC-258)

[1] https://enterprisecontract.dev/docs/ec-policies/task_policy.html#trusted_artifacts__workspace
