### PR TITLE
Comment out how template-build is intended to be processed

### DIFF
--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -1,3 +1,6 @@
+# This build pipeline template is intended to be processed by scripts
+# under hack/ directory rather than by kustomize directly.
+
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
@@ -64,6 +67,7 @@ spec:
           value: "$(params.skip-checks)"
       taskRef:
         name: init
+        # A pointer for referencing the correct version of task in the built bundle.
         version: "0.2"
     - name: clone-repository
       when:

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -67,7 +67,7 @@ spec:
           value: "$(params.skip-checks)"
       taskRef:
         name: init
-        # A pointer for referencing the correct version of task in the built bundle.
+        # A pointer for referencing the correct version of task in the built pipeline bundles.
         version: "0.2"
     - name: clone-repository
       when:


### PR DESCRIPTION
Someone may be confused when processing the build pipeline template YAML by kustomize directly and does not easily know what is the purpose of having fields, e.g. version, that are not valid field of tekton taskRef.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
