### PR TITLE
fix: drop use of /var/workdir in oci-copy task

### DIFF
--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -82,7 +82,7 @@ spec:
 
         oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
 
-        mkdir -p /var/workdir/vars/
+        mkdir -p "/var/workdir/vars/"
 
         for entry in $(cat $oci_copy_file_path | yq '.artifacts[] | @json | @base64'); do
           entry=$(echo $entry | base64 -d)
@@ -91,13 +91,15 @@ spec:
           artifact_type=$(echo $entry | yq .type)
           artifact_digest=$(echo $entry | yq .sha256sum)
 
-          echo "declare OCI_SOURCE=${source}" >/var/workdir/vars/$filename
-          echo "declare OCI_FILENAME=${filename}" >>/var/workdir/vars/$filename
-          echo "declare OCI_ARTIFACT_TYPE=${artifact_type}" >>/var/workdir/vars/$filename
-          echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}" >>/var/workdir/vars/$filename
+          {
+            echo "declare OCI_SOURCE=${source}"
+            echo "declare OCI_FILENAME=${filename}"
+            echo "declare OCI_ARTIFACT_TYPE=${artifact_type}"
+            echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}"
+          } >"/var/workdir/vars/$filename"
 
           echo "Wrote /var/workdir/vars/$filename with contents:"
-          cat /var/workdir/vars/$filename
+          cat "/var/workdir/vars/$filename"
         done
     - name: oci-copy
       image: quay.io/konflux-ci/oras:latest@sha256:99737f436051e6d3866eb8a8706463c35abf72c87f05090ff42ff642f6729661
@@ -232,8 +234,7 @@ spec:
                 ${REPO}@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a \
                 --media-type application/vnd.oci.empty.v1+json --size 2 -
 
-        for varfile in /var/workdir/vars/*; do
-          echo
+        for varfile in "/var/workdir"/vars/*; do
           echo "Reading $varfile"
           # shellcheck source=/dev/null
           source $varfile
@@ -303,7 +304,7 @@ spec:
         }
         EOL
 
-        for varfile in /var/workdir/vars/*; do
+        for varfile in "/var/workdir"/vars/*; do
           echo "Reading $varfile"
           # shellcheck source=/dev/null
           source $varfile

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -66,8 +66,6 @@ spec:
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
-      - mountPath: /var/workdir
-        name: workdir
   steps:
     - name: use-trusted-artifact
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:d6f57d97d19008437680190908fe5444cda380f9c77d0e9efde7153720412e05

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -59,7 +59,7 @@ spec:
 
         oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
 
-        mkdir -p $(workspaces.source.path)/vars/
+        mkdir -p "$(workspaces.source.path)/vars/"
 
         for entry in $(cat $oci_copy_file_path | yq '.artifacts[] | @json | @base64'); do
           entry=$(echo $entry | base64 -d)
@@ -68,13 +68,15 @@ spec:
           artifact_type=$(echo $entry | yq .type)
           artifact_digest=$(echo $entry | yq .sha256sum)
 
-          echo "declare OCI_SOURCE=${source}" > $(workspaces.source.path)/vars/$filename
-          echo "declare OCI_FILENAME=${filename}" >> $(workspaces.source.path)/vars/$filename
-          echo "declare OCI_ARTIFACT_TYPE=${artifact_type}" >> $(workspaces.source.path)/vars/$filename
-          echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}" >> $(workspaces.source.path)/vars/$filename
+          {
+            echo "declare OCI_SOURCE=${source}";
+            echo "declare OCI_FILENAME=${filename}";
+            echo "declare OCI_ARTIFACT_TYPE=${artifact_type}";
+            echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}";
+          } > "$(workspaces.source.path)/vars/$filename"
 
           echo "Wrote $(workspaces.source.path)/vars/$filename with contents:"
-          cat $(workspaces.source.path)/vars/$filename
+          cat "$(workspaces.source.path)/vars/$filename"
         done
       workingDir: $(workspaces.source.path)
     - name: oci-copy
@@ -216,7 +218,7 @@ spec:
                 ${REPO}@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a \
                 --media-type application/vnd.oci.empty.v1+json --size 2 -
 
-        for varfile in $(workspaces.source.path)/vars/*; do
+        for varfile in "$(workspaces.source.path)"/vars/*; do
           echo "Reading $varfile"
           # shellcheck source=/dev/null
           source $varfile
@@ -279,7 +281,7 @@ spec:
         }
         EOL
 
-        for varfile in $(workspaces.source.path)/vars/*; do
+        for varfile in "$(workspaces.source.path)"/vars/*; do
           echo "Reading $varfile"
           # shellcheck source=/dev/null
           source $varfile

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -49,9 +49,6 @@ spec:
         value: $(params.OCI_COPY_FILE)
       - name: IMAGE
         value: $(params.IMAGE)
-    volumeMounts:
-      - mountPath: "/var/workdir"
-        name: workdir
   steps:
     - name: prepare
       image: quay.io/konflux-ci/yq:latest@sha256:f758d9a25bc88cc114bfb6137fd4d649db427de5a4217e818b8466ad5bf9255c
@@ -62,7 +59,7 @@ spec:
 
         oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
 
-        mkdir -p /var/workdir/vars/
+        mkdir -p $(workspaces.source.path)/vars/
 
         for entry in $(cat $oci_copy_file_path | yq '.artifacts[] | @json | @base64'); do
           entry=$(echo $entry | base64 -d)
@@ -71,13 +68,13 @@ spec:
           artifact_type=$(echo $entry | yq .type)
           artifact_digest=$(echo $entry | yq .sha256sum)
 
-          echo "declare OCI_SOURCE=${source}" > /var/workdir/vars/$filename
-          echo "declare OCI_FILENAME=${filename}" >> /var/workdir/vars/$filename
-          echo "declare OCI_ARTIFACT_TYPE=${artifact_type}" >> /var/workdir/vars/$filename
-          echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}" >> /var/workdir/vars/$filename
+          echo "declare OCI_SOURCE=${source}" > $(workspaces.source.path)/vars/$filename
+          echo "declare OCI_FILENAME=${filename}" >> $(workspaces.source.path)/vars/$filename
+          echo "declare OCI_ARTIFACT_TYPE=${artifact_type}" >> $(workspaces.source.path)/vars/$filename
+          echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}" >> $(workspaces.source.path)/vars/$filename
 
-          echo "Wrote /var/workdir/vars/$filename with contents:"
-          cat /var/workdir/vars/$filename
+          echo "Wrote $(workspaces.source.path)/vars/$filename with contents:"
+          cat $(workspaces.source.path)/vars/$filename
         done
       workingDir: $(workspaces.source.path)
     - name: oci-copy
@@ -219,8 +216,7 @@ spec:
                 ${REPO}@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a \
                 --media-type application/vnd.oci.empty.v1+json --size 2 -
 
-        for varfile in /var/workdir/vars/*; do
-          echo
+        for varfile in $(workspaces.source.path)/vars/*; do
           echo "Reading $varfile"
           # shellcheck source=/dev/null
           source $varfile
@@ -283,7 +279,7 @@ spec:
         }
         EOL
 
-        for varfile in /var/workdir/vars/*; do
+        for varfile in $(workspaces.source.path)/vars/*; do
           echo "Reading $varfile"
           # shellcheck source=/dev/null
           source $varfile


### PR DESCRIPTION
This is another take on https://github.com/konflux-ci/build-definitions/pull/1091, but it starts by modifying the oci-copy task first and then running hack/generate-ta-tasks.sh.
