### PR TITLE
gitops-pull-request: allow ignoring missing config

### DIFF
--- a/pipelines/gitops-pull-request-rhtap/README.md
+++ b/pipelines/gitops-pull-request-rhtap/README.md
@@ -7,6 +7,7 @@
 |ec-rekor-host| The Rekor host that EC should use to look up transparency logs| http://rekor-server.rhtap.svc| verify-enteprise-contract:0.1:REKOR_HOST ; download-sboms:0.1:REKOR_HOST|
 |ec-strict| Should EC violations cause the pipeline to fail?| true| verify-enteprise-contract:0.1:STRICT|
 |ec-tuf-mirror| The TUF mirror that EC should use| http://tuf.rhtap.svc| verify-enteprise-contract:0.1:TUF_MIRROR ; download-sboms:0.1:TUF_MIRROR|
+|fail-if-trustification-not-configured| Should the pipeline fail when there are SBOMs to upload but Trustification is not properly configured (i.e. the secret is missing or doesn't have all the required keys)?| true| upload-sboms-to-trustification:0.1:FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED|
 |git-url| Gitops repo url| None| clone-repository:0.1:url|
 |revision| Gitops repo revision| | clone-repository:0.1:revision|
 |target-branch| The target branch for the pull request| main| get-images-to-verify:0.1:TARGET_BRANCH ; get-images-to-upload-sbom:0.1:TARGET_BRANCH|
@@ -57,7 +58,7 @@
 ### upload-sbom-to-trustification:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED| Should the task fail if the Secret does not contain the required keys? (Set "true" to fail, "false" to skip uploading and exit with success).| true| |
+|FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED| Should the task fail if the Secret does not contain the required keys? (Set "true" to fail, "false" to skip uploading and exit with success).| true| '$(params.fail-if-trustification-not-configured)'|
 |HTTP_RETRIES| Maximum number of retries for transient HTTP(S) errors| 3| |
 |SBOMS_DIR| Directory containing SBOM files. The task will search for CycloneDX JSON SBOMs recursively in this directory and upload them all to Trustification. The path is relative to the 'sboms' workspace.| .| 'sboms'|
 |TRUSTIFICATION_SECRET_NAME| Name of the Secret containing auth and configuration| trustification-secret| '$(params.trustification-secret-name)'|

--- a/pipelines/gitops-pull-request-rhtap/gitops-pull-request.yaml
+++ b/pipelines/gitops-pull-request-rhtap/gitops-pull-request.yaml
@@ -39,6 +39,12 @@ spec:
       name: trustification-secret-name
       type: string
       default: tpa-secret
+    - description: >-
+        Should the pipeline fail when there are SBOMs to upload but Trustification is not properly
+        configured (i.e. the secret is missing or doesn't have all the required keys)?
+      name: fail-if-trustification-not-configured
+      type: string
+      default: "true"
   tasks:
     - name: clone-repository
       params:
@@ -148,6 +154,8 @@ spec:
           value: sboms
         - name: TRUSTIFICATION_SECRET_NAME
           value: $(params.trustification-secret-name)
+        - name: FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED
+          value: $(params.fail-if-trustification-not-configured)
       workspaces:
         - name: sboms
           workspace: workspace


### PR DESCRIPTION
Expose the FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED param of the upload-sbom-to-trustification task as a pipeline param.

This allows the caller of the pipeline to decide if missing configuration should cause the pipeline to fail.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
