### PR TITLE
task/operator-sdk-generate-bundle: --extra-service-accounts

### DIFF
--- a/task/operator-sdk-generate-bundle/0.1/README.md
+++ b/task/operator-sdk-generate-bundle/0.1/README.md
@@ -8,6 +8,7 @@ Generate an OLM bundle using the operator-sdk
 |input-dir|Directory to read cluster-ready operator manifests from|deploy|false|
 |channels|Comma-separated list of channels the bundle belongs to|alpha|false|
 |kustomize-dir|Directory containing kustomize bases in a "bases" dir and a kustomization.yaml for operator-framework manifests |""|false|
+|extra-service-accounts|Comma-seperated list of service account names, outside of the operator's Deployment account, that have bindings to {Cluster}Roles that should be added to the CSV |""|false|
 |version|Semantic version of the operator in the generated bundle||true|
 |package-name|Bundle's package name||true|
 

--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -17,6 +17,12 @@ spec:
         Directory containing kustomize bases in a "bases" dir and a
         kustomization.yaml for operator-framework manifests
       default: ""
+    - name: extra-service-accounts
+      description: >
+        Comma-seperated list of service account names, outside of the
+        operator's Deployment account, that have bindings to {Cluster}Roles
+        that should be added to the CSV
+      default: ""
     - name: version
       description: Semantic version of the operator in the generated bundle
     - name: package-name
@@ -44,3 +50,5 @@ spec:
         - $(params.package-name)
         - --kustomize-dir
         - $(params.kustomize-dir)
+        - --extra-service-accounts
+        - $(params.extra-service-accounts)


### PR DESCRIPTION
allow for passing the `--extra-service-accounts` operator-sdk flag in to configure additional cluster permissions in the CSV

```
❯ operator-sdk generate bundle --overwrite \
        --version 4.16.265-f15333d --input-dir deploy \
        --package osd-example-operator --channels stable \
       --kustomize-dir config/manifests/ --extra-service-accounts osd-example-admin
❯ cat bundle/manifests/osd-example-operator.clusterserviceversion.yaml
apiVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
...
  name: osd-example-operator.v4.16.265-f15333d
  namespace: openshift-osd-example-operator
spec:
...
  install:
    spec:
      clusterPermissions:
      - rules:
        - apiGroups:
          - '*'
          resources:
          - '*'
          verbs:
          - '*'
        - nonResourceURLs:
          - '*'
          verbs:
          - '*'
        serviceAccountName: osd-example-admin
...
```