### PR TITLE
Add an oci-copy task

### DIFF
--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -1,0 +1,21 @@
+# oci-copy-oci-ta task
+
+Given an `oci-copy.yaml` file in the user's source directory, the `oci-copy` task will copy content from arbitrary urls into the OCI registry.
+
+It generates a limited SBOM and pushes that into the OCI registry alongside the image.
+
+It is not to be considered safe for general use as it cannot provide a high degree of provenance for artficats and reports them only as "general" type artifacts in the purl spec it reports in the SBOM. Use only in limited situations.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image buildah will produce.||true|
+|SOURCE_ARTIFACT|The trusted artifact URI containing the application source code.||true|
+|OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_URL|Image repository where the built image was pushed|
+

--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -19,3 +19,39 @@ It is not to be considered safe for general use as it cannot provide a high degr
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_URL|Image repository where the built image was pushed|
 
+## oci-copy.yaml schema
+JSON schema for the `oci-copy.yaml` file.
+
+```json
+{
+    "type": "object",
+    "required": ["artifacts"],
+    "properties": {
+        "artifacts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["source", "filename", "type", "sha256sum"],
+                "properties": {
+                    "source": {
+                        "description": "URL of the artifact to copy",
+                        "type": "string"
+                    },
+                    "filename": {
+                        "description": "Filename that should be applied to the artifact in the OCI registry",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Media type that should be applied to the artifact in the OCI registry",
+                        "type": "string"
+                    },
+                    "sha256sum": {
+                        "description": "Digest of the artifact to be checked before copy",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}
+```

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -71,12 +71,7 @@ spec:
       workingDir: $(workspaces.source.path)
 
     - name: oci-copy
-      # I need something with adequate rights to run:
-      # $ skopeo copy docker://quay.io/containers/buildah:v1.35.4 docker://quay.io/redhat-appstudio/buildah:v1.35.4
-      #
-      # For now, use buildah directly from upstream
-      # image: quay.io/containers/buildah:v1.35.4@sha256:f07da1c4c59290dd7ff8c521f5d8f3b0f24985ae933da7381fd5a2c96f887423
-      image: quay.io/containers/buildah:v1.35.4
+      image: quay.io/redhat-appstudio/buildah:v1.35.4@sha256:3d3575bb7d0df64abcf1f22f06e82101a945d03317db1f3caac12814f796d01c
       computeResources:
         limits:
           memory: 1Gi

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -7,12 +7,15 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.1"
     build.appstudio.redhat.com/build_type: oci-artifact
-  name: oci-copy
+  name: oci-copy-oci-ta
 spec:
   description: Given a file in the user's source directory, copy content from arbitrary urls into the OCI registry.
   params:
     - description: Reference of the image we will push
       name: IMAGE
+      type: string
+    - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+      name: SOURCE_ARTIFACT
       type: string
     - default: ./oci-copy.yaml
       description: Path to the oci copy file.
@@ -33,6 +36,12 @@ spec:
       - mountPath: "/var/workdir"
         name: workdir
   steps:
+    - image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:4e39fb97f4444c2946944482df47b39c5bbc195c54c6560b0647635f553ab23d
+      name: use-trusted-artifact
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: prepare
       image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
       script: |

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -132,7 +132,8 @@ spec:
           echo "Reading $varfile"
           source $varfile
 
-          purl="pkg:generic/${OCI_FILENAME}?download_url=${OCI_SOURCE}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
+          ENCODED_URL=$(echo "${OCI_SOURCE}" | python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=":/"))')
+          purl="pkg:generic/${OCI_FILENAME}?download_url=${ENCODED_URL}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
 
           echo "Recording purl $purl"
           yq -oj -i '.components += [ {"purl": "'$purl'", "type": "file", "name": "'$OCI_FILENAME'", "hashes": [{"alg": "SHA-256", "content": "'$OCI_ARTIFACT_DIGEST'"}], "externalReferences": [{"type": "distribution", "url": "'$OCI_SOURCE'"}]} ]' sbom-cyclonedx.json

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -133,7 +133,8 @@ spec:
           source $varfile
 
           ENCODED_URL=$(echo "${OCI_SOURCE}" | python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=":/"))')
-          purl="pkg:generic/${OCI_FILENAME}?download_url=${ENCODED_URL}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
+          ENCODED_FILENAME=$(echo "${OCI_FILENAME}" | python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=":/"))')
+          purl="pkg:generic/${ENCODED_FILENAME}?download_url=${ENCODED_URL}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
 
           echo "Recording purl $purl"
           yq -oj -i '.components += [ {"purl": "'$purl'", "type": "file", "name": "'$OCI_FILENAME'", "hashes": [{"alg": "SHA-256", "content": "'$OCI_ARTIFACT_DIGEST'"}], "externalReferences": [{"type": "distribution", "url": "'$OCI_SOURCE'"}]} ]' sbom-cyclonedx.json

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -79,7 +79,7 @@ spec:
       image: quay.io/containers/buildah:v1.35.4
       computeResources:
         limits:
-          memory: 4Gi
+          memory: 1Gi
         requests:
           cpu: 250m
           memory: 512Mi

--- a/task/oci-copy-oci-ta/OWNERS
+++ b/task/oci-copy-oci-ta/OWNERS
@@ -1,0 +1,1 @@
+ralphbean

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -1,0 +1,24 @@
+# oci-copy task
+
+Given an `oci-copy.yaml` file in the user's source directory, the `oci-copy` task will copy content from arbitrary urls into the OCI registry.
+
+It generates a limited SBOM and pushes that into the OCI registry alongside the image.
+
+It is not to be considered safe for general use as it cannot provide a high degree of provenance for artficats and reports them only as "general" type artifacts in the purl spec it reports in the SBOM. Use only in limited situations.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image buildah will produce.||true|
+|OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_URL|Image repository where the built image was pushed|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace containing the source code to copy.|false|

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -22,3 +22,40 @@ It is not to be considered safe for general use as it cannot provide a high degr
 |name|description|optional|
 |---|---|---|
 |source|Workspace containing the source code to copy.|false|
+
+## oci-copy.yaml schema
+JSON schema for the `oci-copy.yaml` file.
+
+```json
+{
+    "type": "object",
+    "required": ["artifacts"],
+    "properties": {
+        "artifacts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["source", "filename", "type", "sha256sum"],
+                "properties": {
+                    "source": {
+                        "description": "URL of the artifact to copy",
+                        "type": "string"
+                    },
+                    "filename": {
+                        "description": "Filename that should be applied to the artifact in the OCI registry",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Media type that should be applied to the artifact in the OCI registry",
+                        "type": "string"
+                    },
+                    "sha256sum": {
+                        "description": "Digest of the artifact to be checked before copy",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}
+```

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -124,7 +124,8 @@ spec:
           source $varfile
 
           ENCODED_URL=$(echo "${OCI_SOURCE}" | python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=":/"))')
-          purl="pkg:generic/${OCI_FILENAME}?download_url=${ENCODED_URL}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
+          ENCODED_FILENAME=$(echo "${OCI_FILENAME}" | python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=":/"))')
+          purl="pkg:generic/${ENCODED_FILENAME}?download_url=${ENCODED_URL}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
 
           echo "Recording purl $purl"
           yq -oj -i '.components += [ {"purl": "'$purl'", "type": "file", "name": "'$OCI_FILENAME'", "hashes": [{"alg": "SHA-256", "content": "'$OCI_ARTIFACT_DIGEST'"}], "externalReferences": [{"type": "distribution", "url": "'$OCI_SOURCE'"}]} ]' sbom-cyclonedx.json

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -62,12 +62,7 @@ spec:
       workingDir: $(workspaces.source.path)
 
     - name: oci-copy
-      # I need something with adequate rights to run:
-      # $ skopeo copy docker://quay.io/containers/buildah:v1.35.4 docker://quay.io/redhat-appstudio/buildah:v1.35.4
-      #
-      # For now, use buildah directly from upstream
-      # image: quay.io/containers/buildah:v1.35.4@sha256:f07da1c4c59290dd7ff8c521f5d8f3b0f24985ae933da7381fd5a2c96f887423
-      image: quay.io/containers/buildah:v1.35.4
+      image: quay.io/redhat-appstudio/buildah:v1.35.4@sha256:3d3575bb7d0df64abcf1f22f06e82101a945d03317db1f3caac12814f796d01c
       computeResources:
         limits:
           memory: 1Gi

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -1,0 +1,157 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, appstudio, hacbs
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: oci-artifact
+  name: oci-copy
+spec:
+  description: |-
+    TODO
+  params:
+    - description: Reference of the image we will push
+      name: IMAGE
+      type: string
+    - default: ./oci-copy.yaml
+      description: Path to the oci copy file.
+      name: OCI_COPY_FILE
+      type: string
+  results:
+    - description: Digest of the artifact just pushed
+      name: IMAGE_DIGEST
+    - description: Repository where the artifact was pushed
+      name: IMAGE_URL
+  stepTemplate:
+    env:
+      - name: OCI_COPY_FILE
+        value: $(params.OCI_COPY_FILE)
+      - name: IMAGE
+        value: $(params.IMAGE)
+    volumeMounts:
+      - mountPath: "/var/workdir"
+        name: workdir
+  steps:
+    - name: prepare
+      image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
+      script: |
+        set -eu
+        set -o pipefail
+
+        SOURCE_CODE_DIR=source
+        oci_copy_file_path="$(pwd)/$SOURCE_CODE_DIR/$OCI_COPY_FILE"
+
+        mkdir -p /var/workdir/vars/
+
+        for entry in $(cat $oci_copy_file_path | yq '.artifacts[] | @json | @base64'); do
+          entry=$(echo $entry | base64 -d)
+          source=$(echo $entry | yq .source)
+          filename=$(echo $entry | yq .filename)
+          artifact_type=$(echo $entry | yq .type)
+          artifact_digest=$(echo $entry | yq .sha256sum)
+
+          echo "declare OCI_SOURCE=${source}" > /var/workdir/vars/$filename
+          echo "declare OCI_FILENAME=${filename}" >> /var/workdir/vars/$filename
+          echo "declare OCI_ARTIFACT_TYPE=${artifact_type}" >> /var/workdir/vars/$filename
+          echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}" >> /var/workdir/vars/$filename
+
+          echo "Wrote /var/workdir/vars/$filename with contents:"
+          cat /var/workdir/vars/$filename
+        done
+      workingDir: $(workspaces.source.path)
+
+    - name: oci-copy
+      # I need something with adequate rights to run:
+      # $ skopeo copy docker://quay.io/containers/buildah:v1.35.4 docker://quay.io/redhat-appstudio/buildah:v1.35.4
+      #
+      # For now, use buildah directly from upstream
+      # image: quay.io/containers/buildah:v1.35.4@sha256:f07da1c4c59290dd7ff8c521f5d8f3b0f24985ae933da7381fd5a2c96f887423
+      image: quay.io/containers/buildah:v1.35.4
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 250m
+          memory: 512Mi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+      script: |
+        set -eu
+        set -o pipefail
+
+        buildah manifest create $IMAGE
+
+        for varfile in /var/workdir/vars/*; do
+          echo "Reading $varfile"
+          source $varfile
+
+          echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
+          curl --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+
+          echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
+          echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
+
+          echo "Building manifest of type $OCI_ARTIFACT_TYPE from $OCI_FILENAME"
+          buildah manifest add $IMAGE --artifact --artifact-type $OCI_ARTIFACT_TYPE $OCI_FILENAME
+        done
+
+        echo "Pushing conents to $IMAGE"
+        buildah manifest push \
+            --digestfile $(workspaces.source.path)/image-digest \
+            --authfile $HOME/.docker/config.json \
+            --all \
+            $IMAGE
+
+        cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+        echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      workingDir: $(workspaces.source.path)
+    - image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
+      name: sbom-generate
+      script: |
+        cat >sbom-cyclonedx.json <<EOL
+        {
+            "\$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+            "bomFormat": "CycloneDX",
+            "specVersion": "1.5",
+            "version": 1,
+            "components": []
+        }
+        EOL
+
+        for varfile in /var/workdir/vars/*; do
+          echo "Reading $varfile"
+          source $varfile
+
+          purl="pkg:generic/${OCI_FILENAME}?download_url=${OCI_SOURCE}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
+
+          echo "Recording purl $purl"
+          yq -oj -i '.components += [ {"purl": "'$purl'", "type": "file", "name": "'$OCI_FILENAME'", "hashes": [{"alg": "SHA-256", "content": "'$OCI_ARTIFACT_DIGEST'"}], "externalReferences": [{"type": "distribution", "url": "'$OCI_SOURCE'"}]} ]' sbom-cyclonedx.json
+        done
+      workingDir: $(workspaces.source.path)
+    - name: upload-sbom
+      image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+      args:
+        - attach
+        - sbom
+        - --sbom
+        - sbom-cyclonedx.json
+        - --type
+        - cyclonedx
+        - $(params.IMAGE)
+      workingDir: $(workspaces.source.path)
+
+  volumes:
+    - emptyDir: {}
+      name: varlibcontainers
+    - emptyDir: {}
+      name: workdir
+  workspaces:
+    - description: Workspace containing the source artifacts to copy
+      name: source

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -70,7 +70,7 @@ spec:
       image: quay.io/containers/buildah:v1.35.4
       computeResources:
         limits:
-          memory: 4Gi
+          memory: 1Gi
         requests:
           cpu: 250m
           memory: 512Mi

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -123,7 +123,8 @@ spec:
           echo "Reading $varfile"
           source $varfile
 
-          purl="pkg:generic/${OCI_FILENAME}?download_url=${OCI_SOURCE}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
+          ENCODED_URL=$(echo "${OCI_SOURCE}" | python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=":/"))')
+          purl="pkg:generic/${OCI_FILENAME}?download_url=${ENCODED_URL}&checksum=sha256:${OCI_ARTIFACT_DIGEST}"
 
           echo "Recording purl $purl"
           yq -oj -i '.components += [ {"purl": "'$purl'", "type": "file", "name": "'$OCI_FILENAME'", "hashes": [{"alg": "SHA-256", "content": "'$OCI_ARTIFACT_DIGEST'"}], "externalReferences": [{"type": "distribution", "url": "'$OCI_SOURCE'"}]} ]' sbom-cyclonedx.json

--- a/task/oci-copy/OWNERS
+++ b/task/oci-copy/OWNERS
@@ -1,0 +1,1 @@
+ralphbean


### PR DESCRIPTION
The task is an alternative to our buildah task.

It should generally be disallowed by policy because there is not much that can be done to provide high quality provenance for the artifacts.

We'll allow it in limited cases, like in https://issues.redhat.com/browse/KONFLUX-3284