### PR TITLE
feat: add renovate customManager to update buildah image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -77,5 +77,16 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^task/[\\w-]+/[0-9.]+/[\\w-]\\.yaml$"],
+      "matchStrings": [
+        "value: (?<depName>quay\\.io/konflux-ci/buildah):(?<currentValue>latest)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "autoReplaceStringTemplate": "value: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+      "datasourceTemplate": "docker"
+    }
   ]
 }


### PR DESCRIPTION
[STONEBLD-2661](https://issues.redhat.com//browse/STONEBLD-2661)

buildah image is also specified in the .spec.stepTemplate.env. This custom manager updates the buildah image there.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
