### PR TITLE
Use tmpfs for pki entitlements

### DIFF
--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -363,18 +363,21 @@ spec:
         [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
         [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
+        ACTIVATION_KEY_PATH="/activation-key"
         ENTITLEMENT_PATH="/entitlement"
-        if [ -d "$ENTITLEMENT_PATH" ]; then
+
+        # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+        # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+
+        if [ -d "$ACTIVATION_KEY_PATH" ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          mkdir /shared/rhsm-tmp
+          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+          echo "Adding activation key to the build"
+        elif [ -d "$ENTITLEMENT_PATH" ]; then
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"
-        fi
-
-        ACTIVATION_KEY_PATH="/activation-key"
-           if [ -d "$ACTIVATION_KEY_PATH" ]; then
-            cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-            VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-            echo "Adding activation key to the build"
         fi
 
         ADDITIONAL_SECRET_PATH="/additional-secret"

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -363,18 +363,21 @@ spec:
         [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
         [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
+        ACTIVATION_KEY_PATH="/activation-key"
         ENTITLEMENT_PATH="/entitlement"
-        if [ -d "$ENTITLEMENT_PATH" ]; then
+
+        # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+        # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+
+        if [ -d "$ACTIVATION_KEY_PATH" ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          mkdir /shared/rhsm-tmp
+          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+          echo "Adding activation key to the build"
+        elif [ -d "$ENTITLEMENT_PATH" ]; then
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"
-        fi
-
-        ACTIVATION_KEY_PATH="/activation-key"
-           if [ -d "$ACTIVATION_KEY_PATH" ]; then
-            cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-            VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-            echo "Adding activation key to the build"
         fi
 
         ADDITIONAL_SECRET_PATH="/additional-secret"

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -375,18 +375,21 @@ spec:
       [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
       [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
+      ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
-      if [ -d "$ENTITLEMENT_PATH" ]; then
+
+      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+
+      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+      elif [ -d "$ENTITLEMENT_PATH" ]; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
-      fi
-
-      ACTIVATION_KEY_PATH="/activation-key"
-         if [ -d "$ACTIVATION_KEY_PATH" ]; then
-          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-          echo "Adding activation key to the build"
       fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -375,18 +375,21 @@ spec:
       [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
       [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
+      ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
-      if [ -d "$ENTITLEMENT_PATH" ]; then
+
+      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+
+      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+      elif [ -d "$ENTITLEMENT_PATH" ]; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
-      fi
-
-      ACTIVATION_KEY_PATH="/activation-key"
-         if [ -d "$ACTIVATION_KEY_PATH" ]; then
-          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-          echo "Adding activation key to the build"
       fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -367,19 +367,22 @@ spec:
       [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
       [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
+      ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
-      if [ -d "$ENTITLEMENT_PATH" ]; then
+
+      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+
+      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+      elif [ -d "$ENTITLEMENT_PATH" ]; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
       fi
-
-      ACTIVATION_KEY_PATH="/activation-key"
-         if [ -d "$ACTIVATION_KEY_PATH" ]; then
-          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-          echo "Adding activation key to the build"
-        fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -357,19 +357,22 @@ spec:
       [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
       [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
+      ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
-      if [ -d "$ENTITLEMENT_PATH" ]; then
+
+      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+
+      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+      elif [ -d "$ENTITLEMENT_PATH" ]; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
       fi
-
-      ACTIVATION_KEY_PATH="/activation-key"
-         if [ -d "$ACTIVATION_KEY_PATH" ]; then
-          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-          echo "Adding activation key to the build"
-        fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -310,25 +310,22 @@ spec:
       [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
       [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
-      
-
-      
       ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
 
       # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used, mount tmpfs to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
 
       if [ -d "$ACTIVATION_KEY_PATH" ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key --volume --tmpfs /etc/pki/entitlement"
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
         echo "Adding activation key to the build"
       elif [ -d "$ENTITLEMENT_PATH" ]; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
       fi
-
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
@@ -559,7 +556,6 @@ spec:
       - cyclonedx
       - $(params.IMAGE)
     workingDir: $(workspaces.source.path)
-
   volumes:
   - name: varlibcontainers
     emptyDir: {}

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -310,19 +310,25 @@ spec:
       [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
       [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
+      
+
+      
+      ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
-      if [ -d "$ENTITLEMENT_PATH" ]; then
+
+      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # when activation keys are used, mount tmpfs to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+
+      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key --volume --tmpfs /etc/pki/entitlement"
+        echo "Adding activation key to the build"
+      elif [ -d "$ENTITLEMENT_PATH" ]; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
       fi
 
-      ACTIVATION_KEY_PATH="/activation-key"
-         if [ -d "$ACTIVATION_KEY_PATH" ]; then
-          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-          echo "Adding activation key to the build"
-        fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -299,19 +299,22 @@ spec:
       [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
       [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
 
+      ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
-      if [ -d "$ENTITLEMENT_PATH" ]; then
+
+      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+
+      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+      elif [ -d "$ENTITLEMENT_PATH" ]; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
       fi
-
-      ACTIVATION_KEY_PATH="/activation-key"
-         if [ -d "$ACTIVATION_KEY_PATH" ]; then
-          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
-          VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key"
-          echo "Adding activation key to the build"
-        fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"


### PR DESCRIPTION
only allow 1 method for subscription certs at a time; ensure certificates are not included in final image 

this commit updates activation-keys work to mount a temporary directory to /etc/pki/entitlement during the build. **This ensure that any certificates generated by "subscription-manager register" are not included in the final build.**

The subscription manager team has raised that new processes will revoke generated client subscriptions. On a normal machine using subscription-manager or insights, there is a regeneration process that runs and this is not an issue. In Konflux, when certificates stored as secrets are revoked nothing will regenerate them and it will result in a broken build.

For this reason, they asked us to push people to using activation-keys. This change will prefer activation keys when both are present. Docs updates will also be added to recommend using activation and we would be well positioned to deprecated the etc-pki-entitlement secret in the future.
    