### PR TITLE
task/operator-sdk-generate-bundle: kustomize-dir param

### DIFF
--- a/task/operator-sdk-generate-bundle/0.1/README.md
+++ b/task/operator-sdk-generate-bundle/0.1/README.md
@@ -7,6 +7,7 @@ Generate an OLM bundle using the operator-sdk
 |---|---|---|---|
 |input-dir|Directory to read cluster-ready operator manifests from|deploy|false|
 |channels|Comma-separated list of channels the bundle belongs to|alpha|false|
+|kustomize-dir|Directory containing kustomize bases in a "bases" dir and a kustomization.yaml for operator-framework manifests |""|false|
 |version|Semantic version of the operator in the generated bundle||true|
 |package-name|Bundle's package name||true|
 

--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -12,6 +12,11 @@ spec:
     - name: channels
       description: Comma-separated list of channels the bundle belongs to
       default: alpha
+    - name: kustomize-dir
+      description: >
+        Directory containing kustomize bases in a "bases" dir and a
+        kustomization.yaml for operator-framework manifests
+      default: ""
     - name: version
       description: Semantic version of the operator in the generated bundle
     - name: package-name
@@ -37,3 +42,5 @@ spec:
         - $(params.version)
         - --package
         - $(params.package-name)
+        - --kustomize-dir
+        - $(params.kustomize-dir)


### PR DESCRIPTION
allow setting `--kustomize-dir` flag when generating the bundle. This works for generating using a base CSV. If the string is empty (default), it will build without an existing base and generate the default CSV.
