### PR TITLE
fix: false positive yamllinter error

### DIFF
--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -159,7 +159,7 @@ spec:
           export CONFIG_TOML_FILE=config.toml
           if [ -f /var/workdir/source/config.toml ]; then
             echo "Using the config.toml file found in the repository root!"
-            echo "  Remove the config.toml file or set params.CONFIG_TOML_FILE to another file to prevent using config.toml."
+            echo "  Remove the config.toml file or set parameter CONFIG_TOML_FILE to another file to prevent using config.toml."
           else
             echo "No config.toml file found. Using an empty configuration."
             touch /var/workdir/source/$CONFIG_TOML_FILE


### PR DESCRIPTION
Yaml linter looks for any occurence of 'params.' substring in tekton scripts

However this help message matches, updating message to avoid false positive error as quick fix.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
