### PR TITLE
Replace grep base images parsing with dockerfile-json

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -288,14 +288,12 @@ spec:
 
         BUILDAH_ARGS=()
 
-        BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+        BASE_IMAGES=$(dockerfile-json "$dockerfile_path" | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName')
         if [ "${HERMETIC}" == "true" ]; then
           BUILDAH_ARGS+=("--pull=never")
           UNSHARE_ARGS="--net"
           for image in $BASE_IMAGES; do
-            if [ "${image}" != "scratch" ]; then
-              unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
-            fi
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
           done
           echo "Build will be executed with network isolation"
         fi
@@ -415,9 +413,7 @@ spec:
 
         touch /shared/base_images_digests
         for image in $BASE_IMAGES; do
-          if [ "${image}" != "scratch" ]; then
-            buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >>/shared/base_images_digests
-          fi
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >>/shared/base_images_digests
         done
 
         # Needed to generate base images SBOM

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -323,14 +323,12 @@ spec:
 
       BUILDAH_ARGS=()
 
-      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      BASE_IMAGES=$(dockerfile-json "$dockerfile_path" | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName')
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
         for image in $BASE_IMAGES; do
-          if [ "${image}" != "scratch" ]; then
-            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
-          fi
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -450,9 +448,7 @@ spec:
 
       touch /shared/base_images_digests
       for image in $BASE_IMAGES; do
-        if [ "${image}" != "scratch" ]; then
-          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >>/shared/base_images_digests
-        fi
+        buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >>/shared/base_images_digests
       done
 
       # Needed to generate base images SBOM

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -305,14 +305,12 @@ spec:
 
       BUILDAH_ARGS=()
 
-      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      BASE_IMAGES=$(dockerfile-json "$dockerfile_path" | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName')
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
         for image in $BASE_IMAGES; do
-          if [ "${image}" != "scratch" ]; then
-            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
-          fi
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -432,9 +430,7 @@ spec:
 
       touch /shared/base_images_digests
       for image in $BASE_IMAGES; do
-        if [ "${image}" != "scratch" ]; then
-          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> /shared/base_images_digests
-        fi
+        buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> /shared/base_images_digests
       done
 
       # Needed to generate base images SBOM

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -225,14 +225,12 @@ spec:
 
       BUILDAH_ARGS=()
 
-      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      BASE_IMAGES=$(dockerfile-json "$dockerfile_path" | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName')
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
         for image in $BASE_IMAGES; do
-          if [ "${image}" != "scratch" ]; then
-            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
-          fi
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -352,9 +350,7 @@ spec:
 
       touch /shared/base_images_digests
       for image in $BASE_IMAGES; do
-        if [ "${image}" != "scratch" ]; then
-          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> /shared/base_images_digests
-        fi
+        buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> /shared/base_images_digests
       done
 
       # Needed to generate base images SBOM


### PR DESCRIPTION
This is more reliable and allow us to fix bugs where base images were loaded incorrectly.

For example, previously this part in Dockerfile:

LABEL description="this is a build \
                   from single-arch"

Would return "single-arch" as a base image.

Using dockerfile-json also solves the problem of omitting "scratch" from the results.

Another advantage is that when we have something such as:

FROM registry.access.redhat.com/ubi9/ubi:latest as builder ...
FROM builder AS build1

then only the original image
"registry.access.redhat.com/ubi9/ubi:latest" will be reported.

[KFLUXBUGS-1269](https://issues.redhat.com//browse/KFLUXBUGS-1269)
