### PR TITLE
Fix default value in verify-signed-rpms

### DIFF
--- a/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
+++ b/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
@@ -11,7 +11,7 @@ spec:
     - name: FAIL_UNSIGNED
       type: string
       description: "[true | false] If true fail if unsigned RPMs were found"
-      default: ""
+      default: "false"
     - name: WORKDIR
       type: string
       default: /tmp


### PR DESCRIPTION
The value of the `FAIL_UNSIGNED` parameter of the `verify-signed-rpms` Task is used when calling the `rpm_verifier` binary. An empty string value is not a valid value result in this error:

```
Usage: rpm_verifier [OPTIONS]
Try 'rpm_verifier --help' for help.

Error: Invalid value for '--fail-unsigned': '' is not a valid boolean.
```

This commit changes the default value to `"false"`. This is both valid and inline with [ADR-14](https://konflux-ci.dev/architecture/ADR/0014-let-pipelines-proceed.html).

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
