### PR TITLE
prefetch-task-rhsm-integration

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -144,7 +144,7 @@ spec:
           yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}"  >/mnt/config/config.yaml
         fi
     - name: prefetch-dependencies
-      image: quay.io/redhat-appstudio/cachi2:0.9.1@sha256:df67f9e063b544a8c49a271359377fed560562615e0278f6d0b9a3485f3f8fad
+      image: quay.io/bcook/cachi2@sha256:cd0ee8284eb41838071e7987644fcfe05cef77f89ac426c14a2fa4ed5bd1b5ac
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
@@ -212,8 +212,27 @@ spec:
           update-ca-trust
         fi
 
-        cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
-          $dev_pacman_flag \
+        cachi2 --log-level="$LOG_LEVEL" fetch-deps \
+          ACTIVATION_KEY_PATH="/activation-key"
+        if [ -d "$ACTIVATION_KEY_PATH" ]; then
+            echo "Detected activation key, registering with RHSM."
+
+            # todo: make sure orgid key is consistent with buildah task and docs
+            subscription-manager register \
+              --org $(cat "/activation-key/orgid") \
+              --activationkey $(cat "/activation-key/activationkey")
+
+            # detect entitlement certs and setup environment variables
+            ls /etc/pki/entitlement/
+
+            export RHSM_ID=$(ls /etc/pki/entitlement/ | grep key | cut -d - -f 1)
+            echo $RHSM_ID
+            export C2_CLIENT_CERT="/etc/pki/entitlement/$RHSM_ID.pem"
+            export C2_CLIENT_KEY="/etc/pki/entitlement/$RHSM_ID-key.pem"
+            echo "Using client certificate $C2_CLIENT_CERT and key $C2_CLIENT_KEY."
+        fi
+
+        $dev_pacman_flag \
           --source=/var/workdir/source \
           --output=/var/workdir/cachi2/output \
           "${INPUT}"

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -74,7 +74,7 @@ spec:
         yq 'del(.goproxy_url)' <<< "${CONFIG_FILE_CONTENT}" > /mnt/config/config.yaml
       fi
 
-  - image: quay.io/redhat-appstudio/cachi2:0.9.1@sha256:df67f9e063b544a8c49a271359377fed560562615e0278f6d0b9a3485f3f8fad
+  - image: quay.io/bcook/cachi2@sha256:cd0ee8284eb41838071e7987644fcfe05cef77f89ac426c14a2fa4ed5bd1b5ac
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: prefetch-dependencies
@@ -146,7 +146,27 @@ spec:
         update-ca-trust
       fi
 
-      cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+      cachi2 --log-level="$LOG_LEVEL" fetch-deps \
+      ACTIVATION_KEY_PATH="/activation-key"
+      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+          echo "Detected activation key, registering with RHSM."
+        
+          # todo: make sure orgid key is consistent with buildah task and docs
+          subscription-manager register \
+            --org $(cat "/activation-key/orgid") \
+            --activationkey $(cat "/activation-key/activationkey")
+
+          # detect entitlement certs and setup environment variables
+          ls /etc/pki/entitlement/
+
+          export RHSM_ID=$(ls /etc/pki/entitlement/ | grep key | cut -d - -f 1)
+          echo $RHSM_ID
+          export C2_CLIENT_CERT="/etc/pki/entitlement/$RHSM_ID.pem"
+          export C2_CLIENT_KEY="/etc/pki/entitlement/$RHSM_ID-key.pem"
+          echo "Using client certificate $C2_CLIENT_CERT and key $C2_CLIENT_KEY."
+        fi
+
+      
       $dev_pacman_flag \
       --source=$(workspaces.source.path)/source \
       --output=$(workspaces.source.path)/cachi2/output \


### PR DESCRIPTION
These changes are to accompany https://github.com/containerbuildsystem/cachi2/pull/580 and **that PR needs to be merged first.**

The cachi2 changes in that PR enable usage of client certificates for accessing Red Hat content from subscription protected repos, but it is out of scope for cachi2 how those certificates are obtained. They cachi2 find the files via environment variables.

This PR causes the prefetch task to react to the same ACTIVATION_KEY parameter that is used for non-hermetic builds. The container will use the pipeline-provided activation key to register the STEP container and set the proper environment variables before executing cachi2.

The following points are pertinent:
* the RHSM (Red Hat subscription management) files generated by `subscription-manager register` are generated by this task, immediately before running cach2
* they are never used again

Therefore this implementation is safe from certificate revocation / rotation behavior of RHSM.

