### PR TITLE
fix: expose image manifest from build-vm-image task                       

### DIFF
--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -148,7 +148,7 @@ spec:
         # form the --type arguments
         IMAGE_TYPE_ARGUMENT=" --type $IMAGE_TYPE "
 
-        # this heredoc allows expansions for the image name
+        # this unquoted heredoc allows expansions for the image name
         cat >scripts/script-build.sh <<REMOTESSHEOF
         #!/bin/sh
         set -e
@@ -166,7 +166,7 @@ spec:
 
         REMOTESSHEOF
 
-        # no expansions in this one, the env vars are evaluated on the remote vm
+        # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-build.sh <<'REMOTESSHEOF'
         echo >config.toml <<EOF
         [[blueprint.customizations.user]]
@@ -203,9 +203,17 @@ spec:
         REMOTESSHEOF
 
         # script-push.sh script is intended run _inside_ podman on the ssh host and requires sudo
+        # this unquoted heredoc allows expansions for the image name
         cat >scripts/script-push.sh <<REMOTESSHEOF
         #!/bin/bash
         set -ex
+
+        export OUTPUT_IMAGE="$OUTPUT_IMAGE"
+
+        REMOTESSHEOF
+
+        # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
+        cat >>scripts/script-push.sh <<'REMOTESSHEOF'
         dnf -y install buildah pigz jq
 
         # Build an image index of length 1 referring to an image manifest with the content

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -146,7 +146,7 @@ spec:
         rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/entitlement/"
 
         # form the --type arguments
-        IMAGE_TYPES=" --type $IMAGE_TYPE "
+        IMAGE_TYPE_ARGUMENT=" --type $IMAGE_TYPE "
 
         # this heredoc allows expansions for the image name
         cat >scripts/script-build.sh <<REMOTESSHEOF
@@ -162,7 +162,7 @@ spec:
         export BOOTC_BUILDER_IMAGE="$BOOTC_BUILDER_IMAGE"
         export SOURCE_IMAGE="$SOURCE_IMAGE"
         export TAGGED_AS="$TAGGED_AS"
-        export IMAGE_TYPES="$IMAGE_TYPES"
+        export IMAGE_TYPE_ARGUMENT="$IMAGE_TYPE_ARGUMENT"
 
         REMOTESSHEOF
 
@@ -183,13 +183,13 @@ spec:
         echo "TAGGING IMAGE"
         time sudo podman tag $SOURCE_IMAGE $TAGGED_AS
         echo "RUNNING BUILD"
-        echo -e "IMAGE_TYPES = $IMAGE_TYPES"
+        echo -e "IMAGE_TYPE_ARGUMENT = $IMAGE_TYPE_ARGUMENT"
 
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
           -v $(pwd)/config.toml:/config.toml -v $(pwd)/output:/output \
           -v /var/lib/containers/storage:/var/lib/containers/storage \
           -v $BUILD_DIR/entitlement:/etc/pki/entitlement:Z \
-          $BOOTC_BUILDER_IMAGE $IMAGE_TYPES --local $TAGGED_AS
+          $BOOTC_BUILDER_IMAGE $IMAGE_TYPE_ARGUMENT --local $TAGGED_AS
 
         # This script is currently using fedora image because buildah in UBI9 does not have the OCI support (no --artifact* switches)
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -206,7 +206,9 @@ spec:
         cat >scripts/script-push.sh <<REMOTESSHEOF
         #!/bin/bash
         set -ex
-        dnf -y install buildah pigz
+        dnf -y install buildah pigz jq
+
+        # Build an image index of length 1 referring to an image manifest with the content
         buildah --storage-driver=vfs manifest create "$OUTPUT_IMAGE"
 
         # show contents of /output
@@ -226,8 +228,14 @@ spec:
           buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
         fi
         buildah --storage-driver=vfs manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE
+
+        # At this point, we have pushed an image index of length 1 to the registry.
+        # Next, extract a reference to the image manifest and expose that, throwing away the image index.
+        IMAGE_INDEX_DIGEST=$(cat image-digest)
+        MANIFEST_DIGEST=$(buildah manifest inspect --authfile /.docker/config.json $OUTPUT_IMAGE@$IMAGE_INDEX_DIGEST | jq '.manifests[0].digest')
+
         echo -n "$OUTPUT_IMAGE" | tee /tekton-results/IMAGE_URL
-        cat image-digest | tee /tekton-results/IMAGE_DIGEST
+        echo $MANIFEST_DIGEST | tee /tekton-results/IMAGE_DIGEST
         REMOTESSHEOF
 
 

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -214,7 +214,7 @@ spec:
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-push.sh <<'REMOTESSHEOF'
-        dnf -y install buildah pigz jq
+        dnf -y install buildah skopeo pigz jq
 
         # Build an image index of length 1 referring to an image manifest with the content
         buildah --storage-driver=vfs manifest create "$OUTPUT_IMAGE"
@@ -240,15 +240,19 @@ spec:
         # At this point, we have pushed an image index of length 1 to the registry.
         # Next, extract a reference to the image manifest and expose that, throwing away the image index.
         IMAGE_INDEX_DIGEST=$(cat image-digest)
-        MANIFEST_DIGEST=$(buildah manifest inspect --authfile /.docker/config.json $OUTPUT_IMAGE@$IMAGE_INDEX_DIGEST | jq '.manifests[0].digest')
+        REPO=${OUTPUT_IMAGE%:*}
+        MANIFEST_DIGEST=$(buildah manifest inspect --authfile /.docker/config.json $REPO@$IMAGE_INDEX_DIGEST | jq -r '.manifests[0].digest')
 
+        # Overwrite the image index pullspec tag with the image manifest one
+        skopeo copy --authfile /.docker/config.json docker://$REPO@$MANIFEST_DIGEST docker://$OUTPUT_IMAGE
+
+        # Finally, record all that in our results
         echo -n "$OUTPUT_IMAGE" | tee /tekton-results/IMAGE_URL
         echo $MANIFEST_DIGEST | tee /tekton-results/IMAGE_DIGEST
         REMOTESSHEOF
 
 
         # make scripts executable and sync them to the cloud VM.
-
         chmod +x scripts/script-build.sh
         chmod +x scripts/script-push.sh
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"


### PR DESCRIPTION
The way this previously worked was that each build-vm-image task would produce an image index (index1), which was later fed into a the build-image-index task to produce a second image index (index2), which (by use of the --all option) would throwaway the vm image's original index image (index1), keeping only its image manifest.

The problem this caused was that the vm image's original index image (index1) was exposed as a result, and not the image manifest. This meant that tekton chains would not see the image manifest, would not generate an attestation for it, and would not sign it.

Later, when trying to validate the aggregate index image (index2), policy checks would fail since the index image (index2) was signed, but non of the image manifests were signed.

The change here modifies things so that the build-vm-image task exposes only an image manifest, which will be attested to and signed. Its exposed pullspect will be fed to the build-image-index task, which will expose its own image index pullspec as a result to be attested to and signed. And in the end, we should have a correct situation with one image index (signed) referring to $N image manifests (also signed).