### PR TITLE
KONFLUX-3386 emit the commit timestamp

### DIFF
--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -29,6 +29,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |---|---|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
 |commit|The precise commit SHA that was fetched by this Task.|
+|commit-timestamp|The commit timestamp of the checkout|
 |url|The precise URL that was fetched by this Task.|
 
 ## Workspaces

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -101,6 +101,8 @@ spec:
       type: string
     - name: commit
       description: The precise commit SHA that was fetched by this Task.
+    - name: commit-timestamp
+      description: The commit timestamp of the checkout
     - name: url
       description: The precise URL that was fetched by this Task.
   volumes:
@@ -236,6 +238,7 @@ spec:
         fi
         printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
         printf "%s" "${PARAM_URL}" >"$(results.url.path)"
+        printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
 
         if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
           echo "Fetching tags"

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -96,6 +96,8 @@ spec:
     name: commit
   - description: The precise URL that was fetched by this Task.
     name: url
+  - description: The commit timestamp of the checkout
+    name: commit-timestamp
   steps:
   - name: clone
     env:
@@ -235,6 +237,7 @@ spec:
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+      printf "%s" "$(git log -1 --pretty=%ct)" > "$(results.commit-timestamp.path)"
 
       if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
         echo "Fetching tags"


### PR DESCRIPTION
Emit the commit timestamp as a result, this allows for subsequent tasks to consume it to get better reproducability.
