### PR TITLE
Ensure that /shared/base_images_digests exists

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -404,6 +404,7 @@ spec:
           cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
         fi
 
+        touch /shared/base_images_digests
         for image in $BASE_IMAGES; do
           if [ "${image}" != "scratch" ]; then
             buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >>/shared/base_images_digests

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -416,6 +416,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
+      touch /shared/base_images_digests
       for image in $BASE_IMAGES; do
         if [ "${image}" != "scratch" ]; then
           buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >>/shared/base_images_digests

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -398,6 +398,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
+      touch /shared/base_images_digests
       for image in $BASE_IMAGES; do
         if [ "${image}" != "scratch" ]; then
           buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> /shared/base_images_digests

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -340,6 +340,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
+      touch /shared/base_images_digests
       for image in $BASE_IMAGES; do
         if [ "${image}" != "scratch" ]; then
           buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> /shared/base_images_digests


### PR DESCRIPTION
When there are no base images (i.e. it is FROM scratch), we need to make sure that the base_images_digests file exists.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
