### PR TITLE
buildah-rhtap: drop BASE_IMAGES_DIGESTS

### DIFF
--- a/task/buildah-rhtap/0.2/MIGRATION.md
+++ b/task/buildah-rhtap/0.2/MIGRATION.md
@@ -1,0 +1,6 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+* Removes the `BASE_IMAGES_DIGESTS` result. Please remove the references to this
+  result (if any) from your pipeline.

--- a/task/buildah-rhtap/0.2/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.2/buildah-rhtap.yaml
@@ -1,0 +1,230 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: "docker"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "containers, rhtap"
+  name: buildah-rhtap
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    name: TLSVERIFY
+    type: string
+  - name: BUILD_ARGS
+    description: Array of --build-arg values ("arg=value" strings)
+    type: array
+    default: []
+  - name: BUILD_ARGS_FILE
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    type: string
+    default: ""
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: vfs
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository where the built image was pushed
+    name: IMAGE_URL
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - description: Link to the SBOM layer pushed to the registry as part of an OCI artifact.
+    name: SBOM_BLOB_URL
+  stepTemplate:
+    env:
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+  steps:
+  - name: build
+    image: registry.access.redhat.com/ubi9/buildah@sha256:29402688af2b394a8400d946751520dbaea64759bbce2ef6928dc58ede6020e6
+    args:
+      - $(params.BUILD_ARGS[*])
+    script: |
+      # Check if the Dockerfile exists
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$SOURCE_CODE_DIR/$DOCKERFILE"
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      BUILDAH_ARGS=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}")
+      fi
+
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
+      # Build the image
+      buildah build \
+        "${BUILDAH_ARGS[@]}" \
+        --tls-verify=$TLSVERIFY \
+        --ulimit nofile=4096:4096 \
+        -f "$dockerfile_path" -t $IMAGE $SOURCE_CODE_DIR/$CONTEXT
+
+      # Push the image
+      buildah push \
+        --tls-verify=$TLSVERIFY \
+        --retry=5 \
+        --digestfile /tmp/files/image-digest $IMAGE \
+        docker://$IMAGE
+
+      # Set task results
+      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
+      cat /tmp/files/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+
+      # Save the image so it can be used in the generate-sbom step
+      buildah push "$IMAGE" oci:/tmp/files/image
+    securityContext:
+      capabilities:
+        add:
+          # this is needed so that buildah can write to the mounted /var/lib/containers directory
+          - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /tmp/files
+      name: tmpfiles
+    workingDir: $(workspaces.source.path)
+
+  - name: generate-sboms
+    image: registry.redhat.io/rh-syft-tech-preview/syft-rhel9:1.0.1@sha256:27c268d678103a27b6964c2cd5169040941b7304d0078f9727789ffb8ffba370
+    # Respect Syft configuration if the user has it in the root of their repository
+    # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
+    workingDir: $(workspaces.source.path)/source
+    script: |
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json@1.5=/tmp/files/sbom-source.json
+      syft oci-dir:/tmp/files/image --output cyclonedx-json@1.5=/tmp/files/sbom-image.json
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /tmp/files
+      name: tmpfiles
+
+  - name: merge-sboms
+    image: registry.access.redhat.com/ubi8/python-311@sha256:5c31297465e6499bf6cc21602685c02f83b0af3901adb6aea04c3bdf69e40a96
+    env:
+      - name: RESULT_PATH
+        value: $(results.SBOM_BLOB_URL.path)
+    script: |
+      #!/bin/python3
+      import hashlib
+      import json
+      import os
+      import re
+
+      ### load SBOMs ###
+
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+
+      ### attempt to deduplicate components ###
+
+      component_list = image_sbom.get("components", [])
+      existing_purls = [c["purl"] for c in component_list if "purl" in c]
+
+      for component in source_sbom.get("components", []):
+        if "purl" in component:
+          if component["purl"] not in existing_purls:
+            component_list.append(component)
+            existing_purls.append(component["purl"])
+        else:
+          # We won't try to deduplicate components that lack a purl.
+          # This should only happen with operating-system type components,
+          # which are only reported in the image SBOM.
+          component_list.append(component)
+
+      component_list.sort(key=lambda c: c["type"] + c["name"])
+      image_sbom["components"] = component_list
+
+
+      ### write the CycloneDX unified SBOM ###
+
+      with open("./sbom-cyclonedx.json", "w") as f:
+        json.dump(image_sbom, f, indent=4)
+
+
+      ### write the SBOM blob URL result ###
+
+      with open("./sbom-cyclonedx.json", "rb") as f:
+        sbom_digest = hashlib.file_digest(f, "sha256").hexdigest()
+
+      # https://github.com/opencontainers/distribution-spec/blob/main/spec.md?plain=1#L160
+      tag_regex = "[a-zA-Z0-9_][a-zA-Z0-9._-]{0,127}"
+
+      # the tag must be after a colon, but always at the end of the string
+      # this avoids conflict with port numbers
+      image_without_tag = re.sub(f":{tag_regex}$", "", os.getenv("IMAGE"))
+
+      sbom_blob_url = f"{image_without_tag}@sha256:{sbom_digest}"
+
+      with open(os.getenv("RESULT_PATH"), "w") as f:
+        f.write(sbom_blob_url)
+    volumeMounts:
+    - mountPath: /tmp/files
+      name: tmpfiles
+    workingDir: /tmp/files
+
+  - name: upload-sbom
+    image: registry.redhat.io/rhtas-tech-preview/cosign-rhel9:0.0.2@sha256:151f4a1e721b644bafe47bf5bfb8844ff27b95ca098cc37f3f6cbedcda79a897
+    command: [cosign]
+    args:
+      - attach
+      - sbom
+      - --sbom
+      - sbom-cyclonedx.json
+      - --type
+      - cyclonedx
+      - $(params.IMAGE)
+    volumeMounts:
+    - mountPath: /tmp/files
+      name: tmpfiles
+    workingDir: /tmp/files
+
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: tmpfiles
+  workspaces:
+  - name: source
+    description: Workspace containing the source code to build.

--- a/task/buildah-rhtap/0.2/buildah-rhtap.yaml
+++ b/task/buildah-rhtap/0.2/buildah-rhtap.yaml
@@ -45,8 +45,6 @@ spec:
     name: IMAGE_DIGEST
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
-  - description: Digests of the base images used for build
-    name: BASE_IMAGES_DIGESTS
   - description: Link to the SBOM layer pushed to the registry as part of an OCI artifact.
     name: SBOM_BLOB_URL
   stepTemplate:
@@ -104,7 +102,6 @@ spec:
         docker://$IMAGE
 
       # Set task results
-      buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' | grep -v $IMAGE > $(results.BASE_IMAGES_DIGESTS.path)
       cat /tmp/files/image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
 


### PR DESCRIPTION
STONEBLD-2326

The result is a Tekton anti-pattern (an unbounded list of items). It can easily cause builds to hit the result size limit.

In the sample RHTAP pipeline, nothing uses this result. Drop it. (In version 0.2 of the task).