### PR TITLE
Ignore bundle_values.env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 pipeline-bundle-list
 task-bundle-list
+bundle_values.env


### PR DESCRIPTION
This gets generated as a side-effect when you run hack/build-and-push.sh

Is there any value in *not* ignoring it?
