### PR TITLE
buildah: add 'cachi2.env' after any mount options to RUN

### DIFF
--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -326,7 +326,12 @@ spec:
           cp -r "/var/workdir/cachi2" /tmp/
           chmod -R go+rwX /tmp/cachi2
           VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-          sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+          # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+          # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+          sed -E -i \
+              -e 'H;1h;$!d;x' \
+              -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+              "$dockerfile_path"
           echo "Prefetched content will be made available"
 
           prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -320,7 +320,12 @@ spec:
           cp -r "/var/workdir/cachi2" /tmp/
           chmod -R go+rwX /tmp/cachi2
           VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-          sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+          # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+          # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+          sed -E -i \
+              -e 'H;1h;$!d;x' \
+              -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+              "$dockerfile_path"
           echo "Prefetched content will be made available"
 
           prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -338,7 +338,12 @@ spec:
         cp -r "/var/workdir/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
         echo "Prefetched content will be made available"
 
         prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -332,7 +332,12 @@ spec:
         cp -r "/var/workdir/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
         echo "Prefetched content will be made available"
 
         prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -330,7 +330,12 @@ spec:
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
         echo "Prefetched content will be made available"
 
         prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -314,7 +314,12 @@ spec:
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
         echo "Prefetched content will be made available"
 
         prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -273,7 +273,12 @@ spec:
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
         echo "Prefetched content will be made available"
 
         prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -257,7 +257,12 @@ spec:
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
         VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
-        sed -i 's|^\s*run |RUN . /cachi2/cachi2.env \&\& \\\n    |i' "$dockerfile_path"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
         echo "Prefetched content will be made available"
 
         prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"


### PR DESCRIPTION
If you have a Dockerfile like:

```
RUN --mount=type=bind,from=somedir,to=/mnt/somewhere \
   do-something /mnt/somewhere
```
then that will get mangled for a prefetch enabled build to:

```
RUN . /cachi2/cachi2.env && --mount=type=bind,from=somedir,to=/mnt/somewhere \
   do-something /mnt/somewhere
```

Which is of course invalid. This patch uses a more complicated sed invocation to add the cache2.env after any leading options, and handling line continuations.