### PR TITLE
feat: add buildah param to inject secrets into the build

### DIFF
--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -20,6 +20,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|""|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -20,7 +20,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
-|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|does-not-exist|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -8,6 +8,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
@@ -20,7 +21,6 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
-|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -20,7 +20,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
-|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|""|false|
+|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|does-not-exist|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -67,6 +67,11 @@ spec:
         hours, days, and weeks, respectively.
       type: string
       default: ""
+    - name: OPTIONAL_SECRET
+      description: Name of a secret which will be made available to the build
+        with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
+      type: string
+      default: ""
     - name: PREFETCH_INPUT
       description: In case it is not empty, the prefetched content should
         be made available to the build.
@@ -135,6 +140,10 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
+    - name: optional-secret
+      secret:
+        optional: true
+        secretName: $(params.OPTIONAL_SECRET)
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -172,6 +181,8 @@ spec:
         value: $(params.SQUASH)
       - name: SQUASH_ALL
         value: $(params.SQUASH_ALL)
+      - name: OPTIONAL_SECRET
+        value: $(params.OPTIONAL_SECRET)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE
@@ -206,6 +217,8 @@ spec:
           name: varlibcontainers
         - mountPath: /entitlement
           name: etc-pki-entitlement
+        - mountPath: /optional-secret
+          name: optional-secret
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
@@ -334,6 +347,13 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"
+        fi
+
+        OPTIONAL_SECRET_PATH="/optional-secret"
+        if [ -d "$OPTIONAL_SECRET_PATH" ]; then
+          cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
+          BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
+          echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
         fi
 
         unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -71,7 +71,7 @@ spec:
       description: Name of a secret which will be made available to the build
         with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
       type: string
-      default: ""
+      default: does-not-exist
     - name: PREFETCH_INPUT
       description: In case it is not empty, the prefetched content should
         be made available to the build.

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -67,9 +67,9 @@ spec:
         hours, days, and weeks, respectively.
       type: string
       default: ""
-    - name: OPTIONAL_SECRET
+    - name: ADDITIONAL_SECRET
       description: Name of a secret which will be made available to the build
-        with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
+        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
       type: string
       default: does-not-exist
     - name: PREFETCH_INPUT
@@ -140,10 +140,10 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
-    - name: optional-secret
+    - name: additional-secret
       secret:
         optional: true
-        secretName: $(params.OPTIONAL_SECRET)
+        secretName: $(params.ADDITIONAL_SECRET)
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -181,8 +181,8 @@ spec:
         value: $(params.SQUASH)
       - name: SQUASH_ALL
         value: $(params.SQUASH_ALL)
-      - name: OPTIONAL_SECRET
-        value: $(params.OPTIONAL_SECRET)
+      - name: ADDITIONAL_SECRET
+        value: $(params.ADDITIONAL_SECRET)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE
@@ -217,8 +217,8 @@ spec:
           name: varlibcontainers
         - mountPath: /entitlement
           name: etc-pki-entitlement
-        - mountPath: /optional-secret
-          name: optional-secret
+        - mountPath: /additional-secret
+          name: additional-secret
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
@@ -349,11 +349,11 @@ spec:
           echo "Adding the entitlement to the build"
         fi
 
-        OPTIONAL_SECRET_PATH="/optional-secret"
-        if [ -d "$OPTIONAL_SECRET_PATH" ]; then
-          cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
-          BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
-          echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+        ADDITIONAL_SECRET_PATH="/additional-secret"
+        if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+          cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
+          echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
         fi
 
         unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -16,6 +16,11 @@ spec:
     When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
     When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
+    - name: ADDITIONAL_SECRET
+      description: Name of a secret which will be made available to the build
+        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
+      type: string
+      default: does-not-exist
     - name: ADD_CAPABILITIES
       description: Comma separated list of extra capabilities to add when
         running 'buildah build'
@@ -67,11 +72,6 @@ spec:
         hours, days, and weeks, respectively.
       type: string
       default: ""
-    - name: ADDITIONAL_SECRET
-      description: Name of a secret which will be made available to the build
-        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
-      type: string
-      default: does-not-exist
     - name: PREFETCH_INPUT
       description: In case it is not empty, the prefetched content should
         be made available to the build.
@@ -136,14 +136,14 @@ spec:
       description: The counting of Java components by publisher in JSON format
       type: string
   volumes:
-    - name: etc-pki-entitlement
-      secret:
-        optional: true
-        secretName: $(params.ENTITLEMENT_SECRET)
     - name: additional-secret
       secret:
         optional: true
         secretName: $(params.ADDITIONAL_SECRET)
+    - name: etc-pki-entitlement
+      secret:
+        optional: true
+        secretName: $(params.ENTITLEMENT_SECRET)
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -159,6 +159,8 @@ spec:
       emptyDir: {}
   stepTemplate:
     env:
+      - name: ADDITIONAL_SECRET
+        value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
         value: $(params.ADD_CAPABILITIES)
       - name: BUILDAH_FORMAT
@@ -181,8 +183,6 @@ spec:
         value: $(params.SQUASH)
       - name: SQUASH_ALL
         value: $(params.SQUASH_ALL)
-      - name: ADDITIONAL_SECRET
-        value: $(params.ADDITIONAL_SECRET)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -69,8 +69,8 @@ spec:
     type: string
   - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
-      build --secret' at /run/secrets/$OPTIONAL_SECRET
-    name: OPTIONAL_SECRET
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
     type: string
   - default: ""
     description: In case it is not empty, the prefetched content should be made available
@@ -160,8 +160,8 @@ spec:
       value: $(params.SQUASH)
     - name: SQUASH_ALL
       value: $(params.SQUASH_ALL)
-    - name: OPTIONAL_SECRET
-      value: $(params.OPTIONAL_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -233,7 +233,7 @@ spec:
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
-      rsync -ra /optional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/optional-secret/"
+      rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
@@ -365,11 +365,11 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      OPTIONAL_SECRET_PATH="/optional-secret"
-      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
-        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
-        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
+        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
+        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
@@ -416,7 +416,7 @@ spec:
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e SQUASH="$SQUASH" \
        -e SQUASH_ALL="$SQUASH_ALL" \
-       -e OPTIONAL_SECRET="$OPTIONAL_SECRET" \
+       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \
@@ -427,7 +427,7 @@ spec:
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-       -v "$BUILD_DIR/volumes/optional-secret:/optional-secret:Z" \
+       -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
@@ -451,8 +451,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
-    - mountPath: /optional-secret
-      name: optional-secret
+    - mountPath: /additional-secret
+      name: additional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
@@ -626,10 +626,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
-  - name: optional-secret
+  - name: additional-secret
     secret:
       optional: true
-      secretName: $(params.OPTIONAL_SECRET)
+      secretName: $(params.ADDITIONAL_SECRET)
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -16,6 +16,11 @@ spec:
     When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
     When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
   - default: ""
     description: Comma separated list of extra capabilities to add when running 'buildah
       build'
@@ -66,11 +71,6 @@ spec:
       tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
       respectively.
     name: IMAGE_EXPIRES_AFTER
-    type: string
-  - default: does-not-exist
-    description: Name of a secret which will be made available to the build with 'buildah
-      build --secret' at /run/secrets/$ADDITIONAL_SECRET
-    name: ADDITIONAL_SECRET
     type: string
   - default: ""
     description: In case it is not empty, the prefetched content should be made available
@@ -138,6 +138,8 @@ spec:
   stepTemplate:
     computeResources: {}
     env:
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
     - name: ADD_CAPABILITIES
       value: $(params.ADD_CAPABILITIES)
     - name: BUILDAH_FORMAT
@@ -160,8 +162,6 @@ spec:
       value: $(params.SQUASH)
     - name: SQUASH_ALL
       value: $(params.SQUASH_ALL)
-    - name: ADDITIONAL_SECRET
-      value: $(params.ADDITIONAL_SECRET)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -405,6 +405,7 @@ spec:
       chmod +x scripts/script-build.sh
       rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
@@ -416,7 +417,6 @@ spec:
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e SQUASH="$SQUASH" \
        -e SQUASH_ALL="$SQUASH_ALL" \
-       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \
@@ -622,14 +622,14 @@ spec:
     name: upload-sbom
     workingDir: /var/workdir
   volumes:
-  - name: etc-pki-entitlement
-    secret:
-      optional: true
-      secretName: $(params.ENTITLEMENT_SECRET)
   - name: additional-secret
     secret:
       optional: true
       secretName: $(params.ADDITIONAL_SECRET)
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -68,6 +68,11 @@ spec:
     name: IMAGE_EXPIRES_AFTER
     type: string
   - default: ""
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$OPTIONAL_SECRET
+    name: OPTIONAL_SECRET
+    type: string
+  - default: ""
     description: In case it is not empty, the prefetched content should be made available
       to the build.
     name: PREFETCH_INPUT
@@ -155,6 +160,8 @@ spec:
       value: $(params.SQUASH)
     - name: SQUASH_ALL
       value: $(params.SQUASH_ALL)
+    - name: OPTIONAL_SECRET
+      value: $(params.OPTIONAL_SECRET)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -226,6 +233,7 @@ spec:
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+      rsync -ra /optional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/optional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
@@ -357,6 +365,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      OPTIONAL_SECRET_PATH="/optional-secret"
+      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
+        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
+        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      fi
+
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
         $VOLUME_MOUNTS \
         "${BUILDAH_ARGS[@]}" \
@@ -401,6 +416,7 @@ spec:
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e SQUASH="$SQUASH" \
        -e SQUASH_ALL="$SQUASH_ALL" \
+       -e OPTIONAL_SECRET="$OPTIONAL_SECRET" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \
@@ -411,6 +427,7 @@ spec:
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+       -v "$BUILD_DIR/volumes/optional-secret:/optional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
@@ -434,6 +451,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
+    - mountPath: /optional-secret
+      name: optional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
@@ -607,6 +626,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
+  - name: optional-secret
+    secret:
+      optional: true
+      secretName: $(params.OPTIONAL_SECRET)
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -67,7 +67,7 @@ spec:
       respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
-  - default: ""
+  - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
       build --secret' at /run/secrets/$OPTIONAL_SECRET
     name: OPTIONAL_SECRET

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -78,7 +78,7 @@ spec:
     description: Name of secret which contains the entitlement certificates
     name: ENTITLEMENT_SECRET
     type: string
-  - default: ""
+  - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
       build --secret' at /run/secrets/$OPTIONAL_SECRET
     name: OPTIONAL_SECRET

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -80,8 +80,8 @@ spec:
     type: string
   - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
-      build --secret' at /run/secrets/$OPTIONAL_SECRET
-    name: OPTIONAL_SECRET
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
     type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings)
@@ -161,8 +161,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
-    - name: OPTIONAL_SECRET
-      value: $(params.OPTIONAL_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
@@ -221,7 +221,7 @@ spec:
       rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
-      rsync -ra /optional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/optional-secret/"
+      rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
@@ -357,11 +357,11 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      OPTIONAL_SECRET_PATH="/optional-secret"
-      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
-        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
-        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
+        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
+        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
@@ -411,7 +411,7 @@ spec:
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-       -e OPTIONAL_SECRET="$OPTIONAL_SECRET" \
+       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e SQUASH="$SQUASH" \
@@ -420,7 +420,7 @@ spec:
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-       -v "$BUILD_DIR/volumes/optional-secret:/optional-secret:Z" \
+       -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
@@ -444,8 +444,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
-    - mountPath: /optional-secret
-      name: optional-secret
+    - mountPath: /additional-secret
+      name: additional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
@@ -627,10 +627,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
-  - name: optional-secret
+  - name: additional-secret
     secret:
       optional: true
-      secretName: $(params.OPTIONAL_SECRET)
+      secretName: $(params.ADDITIONAL_SECRET)
   - configMap:
       items:
       - key: $(params.caTrustConfigMapKey)

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -78,6 +78,11 @@ spec:
     description: Name of secret which contains the entitlement certificates
     name: ENTITLEMENT_SECRET
     type: string
+  - default: ""
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$OPTIONAL_SECRET
+    name: OPTIONAL_SECRET
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings)
     name: BUILD_ARGS
@@ -156,6 +161,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
+    - name: OPTIONAL_SECRET
+      value: $(params.OPTIONAL_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
@@ -214,6 +221,7 @@ spec:
       rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+      rsync -ra /optional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/optional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
@@ -349,6 +357,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      OPTIONAL_SECRET_PATH="/optional-secret"
+      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
+        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
+        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      fi
+
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
         $VOLUME_MOUNTS \
         "${BUILDAH_ARGS[@]}" \
@@ -396,6 +411,7 @@ spec:
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+       -e OPTIONAL_SECRET="$OPTIONAL_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e SQUASH="$SQUASH" \
@@ -404,6 +420,7 @@ spec:
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+       -v "$BUILD_DIR/volumes/optional-secret:/optional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
        -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
@@ -427,6 +444,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
+    - mountPath: /optional-secret
+      name: optional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
@@ -608,6 +627,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
+  - name: optional-secret
+    secret:
+      optional: true
+      secretName: $(params.OPTIONAL_SECRET)
   - configMap:
       items:
       - key: $(params.caTrustConfigMapKey)

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -23,6 +23,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -23,7 +23,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
-|OPTIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET|does-not-exist|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 |SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -71,6 +71,10 @@ spec:
     description: Name of secret which contains the entitlement certificates
     type: string
     default: "etc-pki-entitlement"
+  - name: OPTIONAL_SECRET
+    description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
+    type: string
+    default: ""
   - name: BUILD_ARGS
     description: Array of --build-arg values ("arg=value" strings)
     type: array
@@ -145,6 +149,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
+    - name: OPTIONAL_SECRET
+      value: $(params.OPTIONAL_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
@@ -296,6 +302,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      OPTIONAL_SECRET_PATH="/optional-secret"
+      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
+        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
+        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      fi
+
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
         $VOLUME_MOUNTS \
         "${BUILDAH_ARGS[@]}" \
@@ -333,6 +346,8 @@ spec:
       name: varlibcontainers
     - mountPath: "/entitlement"
       name: etc-pki-entitlement
+    - mountPath: "/optional-secret"
+      name: optional-secret
     - name: trusted-ca
       mountPath: /mnt/trusted-ca
       readOnly: true
@@ -514,6 +529,10 @@ spec:
   - name: etc-pki-entitlement
     secret:
       secretName: $(params.ENTITLEMENT_SECRET)
+      optional: true
+  - name: optional-secret
+    secret:
+      secretName: $(params.OPTIONAL_SECRET)
       optional: true
   - name: trusted-ca
     configMap:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -74,7 +74,7 @@ spec:
   - name: OPTIONAL_SECRET
     description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
     type: string
-    default: ""
+    default: "does-not-exist"
   - name: BUILD_ARGS
     description: Array of --build-arg values ("arg=value" strings)
     type: array

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -71,8 +71,8 @@ spec:
     description: Name of secret which contains the entitlement certificates
     type: string
     default: "etc-pki-entitlement"
-  - name: OPTIONAL_SECRET
-    description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$OPTIONAL_SECRET
+  - name: ADDITIONAL_SECRET
+    description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
     type: string
     default: "does-not-exist"
   - name: BUILD_ARGS
@@ -149,8 +149,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
-    - name: OPTIONAL_SECRET
-      value: $(params.OPTIONAL_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: ADD_CAPABILITIES
@@ -302,11 +302,11 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      OPTIONAL_SECRET_PATH="/optional-secret"
-      if [ -d "$OPTIONAL_SECRET_PATH" ]; then
-        cp -r --preserve=mode "$OPTIONAL_SECRET_PATH" /tmp/optional-secret
-        BUILDAH_ARGS+=("--secret=id=${OPTIONAL_SECRET},src=/tmp/optional-secret")
-        echo "Adding the secret ${OPTIONAL_SECRET} to the build, available at /run/secrets/${OPTIONAL_SECRET}"
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode "$ADDITIONAL_SECRET_PATH" /tmp/additional-secret
+        BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET},src=/tmp/additional-secret")
+        echo "Adding the secret ${ADDITIONAL_SECRET} to the build, available at /run/secrets/${ADDITIONAL_SECRET}"
       fi
 
       unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
@@ -346,8 +346,8 @@ spec:
       name: varlibcontainers
     - mountPath: "/entitlement"
       name: etc-pki-entitlement
-    - mountPath: "/optional-secret"
-      name: optional-secret
+    - mountPath: "/additional-secret"
+      name: additional-secret
     - name: trusted-ca
       mountPath: /mnt/trusted-ca
       readOnly: true
@@ -530,9 +530,9 @@ spec:
     secret:
       secretName: $(params.ENTITLEMENT_SECRET)
       optional: true
-  - name: optional-secret
+  - name: additional-secret
     secret:
-      secretName: $(params.OPTIONAL_SECRET)
+      secretName: $(params.ADDITIONAL_SECRET)
       optional: true
   - name: trusted-ca
     configMap:


### PR DESCRIPTION
The secret is made available only to RUN lines that are invoked with `--mount`, like this:

```
RUN --mount=type=secret,id={secret-name} cat /run/secrets/{secret-name}
```

See https://docs.podman.io/en/latest/markdown/podman-build.1.html#secret-id-id-src-path