### PR TITLE
Allow 'netrc' workspace for Trusted Artifact tasks

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -11,6 +11,7 @@ sources:
         - git-basic-auth
         - basic-auth
         - ssh-directory
+        - netrc
     config:
       include:
         - kind


### PR DESCRIPTION
The prefetch-dependencies task uses this workspace to let the user pass a ~/.netrc file for authentication.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
