### PR TITLE
Fix clamav-scan task

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -194,6 +194,6 @@ spec:
           name: dbfolder
   volumes:
     - name: dbfolder
-      emptydir: {}
+      emptyDir: {}
     - name: work
-      emptydir: {}
+      emptyDir: {}


### PR DESCRIPTION
Recent version of the bundle resolver does a stricter validation and it is failing on the case sensitivity of `emptydir` (should be `emptyDir`).
