### PR TITLE
Tag bundles after acceptable bundles list pushed

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -125,6 +125,8 @@ spec:
                 value: "$(params.revision)"
               - name: GIT_URL
                 value: "$(params.git-url)"
+              - name: OUTPUT_TASK_BUNDLE_LIST
+                value: $(workspaces.source.path)/full-bundle-list
               script: |
                 #!/bin/bash
                 set -euo pipefail
@@ -138,7 +140,7 @@ spec:
                   [[ -f "$f" ]] && list+=("$f")
                 done
 
-                .tekton/scripts/build-acceptable-bundles.sh "${list[@]}"
+                hack/build-acceptable-bundles.sh "${list[@]}"
 
                 echo -n "${DATA_BUNDLE_TAG}" > acceptable_bundle_tag
               args:
@@ -168,6 +170,14 @@ spec:
                 - mountPath: /root/.docker/config.json
                   subPath: .dockerconfigjson
                   name: quay-secret
+            - name: tag-bundles-konflux-ci
+              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              workingDir: $(workspaces.source.path)/source
+              command: ["./hack/push-and-tag.sh"]
+              env:
+              - name: OUTPUT_TASK_BUNDLE_LIST
+                value: $(workspaces.source.path)/full-bundle-list
+
           volumes:
           - name: quay-secret
             secret:

--- a/hack/push-and-tag.sh
+++ b/hack/push-and-tag.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# File containing the list of images
+OUTPUT_TASK_BUNDLE_LIST="${OUTPUT_TASK_BUNDLE_LIST-${SCRIPTDIR}/../task-bundle-list}"
+
+# Read the file and process each line
+while IFS=, read -r original_image new_image; do
+    # Remove the quotes from the strings
+    original_image=$(echo "$original_image" | tr -d '"' | xargs)
+    new_image=$(echo "$new_image" | tr -d '"' | xargs)
+
+    # Run the skopeo copy command
+    echo "Copying from $original_image to $new_image"
+    skopeo copy "docker://$original_image" "docker://$new_image"
+  
+done < "$OUTPUT_TASK_BUNDLE_LIST"

--- a/spec/hack/bundles_spec.sh
+++ b/spec/hack/bundles_spec.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+# this spec file tests creating Tekton bundles and the acceptable bundles list
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+eval "$(shellspec - -c) exit 1"
+
+check_tkn_push_url() {
+  while read -r line; do
+    if [[ "$line" == quay.io/* ]] && [[ ! "$line" =~ ^quay\.io/[a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+:[0-9a-zA-Z\.-]+@sha256:[a-fA-F0-9]+$ ]]; then
+      return 1
+    fi
+  done
+}
+
+create_test_tasks() {
+    mkdir -p tmp/task1/0.1
+    mkdir -p tmp/task2/0.1
+    touch tmp/task1/0.1/task1.yaml
+    touch tmp/task2/0.1/task2.yaml
+}
+
+cleanup_test_data() {
+    rm -rf tmp
+    rm -f test-task-bundle-list
+    rm -f test-task-bundle-list.csv
+}
+
+Describe "Creating new acceptable bundles"
+    AfterAll 'cleanup_test_data'
+
+    Mock skopeo
+      # Make the skopeo inspect command fail
+      if [ "$1" = "inspect" ]; then
+        return 1
+      fi
+    End
+
+    Mock tkn
+      echo "${5}@sha256:5678"
+    End
+
+    Mock sha256sum
+      echo "1234"
+    End
+
+    Mock ec
+    End
+
+    Mock find
+        echo "tmp/task1/0.1/\ntmp/task2/0.1/"
+    End
+
+    It "builds bundles with the correct sha as the tag"
+        create_test_tasks
+        Mock git
+            echo "1234"
+        End
+        export OUTPUT_TASK_BUNDLE_LIST=test-task-bundle-list
+        export QUAY_NAMESPACE=konflux-ci
+        export SKIP_BUILD=true
+
+        When call "hack/build-and-push.sh"
+        The status should be success
+        # each task and pipeline bundle ends with file checksum @ digest
+        The output should satisfy check_tkn_push_url
+    End
+
+    It 'processes the bundles and generates the correct output file'
+        # this is only used for the task_records var which is unused in this test
+        Mock git
+            echo "task/task1/task1.yaml\ntask/task2/task2.yaml"
+        End
+
+        export OUTPUT_TASK_BUNDLE_LIST="test-task-bundle-list.csv"
+        export GIT_URL="https://my-url/org/repo"
+        export REVISION="abcd1234"
+        export DATA_BUNDLE_REPO="quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles"
+
+        When call hack/build-acceptable-bundles.sh "test-task-bundle-list"
+        The status should be success
+        The path test-task-bundle-list.csv should be file
+        The contents of file "test-task-bundle-list.csv" should equal "quay.io/konflux-ci/task-task1:0.1-1234@sha256:5678,quay.io/konflux-ci/task-task1:0.1
+quay.io/konflux-ci/task-task2:0.1-1234@sha256:5678,quay.io/konflux-ci/task-task2:0.1"
+        The stdout should include "Bundles to be added:"
+        The stdout should include "quay.io/konflux-ci/task-task1:0.1"
+        The stdout should include "quay.io/konflux-ci/task-task2:0.1"
+    End
+
+    It "copies to the right image locations"
+        export OUTPUT_TASK_BUNDLE_LIST="test-task-bundle-list.csv"
+        When call "hack/push-and-tag.sh"
+        The status should be success
+        The output should include "Copying from quay.io/konflux-ci/task-task1:0.1-1234@sha256:5678 to quay.io/konflux-ci/task-task1:0.1"
+        The output should include "Copying from quay.io/konflux-ci/task-task2:0.1-1234@sha256:5678 to quay.io/konflux-ci/task-task2:0.1"
+    End
+End


### PR DESCRIPTION
This change addresses the issue where the acceptable bundles list does not contain new bundle updates. The issue is addressed by tagging new bundles after the acceptable bundle list is pushed. This will ensure renovate  does not trigger until after the acceptable bundles list has been updated.
    
 https://issues.redhat.com/browse/EC-627