### PR TITLE
Add an architecture suffix to images pushed for multi-platform if missing

### DIFF
--- a/hack/generate-buildah-remote.sh
+++ b/hack/generate-buildah-remote.sh
@@ -8,7 +8,7 @@ go build -o /tmp/remote-generator ./remote/main.go
 
 for version in 0.1 0.2; do
     /tmp/remote-generator --buildah-task="${SCRIPTDIR}/../task/buildah/${version}/buildah.yaml" \
-        --remote-task="${SCRIPTDIR}/../task/buildah-remote/${version}/buildah-remote.yaml"
+        --remote-task="${SCRIPTDIR}/../task/buildah-remote/${version}/buildah-remote.yaml" --task-version="$version"
     /tmp/remote-generator --buildah-task="${SCRIPTDIR}/../task/buildah-oci-ta/${version}/buildah-oci-ta.yaml" \
-        --remote-task="${SCRIPTDIR}/../task/buildah-remote-oci-ta/${version}/buildah-remote-oci-ta.yaml"
+        --remote-task="${SCRIPTDIR}/../task/buildah-remote-oci-ta/${version}/buildah-remote-oci-ta.yaml" --task-version="$version"
 done

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -242,6 +242,8 @@ spec:
         - name: COMMIT_SHA
           value: $(params.COMMIT_SHA)
       script: |
+        #!/bin/bash
+        set -e
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
         if [ -f "$ca_bundle" ]; then
           echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -598,18 +600,18 @@ spec:
             - SETFCAP
         runAsUser: 0
     - name: upload-sbom
-      image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-      args:
-        - attach
-        - sbom
-        - --sbom
-        - sbom-cyclonedx.json
-        - --type
-        - cyclonedx
-        - $(params.IMAGE)
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       workingDir: /var/workdir
       volumeMounts:
-        - mountPath: /etc/ssl/certs/ca-bundle.crt
+        - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
-          subPath: ca-bundle.crt
+      script: |
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -214,6 +214,8 @@ spec:
     image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
     name: build
     script: |-
+      #!/bin/bash
+      set -e
       set -o verbose
       mkdir -p ~/.ssh
       if [ -e "/ssh/error" ]; then

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -187,6 +187,8 @@ spec:
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+    - name: PLATFORM
+      value: $(params.PLATFORM)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -214,6 +216,8 @@ spec:
     image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
     name: build
     script: |-
+      #!/bin/bash
+      set -e
       set -o verbose
       mkdir -p ~/.ssh
       if [ -e "/ssh/error" ]; then
@@ -240,6 +244,9 @@ spec:
       PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
       PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
       fi
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
 
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
       rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
@@ -251,7 +258,6 @@ spec:
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/bash
-      set -o verbose
       set -e
       cd /var/workdir
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
@@ -498,6 +504,11 @@ spec:
     image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
     name: sbom-syft-generate
     script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
       echo "Running syft on the source directory"
       syft dir:/var/workdir/source --output cyclonedx-json=/var/workdir/sbom-source.json
       find $(cat /shared/container_path) -xtype l -delete
@@ -513,6 +524,11 @@ spec:
     image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
     name: analyse-dependencies-java-sbom
     script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s /var/workdir/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
         sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
@@ -565,6 +581,11 @@ spec:
     image: quay.io/redhat-appstudio/cachi2:0.9.1@sha256:df67f9e063b544a8c49a271359377fed560562615e0278f6d0b9a3485f3f8fad
     name: merge-cachi2-sbom
     script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
       if [ -f "sbom-cachi2.json" ]; then
         echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
         merge_syft_sbom sbom-cachi2.json sbom-cyclonedx.json >sbom-temp.json
@@ -597,6 +618,11 @@ spec:
     image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
     name: create-base-images-sbom
     script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
       python3 /app/base_images_sbom_script.py \
         --sbom=sbom-cyclonedx.json \
         --base-images-from-dockerfile=/shared/base_images_from_dockerfile \
@@ -610,6 +636,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
@@ -672,22 +701,27 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: /var/workdir
-  - args:
-    - attach
-    - sbom
-    - --sbom
-    - sbom-cyclonedx.json
-    - --type
-    - cyclonedx
-    - $(params.IMAGE)
-    computeResources: {}
-    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+  - computeResources: {}
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     name: upload-sbom
+    script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
     volumeMounts:
-    - mountPath: /etc/ssl/certs/ca-bundle.crt
+    - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
-      subPath: ca-bundle.crt
     workingDir: /var/workdir
   volumes:
   - name: activation-key

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -202,6 +202,8 @@ spec:
     image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
     name: build
     script: |-
+      #!/bin/bash
+      set -e
       set -o verbose
       mkdir -p ~/.ssh
       if [ -e "/ssh/error" ]; then

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -178,6 +178,8 @@ spec:
       value: $(params.SKIP_UNUSED_STAGES)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+    - name: PLATFORM
+      value: $(params.PLATFORM)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -196,6 +198,8 @@ spec:
     image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
     name: build
     script: |-
+      #!/bin/bash
+      set -e
       set -o verbose
       mkdir -p ~/.ssh
       if [ -e "/ssh/error" ]; then
@@ -222,6 +226,9 @@ spec:
       PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
       PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
       fi
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
 
       rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
       rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
@@ -233,7 +240,6 @@ spec:
       rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/bash
-      set -o verbose
       set -e
       cd $(workspaces.source.path)
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
@@ -480,6 +486,11 @@ spec:
     image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
     name: sbom-syft-generate
     script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
       echo "Running syft on the source directory"
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
       find $(cat /shared/container_path) -xtype l -delete
@@ -495,6 +506,11 @@ spec:
     image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
     name: analyse-dependencies-java-sbom
     script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
         sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
@@ -547,6 +563,11 @@ spec:
     image: quay.io/redhat-appstudio/cachi2:0.9.1@sha256:df67f9e063b544a8c49a271359377fed560562615e0278f6d0b9a3485f3f8fad
     name: merge-cachi2-sbom
     script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
       if [ -f "sbom-cachi2.json" ]; then
         echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
         merge_syft_sbom sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
@@ -579,6 +600,11 @@ spec:
     image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
     name: create-base-images-sbom
     script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
       python3 /app/base_images_sbom_script.py \
         --sbom=sbom-cyclonedx.json \
         --base-images-from-dockerfile=/shared/base_images_from_dockerfile \
@@ -592,6 +618,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
@@ -654,22 +683,27 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - args:
-    - attach
-    - sbom
-    - --sbom
-    - sbom-cyclonedx.json
-    - --type
-    - cyclonedx
-    - $(params.IMAGE)
-    computeResources: {}
-    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+  - computeResources: {}
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     name: upload-sbom
+    script: |
+      #!/bin/bash
+      set -e
+      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
+        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      fi
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
     volumeMounts:
-    - mountPath: /etc/ssl/certs/ca-bundle.crt
+    - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
-      subPath: ca-bundle.crt
     workingDir: $(workspaces.source.path)
   volumes:
   - emptyDir: {}

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -178,6 +178,8 @@ spec:
     args:
       - $(params.BUILD_ARGS[*])
     script: |
+      #!/bin/bash
+      set -e
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -552,19 +554,19 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: upload-sbom
-    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-    args:
-      - attach
-      - sbom
-      - --sbom
-      - sbom-cyclonedx.json
-      - --type
-      - cyclonedx
-      - $(params.IMAGE)
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+    script: |
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
     volumeMounts:
     - name: trusted-ca
-      mountPath: /etc/ssl/certs/ca-bundle.crt
-      subPath: ca-bundle.crt
+      mountPath: /mnt/trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
 


### PR DESCRIPTION
In order to reduce the likelihood of users accidentally forgetting to specify unique tags for each architecture, we can add a suffix to the pushed image

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
