### PR TITLE
Ensure that the empty blob exists

### DIFF
--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -128,6 +128,12 @@ spec:
         }
         EOL
 
+        echo "Ensuring that the empty blob exists, for the image manifest config."
+        echo -n "{}" | oras blob push \
+                --registry-config auth.json \
+                ${REPO}@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a \
+                --media-type application/vnd.oci.empty.v1+json --size 2 -
+
         for varfile in /var/workdir/vars/*; do
           echo "Reading $varfile"
           source $varfile


### PR DESCRIPTION
Technically, we could first check that it exists with oras blob fetch, and then only push it if it doesn't exist - but it is so small and oras checks anyways before pushing. Just do it in one command for simplicity's sake.
