### PR TITLE
feat: push Dockerfile to registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 pipeline-bundle-list
 task-bundle-list
 bundle_values.env
+
+*~
+*.swp

--- a/pipelines/docker-build-oci-ta/patch.yaml
+++ b/pipelines/docker-build-oci-ta/patch.yaml
@@ -24,6 +24,7 @@
 #  9  clamav-scan
 # 10  sbom-json-check
 # 11  apply-tags
+# 12  push-dockerfile
 
 # clone-repository Task
 - op: replace
@@ -111,6 +112,18 @@
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
 - op: remove
   path: /spec/tasks/8/workspaces/0
+
+# push-dockerfile
+- op: replace
+  path: /spec/tasks/12/taskRef/name
+  value: push-dockerfile-oci-ta
+- op: add
+  path: /spec/tasks/12/params/-
+  value:
+    name: SOURCE_ARTIFACT
+    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+- op: remove
+  path: /spec/tasks/12/workspaces/0
 
 # Order of finally Tasks from the base docker-build Pipeline:
 # $ kustomize build pipelines/docker-build | yq .spec.finally.[].name | nl -v 0

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -84,6 +84,8 @@
 #      8  sast-snyk-check
 #      9  clamav-scan
 #      10 sbom-json-check
+#      11 apply-tags
+#      12 push-dockerfile
 - op: replace
   path: /spec/tasks/3/runAfter/0
   value: clone-repository

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -240,6 +240,24 @@ spec:
       params:
       - name: IMAGE
         value: $(tasks.build-container.results.IMAGE_URL)
+    - name: push-dockerfile
+      runAfter:
+      - build-container
+      taskRef:
+        name: push-dockerfile
+        version: "0.1"
+      params:
+      - name: IMAGE
+        value: $(tasks.build-container.results.IMAGE_URL)
+      - name: IMAGE_DIGEST
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: CONTEXT
+        value: $(params.path-context)
+      workspaces:
+      - name: workspace
+        workspace: workspace
 
   finally:
     - name: show-sbom

--- a/task/push-dockerfile-oci-ta/0.1/README.md
+++ b/task/push-dockerfile-oci-ta/0.1/README.md
@@ -1,0 +1,20 @@
+# push-dockerfile-oci-ta task
+
+Discover Dockerfile from source code and push it to registry as an OCI artifact.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ARTIFACT_TYPE|Artifact type of the Dockerfile image.|application/vnd.konflux.dockerfile|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|DOCKERFILE|Path to the Dockerfile.|./Dockerfile|false|
+|IMAGE|The built binary image. The Dockerfile is pushed to the same image repository alongside.||true|
+|IMAGE_DIGEST|The built binary image digest, which is used to construct the tag of Dockerfile image.||true|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|TAG_SUFFIX|Suffix of the Dockerfile image tag.|.dockerfile|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_REF|Digest-pinned image reference to the Dockerfile image.|
+

--- a/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
+++ b/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
@@ -1,0 +1,112 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: push-dockerfile-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, appstudio
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+spec:
+  description: Discover Dockerfile from source code and push it to registry
+    as an OCI artifact.
+  params:
+    - name: ARTIFACT_TYPE
+      description: Artifact type of the Dockerfile image.
+      type: string
+      default: application/vnd.konflux.dockerfile
+    - name: CONTEXT
+      description: Path to the directory to use as context.
+      type: string
+      default: .
+    - name: DOCKERFILE
+      description: Path to the Dockerfile.
+      type: string
+      default: ./Dockerfile
+    - name: IMAGE
+      description: The built binary image. The Dockerfile is pushed to the
+        same image repository alongside.
+      type: string
+    - name: IMAGE_DIGEST
+      description: The built binary image digest, which is used to construct
+        the tag of Dockerfile image.
+      type: string
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: TAG_SUFFIX
+      description: Suffix of the Dockerfile image tag.
+      type: string
+      default: .dockerfile
+  results:
+    - name: IMAGE_REF
+      description: Digest-pinned image reference to the Dockerfile image.
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:0651a06076d809c2daf63a2d54abfef1a1d9b00e39aa6238b47f43c4f152f9b1
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: push
+      image: quay.io/konflux-ci/oras@sha256:5d0a8a5535fcc4ba467264cacbdeab2fb8662a538a61cb7fc8b3155e3f20fa39
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /var/workdir
+          name: workdir
+      env:
+        - name: IMAGE
+          value: $(params.IMAGE)
+        - name: IMAGE_DIGEST
+          value: $(params.IMAGE_DIGEST)
+        - name: TAG_SUFFIX
+          value: $(params.TAG_SUFFIX)
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+        - name: ARTIFACT_TYPE
+          value: $(params.ARTIFACT_TYPE)
+        - name: IMAGE_REF_RESULT
+          value: $(results.IMAGE_REF.path)
+      script: |
+        set -eu
+        set -o pipefail
+
+        # Same discovery logic used in buildah task
+        SOURCE_CODE_DIR=source
+        if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+        elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+        elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+          echo "Fetch Dockerfile from $DOCKERFILE"
+          dockerfile_path=$(mktemp --suffix=-dockerfile)
+          http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+          if [ $http_code != 200 ]; then
+            echo "No Dockerfile is fetched. Server responds $http_code"
+            exit 1
+          fi
+        else
+          echo "Cannot find Dockerfile $DOCKERFILE"
+          exit 1
+        fi
+
+        echo "Selecting auth for $IMAGE"
+        auth_json=$(mktemp)
+        select-oci-auth $IMAGE >"$auth_json"
+
+        dockerfile_image=${IMAGE%:*}:${IMAGE_DIGEST/:/-}${TAG_SUFFIX}
+
+        cd "$(dirname $dockerfile_path)"
+        retry oras push --no-tty \
+          --format json \
+          --registry-config "$auth_json" \
+          --artifact-type "$ARTIFACT_TYPE" \
+          "$dockerfile_image" "$(basename $dockerfile_path)" |
+            yq '.reference' | tr -d '\r\n' >"$IMAGE_REF_RESULT"

--- a/task/push-dockerfile-oci-ta/0.1/recipe.yaml
+++ b/task/push-dockerfile-oci-ta/0.1/recipe.yaml
@@ -1,0 +1,10 @@
+---
+base: ../../push-dockerfile/0.1/push-dockerfile.yaml
+add:
+  - use-source
+removeWorkspaces:
+  - workspace
+replacements:
+  workspaces.workspace.path: /var/workdir
+description: |-
+  Discover Dockerfile from source code and push it to registry as an OCI artifact.

--- a/task/push-dockerfile-oci-ta/OWNERS
+++ b/task/push-dockerfile-oci-ta/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Build Team

--- a/task/push-dockerfile/0.1/README.md
+++ b/task/push-dockerfile/0.1/README.md
@@ -1,0 +1,23 @@
+# push-dockerfile task
+
+Discover Dockerfile from source code and push it to registry as an OCI artifact.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|The built binary image. The Dockerfile is pushed to the same image repository alongside.||true|
+|IMAGE_DIGEST|The built binary image digest, which is used to construct the tag of Dockerfile image.||true|
+|DOCKERFILE|Path to the Dockerfile.|./Dockerfile|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|TAG_SUFFIX|Suffix of the Dockerfile image tag.|.dockerfile|false|
+|ARTIFACT_TYPE|Artifact type of the Dockerfile image.|application/vnd.konflux.dockerfile|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_REF|Digest-pinned image reference to the Dockerfile image.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|workspace|Workspace containing the source code from where the Dockerfile is discovered.|false|

--- a/task/push-dockerfile/0.1/push-dockerfile.yaml
+++ b/task/push-dockerfile/0.1/push-dockerfile.yaml
@@ -1,0 +1,98 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: "docker"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, appstudio"
+  name: push-dockerfile
+spec:
+  description: |-
+    Discover Dockerfile from source code and push it to registry as an OCI artifact.
+  params:
+  - name: IMAGE
+    description: The built binary image. The Dockerfile is pushed to the same image repository alongside.
+    type: string
+  - name: IMAGE_DIGEST
+    description: The built binary image digest, which is used to construct the tag of Dockerfile image.
+    type: string
+  - name: DOCKERFILE
+    description: Path to the Dockerfile.
+    type: string
+    default: ./Dockerfile
+  - name: CONTEXT
+    description: Path to the directory to use as context.
+    type: string
+    default: .
+  - name: TAG_SUFFIX
+    description: Suffix of the Dockerfile image tag.
+    type: string
+    default: .dockerfile
+  - name: ARTIFACT_TYPE
+    description: Artifact type of the Dockerfile image.
+    type: string
+    default: application/vnd.konflux.dockerfile
+  results:
+  - name: IMAGE_REF
+    description: Digest-pinned image reference to the Dockerfile image.
+  steps:
+  - name: push
+    image: quay.io/konflux-ci/oras@sha256:5d0a8a5535fcc4ba467264cacbdeab2fb8662a538a61cb7fc8b3155e3f20fa39
+    workingDir: $(workspaces.workspace.path)
+    env:
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: IMAGE_DIGEST
+      value: $(params.IMAGE_DIGEST)
+    - name: TAG_SUFFIX
+      value: $(params.TAG_SUFFIX)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: ARTIFACT_TYPE
+      value: $(params.ARTIFACT_TYPE)
+    - name: IMAGE_REF_RESULT
+      value: $(results.IMAGE_REF.path)
+    script: |
+      set -eu
+      set -o pipefail
+
+      # Same discovery logic used in buildah task
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ $http_code != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      echo "Selecting auth for $IMAGE"
+      auth_json=$(mktemp)
+      select-oci-auth $IMAGE >"$auth_json"
+
+      dockerfile_image=${IMAGE%:*}:${IMAGE_DIGEST/:/-}${TAG_SUFFIX}
+
+      cd "$(dirname $dockerfile_path)"
+      retry oras push --no-tty \
+        --format json \
+        --registry-config "$auth_json" \
+        --artifact-type "$ARTIFACT_TYPE" \
+        "$dockerfile_image" "$(basename $dockerfile_path)" \
+        | yq '.reference' | tr -d '\r\n' >"$IMAGE_REF_RESULT"
+
+  workspaces:
+  - name: workspace
+    description: Workspace containing the source code from where the Dockerfile is discovered.

--- a/task/push-dockerfile/OWNERS
+++ b/task/push-dockerfile/OWNERS
@@ -1,0 +1,1 @@
+Stonesoup Build Team


### PR DESCRIPTION
[STONEBLD-2522](https://issues.redhat.com//browse/STONEBLD-2522)

Add a new task push-dockerfile to push Dockerfile to registry as an OCI
artifact.

Task is configurable to accept varaints of Dockerfile with different
names, like Containerfile.

Use `oras pull' to get the image.

This new task is added to docker-build pipeline and enabled by default.

Trusted Artifacts version of push-dockerfile is created accordingly and
updated into the docker-build-oci-ta pipeline.

