### PR TITLE
feat(RHTAPWATCH-1171): support custom cert in clair-scan

### DIFF
--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -53,6 +53,8 @@
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused, should be removed in next task version.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -51,6 +51,8 @@
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused, should be removed in next task version.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -23,6 +23,8 @@
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused, should be removed in next task version.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -23,6 +23,8 @@
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused, should be removed in next task version.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -23,6 +23,8 @@
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused, should be removed in next task version.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/task/clair-scan/0.1/README.md
+++ b/task/clair-scan/0.1/README.md
@@ -7,11 +7,13 @@ analyzing the components of a container image and comparing them against Clair's
 
 ## Params:
 
-| name         | description                                                    |
-|--------------|----------------------------------------------------------------|
-| image-digest | Image digest to scan.                                          |
-| image-url    | Image URL.                                                     |
-| docker-auth  | unused, should be removed in next task version                 |
+| name         | description                                                     | default |
+|--------------|-----------------------------------------------------------------|-|
+| image-digest | Image digest to scan.                                           | None |
+| image-url    | Image URL.                                                      | None |
+| docker-auth  | unused, should be removed in next task version                  | |
+| ca-trust-config-map-name|The name of the ConfigMap to read CA bundle data from.| trusted-ca |
+| ca-trust-config-map-key |The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt |
 
 ## Results:
 

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -19,6 +19,14 @@ spec:
     - name: docker-auth
       description: unused, should be removed in next task version.
       default: ""
+    - name: ca-trust-config-map-name
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: ca-trust-config-map-key
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.
@@ -26,6 +34,12 @@ spec:
       description: Clair scan result.
     - name: IMAGES_PROCESSED
       description: Images processed in the task.
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        subPath: ca-bundle.crt
+        readOnly: true
   steps:
     - name: get-image-manifests
       image: quay.io/redhat-appstudio/konflux-test:v1.4.5@sha256:801a105ba0f9c7f58f5ba5cde1a3b4404009fbebb1028779ca2c5de211e94940
@@ -196,3 +210,11 @@ spec:
         note="Task $(context.task.name) completed: Refer to Tekton task result CLAIR_SCAN_RESULT for vulnerabilities scanned by Clair."
         TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "$note")
         echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+  volumes:
+  - name: trusted-ca
+    configMap:
+      name: $(params.ca-trust-config-map-name)
+      items:
+        - key: $(params.ca-trust-config-map-key)
+          path: ca-bundle.crt
+      optional: true


### PR DESCRIPTION
Support mounting a custom ca-bundle to allow the clair-scan task to use a registry with a self-signed certificate.