### PR TITLE
Check broken symlinks and don't fail on them unnecessarily

### DIFF
--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -263,7 +263,7 @@ spec:
         check_symlinks() {
           FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
           while read symlink; do
-            target=$(readlink -f "$symlink")
+            target=$(readlink -m "$symlink")
             if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
               echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
               FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -265,7 +265,7 @@ spec:
         FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
         while read symlink
         do
-          target=$(readlink -f "$symlink")
+          target=$(readlink -m "$symlink")
           if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
             echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
             FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true


### PR DESCRIPTION
Previously, we were using the -f option for the readlink command. This means that if the symlink was broken (pointing to nonexistent file), the file path was not evaluated and the readlink command failed which meant that the git clone task failed as well.

By using the -m option, the symlink path will be evaluated every time. This means that we will not break builds that contain broken symlinks pointing to nonexistent files within the directory. However, if the symlink is pointing to nonexistent file OUTSIDE of the repo, we will fail the task, as expected to avoid security concerns.

[STONEBLD-2492](https://issues.redhat.com//browse/STONEBLD-2492)
