### PR TITLE
Ignore .checkton.sarif

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ bundle_values.env
 
 *~
 *.swp
+.checkton.sarif


### PR DESCRIPTION
This is produced by local checkton runs.
