### PR TITLE
Incorporate auth param for oci-copy task

### DIFF
--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -5,6 +5,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header|""|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|

--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -5,7 +5,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header|""|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|""|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -13,6 +13,11 @@ spec:
   description: Given a file in the user's source directory, copy content from
     arbitrary urls into the OCI registry.
   params:
+    - name: BEARER_TOKEN_SECRET_NAME
+      description: Name of a secret which will be made available to the build
+        as an Authorization header
+      type: string
+      default: ""
     - name: IMAGE
       description: Reference of the image we will push
       type: string
@@ -85,16 +90,33 @@ spec:
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers
+      env:
+        - name: BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: $(params.BEARER_TOKEN_SECRET_NAME)
+              optional: true
       script: |
-        set -eu
+        set -e
         set -o pipefail
+
+        CURL_ARGS=()
+        if [ -n "${BEARER_TOKEN}" ]; then
+          echo "Found bearer token. Using it for authentication."
+          CURL_ARGS+=(-H "Authorization: Bearer ${BEARER_TOKEN}")
+        else
+          echo "Proceeding with anonymous requests"
+        fi
+
+        set -u
 
         for varfile in /var/workdir/vars/*; do
           echo "Reading $varfile"
           source $varfile
 
           echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+          curl "${CURL_ARGS[@]}" --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
 
           echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
           echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -15,7 +15,10 @@ spec:
   params:
     - name: BEARER_TOKEN_SECRET_NAME
       description: Name of a secret which will be made available to the build
-        as an Authorization header
+        as an Authorization header. Note, the token will be sent to all servers
+        found in the oci-copy.yaml file. If you do not wish to send the token
+        to all servers, different taskruns and therefore different oci artifacts
+        must be used.
       type: string
       default: ""
     - name: IMAGE
@@ -116,7 +119,7 @@ spec:
           source $varfile
 
           echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl "${CURL_ARGS[@]}" --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+          curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
 
           echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
           echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -11,6 +11,7 @@ It is not to be considered safe for general use as it cannot provide a high degr
 |---|---|---|---|
 |IMAGE|Reference of the image buildah will produce.||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header|""|false|
 
 ## Results
 |name|description|

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -6,12 +6,15 @@ It generates a limited SBOM and pushes that into the OCI registry alongside the 
 
 It is not to be considered safe for general use as it cannot provide a high degree of provenance for artficats and reports them only as "general" type artifacts in the purl spec it reports in the SBOM. Use only in limited situations.
 
+Note: the bearer token secret, if specified, will be sent to **all servers listed in the oci-copy.yaml file**.
+
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
 |IMAGE|Reference of the image buildah will produce.||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
-|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header|""|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|""|false|
+
 
 ## Results
 |name|description|

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -18,6 +18,10 @@ spec:
       description: Path to the oci copy file.
       name: OCI_COPY_FILE
       type: string
+    - name: BEARER_TOKEN_SECRET_NAME
+      description: Name of a secret which will be made available to the build as an Authorization header
+      type: string
+      default: ""
   results:
     - description: Digest of the artifact just pushed
       name: IMAGE_DIGEST
@@ -71,16 +75,33 @@ spec:
         capabilities:
           add:
             - SETFCAP
+      env:
+      - name: BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: $(params.BEARER_TOKEN_SECRET_NAME)
+            key: token
+            optional: true
       script: |
-        set -eu
+        set -e
         set -o pipefail
+
+        CURL_ARGS=()
+        if [ -n "${BEARER_TOKEN}" ]; then
+          echo "Found bearer token. Using it for authentication."
+          CURL_ARGS+=(-H "Authorization: Bearer ${BEARER_TOKEN}")
+        else
+          echo "Proceeding with anonymous requests"
+        fi
+
+        set -u
 
         for varfile in /var/workdir/vars/*; do
           echo "Reading $varfile"
           source $varfile
 
           echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+          curl "${CURL_ARGS[@]}" --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
 
           echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
           echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -19,7 +19,10 @@ spec:
       name: OCI_COPY_FILE
       type: string
     - name: BEARER_TOKEN_SECRET_NAME
-      description: Name of a secret which will be made available to the build as an Authorization header
+      description: >-
+        Name of a secret which will be made available to the build as an Authorization header. Note, the token will
+        be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers,
+        different taskruns and therefore different oci artifacts must be used.
       type: string
       default: ""
   results:

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -101,7 +101,7 @@ spec:
           source $varfile
 
           echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-          curl "${CURL_ARGS[@]}" --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+          curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
 
           echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
           echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check


### PR DESCRIPTION
The use case for this is copying artifacts into the OCI registry from locations that require some authentication, in particular https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1