### PR TITLE
Add S3 bucket authentication to oci-copy

### DIFF
--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -5,6 +5,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
+|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.|does-not-exist|false|
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|

--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -5,7 +5,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.|does-not-exist|false|
+|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.|does-not-exist|false|
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|

--- a/task/oci-copy-oci-ta/0.1/README.md
+++ b/task/oci-copy-oci-ta/0.1/README.md
@@ -5,7 +5,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.|does-not-exist|false|
+|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`. In the future, this will be reimplemented to use v4 auth: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.|does-not-exist|false|
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -13,6 +13,12 @@ spec:
   description: Given a file in the user's source directory, copy content from
     arbitrary urls into the OCI registry.
   params:
+    - name: AWS_SECRET_NAME
+      description: Name of a secret which will be made available to the build
+        to construct Authorization headers for requests to Amazon S3. If specified,
+        this will take precedence over BEARER_TOKEN_SECRET_NAME.
+      type: string
+      default: does-not-exist
     - name: BEARER_TOKEN_SECRET_NAME
       description: Name of a secret which will be made available to the build
         as an Authorization header. Note, the token will be sent to all servers
@@ -69,6 +75,7 @@ spec:
       image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
       workingDir: /var/workdir
       script: |
+        #!/bin/bash
         set -eu
         set -o pipefail
 
@@ -104,17 +111,47 @@ spec:
               key: token
               name: $(params.BEARER_TOKEN_SECRET_NAME)
               optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws_access_key_id
+              name: $(params.AWS_SECRET_NAME)
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws_secret_access_key
+              name: $(params.AWS_SECRET_NAME)
+              optional: true
       script: |
+        #!/bin/bash
         set -e
         set -o pipefail
 
-        CURL_ARGS=()
-        if [ -n "${BEARER_TOKEN}" ]; then
-          echo "Found bearer token. Using it for authentication."
-          CURL_ARGS+=(-H "Authorization: Bearer ${BEARER_TOKEN}")
-        else
-          echo "Proceeding with anonymous requests"
-        fi
+        download() {
+          url="$1"
+          file="$2"
+          method="GET"
+
+          curl_args=(--fail --silent --show-error)
+          if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
+            path=$(echo "$url" | cut -d/ -f4-)
+            echo "Bucket path is $path"
+            date="$(date -u '+%a, %e %b %Y %H:%M:%S +0000')"
+            printf -v string_to_sign "%s\n\n\n%s\n%s" "$method" "$date" "/$path"
+            echo "String to sign is $string_to_sign"
+            signature=$(echo -n "$string_to_sign" | openssl dgst -sha1 -binary -hmac "${AWS_SECRET_ACCESS_KEY}" | openssl base64)
+            authorization="AWS ${AWS_ACCESS_KEY_ID}:${signature}"
+            curl "${curl_args[@]}" -H "Date: ${date}" -H "Authorization: ${authorization}" --location "$url" -o "$file"
+          elif [ -n "${BEARER_TOKEN}" ]; then
+            echo "Found bearer token. Using it for authentication."
+            curl "${curl_args[@]}" -H "Authorization: Bearer ${BEARER_TOKEN}" --location "$url" -o "$file"
+          else
+            echo "Proceeding with anonymous requests"
+            curl "${curl_args[@]}" --location "$url" -o "$file"
+          fi
+        }
 
         set -u
 
@@ -154,6 +191,7 @@ spec:
         for varfile in /var/workdir/vars/*; do
           echo
           echo "Reading $varfile"
+          # shellcheck source=/dev/null
           source $varfile
 
           echo "Checking to see if blob $OCI_ARTIFACT_DIGEST exists"
@@ -162,7 +200,7 @@ spec:
           else
             echo "Blob for ${OCI_FILENAME} does not yet exist in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}."
             echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-            curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+            download "$OCI_SOURCE" "$OCI_FILENAME"
 
             echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
             echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
@@ -210,6 +248,7 @@ spec:
       image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
       workingDir: /var/workdir
       script: |
+        #!/bin/bash
         cat >sbom-cyclonedx.json <<EOL
         {
             "\$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
@@ -222,6 +261,7 @@ spec:
 
         for varfile in /var/workdir/vars/*; do
           echo "Reading $varfile"
+          # shellcheck source=/dev/null
           source $varfile
 
           ENCODED_URL=$(echo "${OCI_SOURCE}" | python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=":/"))')
@@ -246,6 +286,7 @@ spec:
       image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
       workingDir: /var/workdir
       script: |
+        #!/bin/bash
         REPO=${IMAGE%:*}
         echo "Found that ${REPO} is the repository for ${IMAGE}"
         SBOM_DIGEST=$(sha256sum sbom-cyclonedx.json | awk '{ print $1 }')

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -16,9 +16,10 @@ spec:
     - name: AWS_SECRET_NAME
       description: 'Name of a secret which will be made available to the build
         to construct Authorization headers for requests to Amazon S3 using
-        https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.
+        v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html.
         If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.
-        The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.'
+        The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.
+        In the future, this will be reimplemented to use v4 auth: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.'
       type: string
       default: does-not-exist
     - name: BEARER_TOKEN_SECRET_NAME
@@ -138,7 +139,8 @@ spec:
           curl_args=(--fail --silent --show-error)
           if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
             echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
-            # This implements https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
+            # This implements v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html.
+            # TODO - port to v4 auth https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
             path=$(echo "$url" | cut -d/ -f4-)
             echo "Bucket path is $path"
             date="$(date -u '+%a, %e %b %Y %H:%M:%S +0000')"

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -14,9 +14,11 @@ spec:
     arbitrary urls into the OCI registry.
   params:
     - name: AWS_SECRET_NAME
-      description: Name of a secret which will be made available to the build
-        to construct Authorization headers for requests to Amazon S3. If specified,
-        this will take precedence over BEARER_TOKEN_SECRET_NAME.
+      description: 'Name of a secret which will be made available to the build
+        to construct Authorization headers for requests to Amazon S3 using
+        https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.
+        If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.
+        The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.'
       type: string
       default: does-not-exist
     - name: BEARER_TOKEN_SECRET_NAME
@@ -136,6 +138,7 @@ spec:
           curl_args=(--fail --silent --show-error)
           if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
             echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
+            # This implements https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
             path=$(echo "$url" | cut -d/ -f4-)
             echo "Bucket path is $path"
             date="$(date -u '+%a, %e %b %Y %H:%M:%S +0000')"

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -13,9 +13,8 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 |---|---|---|---|
 |IMAGE|Reference of the image buildah will produce.||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
-|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|"does-not-exist"|false|
-|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.|does-not-exist|false|
-
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
+|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.|does-not-exist|false|
 
 ## Results
 |name|description|

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -14,6 +14,7 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 |IMAGE|Reference of the image buildah will produce.||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|"does-not-exist"|false|
+|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.|does-not-exist|false|
 
 
 ## Results

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -14,7 +14,7 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
-|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.|does-not-exist|false|
+|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`. In the future, this will be reimplemented to use v4 auth: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.|does-not-exist|false|
 
 ## Results
 |name|description|

--- a/task/oci-copy/0.1/README.md
+++ b/task/oci-copy/0.1/README.md
@@ -11,7 +11,7 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
-|IMAGE|Reference of the image buildah will produce.||true|
+|IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
 |AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.|does-not-exist|false|
@@ -19,8 +19,8 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 ## Results
 |name|description|
 |---|---|
-|IMAGE_DIGEST|Digest of the image just built|
-|IMAGE_URL|Image repository where the built image was pushed|
+|IMAGE_DIGEST|Digest of the artifact just pushed|
+|IMAGE_URL|Repository where the artifact was pushed|
 |SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
 |IMAGE_REF|Image reference of the built image|
 

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -28,9 +28,10 @@ spec:
     - name: AWS_SECRET_NAME
       description: >-
         Name of a secret which will be made available to the build to construct Authorization headers for requests to
-        Amazon S3 using https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.
+        Amazon S3 using v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html.
         If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys:
-        `aws_access_key_id` and `aws_secret_access_key`.
+        `aws_access_key_id` and `aws_secret_access_key`. In the future, this will be reimplemented to use v4 auth:
+        https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.
       type: string
       default: "does-not-exist"
   results:
@@ -123,7 +124,8 @@ spec:
           curl_args=(--fail --silent --show-error)
           if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
             echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
-            # This implements https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
+            # This implements v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html.
+            # TODO - port to v4 auth https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
             path=$(echo "$url" | cut -d/ -f4-)
             echo "Bucket path is $path"
             date="$(date -u '+%a, %e %b %Y %H:%M:%S +0000')"

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -28,7 +28,9 @@ spec:
     - name: AWS_SECRET_NAME
       description: >-
         Name of a secret which will be made available to the build to construct Authorization headers for requests to
-        Amazon S3. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.
+        Amazon S3 using https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.
+        If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys:
+        `aws_access_key_id` and `aws_secret_access_key`.
       type: string
       default: "does-not-exist"
   results:
@@ -121,6 +123,7 @@ spec:
           curl_args=(--fail --silent --show-error)
           if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
             echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
+            # This implements https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
             path=$(echo "$url" | cut -d/ -f4-)
             echo "Bucket path is $path"
             date="$(date -u '+%a, %e %b %Y %H:%M:%S +0000')"

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -25,6 +25,12 @@ spec:
         different taskruns and therefore different oci artifacts must be used.
       type: string
       default: "does-not-exist"
+    - name: AWS_SECRET_NAME
+      description: >-
+        Name of a secret which will be made available to the build to construct Authorization headers for requests to
+        Amazon S3. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.
+      type: string
+      default: "does-not-exist"
   results:
     - description: Digest of the artifact just pushed
       name: IMAGE_DIGEST
@@ -47,6 +53,7 @@ spec:
     - name: prepare
       image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
       script: |
+        #!/bin/bash
         set -eu
         set -o pipefail
 
@@ -89,17 +96,47 @@ spec:
             name: $(params.BEARER_TOKEN_SECRET_NAME)
             key: token
             optional: true
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: $(params.AWS_SECRET_NAME)
+            key: aws_access_key_id
+            optional: true
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: $(params.AWS_SECRET_NAME)
+            key: aws_secret_access_key
+            optional: true
       script: |
+        #!/bin/bash
         set -e
         set -o pipefail
 
-        CURL_ARGS=()
-        if [ -n "${BEARER_TOKEN}" ]; then
-          echo "Found bearer token. Using it for authentication."
-          CURL_ARGS+=(-H "Authorization: Bearer ${BEARER_TOKEN}")
-        else
-          echo "Proceeding with anonymous requests"
-        fi
+        download() {
+          url="$1"
+          file="$2"
+          method="GET"
+
+          curl_args=(--fail --silent --show-error)
+          if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
+            echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
+            path=$(echo "$url" | cut -d/ -f4-)
+            echo "Bucket path is $path"
+            date="$(date -u '+%a, %e %b %Y %H:%M:%S +0000')"
+            printf -v string_to_sign "%s\n\n\n%s\n%s" "$method" "$date" "/$path"
+            echo "String to sign is $string_to_sign"
+            signature=$(echo -n "$string_to_sign" | openssl dgst -sha1 -binary -hmac "${AWS_SECRET_ACCESS_KEY}" | openssl base64)
+            authorization="AWS ${AWS_ACCESS_KEY_ID}:${signature}"
+            curl "${curl_args[@]}" -H "Date: ${date}" -H "Authorization: ${authorization}" --location "$url" -o "$file"
+          elif [ -n "${BEARER_TOKEN}" ]; then
+            echo "Found bearer token. Using it for authentication."
+            curl "${curl_args[@]}" -H "Authorization: Bearer ${BEARER_TOKEN}" --location "$url" -o "$file"
+          else
+            echo "Proceeding with anonymous requests"
+            curl "${curl_args[@]}" --location "$url" -o "$file"
+          fi
+        }
 
         set -u
 
@@ -139,6 +176,7 @@ spec:
         for varfile in /var/workdir/vars/*; do
           echo
           echo "Reading $varfile"
+          # shellcheck source=/dev/null
           source $varfile
 
           echo "Checking to see if blob $OCI_ARTIFACT_DIGEST exists"
@@ -147,7 +185,7 @@ spec:
           else
             echo "Blob for ${OCI_FILENAME} does not yet exist in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}."
             echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
-            curl "${CURL_ARGS[@]}" --fail --silent --show-error --location $OCI_SOURCE -o $OCI_FILENAME
+            download "$OCI_SOURCE" "$OCI_FILENAME"
 
             echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
             echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
@@ -188,6 +226,7 @@ spec:
     - name: sbom-generate
       image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
       script: |
+        #!/bin/bash
         cat >sbom-cyclonedx.json <<EOL
         {
             "\$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
@@ -200,6 +239,7 @@ spec:
 
         for varfile in /var/workdir/vars/*; do
           echo "Reading $varfile"
+          # shellcheck source=/dev/null
           source $varfile
 
           ENCODED_URL=$(echo "${OCI_SOURCE}" | python3 -c 'import sys; import urllib.parse; print(urllib.parse.quote(sys.stdin.read().strip(), safe=":/"))')
@@ -224,6 +264,7 @@ spec:
     - name: report-sbom-url
       image: quay.io/konflux-ci/yq:latest@sha256:974dea6375ee9df561ffd3baf994db2b61777a71f3bcf0050c5dca91ac9b3430
       script: |
+        #!/bin/bash
         REPO=${IMAGE%:*}
         echo "Found that ${REPO} is the repository for ${IMAGE}"
         SBOM_DIGEST=$(sha256sum sbom-cyclonedx.json | awk '{ print $1 }')


### PR DESCRIPTION
The existing bearer token auth is not sufficient for pulling from an S3 bucket. This enables just that: pulling content from an s3 bucket.

Policy mechanisms (already in place and merged) prevent redistributing content from buckets that are not explicitly allowed.