### PR TITLE
buildah: Handle missing components property in syft-generated SBOM

### DIFF
--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -437,7 +437,7 @@ spec:
         def get_identifier(component):
           return component["name"] + '@' + component.get("version", "")
 
-        image_sbom_components = image_sbom.get("components", [])
+        image_sbom_components = image_sbom.setdefault("components", [])
         existing_components = [get_identifier(component) for component in image_sbom_components]
 
         source_sbom_components = source_sbom.get("components", [])

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -506,7 +506,7 @@ spec:
       def get_identifier(component):
         return component["name"] + '@' + component.get("version", "")
 
-      image_sbom_components = image_sbom.get("components", [])
+      image_sbom_components = image_sbom.setdefault("components", [])
       existing_components = [get_identifier(component) for component in image_sbom_components]
 
       source_sbom_components = source_sbom.get("components", [])

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -499,7 +499,7 @@ spec:
       def get_identifier(component):
         return component["name"] + '@' + component.get("version", "")
 
-      image_sbom_components = image_sbom.get("components", [])
+      image_sbom_components = image_sbom.setdefault("components", [])
       existing_components = [get_identifier(component) for component in image_sbom_components]
 
       source_sbom_components = source_sbom.get("components", [])

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -400,7 +400,7 @@ spec:
       def get_identifier(component):
         return component["name"] + '@' + component.get("version", "")
 
-      image_sbom_components = image_sbom.get("components", [])
+      image_sbom_components = image_sbom.setdefault("components", [])
       existing_components = [get_identifier(component) for component in image_sbom_components]
 
       source_sbom_components = source_sbom.get("components", [])


### PR DESCRIPTION
When the Syft SBOM didn't have the components property, the output was generated incorrectly because - the default empty list needed to be added back to image_sbom.
