### PR TITLE
CI: avoid false-positive $(params.*) detection

### DIFF
--- a/.tekton/tasks/yaml-lint.yaml
+++ b/.tekton/tasks/yaml-lint.yaml
@@ -38,7 +38,7 @@ spec:
       script: |
         #!/bin/bash
         for task in $(find task -name '*.yaml'); do
-          if yq '.spec?.steps[] | .script' $task | grep -q 'params\.'; then
+          if yq '.spec?.steps[] | .script' $task | grep -q '\$(params\.'; then
             FAILED_TASKS="$FAILED_TASKS $task"
           fi
         done


### PR DESCRIPTION
Previously, the yaml-lint task (the custom script that checks for $(params.*) usage) would flag false positives such as

    echo "set params.SOME_PARAM to do X"

Make the regex match actual param usage more closely

