### PR TITLE
renovate: run go mod tidy

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -74,5 +74,8 @@
       "enabled": false,
       "groupName": "ignore"
     }
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
We have a bunch of Go linters enabled, one of them checks that go.mod and go.sum are tidy. Renovate updates for Go modules fail this check almost every time. Try to fix the situation by making Renovate run go mod tidy.

https://docs.renovatebot.com/configuration-options/#postupdateoptions

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
