### PR TITLE
`IMAGE_REF` result from image building Tasks

### DIFF
--- a/task/buildah-oci-ta/0.2/README.md
+++ b/task/buildah-oci-ta/0.2/README.md
@@ -38,6 +38,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |name|description|
 |---|---|
 |IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_REF|Image reference of the built image|
 |IMAGE_URL|Image repository where the built image was pushed|
 |JAVA_COMMUNITY_DEPENDENCIES|The Java dependencies that came from community sources such as Maven central.|
 |SBOM_JAVA_COMPONENTS_COUNT|The counting of Java components by publisher in JSON format|

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -129,6 +129,8 @@ spec:
   results:
     - name: IMAGE_DIGEST
       description: Digest of the image just built
+    - name: IMAGE_REF
+      description: Image reference of the built image
     - name: IMAGE_URL
       description: Image repository where the built image was pushed
     - name: JAVA_COMMUNITY_DEPENDENCIES
@@ -559,6 +561,10 @@ spec:
 
         cat "/var/workdir"/image-digest | tee $(results.IMAGE_DIGEST.path)
         echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+        {
+          echo -n "${IMAGE}@"
+          cat "/var/workdir/image-digest"
+        } >"$(results.IMAGE_REF.path)"
       securityContext:
         capabilities:
           add:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -130,6 +130,8 @@ spec:
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
+  - description: Image reference of the built image
+    name: IMAGE_REF
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
   - description: The Java dependencies that came from community sources such as Maven
@@ -630,6 +632,10 @@ spec:
 
       cat "/var/workdir"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "/var/workdir/image-digest"
+      } >"$(results.IMAGE_REF.path)"
     securityContext:
       capabilities:
         add:

--- a/task/buildah-remote/0.2/README.md
+++ b/task/buildah-remote/0.2/README.md
@@ -1,4 +1,4 @@
-# buildah task
+# buildah-remote task
 
 Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
 In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
@@ -31,6 +31,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
 |STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|PLATFORM|The platform to build on||true|
 
 ## Results
 |name|description|

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -123,6 +123,8 @@ spec:
     name: IMAGE_DIGEST
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
   - description: The counting of Java components by publisher in JSON format
     name: SBOM_JAVA_COMPONENTS_COUNT
     type: string
@@ -612,6 +614,10 @@ spec:
 
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
     securityContext:
       capabilities:
         add:

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -109,6 +109,8 @@ spec:
     name: IMAGE_DIGEST
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
   - name: SBOM_JAVA_COMPONENTS_COUNT
     description: The counting of Java components by publisher in JSON format
     type: string
@@ -509,6 +511,10 @@ spec:
 
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
 
     securityContext:
       runAsUser: 0

--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -14,6 +14,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 |name|description|
 |---|---|
 |IMAGE_DIGEST|Digest of the artifact just pushed|
+|IMAGE_REF|Image reference of the built image|
 |IMAGE_URL|Repository where the artifact was pushed|
 |SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
 

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -35,6 +35,8 @@ spec:
   results:
     - name: IMAGE_DIGEST
       description: Digest of the artifact just pushed
+    - name: IMAGE_REF
+      description: Image reference of the built image
     - name: IMAGE_URL
       description: Repository where the artifact was pushed
     - name: SBOM_BLOB_URL
@@ -193,6 +195,7 @@ spec:
         RESULTING_DIGEST=$(oras resolve --registry-config auth.json "${IMAGE}")
         echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
         echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${IMAGE}@${RESULTING_DIGEST}" >"$(results.IMAGE_REF.path)"
       computeResources:
         limits:
           memory: 1Gi

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -22,6 +22,7 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_URL|Image repository where the built image was pushed|
 |SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
+|IMAGE_REF|Image reference of the built image|
 
 ## Workspaces
 |name|description|optional|

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -32,6 +32,8 @@ spec:
       name: IMAGE_URL
     - description: Link to the SBOM blob pushed to the registry.
       name: SBOM_BLOB_URL
+    - name: IMAGE_REF
+      description: Image reference of the built image
   stepTemplate:
     env:
       - name: OCI_COPY_FILE
@@ -178,6 +180,7 @@ spec:
         RESULTING_DIGEST=$(oras resolve --registry-config auth.json "${IMAGE}")
         echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
         echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${IMAGE}@${RESULTING_DIGEST}" >"$(results.IMAGE_REF.path)"
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers

--- a/task/rpm-ostree/0.1/README.md
+++ b/task/rpm-ostree/0.1/README.md
@@ -1,0 +1,31 @@
+# rpm-ostree task
+
+RPM Ostree
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image rpm-ostree will produce.||true|
+|BUILDER_IMAGE|The location of the rpm-ostree builder image.|quay.io/redhat-user-workloads/project-sagano-tenant/ostree-builder/ostree-builder-fedora-38:d124414a81d17f31b1d734236f55272a241703d7|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|IMAGE_FILE|The file to use to build the image||true|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|PLATFORM|The platform to build on||true|
+|CONFIG_FILE|The relative path of the file used to configure the rpm-ostree tool found in source control. See https://github.com/coreos/rpm-ostree/blob/main/docs/container.md#adding-container-image-configuration|""|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_URL|Image repository where the built image was pushed|
+|IMAGE_REF|Image reference of the built image|
+|BASE_IMAGES_DIGESTS|Digests of the base images used for build|
+|SBOM_BLOB_URL|Reference, including digest to the SBOM blob|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace containing the source code to build.|false|

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -60,6 +60,8 @@ spec:
     name: IMAGE_DIGEST
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
   - description: Digests of the base images used for build
     name: BASE_IMAGES_DIGESTS
   - name: SBOM_BLOB_URL
@@ -260,6 +262,10 @@ spec:
 
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } >"$(results.IMAGE_REF.path)"
 
       # Remove tag from IMAGE while allowing registry to contain a port number.
       sbom_repo="${IMAGE%:*}"

--- a/task/s2i-java/0.1/README.md
+++ b/task/s2i-java/0.1/README.md
@@ -12,15 +12,17 @@ When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup
 |PATH_CONTEXT|The location of the path to run s2i from|.|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |IMAGE|Location of the repo where image has to be pushed||true|
-|BUILDER_IMAGE|The location of the buildah builder image.|registry.access.redhat.com/ubi9/buildah:9.1.0-5@sha256:30eac1803d669d58c033838076a946156e49018e0d4f066d94896f0cc32030af|false|
+|BUILDER_IMAGE|Deprecated. Has no effect. Will be removed in the future.|""|false|
 |DOCKER_AUTH|unused, should be removed in next task version|""|false|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
 
 ## Results
 |name|description|
 |---|---|
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_URL|Image repository where the built image was pushed|
+|IMAGE_REF|Image reference of the built image|
 |BASE_IMAGES_DIGESTS|Digests of the base images used for build|
 |SBOM_JAVA_COMPONENTS_COUNT|The counting of Java components by publisher in JSON format|
 |JAVA_COMMUNITY_DEPENDENCIES|The Java dependencies that came from community sources such as Maven central.|

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -56,6 +56,8 @@ spec:
     name: IMAGE_DIGEST
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
   - description: Digests of the base images used for build
     name: BASE_IMAGES_DIGESTS
   - name: SBOM_JAVA_COMPONENTS_COUNT
@@ -253,6 +255,10 @@ spec:
         docker://$IMAGE
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
 
     securityContext:
       runAsUser: 0

--- a/task/s2i-nodejs/0.1/README.md
+++ b/task/s2i-nodejs/0.1/README.md
@@ -7,20 +7,22 @@ In addition it generates a SBOM file, injects the SBOM file into final container
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|BASE_IMAGE|NodeJS builder image|registry.access.redhat.com/ubi9/nodejs-16:1-75.1669634583|false|
+|BASE_IMAGE|NodeJS builder image|registry.access.redhat.com/ubi9/nodejs-16:1-75.1669634583@sha256:c17111ec54c7f57f22d03f2abba206b0bdc54dcdfb02d6a8278ce088231eced1|false|
 |PATH_CONTEXT|The location of the path to run s2i from.|.|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |IMAGE|Location of the repo where image has to be pushed||true|
-|BUILDER_IMAGE|The location of the buildah builder image.|registry.access.redhat.com/ubi9/buildah:9.1.0-5@sha256:30eac1803d669d58c033838076a946156e49018e0d4f066d94896f0cc32030af|false|
+|BUILDER_IMAGE|Deprecated. Has no effect. Will be removed in the future.|""|false|
 |DOCKER_AUTH|unused, should be removed in next task version|""|false|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |MAVEN_MIRROR_URL|The base URL of a mirror used for retrieving artifacts|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
 
 ## Results
 |name|description|
 |---|---|
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_URL|Image repository where the built image was pushed|
+|IMAGE_REF|Image reference of the built image|
 |BASE_IMAGES_DIGESTS|Digests of the base images used for build|
 
 ## Workspaces

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -74,6 +74,8 @@ spec:
     name: IMAGE_DIGEST
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
   - description: Digests of the base images used for build
     name: BASE_IMAGES_DIGESTS
   steps:
@@ -221,6 +223,10 @@ spec:
         docker://$IMAGE
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
 
     securityContext:
       runAsUser: 0

--- a/task/source-build-oci-ta/0.1/README.md
+++ b/task/source-build-oci-ta/0.1/README.md
@@ -14,6 +14,7 @@ Source image build.
 |name|description|
 |---|---|
 |BUILD_RESULT|Build result.|
+|IMAGE_REF|Image reference of the built image|
 |SOURCE_IMAGE_DIGEST|The source image digest.|
 |SOURCE_IMAGE_URL|The source image url.|
 

--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -35,6 +35,8 @@ spec:
   results:
     - name: BUILD_RESULT
       description: Build result.
+    - name: IMAGE_REF
+      description: Image reference of the built image
     - name: SOURCE_IMAGE_DIGEST
       description: The source image digest.
     - name: SOURCE_IMAGE_URL
@@ -156,6 +158,7 @@ spec:
 
         cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
         cat "$RESULT_FILE" | jq -j ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
+        jq -j '"\(.image_url)@\(.image_digest)"' "${RESULT_FILE}" >"$(results.IMAGE_REF.path)"
 
         cp "$RESULT_FILE" "$WS_BUILD_RESULT_FILE"
       computeResources:

--- a/task/source-build/0.1/README.md
+++ b/task/source-build/0.1/README.md
@@ -14,6 +14,7 @@ Source image build.
 |BUILD_RESULT|Build result.|
 |SOURCE_IMAGE_URL|The source image url.|
 |SOURCE_IMAGE_DIGEST|The source image digest.|
+|IMAGE_REF|Image reference of the built image|
 
 ## Workspaces
 |name|description|optional|

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -29,6 +29,8 @@ spec:
       description: The source image url.
     - name: SOURCE_IMAGE_DIGEST
       description: The source image digest.
+    - name: IMAGE_REF
+      description: Image reference of the built image
   workspaces:
     - name: workspace
       description: The workspace where source code is included.
@@ -157,5 +159,6 @@ spec:
 
         cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
         cat "$RESULT_FILE" | jq -j ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
+        jq -j '"\(.image_url)@\(.image_digest)"' "${RESULT_FILE}" >"$(results.IMAGE_REF.path)"
 
         cp "$RESULT_FILE" "$WS_BUILD_RESULT_FILE"

--- a/task/tkn-bundle/0.1/README.md
+++ b/task/tkn-bundle/0.1/README.md
@@ -45,7 +45,8 @@ Only the `0.1/tkn-bundle.yaml` file will be included in the bundle.
 
 The task emits the following results.
 
-| Name         | Example                 | Description                                                     |
-|--------------|-------------------------|-----------------------------------------------------------------|
-| IMAGE_URL    | registry.io/my-task:tag | Image repository where the built image was pushed with tag only |
-| IMAGE_DIGEST | abc...                  | Digest of the image just built                                  |
+| Name         | Example                               | Description                                                     |
+|--------------|---------------------------------------|-----------------------------------------------------------------|
+| IMAGE_URL    | registry.io/my-task:tag               | Image repository where the built image was pushed with tag only |
+| IMAGE_DIGEST | abc...                                | Digest of the image just built                                  |
+| IMAGE_REF    | registry.io/my-task:tag@sha256:abc... | Image reference of the built image                              |

--- a/task/tkn-bundle/0.1/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.1/tkn-bundle.yaml
@@ -32,6 +32,8 @@ spec:
     name: IMAGE_DIGEST
   - description: Image repository where the built image was pushed with tag only
     name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
   stepTemplate:
     env:
     - name: HOME
@@ -134,7 +136,9 @@ spec:
         $(printf ' -f %s' "${FILES[@]}") \
         |tee /proc/self/fd/3)"
       echo -n "$IMAGE" > $(results.IMAGE_URL.path)
-      echo -n "${OUT#*Pushed Tekton Bundle to *@}" > $(results.IMAGE_DIGEST.path)
+      digest="${OUT#*Pushed Tekton Bundle to *@}"
+      echo -n "${digest}" > $(results.IMAGE_DIGEST.path)
+      echo -n "${IMAGE}@${digest}" > "$(results.IMAGE_REF.path)"
 
       # cleanup task file
       [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"


### PR DESCRIPTION
This helps in the reuse of the results when using matrix feature of Tekton. Given that the concatenation of two results from matrix-spawned Tasks is not supported, e.g.

    $(tasks.build-container-multiarch.results.IMAGE_URL[*])@$(tasks.build-container-multiarch.results.IMAGE_DIGEST[*])

will not expand correctly.

This produces the image reference in full in the `IMAGE_REF` result, so the result from the matrix-spawned Tasks can be referenced using:

    $(tasks.build-container-multiarch.results.IMAGE_REF[*])

Reference: https://issues.redhat.com/browse/EC-654

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
