### PR TITLE
fix: remove duplicate volumeMounts from oci-copy-oci-ta

### DIFF
--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -34,8 +34,6 @@ spec:
       emptyDir: {}
     - name: workdir
       emptyDir: {}
-    - name: workdir
-      emptyDir: {}
   stepTemplate:
     env:
       - name: IMAGE
@@ -43,8 +41,6 @@ spec:
       - name: OCI_COPY_FILE
         value: $(params.OCI_COPY_FILE)
     volumeMounts:
-      - mountPath: /var/workdir
-        name: workdir
       - mountPath: /var/workdir
         name: workdir
   steps:


### PR DESCRIPTION
The oci-copy-oci-ta task had two volumeMounts with the same name and mounting location, which would cause an error when the task was applied to a cluster.  This change removes the duplicate

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
