### PR TITLE
docker-build-rhtap: drop unnecessary things

### DIFF
--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -5,7 +5,7 @@
 |build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.1:BUILD_ARGS|
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.1:BUILD_ARGS_FILE|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.1:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.1:DOCKERFILE|
 |event-type| Event that triggered the pipeline run, e.g. push, pull_request| push| |
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; acs-deploy-check:0.1:gitops-repo-url ; update-deployment:0.1:gitops-repo-url|
 |gitops-auth-secret-name| Secret name to enable this pipeline to update the gitops repo with the new image. | gitops-auth-secret| update-deployment:0.1:gitops-auth-secret-name|
@@ -13,7 +13,7 @@
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.1:IMAGE_EXPIRES_AFTER|
 |java| Java build| false| |
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; acs-image-check:0.1:image ; acs-image-scan:0.1:image|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | |
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
@@ -41,11 +41,6 @@
 |image-digest| Digest of the image to scan | None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |insecure-skip-tls-verify| When set to `"true"`, skip verifying the TLS certs of the Central endpoint.  Defaults to `"false"`. | false| 'true'|
 |rox-secret-name| Secret containing the StackRox server endpoint and API token with CI permissions under rox-api-endpoint and rox-api-token keys. For example: rox-api-endpoint: rox.stackrox.io:443 ; rox-api-token: eyJhbGciOiJS... | None| '$(params.stackrox-secret)'|
-### apply-tags:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
-|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### buildah-rhtap:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -84,15 +79,6 @@
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
-### push-dockerfile:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
-|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
-|DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| '$(params.dockerfile)'|
-|IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-container.results.IMAGE_URL)'|
-|IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
-|TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
 ### show-sbom-rhdh:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -129,8 +115,8 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of the base images used for build| |
-|IMAGE_DIGEST| Digest of the image just built| push-dockerfile:0.1:IMAGE_DIGEST ; acs-image-check:0.1:image-digest ; acs-image-scan:0.1:image-digest|
-|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; update-deployment:0.1:image|
+|IMAGE_DIGEST| Digest of the image just built| acs-image-check:0.1:image-digest ; acs-image-scan:0.1:image-digest|
+|IMAGE_URL| Image repository where the built image was pushed| show-sbom:0.1:IMAGE_URL ; update-deployment:0.1:image|
 |SBOM_BLOB_URL| Link to the SBOM layer pushed to the registry as part of an OCI artifact.| |
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -142,10 +128,6 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### push-dockerfile:0.1 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
 ### show-sbom-rhdh:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -155,8 +137,7 @@
 |name|description|optional|used in tasks
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth|
-|netrc| |True| |
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; build-container:0.1:source ; push-dockerfile:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; build-container:0.1:source|
 ## Available workspaces from tasks
 ### buildah-rhtap:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -168,10 +149,6 @@
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |output| The git repo will be cloned onto the volume backing this Workspace.| False| workspace|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### push-dockerfile:0.1 task workspaces
-|name|description|optional|workspace from pipeline
-|---|---|---|---|
-|workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
 ### summary:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -90,7 +90,11 @@
   path: /spec/tasks/3/runAfter/0
   value: clone-repository
 - op: remove
-  path: /spec/tasks/10  # sbom-json-check
+  path: /spec/tasks/12 # push-dockerfile
+- op: remove
+  path: /spec/tasks/11 # apply-tags
+- op: remove
+  path: /spec/tasks/10 # sbom-json-check
 - op: remove
   path: /spec/tasks/9  # clamav-scan
 - op: remove
@@ -105,6 +109,8 @@
   path: /spec/tasks/4  # build-source-image
 - op: remove
   path: /spec/tasks/2  # prefetch-dependencies
+- op: remove
+  path: /spec/workspaces/2  # netrc (only used for prefetch-dependencies)
 - op: add
   path: /spec/tasks/-
   value:


### PR DESCRIPTION
As usual, the docker-build-rhtap pipeline has inherited unnecessary things from template-build.yaml because the approach of using kustomization to strip out tasks is fragile.

* Remove unnecessary tasks: apply-tags, push-dockerfile
* Remove unused workspace: netrc
