### PR TITLE
source-build-oci-ta: fix non-existent filepath

### DIFF
--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -45,7 +45,7 @@ spec:
   stepTemplate:
     env:
       - name: BASE_IMAGES_FILE
-        value: /var/source-build/base-images.txt
+        value: /var/workdir/base-images.txt
       - name: BINARY_IMAGE
         value: $(params.BINARY_IMAGE)
     volumeMounts:


### PR DESCRIPTION
The oci-ta variant of the task doesn't have the /var/source-build volume
mount

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
