### PR TITLE
.tekton/pull-request: run conditionally

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -4,7 +4,15 @@ kind: PipelineRun
 metadata:
   name: build-definitions-pull-request
   annotations:
-    pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || !body.pull_request.draft) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      (
+          // PR to "main" branch, not draft
+          event == "pull_request" && target_branch == "main"
+          && (!has(body.pull_request) || !body.pull_request.draft)
+      ) || (
+          // PR enters the merge queue
+          event == "push" && target_branch.startsWith("gh-readonly-queue/main/")
+      )
     pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/yaml-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.1/sast-snyk-check.yaml]"
     pipelinesascode.tekton.dev/task-2: "yaml-lint"
     pipelinesascode.tekton.dev/max-keep-runs: "5"

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -6,12 +6,18 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: |
       (
-          // PR to "main" branch, not draft
-          event == "pull_request" && target_branch == "main"
-          && (!has(body.pull_request) || !body.pull_request.draft)
-      ) || (
-          // PR enters the merge queue
-          event == "push" && target_branch.startsWith("gh-readonly-queue/main/")
+          (
+              // PR to "main" branch, not draft
+              event == "pull_request" && target_branch == "main"
+              && (!has(body.pull_request) || !body.pull_request.draft)
+          ) || (
+              // PR enters the merge queue
+              event == "push" && target_branch.startsWith("gh-readonly-queue/main/")
+          )
+      ) && (
+          // Don't run pipeline if only these files changed. Note that 'files.all' is an object
+          // coming from PaC (list of all changed files) while the second 'all' is a CEL macro.
+          !files.all.all(x, x.matches(r"^(renovate\.json|.*\.md|\.github/.*)$"))
       )
     pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/yaml-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.1/sast-snyk-check.yaml]"
     pipelinesascode.tekton.dev/task-2: "yaml-lint"


### PR DESCRIPTION
Don't run the pipeline if the only changed files are

- `*.md`
- `.github/*`
- `renovate.json`

Note that a similar attempt was made in https://github.com/konflux-ci/build-definitions/pull/524, which took the approach of enumerating every file/directory which _should_ trigger the pipeline (maybe `files.all` wasn't available at the time). This PR takes the opposite approach.
