### PR TITLE
Convert STORAGE_DRIVER to a buildah parameter

### DIFF
--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -33,7 +33,7 @@ spec:
   - name: STORAGE_DRIVER
     description: Storage driver to configure for buildah
     type: string
-    default: "vfs"
+    default: vfs
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -30,6 +30,10 @@ spec:
     description: Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: "vfs"
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -40,7 +44,7 @@ spec:
     - name: BUILDAH_FORMAT
       value: oci
     - name: STORAGE_DRIVER
-      value: vfs
+      value: $(params.STORAGE_DRIVER)
     - name: IMAGE
       value: $(params.IMAGE)
     - name: TLSVERIFY

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -33,7 +33,7 @@ spec:
     - name: STORAGE_DRIVER
       description: Storage driver to configure for buildah
       type: string
-      default: "vfs"
+      default: vfs
   results:
     - description: Digest of the manifest list just built
       name: IMAGE_DIGEST

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -30,6 +30,10 @@ spec:
       description: Name of secret which contains the entitlement certificates
       name: ENTITLEMENT_SECRET
       type: string
+    - name: STORAGE_DRIVER
+      description: Storage driver to configure for buildah
+      type: string
+      default: "vfs"
   results:
     - description: Digest of the manifest list just built
       name: IMAGE_DIGEST
@@ -45,6 +49,8 @@ spec:
         value: $(params.IMAGE_TYPE)
       - name: ENTITLEMENT_SECRET
         value: $(params.ENTITLEMENT_SECRET)
+      - name: STORAGE_DRIVER
+        value: $(params.STORAGE_DRIVER)
 
     volumeMounts:
       - mountPath: "/var/workdir"
@@ -163,6 +169,7 @@ spec:
         export SOURCE_IMAGE="$SOURCE_IMAGE"
         export TAGGED_AS="$TAGGED_AS"
         export IMAGE_TYPE_ARGUMENT="$IMAGE_TYPE_ARGUMENT"
+        export STORAGE_DRIVER="$STORAGE_DRIVER"
 
         REMOTESSHEOF
 
@@ -217,7 +224,7 @@ spec:
         dnf -y install buildah skopeo pigz jq
 
         # Build an image index of length 1 referring to an image manifest with the content
-        buildah --storage-driver=vfs manifest create "$OUTPUT_IMAGE"
+        buildah manifest create "$OUTPUT_IMAGE"
 
         # show contents of /output
         ls -alR /output
@@ -225,17 +232,17 @@ spec:
         if [ -f "/output/qcow2/disk.qcow2" ]; then
           echo -e "Found qcow2 image."
           # don't zip qcow2 images, it is already compressed.
-          buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2
         elif [ -f "/output/image/disk.raw" ]; then
           echo -e "Found raw image."
           pigz /output/image/disk.raw
-          buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
         elif [ -f "/output/bootiso/install.iso" ]; then
           echo -e "Found iso image."
           pigz /output/bootiso/install.iso
-          buildah --storage-driver=vfs manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
         fi
-        buildah --storage-driver=vfs manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE
+        buildah manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE
 
         # At this point, we have pushed an image index of length 1 to the registry.
         # Next, extract a reference to the image manifest and expose that, throwing away the image index.

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -24,6 +24,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -86,6 +86,10 @@ spec:
         build, as per --squash
       type: string
       default: "false"
+    - name: STORAGE_DRIVER
+      description: Storage driver to configure for buildah
+      type: string
+      default: "vfs"
     - name: TARGET_STAGE
       description: Target stage in Dockerfile to build. If not specified,
         the Dockerfile is processed entirely to (and including) its last stage.
@@ -177,7 +181,7 @@ spec:
       - name: SQUASH
         value: $(params.SQUASH)
       - name: STORAGE_DRIVER
-        value: vfs
+        value: $(params.STORAGE_DRIVER)
       - name: TARGET_STAGE
         value: $(params.TARGET_STAGE)
       - name: TLSVERIFY

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -89,7 +89,7 @@ spec:
     - name: STORAGE_DRIVER
       description: Storage driver to configure for buildah
       type: string
-      default: "vfs"
+      default: vfs
     - name: TARGET_STAGE
       description: Target stage in Dockerfile to build. If not specified,
         the Dockerfile is processed entirely to (and including) its last stage.

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -86,10 +86,10 @@ spec:
       as per --squash
     name: SQUASH
     type: string
-  - name: STORAGE_DRIVER
+  - default: vfs
     description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
     type: string
-    default: "vfs"
   - default: ""
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile
       is processed entirely to (and including) its last stage.

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -86,6 +86,10 @@ spec:
       as per --squash
     name: SQUASH
     type: string
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: "vfs"
   - default: ""
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile
       is processed entirely to (and including) its last stage.
@@ -157,7 +161,7 @@ spec:
     - name: SQUASH
       value: $(params.SQUASH)
     - name: STORAGE_DRIVER
-      value: vfs
+      value: $(params.STORAGE_DRIVER)
     - name: TARGET_STAGE
       value: $(params.TARGET_STAGE)
     - name: TLSVERIFY

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -110,10 +110,10 @@ spec:
       as per --squash
     name: SQUASH
     type: string
-  - name: STORAGE_DRIVER
+  - default: vfs
     description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
     type: string
-    default: "vfs"
   - description: The platform to build on
     name: PLATFORM
     type: string

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -110,6 +110,10 @@ spec:
       as per --squash
     name: SQUASH
     type: string
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: "vfs"
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -132,7 +136,7 @@ spec:
     - name: BUILDAH_FORMAT
       value: oci
     - name: STORAGE_DRIVER
-      value: vfs
+      value: $(params.STORAGE_DRIVER)
     - name: HERMETIC
       value: $(params.HERMETIC)
     - name: CONTEXT

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -39,7 +39,7 @@ spec:
   - name: STORAGE_DRIVER
     description: Storage driver to configure for buildah
     type: string
-    default: "vfs"
+    default: vfs
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST

--- a/task/buildah-rhtap/0.1/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.1/buildah-rhtap.yaml
@@ -36,6 +36,10 @@ spec:
     description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
     type: string
     default: ""
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: "vfs"
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -48,7 +52,7 @@ spec:
   stepTemplate:
     env:
     - name: STORAGE_DRIVER
-      value: vfs
+      value: $(params.STORAGE_DRIVER)
     - name: CONTEXT
       value: $(params.CONTEXT)
     - name: DOCKERFILE

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -102,7 +102,7 @@ spec:
   - name: STORAGE_DRIVER
     description: Storage driver to configure for buildah
     type: string
-    default: "vfs"
+    default: vfs
 
   results:
   - description: Digest of the image just built

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -99,6 +99,10 @@ spec:
     description: Squash all new and previous layers added as a part of this build, as per --squash
     type: string
     default: "false"
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: "vfs"
 
   results:
   - description: Digest of the image just built
@@ -120,7 +124,7 @@ spec:
     - name: BUILDAH_FORMAT
       value: oci
     - name: STORAGE_DRIVER
-      value: vfs
+      value: $(params.STORAGE_DRIVER)
     - name: HERMETIC
       value: $(params.HERMETIC)
     - name: CONTEXT

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -50,7 +50,7 @@ spec:
   - name: STORAGE_DRIVER
     description: Storage driver to configure for buildah
     type: string
-    default: "vfs"
+    default: vfs
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -47,6 +47,10 @@ spec:
     description: The image is built from this commit.
     type: string
     default: ""
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: "vfs"
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -64,7 +68,7 @@ spec:
     - name: BUILDAH_FORMAT
       value: oci
     - name: STORAGE_DRIVER
-      value: vfs
+      value: $(params.STORAGE_DRIVER)
     - name: PATH_CONTEXT
       value: $(params.PATH_CONTEXT)
     - name: BASE_IMAGE

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -54,7 +54,7 @@ spec:
   - name: STORAGE_DRIVER
     description: Storage driver to configure for buildah
     type: string
-    default: "vfs"
+    default: vfs
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -51,12 +51,16 @@ spec:
     description: The image is built from this commit.
     type: string
     default: ""
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: "vfs"
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
       value: oci
     - name: STORAGE_DRIVER
-      value: vfs
+      value: $(params.STORAGE_DRIVER)
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
     - name: IMAGE


### PR DESCRIPTION
Some builds on remote VMs will fail if the storage driver is not set to the default of overlay. In order to enable this customization, I am exposing it as a parameter to allow it to be set on the PipelineRun instead of trying to configure the task generation to modify this property.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
