### PR TITLE
renovate: fix regex pattern for buildah image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -84,7 +84,7 @@
       "customType": "regex",
       "fileMatch": ["^task/[\\w-]+/[0-9.]+/[\\w-]\\.yaml$"],
       "matchStrings": [
-        "value: (?<depName>quay\\.io/konflux-ci/buildah):(?<currentValue>latest)@(?<currentDigest>sha256:[a-f0-9]{64})"
+        "value: (?<depName>quay\\.io/konflux-ci/buildah[^:]*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "autoReplaceStringTemplate": "value: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
       "datasourceTemplate": "docker"


### PR DESCRIPTION
We previously enabled a customManager for the buildah image used in buildah-remote (in e49a405ee38019dfa39abe66b2d85684efe881c0).

Since then, the name of the buildah image has changed to 'buildah-task', so the updates stopped working. Make the regex more general.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
