### PR TITLE
gitops-pull-request: add missing when conditions

### DIFF
--- a/pipelines/gitops-pull-request-rhtap/gitops-pull-request.yaml
+++ b/pipelines/gitops-pull-request-rhtap/gitops-pull-request.yaml
@@ -88,6 +88,10 @@ spec:
           value: $(params.ec-tuf-mirror)
       runAfter:
         - get-images-to-verify
+      when:
+        - input: $(tasks.get-images-to-verify.results.IMAGES_TO_VERIFY)
+          operator: notin
+          values: [""]
       taskRef:
         name: verify-enterprise-contract
         version: "0.1"
@@ -110,6 +114,10 @@ spec:
     - name: download-sboms
       runAfter:
         - get-images-to-upload-sbom
+      when:
+        - input: $(tasks.get-images-to-upload-sbom.results.IMAGES_TO_VERIFY)
+          operator: notin
+          values: [""]
       params:
         - name: IMAGES
           value: $(tasks.get-images-to-upload-sbom.results.IMAGES_TO_VERIFY)
@@ -131,6 +139,10 @@ spec:
     - name: upload-sboms-to-trustification
       runAfter:
         - download-sboms
+      when:
+        - input: $(tasks.get-images-to-upload-sbom.results.IMAGES_TO_VERIFY)
+          operator: notin
+          values: [""]
       params:
         - name: SBOMS_DIR
           value: sboms


### PR DESCRIPTION
When the 'gather-deploy-images' task doesn't find any images that changed between the current ref and the base branch, it returns an empty string.

Skip the verify-ec and download-sbom -> upload-sbom tasks when this happens. Otherwise, those tasks would run unnecessarily and/or fail.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
