### PR TITLE
feat(RHTAPWATCH-1177): support custom certificate in sbom-json-check

### DIFF
--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -134,6 +134,8 @@
 ### sbom-json-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |IMAGE_URL| Fully qualified image name to verify.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -128,6 +128,8 @@
 ### sbom-json-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |IMAGE_URL| Fully qualified image name to verify.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -108,6 +108,8 @@
 ### sbom-json-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |IMAGE_URL| Fully qualified image name to verify.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -112,6 +112,8 @@
 ### sbom-json-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |IMAGE_URL| Fully qualified image name to verify.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -113,6 +113,8 @@
 ### sbom-json-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |IMAGE_URL| Fully qualified image name to verify.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -86,6 +86,8 @@
 ### sbom-json-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |IMAGE_URL| Fully qualified image name to verify.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### summary:0.2 task parameters

--- a/task/sbom-json-check/0.1/README.md
+++ b/task/sbom-json-check/0.1/README.md
@@ -8,10 +8,12 @@ The syntax of the sbom-cyclonedx.json file (found in the `/root/buildinfo/conten
 
 ## Params:
 
-| name         | description                           |
-|--------------|---------------------------------------|
-| IMAGE_URL    | Fully qualified image name to verify. |
-| IMAGE_DIGEST | Image digest.                         |
+| name                     | description                                                            | default       |
+|--------------------------|------------------------------------------------------------------------|---------------|
+| IMAGE_URL                | Fully qualified image name to verify.                                  | None          |
+| IMAGE_DIGEST             | Image digest.                                                          | None          |
+| CA_TRUST_CONFIG_MAP_NAME | The name of the ConfigMap to read CA bundle data from.                 | trusted-ca    |
+| CA_TRUST_CONFIG_MAP_KEY  | The name of the key in the ConfigMap that contains the CA bundle data. | ca-bundle.crt |
 
 ## Results:
 

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -13,6 +13,14 @@ spec:
     - name: IMAGE_DIGEST
       description: Image digest.
       type: string
+    - name: CA_TRUST_CONFIG_MAP_NAME
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: CA_TRUST_CONFIG_MAP_KEY
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
   results:
     - description: Tekton task test output.
       name: TEST_OUTPUT
@@ -31,6 +39,10 @@ spec:
     volumeMounts:
       - mountPath: /shared
         name: shared
+      - name: trusted-ca
+        mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        subPath: ca-bundle.crt
+        readOnly: true
     env:
       - name: IMAGE_URL
         value: $(params.IMAGE_URL)
@@ -114,3 +126,10 @@ spec:
   volumes:
   - name: shared
     emptyDir: {}
+  - name: trusted-ca
+    configMap:
+      name: $(params.CA_TRUST_CONFIG_MAP_NAME)
+      items:
+        - key: $(params.CA_TRUST_CONFIG_MAP_KEY)
+          path: ca-bundle.crt
+      optional: true


### PR DESCRIPTION
Support mounting a custom ca-bundle to allow the sbom-json-check task to use a registry with a self-signed certificate.