### PR TITLE
Use :latest tag for yq image consistently

### DIFF
--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -70,7 +70,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: validate-bib-config
-      image: quay.io/konflux-ci/yq@sha256:e240014fd357bd00fa3aeaae3e5c0507e5b4fff54a392ea030b785ca3128c509
+      image: quay.io/konflux-ci/yq:latest@sha256:e240014fd357bd00fa3aeaae3e5c0507e5b4fff54a392ea030b785ca3128c509
       script: |-
         #!/bin/bash
         set -o verbose

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -135,7 +135,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: sanitize-cachi2-config-file-with-yq
-      image: quay.io/konflux-ci/yq@sha256:e240014fd357bd00fa3aeaae3e5c0507e5b4fff54a392ea030b785ca3128c509
+      image: quay.io/konflux-ci/yq:latest@sha256:e240014fd357bd00fa3aeaae3e5c0507e5b4fff54a392ea030b785ca3128c509
       script: |
         if [ -n "${CONFIG_FILE_CONTENT}" ]; then
           # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -64,7 +64,7 @@ spec:
 
   steps:
   - name: sanitize-cachi2-config-file-with-yq
-    image: quay.io/konflux-ci/yq@sha256:e240014fd357bd00fa3aeaae3e5c0507e5b4fff54a392ea030b785ca3128c509
+    image: quay.io/konflux-ci/yq:latest@sha256:e240014fd357bd00fa3aeaae3e5c0507e5b4fff54a392ea030b785ca3128c509
     script: |
       if [ -n "${CONFIG_FILE_CONTENT}" ]
       then


### PR DESCRIPTION
Previously, some of the quay.io/konflux-ci/yq pullspecs included the tag and some did not. This made Renovate open two PRs to update yq instead of one.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
