### PR TITLE
feat(RHTAPWATCH-1178): support custom certificate in apply-tags

### DIFF
--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -21,6 +21,8 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### buildah-oci-ta:0.2 task parameters
 |name|description|default value|already set by|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -21,6 +21,8 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### buildah:0.2 task parameters
 |name|description|default value|already set by|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -19,6 +19,8 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### buildah:0.1 task parameters
 |name|description|default value|already set by|

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -19,6 +19,8 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -19,6 +19,8 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -19,6 +19,8 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
+|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-container.results.IMAGE_URL)'|
 ### clair-scan:0.1 task parameters
 |name|description|default value|already set by|

--- a/task/apply-tags/0.1/README.md
+++ b/task/apply-tags/0.1/README.md
@@ -10,7 +10,9 @@ LABEL konflux.additional-tags="tag tag2"
 ```
 
 ## Parameters
-|name|description|default value|required|
-|---|---|---|---|
-|IMAGE|Reference of image that was pushed to registry in the buildah task.||true|
-|ADDITIONAL_TAGS|Additional tags that will be applied to the image in the registry.|[]|false|
+| name                     | description                                                            | default value | required |
+|--------------------------|------------------------------------------------------------------------|---------------|----------|
+| IMAGE                    | Reference of image that was pushed to registry in the buildah task.    |               | true     |
+| ADDITIONAL_TAGS          | Additional tags that will be applied to the image in the registry.     | []            | false    |
+| CA_TRUST_CONFIG_MAP_NAME | The name of the ConfigMap to read CA bundle data from.                 | trusted-ca    | false    |
+| CA_TRUST_CONFIG_MAP_KEY  | The name of the key in the ConfigMap that contains the CA bundle data. | ca-bundle.crt | false    |

--- a/task/apply-tags/0.1/apply-tags.yaml
+++ b/task/apply-tags/0.1/apply-tags.yaml
@@ -18,6 +18,20 @@ spec:
     description: Additional tags that will be applied to the image in the registry.
     type: array
     default: []
+  - name: CA_TRUST_CONFIG_MAP_NAME
+    type: string
+    description: The name of the ConfigMap to read CA bundle data from.
+    default: trusted-ca
+  - name: CA_TRUST_CONFIG_MAP_KEY
+    type: string
+    description: The name of the key in the ConfigMap that contains the CA bundle data.
+    default: ca-bundle.crt
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        subPath: ca-bundle.crt
+        readOnly: true
   steps:
     - name: apply-additional-tags-from-parameter
       image: registry.access.redhat.com/ubi9/skopeo:9.4-12@sha256:61871ab37e9b1291e3547f36ba692a4dc59c22e9e045a5b4d5bf9a55155ab779
@@ -61,3 +75,11 @@ spec:
         else
           echo "No additional tags specified in the image labels"
         fi
+  volumes:
+  - name: trusted-ca
+    configMap:
+      name: $(params.CA_TRUST_CONFIG_MAP_NAME)
+      items:
+        - key: $(params.CA_TRUST_CONFIG_MAP_KEY)
+          path: ca-bundle.crt
+      optional: true


### PR DESCRIPTION
Support mounting a custom ca-bundle to allow the apply-tags task to use a registry with a self-signed certificate.
