### PR TITLE
rpm-ostree: drop BASE_IMAGES_DIGESTS result

### DIFF
--- a/task/rpm-ostree/0.2/MIGRATION.md
+++ b/task/rpm-ostree/0.2/MIGRATION.md
@@ -1,0 +1,43 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+* Removes the `BASE_IMAGES_DIGESTS` result. Please remove all the references to this
+  result from your pipeline.
+  * Note that the result never provided any value. It did not contain base image
+    digests, it contained a local-only reference for the **output** image
+    (`localhost/rhtap-final-image@sha256:...`). The task returns a usable reference
+    for the output image as well (`IMAGE_URL` + `IMAGE_DIGEST`).
+
+## Konflux-specific
+
+In a typical Konflux pipeline, the two tasks that used to depend on the `BASE_IMAGES_DIGESTS`
+result are `build-source-image` and `deprecated-base-image-check`.
+
+1. Make sure your version of `deprecated-base-image-check` is at least `0.4`.
+2. Remove the parameters that reference the `BASE_IMAGES_DIGESTS` result:
+
+```diff
+@@ -255,10 +255,8 @@ spec:
+     - name: build-source-image
+       params:
+       - name: BINARY_IMAGE
+         value: $(params.output-image)
+-      - name: BASE_IMAGES
+-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+       runAfter:
+       - build-container
+       taskRef:
+         params:
+@@ -282,10 +280,8 @@ spec:
+       - name: workspace
+         workspace: workspace
+     - name: deprecated-base-image-check
+       params:
+-      - name: BASE_IMAGES_DIGESTS
+-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
+       - name: IMAGE_URL
+         value: $(tasks.build-container.results.IMAGE_URL)
+       - name: IMAGE_DIGEST
+         value: $(tasks.build-container.results.IMAGE_DIGEST)
+```

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -62,8 +62,6 @@ spec:
     name: IMAGE_URL
   - description: Image reference of the built image
     name: IMAGE_REF
-  - description: Digests of the base images used for build
-    name: BASE_IMAGES_DIGESTS
   - name: SBOM_BLOB_URL
     description: Reference, including digest to the SBOM blob
   stepTemplate:
@@ -234,9 +232,6 @@ spec:
     computeResources: {}
     script: |
       #!/bin/bash
-      # Expose base image digests
-      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
-
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
       base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
       container=$(buildah from --pull-never $IMAGE)

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -1,0 +1,307 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: rpm-ostree
+    build.appstudio.redhat.com/multi-platform-required: "true"
+  name: rpm-ostree
+spec:
+  description: RPM Ostree
+  params:
+  - description: Reference of the image rpm-ostree will produce.
+    name: IMAGE
+    type: string
+  - default: quay.io/redhat-user-workloads/project-sagano-tenant/ostree-builder/ostree-builder-fedora-38:d124414a81d17f31b1d734236f55272a241703d7
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    description: The location of the rpm-ostree builder image.
+    name: BUILDER_IMAGE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - description: The file to use to build the image
+    name: IMAGE_FILE
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - description: The platform to build on
+    name: PLATFORM
+    type: string
+  - description: The relative path of the file used to configure the rpm-ostree tool found in source control.
+      See https://github.com/coreos/rpm-ostree/blob/main/docs/container.md#adding-container-image-configuration
+    name: CONFIG_FILE
+    type: string
+    default: ""
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - name: SBOM_BLOB_URL
+    description: Reference, including digest to the SBOM blob
+  stepTemplate:
+    env:
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: IMAGE_FILE
+      value: $(params.IMAGE_FILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: BUILDER_IMAGE
+      value: $(params.BUILDER_IMAGE)
+    - name: CONFIG_FILE
+      value: $(params.CONFIG_FILE)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    computeResources: {}
+  steps:
+  - env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    name: build
+    computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 250m
+        memory: 128Mi
+    script: |-
+      set -o verbose
+      set -eu
+      set -o pipefail
+      mkdir -p ~/.ssh
+      if [ -e "/ssh/error" ]; then
+        #no server could be provisioned
+        cat /ssh/error
+        exit 1
+      elif [ -e "/ssh/otp" ]; then
+       curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+       echo "" >> ~/.ssh/id_rsa
+      else
+        cp /ssh/id_rsa ~/.ssh
+      fi
+      chmod 0400 ~/.ssh/id_rsa
+      export SSH_HOST=$(cat /ssh/host)
+      export BUILD_DIR=$(cat /ssh/user-dir)
+      export SSH_ARGS="-o StrictHostKeyChecking=no"
+      mkdir -p scripts
+      echo "$BUILD_DIR"
+      ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp"
+
+      rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
+      cat >scripts/script-build.sh <<'REMOTESSHEOF'
+      #!/bin/sh
+      set -o verbose
+      cd $(workspaces.source.path)
+      if [ -z "$CONFIG_FILE" ] ; then
+        CONFIG_FILE_ARG=""
+      else
+        CONFIG_FILE_ARG="  --image-config=source/$CONFIG_FILE "
+      fi
+
+      prefetched_rpms_for_my_arch="./cachi2/output/deps/rpm/$(uname -m)"
+      if [ -d "$prefetched_rpms_for_my_arch" ]; then
+        # move all repo files out of the source repository to avoid conflicts with the cachi2.repo
+        mkdir /tmp/original-repos
+        find ./source -maxdepth 1 -name '*.repo' -exec mv {} /tmp/original-repos \;
+
+        # copy the platform-specific cachi2.repo into the source repository
+        cp "$prefetched_rpms_for_my_arch/repos.d/cachi2.repo" ./source
+
+        # set up cleanup handler
+        trap 'rm ./source/cachi2.repo; cp -r /tmp/original-repos/. ./source' EXIT
+
+        # link the cachi2 output dir to the expected location
+        #   (the prefetch task expects the output to be at /cachi2/output during the build)
+        mkdir /cachi2
+        ln -s "$(realpath ./cachi2/output)" /cachi2/output
+      fi
+
+      rpm-ostree compose image --initialize --format oci $CONFIG_FILE_ARG "source/$IMAGE_FILE" rhtap-final-image
+      REMOTESSHEOF
+
+      if [ "$HERMETIC" = "true" ]; then
+        network_opt="--network=none"
+      else
+        network_opt=""
+      fi
+
+      chmod +x scripts/script-build.sh
+      rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
+      ssh $SSH_ARGS "$SSH_HOST" \
+        podman run \
+          $network_opt \
+          --mount type=bind,source=$BUILD_DIR/tmp,target=/var/tmp,relabel=shared \
+          --privileged \
+          -e CONTEXT="$CONTEXT" \
+          -e IMAGE_FILE="$IMAGE_FILE" \
+          -e CONFIG_FILE="$CONFIG_FILE" \
+          -e IMAGE="$IMAGE" \
+          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+          -e COMMIT_SHA="$COMMIT_SHA" \
+          --rm \
+          -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
+          -v $BUILD_DIR/scripts:/script:Z \
+          --user=0 \
+          --entrypoint bash \
+          "$BUILDER_IMAGE" \
+          /script/script-build.sh
+      rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
+      cp -r rhtap-final-image /var/lib/containers/rhtap-final-image
+      buildah pull oci:rhtap-final-image
+      buildah images
+      buildah tag localhost/rhtap-final-image "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /ssh
+      name: ssh
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    name: sbom-syft-generate
+    computeResources:
+      limits:
+        memory: 6Gi
+      requests:
+        memory: 6Gi
+    # Respect Syft configuration if the user has it in the root of their repository
+    # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
+    workingDir: $(workspaces.source.path)/source
+    script: |
+      syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json=$(workspaces.source.path)/sbom-cyclonedx.json
+    volumeMounts:
+      - mountPath: /var/lib/containers
+        name: varlibcontainers
+  - name: merge-cachi2-sbom
+    image: quay.io/redhat-appstudio/cachi2:0.9.1@sha256:df67f9e063b544a8c49a271359377fed560562615e0278f6d0b9a3485f3f8fad
+    script: |
+      cachi2_sbom=./cachi2/output/bom.json
+      if [ -f "$cachi2_sbom" ]; then
+        echo "Merging contents of $cachi2_sbom into sbom-cyclonedx.json"
+        merge_syft_sbom "$cachi2_sbom" sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 0
+  - image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    name: inject-sbom-and-push
+    computeResources: {}
+    script: |
+      #!/bin/bash
+      # Expose base image digests
+      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
+
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
+      container=$(buildah from --pull-never $IMAGE)
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
+      buildah commit $container $IMAGE
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing sbom image to registry"
+        buildah push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push sbom image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } >"$(results.IMAGE_REF.path)"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee $(results.SBOM_BLOB_URL.path)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - args:
+    - attach
+    - sbom
+    - --sbom
+    - sbom-cyclonedx.json
+    - --type
+    - cyclonedx
+    - $(params.IMAGE)
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    name: upload-sbom
+    computeResources: {}
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - name: ssh
+    secret:
+      optional: false
+      secretName: multi-platform-ssh-$(context.taskRun.name)
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source


### PR DESCRIPTION
[STONEBLD-2326](https://issues.redhat.com//browse/STONEBLD-2326)

For consistency with the buildah tasks, don't return BASE_IMAGES_DIGESTS from rpm-ostree either.