### PR TITLE
Remove the squash_all parameter

### DIFF
--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -22,8 +22,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
-|SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|
-|SQUASH_ALL|Squash all new and previous layers added as a part of this build, as per --squash-all|false|false|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -77,13 +77,8 @@ spec:
         the application source code.
       type: string
     - name: SQUASH
-      description: Squash new layers added as a part of this build, as per
-        --squash
-      type: string
-      default: "false"
-    - name: SQUASH_ALL
       description: Squash all new and previous layers added as a part of this
-        build, as per --squash-all
+        build, as per --squash
       type: string
       default: "false"
     - name: TARGET_STAGE
@@ -170,8 +165,6 @@ spec:
         value: $(params.IMAGE_EXPIRES_AFTER)
       - name: SQUASH
         value: $(params.SQUASH)
-      - name: SQUASH_ALL
-        value: $(params.SQUASH_ALL)
       - name: STORAGE_DRIVER
         value: vfs
       - name: TARGET_STAGE
@@ -287,10 +280,6 @@ spec:
 
         if [ "${SQUASH}" == "true" ]; then
           BUILDAH_ARGS+=("--squash")
-        fi
-
-        if [ "${SQUASH_ALL}" == "true" ]; then
-          BUILDAH_ARGS+=("--squash-all")
         fi
 
         if [ -f "/var/workdir/cachi2/cachi2.env" ]; then

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -77,13 +77,9 @@ spec:
     name: SOURCE_ARTIFACT
     type: string
   - default: "false"
-    description: Squash new layers added as a part of this build, as per --squash
-    name: SQUASH
-    type: string
-  - default: "false"
     description: Squash all new and previous layers added as a part of this build,
-      as per --squash-all
-    name: SQUASH_ALL
+      as per --squash
+    name: SQUASH
     type: string
   - default: ""
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile
@@ -153,8 +149,6 @@ spec:
       value: $(params.IMAGE_EXPIRES_AFTER)
     - name: SQUASH
       value: $(params.SQUASH)
-    - name: SQUASH_ALL
-      value: $(params.SQUASH_ALL)
     - name: STORAGE_DRIVER
       value: vfs
     - name: TARGET_STAGE
@@ -310,10 +304,6 @@ spec:
         BUILDAH_ARGS+=("--squash")
       fi
 
-      if [ "${SQUASH_ALL}" == "true" ]; then
-        BUILDAH_ARGS+=("--squash-all")
-      fi
-
       if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
         cp -r "/var/workdir/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -400,7 +390,6 @@ spec:
        -e IMAGE="$IMAGE" \
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
        -e SQUASH="$SQUASH" \
-       -e SQUASH_ALL="$SQUASH_ALL" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e TLSVERIFY="$TLSVERIFY" \

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -101,13 +101,9 @@ spec:
     name: ADD_CAPABILITIES
     type: string
   - default: "false"
-    description: Squash new layers added as a part of this build, as per --squash
-    name: SQUASH
-    type: string
-  - default: "false"
     description: Squash all new and previous layers added as a part of this build,
-      as per --squash-all
-    name: SQUASH_ALL
+      as per --squash
+    name: SQUASH
     type: string
   - description: The platform to build on
     name: PLATFORM
@@ -162,8 +158,6 @@ spec:
       value: $(params.ADD_CAPABILITIES)
     - name: SQUASH
       value: $(params.SQUASH)
-    - name: SQUASH_ALL
-      value: $(params.SQUASH_ALL)
     - name: BUILDER_IMAGE
       value: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
     volumeMounts:
@@ -302,10 +296,6 @@ spec:
         BUILDAH_ARGS+=("--squash")
       fi
 
-      if [ "${SQUASH_ALL}" == "true" ]; then
-        BUILDAH_ARGS+=("--squash-all")
-      fi
-
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
@@ -399,7 +389,6 @@ spec:
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e SQUASH="$SQUASH" \
-       -e SQUASH_ALL="$SQUASH_ALL" \
        -e COMMIT_SHA="$COMMIT_SHA" \
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \

--- a/task/buildah/0.1/README.md
+++ b/task/buildah/0.1/README.md
@@ -25,8 +25,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
-|SQUASH|Squash new layers added as a part of this build, as per --squash|false|false|
-|SQUASH_ALL|Squash all new and previous layers added as a part of this build, as per --squash-all|false|false|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -92,11 +92,7 @@ spec:
     type: string
     default: ""
   - name: SQUASH
-    description: Squash new layers added as a part of this build, as per --squash
-    type: string
-    default: "false"
-  - name: SQUASH_ALL
-    description: Squash all new and previous layers added as a part of this build, as per --squash-all
+    description: Squash all new and previous layers added as a part of this build, as per --squash
     type: string
     default: "false"
 
@@ -151,8 +147,6 @@ spec:
       value: $(params.ADD_CAPABILITIES)
     - name: SQUASH
       value: $(params.SQUASH)
-    - name: SQUASH_ALL
-      value: $(params.SQUASH_ALL)
 
   steps:
   - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
@@ -247,10 +241,6 @@ spec:
 
       if [ "${SQUASH}" == "true" ]; then
         BUILDAH_ARGS+=("--squash")
-      fi
-
-      if [ "${SQUASH_ALL}" == "true" ]; then
-        BUILDAH_ARGS+=("--squash-all")
       fi
 
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then


### PR DESCRIPTION
I got confused before in https://github.com/konflux-ci/build-definitions/pull/1107

`podman build` has both a `--squash` and a `--squash-all` option.

`buildah build` has only a `--squash` option which behaves like the `--squash-all` option from `podman build`.

We _just_ added this param earlier this morning. Hopefully we can remove it here without needing a task version bump.
