### PR TITLE
Add forgotten recipe for oci-copy task

### DIFF
--- a/task/oci-copy-oci-ta/0.1/recipe.yaml
+++ b/task/oci-copy-oci-ta/0.1/recipe.yaml
@@ -1,0 +1,10 @@
+---
+base: ../../oci-copy/0.1/oci-copy.yaml
+add:
+  - use-source
+removeWorkspaces:
+  - source
+replacements:
+  workspaces.source.path: /var/workdir
+regexReplacements:
+  "/workspace(/.*)": /var/workdir$1


### PR DESCRIPTION
I didn't understand how the recipe worked before.

I figured this out in the course of working on https://github.com/konflux-ci/build-definitions/pull/1086, but I split this out to a separate PR.
