### PR TITLE
Use a var for the images file path in the RHTAP gather-deploy-images task

### DIFF
--- a/task/gather-deploy-images/0.1/gather-deploy-images.yaml
+++ b/task/gather-deploy-images/0.1/gather-deploy-images.yaml
@@ -40,6 +40,7 @@ spec:
       set -euo pipefail
 
       IMAGE_PATH='.spec.template.spec.containers[0].image'
+      IMAGES_FILE='/tmp/all-images.txt'
       component_name=$(yq .metadata.name application.yaml)
 
       for env in "$@"; do
@@ -55,9 +56,9 @@ spec:
         fi
 
         printf "%s\n" "$image"
-      done | sort -u > /tmp/all-images.txt
+      done | sort -u > $IMAGES_FILE
 
-      if [ ! -s /tmp/all-images.txt ]; then
+      if [ ! -s $IMAGES_FILE ]; then
         echo "No images to verify"
         touch $(results.IMAGES_TO_VERIFY.path)
         exit 0
@@ -66,7 +67,7 @@ spec:
       # TODO: each component needs a {"source": {"git": {"url": "...", "revision": "..."}}}
       #       will that be too large for Tekton results?
 
-      jq --compact-output --raw-input --slurp < /tmp/all-images.txt '
+      jq --compact-output --raw-input --slurp < $IMAGES_FILE '
         # split input file
         split("\n") |
         # drop empty lines


### PR DESCRIPTION
Short explanation: Clean up the code a little by using a variable.

Long explanation: This task gets converted to a bash script and wrapped by a Jenkins shared library in the brand new RHTAP Jenkins pipeline sample templates. When testing the RHTAP Jenkins pipeline I found the default Jenkins user could not write to `/tmp/`, so I wanted to change the location of the file. This refactor makes that just a single line change, rather than having to change the path in three places.

See also
https://github.com/redhat-appstudio/tssc-sample-jenkins/pull/1/ where this PR was suggested by @mmorhun, and also
https://github.com/jduimovich/tssc-jenkins/pull/2 where the cosign, Enterprise Contract, and promote pipeline support was being added to the RHTAP Jenkins templates.