### PR TITLE
Don't verify redhat-appstudio/dance-bootstrap-app

### DIFF
--- a/task/gather-deploy-images/0.1/gather-deploy-images.yaml
+++ b/task/gather-deploy-images/0.1/gather-deploy-images.yaml
@@ -53,6 +53,13 @@ spec:
             # don't check images that didn't change between the current revision and the target branch
             continue
           fi
+
+        fi
+
+        # Workaround for RHTAPBUGS-1284
+        if [[ "$image" =~ quay.io/redhat-appstudio/dance-bootstrap-app ]]; then
+          # Don't check the dance-bootstrap-app image
+          continue
         fi
 
         printf "%s\n" "$image"


### PR DESCRIPTION
This is the upstream change related to the following downstream changes to make sure everything stays in sync.

- https://github.com/redhat-appstudio/tssc-sample-jenkins/pull/5
- https://github.com/redhat-appstudio/tssc-sample-pipelines/pull/54

Explanation: For various reasons quay.io/redhat-appstudio/dance-bootstrap-app will never pass an EC check, so try to validate it.

This was causing problems during QE testing of the Jenkins pipeline in RHTAP 1.2.

Ref: https://issues.redhat.com/browse/RHTAPBUGS-1284
