### PR TITLE
Support netrc auth for prefetch-dependencies

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -103,6 +103,8 @@ spec:
           workspace: workspace
         - name: git-basic-auth
           workspace: git-auth
+        - name: netrc
+          workspace: netrc
     - name: build-container
       when:
       - input: $(tasks.init.results.build)
@@ -275,4 +277,6 @@ spec:
   workspaces:
     - name: workspace
     - name: git-auth
+      optional: true
+    - name: netrc
       optional: true

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -416,7 +416,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: merge-cachi2-sbom
-      image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+      image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
       workingDir: /var/workdir
       script: |
         if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -486,7 +486,7 @@ spec:
       runAsUser: 0
     workingDir: /var/workdir
   - computeResources: {}
-    image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+    image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     name: merge-cachi2-sbom
     script: |
       if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -479,7 +479,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+    image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     name: merge-cachi2-sbom
     script: |
       if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -387,7 +387,7 @@ spec:
       runAsUser: 0
 
   - name: merge-cachi2-sbom
-    image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+    image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     script: |
       if [ -f "sbom-cachi2.json" ]; then
         echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"

--- a/task/prefetch-dependencies-oci-ta/0.1/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.1/README.md
@@ -27,3 +27,4 @@ https://github.com/containerbuildsystem/cachi2#basic-usage.
 |name|description|optional|
 |---|---|---|
 |git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -73,6 +73,11 @@ spec:
         other files in this Workspace are ignored. It is strongly recommended
         to bind a Secret to this Workspace over other volume types.
       optional: true
+    - name: netrc
+      description: |
+        Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+        performing http(s) requests.
+      optional: true
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -116,6 +121,10 @@ spec:
           value: $(workspaces.git-basic-auth.bound)
         - name: WORKSPACE_GIT_AUTH_PATH
           value: $(workspaces.git-basic-auth.path)
+        - name: WORKSPACE_NETRC_BOUND
+          value: $(workspaces.netrc.bound)
+        - name: WORKSPACE_NETRC_PATH
+          value: $(workspaces.netrc.path)
       script: |
         if [ -z "${INPUT}" ]; then
           # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
@@ -145,6 +154,10 @@ spec:
           fi
           chmod 400 "${HOME}/.git-credentials"
           chmod 400 "${HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
+          cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
         fi
 
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -100,7 +100,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: prefetch-dependencies
-      image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+      image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca

--- a/task/prefetch-dependencies/0.1/README.md
+++ b/task/prefetch-dependencies/0.1/README.md
@@ -17,3 +17,4 @@ See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
 |---|---|---|
 |source|Workspace with the source code, cachi2 artifacts will be stored on the workspace as well|false|
 |git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -31,7 +31,7 @@ spec:
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
   steps:
-  - image: quay.io/redhat-appstudio/cachi2:0.7.0@sha256:1fc772aa3636fd0b43d62120d832e5913843e028e8cac42814b487c3a0a32bd8
+  - image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: prefetch-dependencies

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -46,6 +46,10 @@ spec:
       value: $(workspaces.git-basic-auth.bound)
     - name: WORKSPACE_GIT_AUTH_PATH
       value: $(workspaces.git-basic-auth.path)
+    - name: WORKSPACE_NETRC_BOUND
+      value: $(workspaces.netrc.bound)
+    - name: WORKSPACE_NETRC_PATH
+      value: $(workspaces.netrc.path)
     volumeMounts:
       - name: trusted-ca
         mountPath: /mnt/trusted-ca
@@ -82,6 +86,10 @@ spec:
         chmod 400 "${HOME}/.gitconfig"
       fi
 
+      if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
+        cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
+      fi
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -111,6 +119,11 @@ spec:
       These will be copied to the user's home before any cachi2 commands are run. Any
       other files in this Workspace are ignored. It is strongly recommended
       to bind a Secret to this Workspace over other volume types.
+    optional: true
+  - name: netrc
+    description: |
+      Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+      performing http(s) requests.
     optional: true
   volumes:
     - name: trusted-ca


### PR DESCRIPTION
[STONEBLD-2506](https://issues.redhat.com//browse/STONEBLD-2506)

* Update to cachi2 0.8.0 (among other things, introduces .netrc support and --index-url support for pip)
* Allow user to supply a workspace containing a .netrc file. Cachi2 will authenticate https requests using the credentials in this file.