### PR TITLE
issue-1249: entitlements cert not working using buildah task with support for activation keys

### DIFF
--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -171,8 +171,6 @@ spec:
       emptyDir: {}
   stepTemplate:
     env:
-      - name: ACTIVATION_KEY
-        value: $(params.ACTIVATION_KEY)
       - name: ADDITIONAL_SECRET
         value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
@@ -366,15 +364,13 @@ spec:
         ACTIVATION_KEY_PATH="/activation-key"
         ENTITLEMENT_PATH="/entitlement"
 
-        # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-        # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
-
-        if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        if [ -e /activation-key/org ]; then
           cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
           mkdir /shared/rhsm-tmp
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
           echo "Adding activation key to the build"
-        elif [ -d "$ENTITLEMENT_PATH" ]; then
+
+        elif find /entitlement -name "*.pem" >>null; then
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -367,14 +367,16 @@ spec:
         ENTITLEMENT_PATH="/entitlement"
 
         # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-        # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+        # when activation keys are used an empty directory on shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced container
+        # To use activation key file 'org' must exist, which means the key 'org' must exist in the key/value secret
 
-        if [ -d "$ACTIVATION_KEY_PATH" ]; then
+        if [ -e /activation-key/org ]; then
           cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
           mkdir /shared/rhsm-tmp
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
           echo "Adding activation key to the build"
-        elif [ -d "$ENTITLEMENT_PATH" ]; then
+
+        elif find /entitlement -name "*.pem" >>null; then
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
           echo "Adding the entitlement to the build"

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -147,8 +147,6 @@ spec:
   stepTemplate:
     computeResources: {}
     env:
-    - name: ACTIVATION_KEY
-      value: $(params.ACTIVATION_KEY)
     - name: ADDITIONAL_SECRET
       value: $(params.ADDITIONAL_SECRET)
     - name: ADD_CAPABILITIES
@@ -378,15 +376,13 @@ spec:
       ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
 
-      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
-
-      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+      if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
         echo "Adding activation key to the build"
-      elif [ -d "$ENTITLEMENT_PATH" ]; then
+
+      elif find /entitlement -name "*.pem" >>null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
@@ -436,7 +432,6 @@ spec:
       rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
        --tmpfs /run/secrets \
-       -e ACTIVATION_KEY="$ACTIVATION_KEY" \
        -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
        -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -379,14 +379,16 @@ spec:
       ENTITLEMENT_PATH="/entitlement"
 
       # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+      # when activation keys are used an empty directory on shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced container
+      # To use activation key file 'org' must exist, which means the key 'org' must exist in the key/value secret
 
-      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+      if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
         echo "Adding activation key to the build"
-      elif [ -d "$ENTITLEMENT_PATH" ]; then
+
+      elif find /entitlement -name "*.pem" >>null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -170,8 +170,6 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
-    - name: ACTIVATION_KEY
-      value: $(params.ACTIVATION_KEY)
     - name: ADDITIONAL_SECRET
       value: $(params.ADDITIONAL_SECRET)
     - name: BUILD_ARGS_FILE
@@ -370,15 +368,13 @@ spec:
       ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
 
-      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
-
-      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+      if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
         echo "Adding activation key to the build"
-      elif [ -d "$ENTITLEMENT_PATH" ]; then
+
+      elif find /entitlement -name "*.pem" >> null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"
@@ -442,7 +438,6 @@ spec:
        -e TARGET_STAGE="$TARGET_STAGE" \
        -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
        -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-       -e ACTIVATION_KEY="$ACTIVATION_KEY" \
        -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
        -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
        -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -361,14 +361,16 @@ spec:
       ENTITLEMENT_PATH="/entitlement"
 
       # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+      # when activation keys are used an empty directory on shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced container
+      # To use activation key file 'org' must exist, which means the key 'org' must exist in the key/value secret
 
-      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+      if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
         echo "Adding activation key to the build"
-      elif [ -d "$ENTITLEMENT_PATH" ]; then
+
+      elif find /entitlement -name "*.pem" >> null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -157,8 +157,6 @@ spec:
       value: $(params.BUILDER_IMAGE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
-    - name: ACTIVATION_KEY
-      value: $(params.ACTIVATION_KEY)
     - name: ADDITIONAL_SECRET
       value: $(params.ADDITIONAL_SECRET)
     - name: BUILD_ARGS_FILE
@@ -313,15 +311,13 @@ spec:
       ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
 
-      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
-
-      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+      if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
         echo "Adding activation key to the build"
-      elif [ -d "$ENTITLEMENT_PATH" ]; then
+
+      elif find /entitlement -name "*.pem" >> null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -303,14 +303,16 @@ spec:
       ENTITLEMENT_PATH="/entitlement"
 
       # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used, an empty directory on shared emptydir volume to /etc/pki/entitlement to prevent certificates from being included in the produced container.
+      # when activation keys are used an empty directory on shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced container
+      # To use activation key file 'org' must exist, which means the key 'org' must exist in the key/value secret
 
-      if [ -d "$ACTIVATION_KEY_PATH" ]; then
+      if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
         echo "Adding activation key to the build"
-      elif [ -d "$ENTITLEMENT_PATH" ]; then
+
+      elif find /entitlement -name "*.pem" >> null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
         echo "Adding the entitlement to the build"


### PR DESCRIPTION
closes https://github.com/konflux-ci/build-definitions/issues/1249 

When an activation key secret is not provided, Kubernetes still mounts a volume. This volume is also not truly empty but contains some symlinks in it. To ensure that the fallback to mounted certificates works for backwards compatibility, activation keys will only be mounted now if the 'org' key is present in the key/value secret. This is tested by checking for a file-like-object (-e) in the dir where the secret is mounted.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
