### PR TITLE
SDCICD-1337: custom task to generate an olm bundle

### DIFF
--- a/task/operator-sdk-generate-bundle/0.1/README.md
+++ b/task/operator-sdk-generate-bundle/0.1/README.md
@@ -1,0 +1,16 @@
+# operator-sdk-generate-bundle task
+
+Generate an OLM bundle using the operator-sdk
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|input-dir|Directory to read cluster-ready operator manifests from|deploy|false|
+|channels|Comma-separated list of channels the bundle belongs to|alpha|false|
+|version|Semantic version of the operator in the generated bundle||true|
+|package-name|Bundle's package name||true|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace with the source code|false|

--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: operator-sdk-generate-bundle
+spec:
+  description: Generate an OLM bundle using the operator-sdk
+  params:
+    - name: input-dir
+      description: Directory to read cluster-ready operator manifests from
+      default: deploy
+    - name: channels
+      description: Comma-separated list of channels the bundle belongs to
+      default: alpha
+    - name: version
+      description: Semantic version of the operator in the generated bundle
+    - name: package-name
+      description: Bundle's package name
+  workspaces:
+    - name: source
+      description: Workspace with the source code
+  steps:
+    - name: operator-sdk-generate-bundle
+      image: "registry.redhat.io/openshift4/ose-operator-sdk-rhel9:v4.16"
+      workingDir: $(workspaces.source.path)/source
+      args:
+        - generate
+        - bundle
+        - --overwrite
+        - --channels
+        - $(params.channels)
+        - --input-dir
+        - $(params.input-dir)
+        - --version
+        - $(params.version)
+        - --package
+        - $(params.package-name)

--- a/task/operator-sdk-generate-bundle/OWNERS
+++ b/task/operator-sdk-generate-bundle/OWNERS
@@ -1,0 +1,6 @@
+approvers:
+- jbpratt
+- gurnben
+reviewers:
+- jbpratt
+- gurnben


### PR DESCRIPTION
Add a new custom task to generate the OLM bundle from the provided input
directory. This generates the on-disk representation of an operator (a
bundle) including the CSV, CRDs, manifests, additional metadata and the
Dockerfile to be built. Once built, it can be submitted to a catalog and
deployed to a cluster.

```
$ operator-sdk generate bundle \
    --overwrite \
    --version 4.16.265-f15333d \
    --input-dir deploy/ \
    --package osd-example-operator-bundle
Generating bundle version 4.16.265-f15333d
Generating bundle manifests
Building a ClusterServiceVersion without an existing base
Bundle manifests generated successfully in bundle
Generating bundle metadata
INFO[0000] Creating bundle.Dockerfile
INFO[0000] Creating bundle/metadata/annotations.yaml
INFO[0000] Bundle metadata generated successfully
```

This is different from the traditional flow of an operator where the
bundle metadata and manifests are stored somewhere to be built from or
actively generated on new versions. SRE-P operators do not actively
version their operators or maintain an upgrade graph so this allows
dynamically generating a bundle at build time based on the current state
of the repository.

Signed-off-by: Brady Pratt <bpratt@redhat.com>

---

This new task is highly specific to the way that SRE-P builds and deploys
operators, so it may not be generally useful to others without additional
changes. I'm more than open to a better name for the task or any additional
context needed to ensure it isn't misused or leads to confusion when someone
else is onboarding a standard OLM operator.

/hold

The only things I want to make sure of are the two TODOs left. First is
ensuring this image is actually built in Konflux and can be used. Second is a
parameter to set the image based on targeted version.

https://issues.redhat.com/browse/SDCICD-1337
