### PR TITLE
fix: specify tag for oras image

### DIFF
--- a/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
+++ b/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
@@ -58,7 +58,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: push
-      image: quay.io/konflux-ci/oras@sha256:ecf9ba09b3a194a32ad82fe6e29ef7391cbc008e23d8d79698386d817a5572b3
+      image: quay.io/konflux-ci/oras:latest@sha256:ecf9ba09b3a194a32ad82fe6e29ef7391cbc008e23d8d79698386d817a5572b3
       workingDir: /var/workdir
       env:
         - name: IMAGE

--- a/task/push-dockerfile/0.1/push-dockerfile.yaml
+++ b/task/push-dockerfile/0.1/push-dockerfile.yaml
@@ -39,7 +39,7 @@ spec:
     description: Digest-pinned image reference to the Dockerfile image.
   steps:
   - name: push
-    image: quay.io/konflux-ci/oras@sha256:ecf9ba09b3a194a32ad82fe6e29ef7391cbc008e23d8d79698386d817a5572b3
+    image: quay.io/konflux-ci/oras:latest@sha256:ecf9ba09b3a194a32ad82fe6e29ef7391cbc008e23d8d79698386d817a5572b3
     workingDir: $(workspaces.workspace.path)
     env:
     - name: IMAGE


### PR DESCRIPTION
By specifying the tag explicitly, the oras image gets update along with others in other tasks. Otherwise, two separate pull requests are created, one for tasks that reference oras image with tag latest and digest, and another one for this task.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
