### PR TITLE
Upload Snyk report to snyk.io on push

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -49,9 +49,6 @@ spec:
         - name: args
           value: [".", "-c", "/workspace/shared-workspace/source/.yamllint"]
       - name: sast-snyk-check
-        params:
-          - name: SNYK_SECRET
-            value: snyk-shared-secret
         runAfter:
           - fetch-repository
         taskRef:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-event: "push"
     pipelinesascode.tekton.dev/on-target-branch: "main"
-    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml, task/apply-tags/0.1/apply-tags.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml, task/apply-tags/0.1/apply-tags.yaml, task/sast-snyk-check/0.1/sast-snyk-check.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:
@@ -40,6 +40,18 @@ spec:
           name: git-clone
         workspaces:
           - name: output
+            workspace: workspace
+
+      - name: sast-snyk-check
+        params:
+          - name: ARGS
+            value: --report --project-name=konflux-ci/build-definitions
+        runAfter:
+          - clone-repository
+        taskRef:
+          name: sast-snyk-check
+        workspaces:
+          - name: workspace
             workspace: workspace
 
       - name: ec-task-checks


### PR DESCRIPTION
The PR pipeline already runs Snyk, but doesn't upload the results
anywhere. Run Snyk in the push pipeline as well and upload the results
to snyk.io.

Note: we should not upload to Snyk from the PR pipeline. Each PR would
overwrite the Snyk results from other PRs. By uploading only in the push
pipeline, the results will at least always reflect the state in 'main'.

The results can be found in the 'konflux-ci/build-definitions' project
in the Snyk organization associated with the Snyk token used by the
pipeline (currently the 'developer-red-hat-trusted-application-pipeline'
organization).