### PR TITLE
feat(STONEINTG-931): adding deprecation warning for sbom-json-check task

### DIFF
--- a/task/sbom-json-check/0.1/README.md
+++ b/task/sbom-json-check/0.1/README.md
@@ -1,5 +1,9 @@
 # sbom-json-check task
 
+## Deprecation notice
+
+This task is deprecated, please remove it from you pipeline.
+
 ## Description:
 
 The sbom-json-check task verifies the integrity and security of a Software Bill of Materials (SBOM) file in JSON format using the CyloneDX tool.

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: sbom-json-check
+  annotations:
+    build.appstudio.redhat.com/expires-on: 2025-09-30T00:00:00Z
 spec:
   description: >-
     Verifies the integrity and security of the Software Bill of Materials (SBOM) file in JSON format using CyloneDX tool.
@@ -52,6 +54,7 @@ spec:
       #!/usr/bin/env bash
       set -euo pipefail
       source /utils.sh
+      echo "[WARNING]: !!!DEPRECATED!!! - sbom-json-check task is going to be removed in near future, please remove it from your pipeline. (Deprecation date: 2024-09-30)"
       trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
       images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'


### PR DESCRIPTION
We want to completely remove sbom-json-check task from build-definitions in future,
for now, we just want to inform customers about such fact.

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
