### PR TITLE
Skip bundle list files that have not been created

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -137,7 +137,7 @@ spec:
                   [[ -f "$f" ]] && list+=("$f")
                 done
 
-                .tekton/scripts/build-acceptable-bundles.sh "${list[*]}"
+                .tekton/scripts/build-acceptable-bundles.sh "${list[@]}"
 
                 echo -n "${DATA_BUNDLE_TAG}" > acceptable_bundle_tag
               args:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -132,7 +132,12 @@ spec:
                 DATA_BUNDLE_TAG=$(date '+%s')
                 export DATA_BUNDLE_REPO DATA_BUNDLE_TAG
 
-                .tekton/scripts/build-acceptable-bundles.sh "$@"
+                list=()
+                for f in "$@"; do
+                  [[ -f "$f" ]] && list+=("$f")
+                done
+
+                .tekton/scripts/build-acceptable-bundles.sh "${list[*]}"
 
                 echo -n "${DATA_BUNDLE_TAG}" > acceptable_bundle_tag
               args:


### PR DESCRIPTION
Follow up to #1112, let's not confuse folk by printing:

```
cat: /workspace/source/task-bundle-list-konflux-ci: No such file or directory
cat: /workspace/source/task-bundle-list-appstudio: No such file or directory
```

In the TaskRun logs. Those files do not exist if no Tasks were changed.

Reference: https://issues.redhat.com/browse/EC-705
