### PR TITLE
Ensure that Chains sees all image manifests referenced

### DIFF
--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -39,6 +39,8 @@ spec:
     name: IMAGE_DIGEST
   - description: Image repository where the built image was pushed
     name: IMAGE_URL
+  - description: List of all referenced image manifests
+    name: IMAGES
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
@@ -72,6 +74,7 @@ spec:
 
       sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
 
+      image_manifests=""
       buildah manifest create "$IMAGE"
       for i in $@
       do
@@ -82,6 +85,7 @@ spec:
           TOADD="$(echo $i | cut -d: -f1)@sha256:$(echo $i | cut -d: -f3)"
         fi
         echo "Adding $TOADD"
+        image_manifests="${image_manifests} ${TOADD},"
         buildah manifest add $IMAGE "docker://$TOADD" --all
       done
 
@@ -103,7 +107,8 @@ spec:
       fi
 
       cat image-digest | tee $(results.IMAGE_DIGEST.path)
-      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+      echo -n "${image_manifests:1:-1}" > "$(results.IMAGES.path)"
     securityContext:
       capabilities:
         add:

--- a/task/build-image-manifest/README.md
+++ b/task/build-image-manifest/README.md
@@ -1,0 +1,21 @@
+# build-image-manifest task
+
+This takes existing images and stiches them together into a multi platform image.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image buildah will produce.||true|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|IMAGES|List of images that are to be merged into the multi platform image||true|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_URL|Image repository where the built image was pushed|
+|IMAGES|List of all referenced image manifests|
+


### PR DESCRIPTION
Due to a [bug in Chains](https://github.com/tektoncd/chains/issues/1164), it does not currently see all images produced within a matrix. In order to work around this, we can expose all images that we include in our Image Index so that Chains can generate the provenance for all of them.

This fix is also relevant if any of the images added are themselves an image index due to https://github.com/tektoncd/chains/issues/1070.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
