### PR TITLE
Add ssh keepalives into buildah-remote to prevent (or at least debug) the ssh conection interruptions

### DIFF
--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -118,7 +118,7 @@ fi
 chmod 0400 ~/.ssh/id_rsa
 export SSH_HOST=$(cat /ssh/host)
 export BUILD_DIR=$(cat /ssh/user-dir)
-export SSH_ARGS="-o StrictHostKeyChecking=no"
+export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
 mkdir -p scripts
 echo "$BUILD_DIR"
 ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -229,7 +229,7 @@ spec:
       chmod 0400 ~/.ssh/id_rsa
       export SSH_HOST=$(cat /ssh/host)
       export BUILD_DIR=$(cat /ssh/user-dir)
-      export SSH_ARGS="-o StrictHostKeyChecking=no"
+      export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
       mkdir -p scripts
       echo "$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -229,7 +229,7 @@ spec:
       chmod 0400 ~/.ssh/id_rsa
       export SSH_HOST=$(cat /ssh/host)
       export BUILD_DIR=$(cat /ssh/user-dir)
-      export SSH_ARGS="-o StrictHostKeyChecking=no"
+      export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
       mkdir -p scripts
       echo "$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -217,7 +217,7 @@ spec:
       chmod 0400 ~/.ssh/id_rsa
       export SSH_HOST=$(cat /ssh/host)
       export BUILD_DIR=$(cat /ssh/user-dir)
-      export SSH_ARGS="-o StrictHostKeyChecking=no"
+      export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
       mkdir -p scripts
       echo "$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -211,7 +211,7 @@ spec:
       chmod 0400 ~/.ssh/id_rsa
       export SSH_HOST=$(cat /ssh/host)
       export BUILD_DIR=$(cat /ssh/user-dir)
-      export SSH_ARGS="-o StrictHostKeyChecking=no"
+      export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
       mkdir -p scripts
       echo "$BUILD_DIR"
       ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"


### PR DESCRIPTION
It is reported some ssh conection interruptions during the long running remote build tasks. It is not yet 100% clear what causes it, but sending those keepalives might help to keep the channel up, or understood which side is closing the connections.
See https://issues.redhat.com/browse/KFLUXBUGS-1523 for more details