### PR TITLE
renovate: fix fileMatch pattern for regex manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -82,7 +82,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "fileMatch": ["^task/[\\w-]+/[0-9.]+/[\\w-]\\.yaml$"],
+      "fileMatch": ["^task/[\\w-]+/[0-9.]+/[\\w-]+\\.yaml$"],
       "matchStrings": [
         "value: (?<depName>quay\\.io/konflux-ci/buildah[^:]*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],


### PR DESCRIPTION
#1316 wasn't enough, the file pattern was broken too

Tested in https://github.com/chmeliik/build-definitions/pull/18