### PR TITLE
User configurable timeout for EaaS cluster provisioning

### DIFF
--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/README.md
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/README.md
@@ -9,9 +9,10 @@ This StepAction provisions an ephemeral cluster using Hypershift with 3 worker n
 |version|The version of OpenShift to install. Container images will be pulled from: `quay.io/openshift-release-dev/ocp-release:${version}-multi`.||true|
 |instanceType|AWS EC2 instance type for worker nodes. Supported values: `m5.large`, `m5.xlarge`, `m5.2xlarge`, `m6g.large`, `m6g.xlarge`, `m6g.2xlarge`|m6g.large|false|
 |insecureSkipTLSVerify|Skip TLS verification when accessing the EaaS hub cluster. This should not be set to "true" in a production environment.|false|false|
+|timeout|How long to wait for cluster provisioning to complete.|30m|false|
 
 ## Results
 |name|description|
 |---|---|
-|clusterName|The name of the generated ClusterTemplateInstance resource|
+|clusterName|The name of the generated ClusterTemplateInstance resource.|
 

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
@@ -28,6 +28,10 @@ spec:
       description: >-
         Skip TLS verification when accessing the EaaS hub cluster.
         This should not be set to "true" in a production environment.
+    - name: timeout
+      type: string
+      default: 30m
+      description: How long to wait for cluster provisioning to complete.
   results:
     - name: clusterName
       description: The name of the generated ClusterTemplateInstance resource.
@@ -45,6 +49,8 @@ spec:
           key: kubeconfig
     - name: INSECURE_SKIP_TLS_VERIFY
       value: "$(params.insecureSkipTLSVerify)"
+    - name: TIMEOUT
+      value: "$(params.timeout)"
   script: |
     #!/bin/bash
     set -eo pipefail
@@ -61,6 +67,8 @@ spec:
           value: $INSTANCE_TYPE
         - name: version
           value: $VERSION
+        - name: timeout
+          value: $TIMEOUT
     EOF
 
     trap 'rm -f "$KUBECONFIG"' EXIT
@@ -71,8 +79,8 @@ spec:
     echo "Created ClusterTemplateInstance $CTI_NAME"
     echo -n $CTI_NAME > $(step.results.clusterName.path)
 
-    echo "Waiting for ClusterTemplateInstance to be ready (20m timeout)"
-    if "${OC[@]}" wait cti $CTI_NAME --for=jsonpath='{.status.phase}'=Ready --timeout=20m; then
+    echo "Waiting for ClusterTemplateInstance to be ready ($TIMEOUT timeout)"
+    if "${OC[@]}" wait cti $CTI_NAME --for=jsonpath='{.status.phase}'=Ready --timeout="$TIMEOUT"; then
       echo "Successfully provisioned $CTI_NAME"
       exit 0
     else

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
@@ -80,11 +80,11 @@ spec:
     echo -n $CTI_NAME > $(step.results.clusterName.path)
 
     echo "Waiting for ClusterTemplateInstance to be ready ($TIMEOUT timeout)"
-    if "${OC[@]}" wait cti $CTI_NAME --for=jsonpath='{.status.phase}'=Ready --timeout="$TIMEOUT"; then
+    if "${OC[@]}" wait cti "$CTI_NAME" --for=jsonpath='{.status.phase}'=Ready --timeout="$TIMEOUT"; then
       echo "Successfully provisioned $CTI_NAME"
       exit 0
     else
-      "${OC[@]}" get cti $CTI_NAME -o yaml
+      "${OC[@]}" get cti "$CTI_NAME" -o yaml
       echo "Failed to provision $CTI_NAME"
       exit 1
     fi


### PR DESCRIPTION
The default is increased to 30m to add more buffer for unforeseen performance issues.