### PR TITLE
KONFLUX-3386 emit the commit timestamp

### DIFF
--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -2,37 +2,11 @@
 
 The git-clone-oci-ta Task will clone a repo from the provided url and store it as a trusted artifact in the provided OCI repository.
 
-## Parameters
-|name|description|default value|required|
-|---|---|---|---|
-|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
-|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
-|depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
-|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
-|fetchTags|Fetch all tags for the repo.|false|false|
-|httpProxy|HTTP proxy server for non-SSL requests.|""|false|
-|httpsProxy|HTTPS proxy server for SSL requests.|""|false|
-|noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
-|ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
-|ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
-|refspec|Refspec to fetch before checking out revision.|""|false|
-|revision|Revision to checkout. (branch, tag, sha, ref, etc...)|""|false|
-|sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
-|sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
-|submodules|Initialize and fetch git submodules.|true|false|
-|url|Repository URL to clone from.||true|
-|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
-|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
-
 ## Results
 |name|description|
 |---|---|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
 |commit|The precise commit SHA that was fetched by this Task.|
+|commit-timestamp|The commit timestamp of the checkout|
 |url|The precise URL that was fetched by this Task.|
 
-## Workspaces
-|name|description|optional|
-|---|---|---|
-|basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. |true|
-|ssh-directory|A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. |true|

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -101,6 +101,8 @@ spec:
       type: string
     - name: commit
       description: The precise commit SHA that was fetched by this Task.
+    - name: commit-timestamp
+      description: The commit timestamp of the checkout
     - name: url
       description: The precise URL that was fetched by this Task.
   volumes:
@@ -236,6 +238,7 @@ spec:
         fi
         printf "%s" "${RESULT_SHA}" >"$( results.commit.path)"
         printf "%s" "${PARAM_URL}" >"$( results.url.path)"
+        git log -1 --pretty=%ct >"$( results.commit-timestamp.path)"
 
         if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
           echo "Fetching tags"

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -96,6 +96,8 @@ spec:
     name: commit
   - description: The precise URL that was fetched by this Task.
     name: url
+  - description: The commit timestamp of the checkout
+    name: commit-timestamp
   steps:
   - name: clone
     env:
@@ -235,6 +237,7 @@ spec:
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+      git log -1 --pretty=%ct > "$(results.commit-timestamp.path)"
 
       if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
         echo "Fetching tags"


### PR DESCRIPTION
Emit the commit timestamp as a result, this allows for subsequent tasks to consume it to get better reproducability.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
