### PR TITLE
Provide non-empty default for bearer token secret

### DIFF
--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -5,7 +5,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|""|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -20,7 +20,7 @@ spec:
         to all servers, different taskruns and therefore different oci artifacts
         must be used.
       type: string
-      default: ""
+      default: does-not-exist
     - name: IMAGE
       description: Reference of the image we will push
       type: string

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -13,7 +13,7 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 |---|---|---|---|
 |IMAGE|Reference of the image buildah will produce.||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
-|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|""|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|"does-not-exist"|false|
 
 
 ## Results

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -24,7 +24,7 @@ spec:
         be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers,
         different taskruns and therefore different oci artifacts must be used.
       type: string
-      default: ""
+      default: "does-not-exist"
   results:
     - description: Digest of the artifact just pushed
       name: IMAGE_DIGEST


### PR DESCRIPTION
If empty, then the pod will try to access the empty-string secret which results in pipeline failure.

If this non-sense value is provided, then the pipeline will proceed.

An alternative could be to make this param required instead of optional.

