### PR TITLE
download-sbom: make auth work with curl < 7.83.0

### DIFF
--- a/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
+++ b/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
@@ -207,25 +207,30 @@ spec:
 
         local tmp_dest=$(mktemp --tmpdir)
 
+        local headers_file
+        headers_file=$(mktemp --tmpdir download-sbom-task.headers.XXXXXX)
+
         local common_curl_opts=(--silent --show-error --retry "${HTTP_RETRIES:-3}")
 
         echo "GET $blob_url" >&2
-        local outputs
-        mapfile -t outputs < <(curl \
+        local response_code
+        response_code=$(curl \
             "${common_curl_opts[@]}" \
             -L \
-            --write-out '%header{www-authenticate}\n%{response_code}' \
+            --write-out '%{response_code}' \
             --output "$tmp_dest" \
+            --dump-header "$headers_file" \
             "$blob_url"
         )
-        local www_authenticate=${outputs[0]}
-        local response_code=${outputs[1]}
 
         if [[ "$response_code" -eq 200 ]]; then
             # Blob download didn't require auth, we're done
             :
         elif [[ "$response_code" -eq 401 ]]; then
             echo "Got 401, trying to authenticate" >&2
+
+            local www_authenticate
+            www_authenticate=$(sed -n 's/^www-authenticate:\s*//ip' "$headers_file")
 
             local realm service scope token_url
             realm=$(get_from_www_auth_header "$www_authenticate" realm)

--- a/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
+++ b/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
@@ -205,7 +205,8 @@ spec:
         # ->  https://registry.com/v2/namespace/repo/blobs/sha256:digest
         blob_url=$(sed -E 's;([^/]*)/(.*)@(.*);https://\1/v2/\2/blobs/\3;' <<< "$blob_ref")
 
-        local tmp_dest=$(mktemp --tmpdir)
+        local tmp_dest
+        tmp_dest=$(mktemp --tmpdir download-sbom-task.out.XXXXXX)
 
         local headers_file
         headers_file=$(mktemp --tmpdir download-sbom-task.headers.XXXXXX)


### PR DESCRIPTION
[RHTAPBUGS-1289](https://issues.redhat.com//browse/RHTAPBUGS-1289)

Curl versions lower than 7.83.0 do not support the %header{...} syntax.
Write out all the headers and pick out the one we need using sed.
