### PR TITLE
feat(RHTAPWATCH-1180): support custom certificate in clamav-scan

### DIFF
--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -61,6 +61,8 @@
 ### clamav-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -59,6 +59,8 @@
 ### clamav-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -31,6 +31,8 @@
 ### clamav-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -31,6 +31,8 @@
 ### clamav-scan:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |docker-auth| unused| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-container.results.IMAGE_URL)'|

--- a/task/clamav-scan/0.1/README.md
+++ b/task/clamav-scan/0.1/README.md
@@ -7,11 +7,13 @@ The task will extract compiled code to compare it against the latest virus datab
 
 ## Params:
 
-| name         | description                                                    |
-|--------------|----------------------------------------------------------------|
-| image-digest | Image digest to scan.                                          |
-| image-url    | Image URL.                                                     |
-| docker-auth  | Unused, should be removed in next task version.                |
+| name                     | description                                                            | default       |
+|--------------------------|------------------------------------------------------------------------|---------------|
+| image-digest             | Image digest to scan.                                                  | None          |
+| image-url                | Image URL.                                                             | None          |
+| docker-auth              | Unused, should be removed in next task version.                        |               |
+| ca-trust-config-map-name | The name of the ConfigMap to read CA bundle data from.                 | trusted-ca    |
+| ca-trust-config-map-key  | The name of the key in the ConfigMap that contains the CA bundle data. | ca-bundle.crt |
 
 ## Results:
 

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -23,6 +23,14 @@ spec:
     - name: docker-auth
       description: unused
       default: ""
+    - name: ca-trust-config-map-name
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: ca-trust-config-map-key
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
 
   steps:
     - name: extract-and-scan-image
@@ -143,6 +151,10 @@ spec:
           name: dbfolder
         - mountPath: /work
           name: work
+        - name: trusted-ca
+          mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
     - name: upload
       image: quay.io/konflux-ci/oras:latest@sha256:f4b891ee3038a5f13cd92ff4f473faad5601c2434d1c6b9bccdfc134d9d5f820
       computeResources:
@@ -205,3 +217,10 @@ spec:
       emptyDir: {}
     - name: work
       emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        name: $(params.ca-trust-config-map-name)
+        items:
+          - key: $(params.ca-trust-config-map-key)
+            path: ca-bundle.crt
+        optional: true


### PR DESCRIPTION
Support mounting a custom ca-bundle to allow the clamav-scan task to use a registry with a self-signed certificate.
