### PR TITLE
Run prefetch-deps Task unconditionally in TA

### DIFF
--- a/pipelines/docker-build-oci-ta/patch.yaml
+++ b/pipelines/docker-build-oci-ta/patch.yaml
@@ -64,6 +64,8 @@
     value: $(params.image-expires-after)
 - op: remove
   path: /spec/tasks/2/workspaces/0
+- op: remove
+  path: /spec/tasks/2/when
 
 # build-container
 - op: replace


### PR DESCRIPTION
The way the docker-build-oci-ta Pipeline is defined, the prefetch-dependencies Task must always execute. In some cases this becomes a no-op operation and the provided source artifact is passed through to its result.

This change removes the `when` clause from the Task in the docker-build-oci-ta Pipeline. Without this, all Tasks are skipped after the prefetch-dependencies Task.

Ref: [KFLUXBUGS-1516](https://issues.redhat.com//browse/KFLUXBUGS-1516)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
