### PR TITLE
chore: update konflux-test image references to v1.4.3

### DIFF
--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -28,7 +28,7 @@ spec:
       description: Images processed in the task.
   steps:
     - name: get-image-manifests
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # the clair-in-ci image neither has skopeo or jq installed. Hence, we create an extra step to get the image manifest digests
       env:
         - name: IMAGE_URL
@@ -91,7 +91,7 @@ spec:
         images_processed=$(echo "${images_processed_template/\[%s]/[$digests_processed_string]}")
         echo "$images_processed" > /tekton/home/images-processed.json
     - name: conftest-vulnerabilities
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       securityContext:

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -26,7 +26,7 @@ spec:
 
   steps:
     - name: extract-and-scan-image
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: /work

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -31,7 +31,7 @@ spec:
   steps:
     # Download Pyxis metadata about the image
     - name: query-pyxis
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:
@@ -61,7 +61,7 @@ spec:
 
     # Run the tests and save output
     - name: run-conftest
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -31,7 +31,7 @@ spec:
   steps:
     # Download Pyxis metadata about the image
     - name: query-pyxis
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:
@@ -61,7 +61,7 @@ spec:
 
     # Run the tests and save output
     - name: run-conftest
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -29,7 +29,7 @@ spec:
 
   steps:
     - name: check-images
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -34,7 +34,7 @@ spec:
 
   steps:
     - name: check-images
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -17,7 +17,7 @@ spec:
     - name: workspace
   steps:
     - name: check-related-images
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -26,7 +26,7 @@ spec:
     - name: workspace
   steps:
     - name: extract-and-check-binaries
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)

--- a/task/inspect-image/0.1/inspect-image.yaml
+++ b/task/inspect-image/0.1/inspect-image.yaml
@@ -33,7 +33,7 @@ spec:
     - name: source
   steps:
   - name: inspect-image
-    image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+    image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)

--- a/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
@@ -58,7 +58,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: sast-snyk-check
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       workingDir: /var/workdir/source
       volumeMounts:
         - mountPath: /etc/secrets

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -38,7 +38,7 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -20,7 +20,7 @@ spec:
       name: IMAGES_PROCESSED
   steps:
   - name: sbom-json-check
-    image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+    image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     securityContext:

--- a/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
+++ b/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
@@ -48,7 +48,7 @@ spec:
           --workdir "${WORKDIR}" \
           --status-path "${WORKDIR}"/status
     - name: output-results
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.1@sha256:64955981bbcd37350513dc52dee7a89defb57bf6ad559c53944cdadeb82866e3
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.3@sha256:75d3e0ada1d07511e6b9342398929fe2690367b33142bf99ecad7dc3bccc3847
       volumeMounts:
         - name: workdir
           mountPath: "$(params.WORKDIR)"


### PR DESCRIPTION
Update the `konflux-test` image to the newest [v1.4.3 release](https://github.com/konflux-ci/konflux-test/releases/tag/v1.4.3).

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
