### PR TITLE
Switch to a new buildah image source

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,7 @@
         "quay.io/konflux-ci/pull-request-builds",
         "quay.io/redhat-appstudio/github-app-token",
         "quay.io/konflux-ci/appstudio-utils",
+        "quay.io/konflux-ci/buildah",
         "quay.io/konflux-ci/source-container-build",
         "quay.io/redhat-appstudio/e2e-tests",
         "quay.io/redhat-appstudio/buildah",

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -46,7 +46,7 @@ spec:
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
   steps:
-  - image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+  - image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -46,7 +46,7 @@ spec:
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
   steps:
-  - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+  - image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -46,7 +46,7 @@ spec:
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
   steps:
-  - image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+  - image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -201,7 +201,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: build
-      image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+      image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
       args:
         - $(params.BUILD_ARGS[*])
       workingDir: /var/workdir
@@ -490,7 +490,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: inject-sbom-and-push
-      image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+      image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -201,7 +201,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: build
-      image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+      image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
       args:
         - $(params.BUILD_ARGS[*])
       workingDir: /var/workdir
@@ -490,7 +490,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: inject-sbom-and-push
-      image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+      image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -201,7 +201,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: build
-      image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+      image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
       args:
         - $(params.BUILD_ARGS[*])
       workingDir: /var/workdir
@@ -490,7 +490,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: inject-sbom-and-push
-      image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+      image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -169,7 +169,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+      value: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -563,7 +563,7 @@ spec:
       runAsUser: 0
     workingDir: /var/workdir
   - computeResources: {}
-    image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+    image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
     name: inject-sbom-and-push
     script: |
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -169,7 +169,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+      value: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -563,7 +563,7 @@ spec:
       runAsUser: 0
     workingDir: /var/workdir
   - computeResources: {}
-    image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+    image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     name: inject-sbom-and-push
     script: |
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -169,7 +169,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+      value: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -563,7 +563,7 @@ spec:
       runAsUser: 0
     workingDir: /var/workdir
   - computeResources: {}
-    image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+    image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
     name: inject-sbom-and-push
     script: |
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -166,7 +166,7 @@ spec:
     - name: SQUASH
       value: $(params.SQUASH)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+      value: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -556,7 +556,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+    image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
     name: inject-sbom-and-push
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -166,7 +166,7 @@ spec:
     - name: SQUASH
       value: $(params.SQUASH)
     - name: BUILDER_IMAGE
-      value: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+      value: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -556,7 +556,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+    image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
     name: inject-sbom-and-push
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -166,7 +166,7 @@ spec:
     - name: SQUASH
       value: $(params.SQUASH)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+      value: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -556,7 +556,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+    image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     name: inject-sbom-and-push
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -155,7 +155,7 @@ spec:
       value: $(params.SQUASH)
 
   steps:
-  - image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+  - image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
     name: build
     computeResources:
       limits:
@@ -458,7 +458,7 @@ spec:
       runAsUser: 0
 
   - name: inject-sbom-and-push
-    image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
+    image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
     computeResources: {}
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -155,7 +155,7 @@ spec:
       value: $(params.SQUASH)
 
   steps:
-  - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+  - image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
     name: build
     computeResources:
       limits:
@@ -458,7 +458,7 @@ spec:
       runAsUser: 0
 
   - name: inject-sbom-and-push
-    image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
+    image: quay.io/konflux-ci/buildah:latest@sha256:6d41d76152f635b0cb4fe37e96255fe545709a693eeb50f9a3aa63206a372d9e
     computeResources: {}
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -155,7 +155,7 @@ spec:
       value: $(params.SQUASH)
 
   steps:
-  - image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+  - image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     name: build
     computeResources:
       limits:
@@ -458,7 +458,7 @@ spec:
       runAsUser: 0
 
   - name: inject-sbom-and-push
-    image: quay.io/konflux-ci/buildah:latest@sha256:31e20c4b4ef06a0ecb8ab199e1e7c040d8c53f77ee3b30c6d981544b177e849c
+    image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     computeResources: {}
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then


### PR DESCRIPTION
Some changes:
* The image is built from https://github.com/konflux-ci/buildah-container
* The image is now built and released from Konflux so now we can easily track the provenance of the image
* The buildah image will just update the floating latest tag
* Buildah is now multi-arch
* Buildah has been updated to a recent commit and is therefore a newer verison

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
