### PR TITLE
Create the SBOM_BLOB_URL for v0.2 buildah tasks

### DIFF
--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -165,6 +165,7 @@
 |IMAGE_REF| Image reference of the built image| |
 |IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
+|SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
 ### clair-scan:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -164,6 +164,7 @@
 |IMAGE_REF| Image reference of the built image| |
 |IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.1:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.1:image-url ; clamav-scan:0.1:image-url ; sbom-json-check:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
+|SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
 ### clair-scan:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -136,6 +136,10 @@ spec:
     - name: JAVA_COMMUNITY_DEPENDENCIES
       description: The Java dependencies that came from community sources
         such as Maven central.
+    - name: SBOM_BLOB_URL
+      description: Reference of SBOM blob digest to enable digest-based verification
+        from provenance
+      type: string
     - name: SBOM_JAVA_COMPONENTS_COUNT
       description: The counting of Java components by publisher in JSON format
       type: string
@@ -529,6 +533,8 @@ spec:
         - mountPath: /var/lib/containers
           name: varlibcontainers
       script: |
+        #!/bin/bash
+        set -e
         base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
         base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
         container=$(buildah from --pull-never $IMAGE)
@@ -565,6 +571,12 @@ spec:
           echo -n "${IMAGE}@"
           cat "/var/workdir/image-digest"
         } >"$(results.IMAGE_REF.path)"
+
+        # Remove tag from IMAGE while allowing registry to contain a port number.
+        sbom_repo="${IMAGE%:*}"
+        sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+        # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+        echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
       securityContext:
         capabilities:
           add:

--- a/task/buildah-remote-oci-ta/0.2/README.md
+++ b/task/buildah-remote-oci-ta/0.2/README.md
@@ -1,4 +1,4 @@
-# buildah-oci-ta task
+# buildah-remote-oci-ta task
 
 Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
 In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
@@ -33,6 +33,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|PLATFORM|The platform to build on||true|
 
 ## Results
 |name|description|

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -137,6 +137,10 @@ spec:
   - description: The Java dependencies that came from community sources such as Maven
       central.
     name: JAVA_COMMUNITY_DEPENDENCIES
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
   - description: The counting of Java components by publisher in JSON format
     name: SBOM_JAVA_COMPONENTS_COUNT
     type: string
@@ -600,6 +604,8 @@ spec:
     image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     name: inject-sbom-and-push
     script: |
+      #!/bin/bash
+      set -e
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
       base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
       container=$(buildah from --pull-never $IMAGE)
@@ -636,6 +642,12 @@ spec:
         echo -n "${IMAGE}@"
         cat "/var/workdir/image-digest"
       } >"$(results.IMAGE_REF.path)"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     securityContext:
       capabilities:
         add:

--- a/task/buildah-remote/0.2/README.md
+++ b/task/buildah-remote/0.2/README.md
@@ -39,6 +39,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_URL|Image repository where the built image was pushed|
 |IMAGE_REF|Image reference of the built image|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
 |SBOM_JAVA_COMPONENTS_COUNT|The counting of Java components by publisher in JSON format|
 |JAVA_COMMUNITY_DEPENDENCIES|The Java dependencies that came from community sources such as Maven central.|
 

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -125,6 +125,10 @@ spec:
     name: IMAGE_URL
   - description: Image reference of the built image
     name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
   - description: The counting of Java components by publisher in JSON format
     name: SBOM_JAVA_COMPONENTS_COUNT
     type: string
@@ -582,6 +586,8 @@ spec:
     image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     name: inject-sbom-and-push
     script: |
+      #!/bin/bash
+      set -e
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
       base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
       container=$(buildah from --pull-never $IMAGE)
@@ -618,6 +624,12 @@ spec:
         echo -n "${IMAGE}@"
         cat "$(workspaces.source.path)/image-digest"
       } > "$(results.IMAGE_REF.path)"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     securityContext:
       capabilities:
         add:

--- a/task/buildah/0.2/README.md
+++ b/task/buildah/0.2/README.md
@@ -38,6 +38,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_URL|Image repository where the built image was pushed|
 |IMAGE_REF|Image reference of the built image|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
 |SBOM_JAVA_COMPONENTS_COUNT|The counting of Java components by publisher in JSON format|
 |JAVA_COMMUNITY_DEPENDENCIES|The Java dependencies that came from community sources such as Maven central.|
 

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -111,6 +111,9 @@ spec:
     name: IMAGE_URL
   - description: Image reference of the built image
     name: IMAGE_REF
+  - name: SBOM_BLOB_URL
+    description: Reference of SBOM blob digest to enable digest-based verification from provenance
+    type: string
   - name: SBOM_JAVA_COMPONENTS_COUNT
     description: The counting of Java components by publisher in JSON format
     type: string
@@ -479,6 +482,8 @@ spec:
     image: quay.io/konflux-ci/buildah:latest@sha256:9ef792d74bcc1d330de6be58b61f2cdbfa1c23b74a291eb2136ffd452d373050
     computeResources: {}
     script: |
+      #!/bin/bash
+      set -e
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
       base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
       container=$(buildah from --pull-never $IMAGE)
@@ -516,6 +521,11 @@ spec:
         cat "$(workspaces.source.path)/image-digest"
       } > "$(results.IMAGE_REF.path)"
 
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     securityContext:
       runAsUser: 0
       capabilities:


### PR DESCRIPTION
Now that the BASE_IMAGE_DIGESTS result has been removed, there should be enough room for us to re-add the SBOM_BLOB_URL. This will enable EC verification of the SBOM based on the digest which is recorded in the provenenance. It will prevent supply-chain attacks which are driven by modifying the floating tag of the uploaded SBOM.

Even with the referrer's API, the digest can be used to identify which SBOM should be the one built from Konflux.

This was added in #645 and then removed in #654 due to the limitation of Tekton results' size.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
