### PR TITLE
add support for subscription activation keys to trusted artifacts

### DIFF
--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -16,6 +16,10 @@ package main
 import (
 	"bytes"
 	"flag"
+	"os"
+	"path/filepath"
+	"strings"
+
 	tektonapi "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -23,10 +27,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/cli-runtime/pkg/printers"
 	klog "k8s.io/klog/v2"
-	"os"
-	"path/filepath"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"strings"
 )
 
 func main() {
@@ -127,6 +128,10 @@ fi
 `
 
 		env := "$PODMAN_PORT_FORWARD \\\n"
+
+		// disable podman subscription-manager integration
+		env += " --tmpfs /run/secrets \\\n"
+
 		// Before the build we sync the contents of the workspace to the remote host
 		for _, workspace := range task.Spec.Workspaces {
 			ret += "\nrsync -ra $(workspaces." + workspace.Name + ".path)/ \"$SSH_HOST:$BUILD_DIR/workspaces/" + workspace.Name + "/\""

--- a/task/buildah-oci-ta/0.1/README.md
+++ b/task/buildah-oci-ta/0.1/README.md
@@ -8,6 +8,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -59,10 +59,6 @@ spec:
       description: Name of secret which contains the entitlement certificates
       type: string
       default: etc-pki-entitlement
-    - name: ACTIVATION_KEY
-      default: activation-key
-      description: Name of secret which contains subscription activation key
-      type: string
     - name: HERMETIC
       description: Determines if build will be executed without network access.
       type: string
@@ -152,10 +148,7 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
-    - name: activation-key
-      secret:
-        optional: true
-        secretName: $(params.ACTIVATION_KEY)
+
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -185,8 +178,6 @@ spec:
         value: $(params.DOCKERFILE)
       - name: ENTITLEMENT_SECRET
         value: $(params.ENTITLEMENT_SECRET)
-      - name: ACTIVATION_KEY
-        value: $(params.ACTIVATION_KEY)
       - name: HERMETIC
         value: $(params.HERMETIC)
       - name: IMAGE
@@ -231,8 +222,6 @@ spec:
           name: varlibcontainers
         - mountPath: /entitlement
           name: etc-pki-entitlement
-        - mountPath: /activation-key
-          name: activation-key
         - mountPath: /additional-secret
           name: additional-secret
         - mountPath: /mnt/trusted-ca
@@ -363,13 +352,6 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"
-        fi
-
-        ACTIVATION_KEY_PATH="/activation-key"
-         if [ -d "$ACTIVATION_KEY_PATH" ]; then
-          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-          echo "Adding activation key to the build"
         fi
 
         ADDITIONAL_SECRET_PATH="/additional-secret"

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -59,6 +59,10 @@ spec:
       description: Name of secret which contains the entitlement certificates
       type: string
       default: etc-pki-entitlement
+    - name: ACTIVATION_KEY
+      default: activation-key
+      description: Name of secret which contains subscription activation key
+      type: string
     - name: HERMETIC
       description: Determines if build will be executed without network access.
       type: string
@@ -148,6 +152,10 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
+    - name: activation-key
+      secret:
+        optional: true
+        secretName: $(params.ACTIVATION_KEY)
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -177,6 +185,8 @@ spec:
         value: $(params.DOCKERFILE)
       - name: ENTITLEMENT_SECRET
         value: $(params.ENTITLEMENT_SECRET)
+      - name: ACTIVATION_KEY
+        value: $(params.ACTIVATION_KEY)
       - name: HERMETIC
         value: $(params.HERMETIC)
       - name: IMAGE
@@ -221,6 +231,8 @@ spec:
           name: varlibcontainers
         - mountPath: /entitlement
           name: etc-pki-entitlement
+        - mountPath: /activation-key
+          name: activation-key
         - mountPath: /additional-secret
           name: additional-secret
         - mountPath: /mnt/trusted-ca
@@ -351,6 +363,13 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"
+        fi
+
+        ACTIVATION_KEY_PATH="/activation-key"
+         if [ -d "$ACTIVATION_KEY_PATH" ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
+          echo "Adding activation key to the build"
         fi
 
         ADDITIONAL_SECRET_PATH="/additional-secret"

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -16,6 +16,10 @@ spec:
     When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
     When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
+    - name: ACTIVATION_KEY
+      description: Name of secret which contains subscription activation key
+      type: string
+      default: activation-key
     - name: ADDITIONAL_SECRET
       description: Name of a secret which will be made available to the build
         with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
@@ -140,6 +144,10 @@ spec:
       description: The counting of Java components by publisher in JSON format
       type: string
   volumes:
+    - name: activation-key
+      secret:
+        optional: true
+        secretName: $(params.ACTIVATION_KEY)
     - name: additional-secret
       secret:
         optional: true
@@ -148,7 +156,6 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
-
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -164,6 +171,8 @@ spec:
       emptyDir: {}
   stepTemplate:
     env:
+      - name: ACTIVATION_KEY
+        value: $(params.ACTIVATION_KEY)
       - name: ADDITIONAL_SECRET
         value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
@@ -222,6 +231,8 @@ spec:
           name: varlibcontainers
         - mountPath: /entitlement
           name: etc-pki-entitlement
+        - mountPath: /activation-key
+          name: activation-key
         - mountPath: /additional-secret
           name: additional-secret
         - mountPath: /mnt/trusted-ca
@@ -352,6 +363,13 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"
+        fi
+
+        ACTIVATION_KEY_PATH="/activation-key"
+           if [ -d "$ACTIVATION_KEY_PATH" ]; then
+            cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+            VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
+            echo "Adding activation key to the build"
         fi
 
         ADDITIONAL_SECRET_PATH="/additional-secret"

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -59,6 +59,10 @@ spec:
     description: Name of secret which contains the entitlement certificates
     name: ENTITLEMENT_SECRET
     type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
   - default: "false"
     description: Determines if build will be executed without network access.
     name: HERMETIC
@@ -157,6 +161,8 @@ spec:
       value: $(params.DOCKERFILE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
     - name: HERMETIC
       value: $(params.HERMETIC)
     - name: IMAGE
@@ -238,6 +244,7 @@ spec:
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+      rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
       rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
@@ -370,6 +377,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      ACTIVATION_KEY_PATH="/activation-key"
+       if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
+        echo "Adding activation key to the build"
+      fi
+
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
@@ -413,6 +427,7 @@ spec:
       chmod +x scripts/script-build.sh
       rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+       --tmpfs /run/secrets \
        -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
@@ -420,6 +435,7 @@ spec:
        -e CONTEXT="$CONTEXT" \
        -e DOCKERFILE="$DOCKERFILE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+       -e ACTIVATION_KEY="$ACTIVATION_KEY" \
        -e HERMETIC="$HERMETIC" \
        -e IMAGE="$IMAGE" \
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
@@ -435,6 +451,7 @@ spec:
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+       -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
        -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
@@ -459,6 +476,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
     - mountPath: /additional-secret
       name: additional-secret
     - mountPath: /mnt/trusted-ca
@@ -644,6 +663,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: false
+      secretName: $(params.ACTIVATION_KEY)
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -16,6 +16,10 @@ spec:
     When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
     When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
   - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
       build --secret' at /run/secrets/$ADDITIONAL_SECRET
@@ -58,10 +62,6 @@ spec:
   - default: etc-pki-entitlement
     description: Name of secret which contains the entitlement certificates
     name: ENTITLEMENT_SECRET
-    type: string
-  - default: activation-key
-    description: Name of secret which contains subscription activation key
-    name: ACTIVATION_KEY
     type: string
   - default: "false"
     description: Determines if build will be executed without network access.
@@ -147,6 +147,8 @@ spec:
   stepTemplate:
     computeResources: {}
     env:
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
     - name: ADDITIONAL_SECRET
       value: $(params.ADDITIONAL_SECRET)
     - name: ADD_CAPABILITIES
@@ -161,8 +163,6 @@ spec:
       value: $(params.DOCKERFILE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
-    - name: ACTIVATION_KEY
-      value: $(params.ACTIVATION_KEY)
     - name: HERMETIC
       value: $(params.HERMETIC)
     - name: IMAGE
@@ -378,10 +378,10 @@ spec:
       fi
 
       ACTIVATION_KEY_PATH="/activation-key"
-       if [ -d "$ACTIVATION_KEY_PATH" ]; then
-        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-        echo "Adding activation key to the build"
+         if [ -d "$ACTIVATION_KEY_PATH" ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
+          echo "Adding activation key to the build"
       fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
@@ -428,6 +428,7 @@ spec:
       rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
        --tmpfs /run/secrets \
+       -e ACTIVATION_KEY="$ACTIVATION_KEY" \
        -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
@@ -435,7 +436,6 @@ spec:
        -e CONTEXT="$CONTEXT" \
        -e DOCKERFILE="$DOCKERFILE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-       -e ACTIVATION_KEY="$ACTIVATION_KEY" \
        -e HERMETIC="$HERMETIC" \
        -e IMAGE="$IMAGE" \
        -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
@@ -655,6 +655,10 @@ spec:
     name: upload-sbom
     workingDir: /var/workdir
   volumes:
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
   - name: additional-secret
     secret:
       optional: true
@@ -663,10 +667,6 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
-  - name: activation-key
-    secret:
-      optional: false
-      secretName: $(params.ACTIVATION_KEY)
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -78,6 +78,10 @@ spec:
     description: Name of secret which contains the entitlement certificates
     name: ENTITLEMENT_SECRET
     type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
   - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
       build --secret' at /run/secrets/$ADDITIONAL_SECRET
@@ -166,6 +170,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
     - name: ADDITIONAL_SECRET
       value: $(params.ADDITIONAL_SECRET)
     - name: BUILD_ARGS_FILE
@@ -226,6 +232,7 @@ spec:
       rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+      rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
       rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
       rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
       rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
@@ -362,6 +369,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      ACTIVATION_KEY_PATH="/activation-key"
+         if [ -d "$ACTIVATION_KEY_PATH" ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
+          echo "Adding activation key to the build"
+        fi
+
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
@@ -420,6 +434,7 @@ spec:
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+       -e ACTIVATION_KEY="$ACTIVATION_KEY" \
        -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
@@ -429,6 +444,7 @@ spec:
        -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
        -v "$BUILD_DIR/volumes/shared:/shared:Z" \
        -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+       -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
        -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
        -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
        -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
@@ -453,6 +469,8 @@ spec:
       name: varlibcontainers
     - mountPath: /entitlement
       name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
     - mountPath: /additional-secret
       name: additional-secret
     - mountPath: /mnt/trusted-ca
@@ -642,6 +660,10 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
   - name: additional-secret
     secret:
       optional: true

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -405,6 +405,7 @@ spec:
       chmod +x scripts/script-build.sh
       rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+       --tmpfs /run/secrets \
        -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
        -e STORAGE_DRIVER="$STORAGE_DRIVER" \
        -e HERMETIC="$HERMETIC" \

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -71,6 +71,10 @@ spec:
     description: Name of secret which contains the entitlement certificates
     type: string
     default: "etc-pki-entitlement"
+  - name: ACTIVATION_KEY
+    default: activation-key
+    description: Name of secret which contains subscription activation key
+    type: string
   - name: ADDITIONAL_SECRET
     description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
     type: string
@@ -153,6 +157,8 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
     - name: ADDITIONAL_SECRET
       value: $(params.ADDITIONAL_SECRET)
     - name: BUILD_ARGS_FILE
@@ -306,6 +312,13 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      ACTIVATION_KEY_PATH="/activation-key"
+         if [ -d "$ACTIVATION_KEY_PATH" ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
+          echo "Adding activation key to the build"
+        fi
+
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
@@ -353,6 +366,8 @@ spec:
       name: varlibcontainers
     - mountPath: "/entitlement"
       name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
     - mountPath: "/additional-secret"
       name: additional-secret
     - name: trusted-ca
@@ -543,6 +558,10 @@ spec:
     secret:
       secretName: $(params.ENTITLEMENT_SECRET)
       optional: true
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
   - name: additional-secret
     secret:
       secretName: $(params.ADDITIONAL_SECRET)


### PR DESCRIPTION
… tasks, including buildah-remoate-oci-ta. It also disables podman subscription-manager integration on all remote builders so that subscription-manager commands can be used to configure which repos are enabled.  

i had recently had a couple interactions with people smart about subscription mgmt and they all said that using certs the way we are is wrong and eventually will lead to random build failures due to revoked certs. Activation keys solves that problems, and it solves the problem that Camilla was having in this thread, so I just went ahead and did it.

ref slack thread https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1721226430548109

