### PR TITLE
Enable remote tasks to be run in cluster

### DIFF
--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -224,7 +224,7 @@ if ! [[ $IS_LOCALHOST ]]; then
 			ret += "cd " + step.WorkingDir + "\n"
 		}
 		ret += step.Script
-		ret += "\nbuildah push \"$IMAGE\" oci:rhtap-final-image"
+		ret += "\nbuildah push \"$IMAGE\" \"oci:konflux-final-image:$IMAGE\""
 		ret += "\nREMOTESSHEOF"
 		ret += "\nchmod +x " + script + "\n"
 
@@ -253,7 +253,7 @@ if ! [[ $IS_LOCALHOST ]]; then
 		//sync back results
 		ret += "\n  rsync -ra \"$SSH_HOST:$BUILD_DIR/results/\" \"/tekton/results/\""
 
-		ret += "\n  buildah pull oci:rhtap-final-image"
+		ret += "\n  buildah pull \"oci:konflux-final-image:$IMAGE\""
 		ret += "\nelse\n  bash " + containerScript
 		ret += "\nfi"
 		ret += "\nbuildah images"
@@ -266,7 +266,6 @@ if ! [[ $IS_LOCALHOST ]]; then
 		}
 		step.Script = ret
 		builderImage = step.Image
-		step.Image = "quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44"
 		step.VolumeMounts = append(step.VolumeMounts, v1.VolumeMount{
 			Name:      "ssh",
 			ReadOnly:  true,

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -54,7 +54,7 @@ spec:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
   steps:
-  - image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -220,7 +220,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: build
-      image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
       args:
         - $(params.BUILD_ARGS[*])
       workingDir: /var/workdir
@@ -528,7 +528,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: inject-sbom-and-push
-      image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -222,7 +222,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: build
-      image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
       args:
         - $(params.BUILD_ARGS[*])
       workingDir: /var/workdir
@@ -506,7 +506,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: inject-sbom-and-push
-      image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -184,7 +184,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -209,7 +209,7 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
-    image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: build
     script: |-
       #!/bin/bash
@@ -438,7 +438,7 @@ spec:
       # Needed to generate base images SBOM
       echo "$BASE_IMAGES" >/var/workdir/base_images_from_dockerfile
 
-      buildah push "$IMAGE" oci:rhtap-final-image
+      buildah push "$IMAGE" "oci:konflux-final-image:$IMAGE"
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
@@ -478,7 +478,7 @@ spec:
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
-        buildah pull oci:rhtap-final-image
+        buildah pull "oci:konflux-final-image:$IMAGE"
       else
         bash scripts/script-build.sh
       fi
@@ -617,7 +617,7 @@ spec:
       runAsUser: 0
     workingDir: /var/workdir
   - computeResources: {}
-    image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: inject-sbom-and-push
     script: |
       base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -220,35 +220,45 @@ spec:
         #no server could be provisioned
         cat /ssh/error
         exit 1
+      fi
+      export SSH_HOST=$(cat /ssh/host)
+
+      if [ "$SSH_HOST" == "localhost" ] ; then
+        IS_LOCALHOST=true
+        echo "Localhost detected; running build in cluster"
       elif [ -e "/ssh/otp" ]; then
-       curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
-       echo "" >> ~/.ssh/id_rsa
+        curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+        echo "" >> ~/.ssh/id_rsa
       else
         cp /ssh/id_rsa ~/.ssh
       fi
-      chmod 0400 ~/.ssh/id_rsa
-      export SSH_HOST=$(cat /ssh/host)
-      export BUILD_DIR=$(cat /ssh/user-dir)
-      export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
-      mkdir -p scripts
-      echo "$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
 
-      PORT_FORWARD=""
-      PODMAN_PORT_FORWARD=""
-      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
-      PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
-      PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+      mkdir -p scripts
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        chmod 0400 ~/.ssh/id_rsa
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+        echo "$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+
+        PORT_FORWARD=""
+        PODMAN_PORT_FORWARD=""
+        if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
+          PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
+          PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+        fi
+
+        rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
+        rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
+        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+        rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
+        rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
+        rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
+        rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+        rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/results/"
       fi
 
-      rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
-      rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
-      rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
-      rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
-      rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
-      rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
-      rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
-      rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/bash
       set -o verbose
@@ -431,44 +441,48 @@ spec:
       buildah push "$IMAGE" oci:rhtap-final-image
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
-      rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
-       --tmpfs /run/secrets \
-       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-       -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-       -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-       -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-       -e CONTEXT="$CONTEXT" \
-       -e DOCKERFILE="$DOCKERFILE" \
-       -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-       -e HERMETIC="$HERMETIC" \
-       -e IMAGE="$IMAGE" \
-       -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-       -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-       -e SQUASH="$SQUASH" \
-       -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-       -e TARGET_STAGE="$TARGET_STAGE" \
-       -e TLSVERIFY="$TLSVERIFY" \
-       -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-       -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-       -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-       -e COMMIT_SHA="$COMMIT_SHA" \
-       -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-       -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
-       -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-       -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-       -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-       -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-       -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-       -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
-       -v $BUILD_DIR/scripts:/script:Z \
-      --user=0  --rm  "$BUILDER_IMAGE" /script/script-build.sh
-      rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
-      rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
-      rsync -ra "$SSH_HOST:$BUILD_DIR/tekton-results/" "/tekton/results/"
-      buildah pull oci:rhtap-final-image
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+          --tmpfs /run/secrets \
+          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
+          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
+          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
+          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
+          -e CONTEXT="$CONTEXT" \
+          -e DOCKERFILE="$DOCKERFILE" \
+          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+          -e HERMETIC="$HERMETIC" \
+          -e IMAGE="$IMAGE" \
+          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
+          -e SQUASH="$SQUASH" \
+          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
+          -e TARGET_STAGE="$TARGET_STAGE" \
+          -e TLSVERIFY="$TLSVERIFY" \
+          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
+          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
+          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
+          -e COMMIT_SHA="$COMMIT_SHA" \
+          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
+          -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
+          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
+          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
+          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
+          -v "$BUILD_DIR/results/:/tekton/results:Z" \
+          -v "$BUILD_DIR/scripts:/scripts:Z" \
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
+        buildah pull oci:rhtap-final-image
+      else
+        bash scripts/script-build.sh
+      fi
       buildah images
-      buildah tag localhost/rhtap-final-image "$IMAGE"
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path
       echo $container > /shared/container_name

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -127,6 +127,11 @@ spec:
   - description: The platform to build on
     name: PLATFORM
     type: string
+  - default: "false"
+    description: Whether to append a sanitized platform architecture on the IMAGE
+      tag
+    name: IMAGE_APPEND_PLATFORM
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -189,6 +194,8 @@ spec:
       value: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
     - name: PLATFORM
       value: $(params.PLATFORM)
+    - name: IMAGE_APPEND_PLATFORM
+      value: $(params.IMAGE_APPEND_PLATFORM)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -225,38 +232,49 @@ spec:
         #no server could be provisioned
         cat /ssh/error
         exit 1
+      fi
+      export SSH_HOST=$(cat /ssh/host)
+
+      if [ "$SSH_HOST" == "localhost" ] ; then
+        IS_LOCALHOST=true
+        echo "Localhost detected; running build in cluster"
       elif [ -e "/ssh/otp" ]; then
-       curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
-       echo "" >> ~/.ssh/id_rsa
+        curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+        echo "" >> ~/.ssh/id_rsa
       else
         cp /ssh/id_rsa ~/.ssh
       fi
-      chmod 0400 ~/.ssh/id_rsa
-      export SSH_HOST=$(cat /ssh/host)
-      export BUILD_DIR=$(cat /ssh/user-dir)
-      export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+
       mkdir -p scripts
-      echo "$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
 
-      PORT_FORWARD=""
-      PODMAN_PORT_FORWARD=""
-      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
-      PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
-      PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+      if ! [[ $IS_LOCALHOST ]]; then
+        chmod 0400 ~/.ssh/id_rsa
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+        echo "$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+
+        PORT_FORWARD=""
+        PODMAN_PORT_FORWARD=""
+        if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
+          PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
+          PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+        fi
+
+        rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
+        rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
+        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+        rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
+        rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
+        rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
+        rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+        rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/results/"
       fi
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
 
-      rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
-      rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
-      rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
-      rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
-      rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
-      rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
-      rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
-      rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/bash
       set -e
@@ -441,45 +459,49 @@ spec:
       buildah push "$IMAGE" oci:rhtap-final-image
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
-      rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
-       --tmpfs /run/secrets \
-       -e ACTIVATION_KEY="$ACTIVATION_KEY" \
-       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-       -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-       -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-       -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-       -e CONTEXT="$CONTEXT" \
-       -e DOCKERFILE="$DOCKERFILE" \
-       -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-       -e HERMETIC="$HERMETIC" \
-       -e IMAGE="$IMAGE" \
-       -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-       -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-       -e SQUASH="$SQUASH" \
-       -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-       -e TARGET_STAGE="$TARGET_STAGE" \
-       -e TLSVERIFY="$TLSVERIFY" \
-       -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-       -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-       -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-       -e COMMIT_SHA="$COMMIT_SHA" \
-       -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-       -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
-       -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-       -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-       -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-       -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-       -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-       -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
-       -v $BUILD_DIR/scripts:/script:Z \
-      --user=0  --rm  "$BUILDER_IMAGE" /script/script-build.sh
-      rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
-      rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
-      rsync -ra "$SSH_HOST:$BUILD_DIR/tekton-results/" "/tekton/results/"
-      buildah pull oci:rhtap-final-image
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+          --tmpfs /run/secrets \
+          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
+          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
+          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
+          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
+          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
+          -e CONTEXT="$CONTEXT" \
+          -e DOCKERFILE="$DOCKERFILE" \
+          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+          -e HERMETIC="$HERMETIC" \
+          -e IMAGE="$IMAGE" \
+          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
+          -e SQUASH="$SQUASH" \
+          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
+          -e TARGET_STAGE="$TARGET_STAGE" \
+          -e TLSVERIFY="$TLSVERIFY" \
+          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
+          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
+          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
+          -e COMMIT_SHA="$COMMIT_SHA" \
+          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
+          -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
+          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
+          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
+          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
+          -v "$BUILD_DIR/results/:/tekton/results:Z" \
+          -v "$BUILD_DIR/scripts:/scripts:Z" \
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
+        buildah pull oci:rhtap-final-image
+      else
+        bash scripts/script-build.sh
+      fi
       buildah images
-      buildah tag localhost/rhtap-final-image "$IMAGE"
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path
       echo $container > /shared/container_name
@@ -515,8 +537,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
       echo "Running syft on the source directory"
       syft dir:/var/workdir/source --output cyclonedx-json=/var/workdir/sbom-source.json
@@ -541,8 +564,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s /var/workdir/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
@@ -569,8 +593,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
       echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
       python3 /scripts/merge_syft_sboms.py
@@ -604,8 +629,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
@@ -681,8 +707,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -191,7 +191,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -221,7 +221,7 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
-    image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: build
     script: |-
       #!/bin/bash
@@ -456,7 +456,7 @@ spec:
       # Needed to generate base images SBOM
       echo "$BASE_IMAGES" >/shared/base_images_from_dockerfile
 
-      buildah push "$IMAGE" oci:rhtap-final-image
+      buildah push "$IMAGE" "oci:konflux-final-image:$IMAGE"
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
@@ -497,7 +497,7 @@ spec:
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
-        buildah pull oci:rhtap-final-image
+        buildah pull "oci:konflux-final-image:$IMAGE"
       else
         bash scripts/script-build.sh
       fi
@@ -624,7 +624,7 @@ spec:
       requests:
         cpu: "1"
         memory: 1Gi
-    image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: inject-sbom-and-push
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -181,7 +181,7 @@ spec:
     - name: SKIP_UNUSED_STAGES
       value: $(params.SKIP_UNUSED_STAGES)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -197,7 +197,7 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
-    image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: build
     script: |-
       #!/bin/bash
@@ -430,7 +430,7 @@ spec:
       # Needed to generate base images SBOM
       echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
 
-      buildah push "$IMAGE" oci:rhtap-final-image
+      buildah push "$IMAGE" "oci:konflux-final-image:$IMAGE"
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
@@ -471,7 +471,7 @@ spec:
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
-        buildah pull oci:rhtap-final-image
+        buildah pull "oci:konflux-final-image:$IMAGE"
       else
         bash scripts/script-build.sh
       fi
@@ -610,7 +610,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: inject-sbom-and-push
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -208,35 +208,45 @@ spec:
         #no server could be provisioned
         cat /ssh/error
         exit 1
+      fi
+      export SSH_HOST=$(cat /ssh/host)
+
+      if [ "$SSH_HOST" == "localhost" ] ; then
+        IS_LOCALHOST=true
+        echo "Localhost detected; running build in cluster"
       elif [ -e "/ssh/otp" ]; then
-       curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
-       echo "" >> ~/.ssh/id_rsa
+        curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+        echo "" >> ~/.ssh/id_rsa
       else
         cp /ssh/id_rsa ~/.ssh
       fi
-      chmod 0400 ~/.ssh/id_rsa
-      export SSH_HOST=$(cat /ssh/host)
-      export BUILD_DIR=$(cat /ssh/user-dir)
-      export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
-      mkdir -p scripts
-      echo "$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
 
-      PORT_FORWARD=""
-      PODMAN_PORT_FORWARD=""
-      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
-      PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
-      PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+      mkdir -p scripts
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        chmod 0400 ~/.ssh/id_rsa
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+        echo "$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+
+        PORT_FORWARD=""
+        PODMAN_PORT_FORWARD=""
+        if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
+          PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
+          PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+        fi
+
+        rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
+        rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
+        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+        rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
+        rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
+        rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
+        rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+        rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/results/"
       fi
 
-      rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
-      rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
-      rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
-      rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
-      rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
-      rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
-      rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
-      rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/bash
       set -o verbose
@@ -423,45 +433,49 @@ spec:
       buildah push "$IMAGE" oci:rhtap-final-image
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
-      rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
-       --tmpfs /run/secrets \
-       -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-       -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-       -e HERMETIC="$HERMETIC" \
-       -e CONTEXT="$CONTEXT" \
-       -e DOCKERFILE="$DOCKERFILE" \
-       -e IMAGE="$IMAGE" \
-       -e TLSVERIFY="$TLSVERIFY" \
-       -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-       -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-       -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-       -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-       -e TARGET_STAGE="$TARGET_STAGE" \
-       -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
-       -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-       -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-       -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-       -e SQUASH="$SQUASH" \
-       -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-       -e COMMIT_SHA="$COMMIT_SHA" \
-       -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
-       -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-       -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-       -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-       -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-       -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-       -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-       -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
-       -v $BUILD_DIR/scripts:/script:Z \
-      --user=0  --rm  "$BUILDER_IMAGE" /script/script-build.sh
-      rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
-      rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
-      rsync -ra "$SSH_HOST:$BUILD_DIR/tekton-results/" "/tekton/results/"
-      buildah pull oci:rhtap-final-image
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+          --tmpfs /run/secrets \
+          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
+          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
+          -e HERMETIC="$HERMETIC" \
+          -e CONTEXT="$CONTEXT" \
+          -e DOCKERFILE="$DOCKERFILE" \
+          -e IMAGE="$IMAGE" \
+          -e TLSVERIFY="$TLSVERIFY" \
+          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
+          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
+          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
+          -e TARGET_STAGE="$TARGET_STAGE" \
+          -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
+          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
+          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
+          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
+          -e SQUASH="$SQUASH" \
+          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
+          -e COMMIT_SHA="$COMMIT_SHA" \
+          -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
+          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
+          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
+          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
+          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
+          -v "$BUILD_DIR/results/:/tekton/results:Z" \
+          -v "$BUILD_DIR/scripts:/scripts:Z" \
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh
+        rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
+        buildah pull oci:rhtap-final-image
+      else
+        bash scripts/script-build.sh
+      fi
       buildah images
-      buildah tag localhost/rhtap-final-image "$IMAGE"
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path
       echo $container > /shared/container_name

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -118,6 +118,11 @@ spec:
   - description: The platform to build on
     name: PLATFORM
     type: string
+  - default: "false"
+    description: Whether to append a sanitized platform architecture on the IMAGE
+      tag
+    name: IMAGE_APPEND_PLATFORM
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -180,6 +185,8 @@ spec:
       value: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
     - name: PLATFORM
       value: $(params.PLATFORM)
+    - name: IMAGE_APPEND_PLATFORM
+      value: $(params.IMAGE_APPEND_PLATFORM)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -207,38 +214,49 @@ spec:
         #no server could be provisioned
         cat /ssh/error
         exit 1
+      fi
+      export SSH_HOST=$(cat /ssh/host)
+
+      if [ "$SSH_HOST" == "localhost" ] ; then
+        IS_LOCALHOST=true
+        echo "Localhost detected; running build in cluster"
       elif [ -e "/ssh/otp" ]; then
-       curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
-       echo "" >> ~/.ssh/id_rsa
+        curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+        echo "" >> ~/.ssh/id_rsa
       else
         cp /ssh/id_rsa ~/.ssh
       fi
-      chmod 0400 ~/.ssh/id_rsa
-      export SSH_HOST=$(cat /ssh/host)
-      export BUILD_DIR=$(cat /ssh/user-dir)
-      export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+
       mkdir -p scripts
-      echo "$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
 
-      PORT_FORWARD=""
-      PODMAN_PORT_FORWARD=""
-      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
-      PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
-      PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+      if ! [[ $IS_LOCALHOST ]]; then
+        chmod 0400 ~/.ssh/id_rsa
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+        echo "$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+
+        PORT_FORWARD=""
+        PODMAN_PORT_FORWARD=""
+        if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
+          PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
+          PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+        fi
+
+        rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
+        rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
+        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+        rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
+        rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
+        rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
+        rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+        rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/results/"
       fi
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
 
-      rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
-      rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
-      rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
-      rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
-      rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
-      rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
-      rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
-      rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/tekton-results/"
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/bash
       set -e
@@ -423,45 +441,49 @@ spec:
       buildah push "$IMAGE" oci:rhtap-final-image
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
-      rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
-      ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
-       --tmpfs /run/secrets \
-       -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-       -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-       -e HERMETIC="$HERMETIC" \
-       -e CONTEXT="$CONTEXT" \
-       -e DOCKERFILE="$DOCKERFILE" \
-       -e IMAGE="$IMAGE" \
-       -e TLSVERIFY="$TLSVERIFY" \
-       -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-       -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-       -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-       -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-       -e TARGET_STAGE="$TARGET_STAGE" \
-       -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-       -e ACTIVATION_KEY="$ACTIVATION_KEY" \
-       -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-       -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-       -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-       -e SQUASH="$SQUASH" \
-       -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-       -e COMMIT_SHA="$COMMIT_SHA" \
-       -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
-       -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-       -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-       -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-       -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-       -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-       -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-       -v "$BUILD_DIR/tekton-results/:/tekton/results:Z" \
-       -v $BUILD_DIR/scripts:/script:Z \
-      --user=0  --rm  "$BUILDER_IMAGE" /script/script-build.sh
-      rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
-      rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
-      rsync -ra "$SSH_HOST:$BUILD_DIR/tekton-results/" "/tekton/results/"
-      buildah pull oci:rhtap-final-image
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
+        ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+          --tmpfs /run/secrets \
+          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
+          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
+          -e HERMETIC="$HERMETIC" \
+          -e CONTEXT="$CONTEXT" \
+          -e DOCKERFILE="$DOCKERFILE" \
+          -e IMAGE="$IMAGE" \
+          -e TLSVERIFY="$TLSVERIFY" \
+          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
+          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
+          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
+          -e TARGET_STAGE="$TARGET_STAGE" \
+          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
+          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
+          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
+          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
+          -e SQUASH="$SQUASH" \
+          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
+          -e COMMIT_SHA="$COMMIT_SHA" \
+          -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
+          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
+          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
+          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
+          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
+          -v "$BUILD_DIR/results/:/tekton/results:Z" \
+          -v "$BUILD_DIR/scripts:/scripts:Z" \
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh
+        rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
+        buildah pull oci:rhtap-final-image
+      else
+        bash scripts/script-build.sh
+      fi
       buildah images
-      buildah tag localhost/rhtap-final-image "$IMAGE"
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path
       echo $container > /shared/container_name
@@ -497,8 +519,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
       echo "Running syft on the source directory"
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
@@ -523,8 +546,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
       if [ -f /var/lib/containers/java ]; then
         /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
@@ -551,8 +575,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
       echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
       python3 /scripts/merge_syft_sboms.py
@@ -586,8 +611,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
@@ -663,8 +689,9 @@ spec:
     script: |
       #!/bin/bash
       set -e
-      if [[ "${IMAGE##*-}" != "${PLATFORM##*/}" ]]; then
-        export IMAGE="${IMAGE}-${PLATFORM##*/}"
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
       fi
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -182,7 +182,7 @@ spec:
     - name: SKIP_UNUSED_STAGES
       value: $(params.SKIP_UNUSED_STAGES)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -203,7 +203,7 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
-    image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: build
     script: |-
       #!/bin/bash
@@ -438,7 +438,7 @@ spec:
       # Needed to generate base images SBOM
       echo "$BASE_IMAGES" > /shared/base_images_from_dockerfile
 
-      buildah push "$IMAGE" oci:rhtap-final-image
+      buildah push "$IMAGE" "oci:konflux-final-image:$IMAGE"
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
@@ -479,7 +479,7 @@ spec:
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
-        buildah pull oci:rhtap-final-image
+        buildah pull "oci:konflux-final-image:$IMAGE"
       else
         bash scripts/script-build.sh
       fi
@@ -606,7 +606,7 @@ spec:
       requests:
         cpu: "1"
         memory: 1Gi
-    image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: inject-sbom-and-push
     script: |
       #!/bin/bash

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -169,7 +169,7 @@ spec:
       value: $(params.SKIP_UNUSED_STAGES)
 
   steps:
-  - image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: build
     computeResources:
       limits:
@@ -491,7 +491,7 @@ spec:
       runAsUser: 0
 
   - name: inject-sbom-and-push
-    image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     computeResources: {}
     script: |
       if [ -n "${PARAM_BUILDER_IMAGE}" ]; then

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -164,7 +164,7 @@ spec:
       value: $(params.SKIP_UNUSED_STAGES)
 
   steps:
-  - image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     name: build
     computeResources:
       limits:
@@ -455,7 +455,7 @@ spec:
       runAsUser: 0
 
   - name: inject-sbom-and-push
-    image: quay.io/konflux-ci/buildah:latest@sha256:7cb5a35b7fe44e397fbf3b834f3bd8dcd9403a7c0a0b51469e6ec75b107d0846
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:5d933087a49a6e0b959b9a9fa5a91d545380217e565d7be7cc74a9588f64c314
     computeResources:
       limits:
         memory: 4Gi


### PR DESCRIPTION
By default, we should run builds matching the local architecture in-cluster to reduce the overhead of provisioning platforms. This will enable a fully matrixed build for all images using only the remote builds. This change will require the multi-platform controller to set the /ssh/host to localhost in order for the builds to run in-cluster.

In a change from the prior behavior of auto-appending the architecture to the tag, we will now append a sanitized version of the entire PLATFORM to the image tag upon request. This behavior is now needs to be explicitly requested which fixes a bug where users cannot specify the specific tag desired when using a remote build.

NOTE: There are not currently any local platforms configured. These need to be added before this PR have an effect in production.