### PR TITLE
STONEBLD-2649: add github action workflow to check task owners

### DIFF
--- a/.github/workflows/check-task-owners.yaml
+++ b/.github/workflows/check-task-owners.yaml
@@ -1,0 +1,15 @@
+name: Validate PR - check task owners
+'on':
+  pull_request:
+    branches: [main]
+jobs:
+  check:
+    name: Check Task OWNERS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Check task owners
+        run: |
+          ./hack/check-task-owners.sh

--- a/hack/check-task-owners.sh
+++ b/hack/check-task-owners.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+check_result=$(mktemp)
+
+# Check the OWNERS file is present for each task
+find task/ -mindepth 1 -maxdepth 1 -type d | \
+    while read -r task_dir; do
+        owners_file="$task_dir/OWNERS"
+        if [ ! -e "$owners_file" ]; then
+            echo "error: missing owners file $owners_file" >>"$check_result"
+            continue
+        fi
+        approvers=$(yq '.approvers[]' $owners_file)
+        reviewers=$(yq '.reviwers[]' $owners_file)
+        if [ -z "$approvers" ] && [ -z "$reviewers" ]; then
+            echo "error: $task_dir/OWNERS don't have atleast 1 approver and 1 reviewer" >>"$check_result"
+        fi
+    done
+
+if [ -s "$check_result" ]; then
+    cat "$check_result"
+    echo "Please add OWNERS file with atleast 1 approver and 1 reviewer"
+    exit 1
+fi
+

--- a/task/acs-deploy-check/OWNERS
+++ b/task/acs-deploy-check/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - build-team
+reviewers:
+  - build-team

--- a/task/acs-image-check/OWNERS
+++ b/task/acs-image-check/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - build-team
+reviewers:
+  - build-team

--- a/task/acs-image-scan/OWNERS
+++ b/task/acs-image-scan/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - build-team
+reviewers:
+  - build-team

--- a/task/buildah-remote-oci-ta/OWNERS
+++ b/task/buildah-remote-oci-ta/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - build-team
+reviewers:
+  - build-team

--- a/task/download-sbom-from-url-in-attestation/OWNERS
+++ b/task/download-sbom-from-url-in-attestation/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - build-team
+reviewers:
+  - build-team

--- a/task/gather-deploy-images/OWNERS
+++ b/task/gather-deploy-images/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - build-team
+reviewers:
+  - build-team

--- a/task/rpm-ostree/OWNERS
+++ b/task/rpm-ostree/OWNERS
@@ -1,0 +1,6 @@
+
+#See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - cgwalters
+reviewers:
+  - cgwalters

--- a/task/upload-sbom-to-trustification/OWNERS
+++ b/task/upload-sbom-to-trustification/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - build-team
+reviewers:
+  - build-team


### PR DESCRIPTION
- This PR adds a github workflow to check task owners file is present and having atleast  1 approver and 1 reviewer 
- Also adds missing owners file

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
