### PR TITLE
Change e2e image to konflux workloads

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -26,7 +26,7 @@ spec:
       type: string
   steps:
     - name: e2e-test
-      image: quay.io/konflux-ci/e2e-tests:a1fd47cbb639276f08f9c51769a15a106a9e68ff
+      image: quay.io/redhat-user-workloads/rhtap-qe-shared-tenant/konflux-e2e/konflux-e2e-tests:7dab163f24f482021262680e7a602d6af84ca84b
       # a la infra-deployment updates, when PRs merge in e2e-tests, PRs will be opened
       # against build-definitions to update this tag
       args: [


### PR DESCRIPTION
# Before you complete this pull request ...

E2e tests repo was onboarded in Konflux and now is using user workloads to save quay images
