### PR TITLE
Support cachi2 config passing in prefetch-dependencies

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.1/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.1/README.md
@@ -11,6 +11,7 @@ https://github.com/containerbuildsystem/cachi2#basic-usage.
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
 |dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
 |input|Configures project packages that will have their dependencies prefetched.||true|
 |log-level|Set cachi2 log level (debug, info, warning, error)|info|false|

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -28,6 +28,11 @@ spec:
       description: The name of the ConfigMap to read CA bundle data from.
       type: string
       default: trusted-ca
+    - name: config-file-content
+      description: |
+        Pass configuration to cachi2.
+        Note this needs to be passed as a YAML-formatted config dump, not as a file path!
+      default: ""
     - name: dev-package-managers
       description: |
         Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk.
@@ -56,6 +61,8 @@ spec:
         the application source code.
       type: string
   volumes:
+    - name: config
+      emptyDir: {}
     - name: trusted-ca
       configMap:
         items:
@@ -79,7 +86,12 @@ spec:
         performing http(s) requests.
       optional: true
   stepTemplate:
+    env:
+      - name: CONFIG_FILE_CONTENT
+        value: $(params.config-file-content)
     volumeMounts:
+      - mountPath: /mnt/config
+        name: config
       - mountPath: /var/workdir
         name: workdir
   steps:
@@ -104,6 +116,15 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: sanitize-cachi2-config-file-with-yq
+      image: quay.io/konflux-ci/yq@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
+      script: |
+        if [ -n "${CONFIG_FILE_CONTENT}" ]; then
+          # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM
+          # impact of this configuration option will be:
+          # https://github.com/containerbuildsystem/cachi2/issues/577
+          yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}"  >/mnt/config/config.yaml
+        fi
     - name: prefetch-dependencies
       image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
       volumeMounts:
@@ -130,6 +151,12 @@ spec:
           # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
           echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
           exit 0
+        fi
+
+        if [ -f /mnt/config/config.yaml ]; then
+          config_flag=--config-file=/mnt/config/config.yaml
+        else
+          config_flag=""
         fi
 
         if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
@@ -167,7 +194,7 @@ spec:
           update-ca-trust
         fi
 
-        cachi2 --log-level="$LOG_LEVEL" fetch-deps \
+        cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
           $dev_pacman_flag \
           --source=/var/workdir/source \
           --output=/var/workdir/cachi2/output \

--- a/task/prefetch-dependencies/0.1/README.md
+++ b/task/prefetch-dependencies/0.1/README.md
@@ -9,6 +9,7 @@ See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
 |input|Configures project packages that will have their dependencies prefetched.||true|
 |dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
 |log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
+|config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -22,6 +22,11 @@ spec:
   - description: Set cachi2 log level (debug, info, warning, error)
     name: log-level
     default: "info"
+  - description: |
+      Pass configuration to cachi2.
+      Note this needs to be passed as a YAML-formatted config dump, not as a file path!
+    name: config-file-content
+    default: ""
   - name: caTrustConfigMapName
     type: string
     description: The name of the ConfigMap to read CA bundle data from.
@@ -30,7 +35,27 @@ spec:
     type: string
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
+
+  stepTemplate:
+    env:
+      - name: CONFIG_FILE_CONTENT
+        value: $(params.config-file-content)
+    volumeMounts:
+      - name: config
+        mountPath: /mnt/config
+
   steps:
+  - name: sanitize-cachi2-config-file-with-yq
+    image: quay.io/konflux-ci/yq@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
+    script: |
+      if [ -n "${CONFIG_FILE_CONTENT}" ]
+      then
+        # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM
+        # impact of this configuration option will be:
+        # https://github.com/containerbuildsystem/cachi2/issues/577
+        yq 'del(.goproxy_url)' <<< "${CONFIG_FILE_CONTENT}" > /mnt/config/config.yaml
+      fi
+
   - image: quay.io/redhat-appstudio/cachi2:0.8.0@sha256:5cf15d6f3fb151a3e12c8a17024062b7cc62b0c3e1b165e4a9fa5bf7a77bdc30
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
@@ -60,6 +85,12 @@ spec:
         # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
         echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
         exit 0
+      fi
+
+      if [ -f /mnt/config/config.yaml ]; then
+        config_flag=--config-file=/mnt/config/config.yaml
+      else
+        config_flag=""
       fi
 
       if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
@@ -97,7 +128,7 @@ spec:
         update-ca-trust
       fi
 
-      cachi2 --log-level="$LOG_LEVEL" fetch-deps \
+      cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
       $dev_pacman_flag \
       --source=$(workspaces.source.path)/source \
       --output=$(workspaces.source.path)/cachi2/output \
@@ -133,3 +164,5 @@ spec:
           - key: $(params.caTrustConfigMapKey)
             path: ca-bundle.crt
         optional: true
+    - name: config
+      emptyDir: {}


### PR DESCRIPTION
Allow consumers to pass a cachi2 config to the tool in the prefetch task.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
