### PR TITLE
Remove java references from pipelines

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -11,7 +11,6 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.2:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-images:0.2:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|java| Java build| false| |
 |output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-images:0.2:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-images:0.2:PREFETCH_INPUT|
@@ -185,7 +184,6 @@
 |CHAINS-GIT_URL| |$(tasks.clone-repository.results.url)|
 |IMAGE_DIGEST| |$(tasks.build-image-index.results.IMAGE_DIGEST)|
 |IMAGE_URL| |$(tasks.build-image-index.results.IMAGE_URL)|
-|JAVA_COMMUNITY_DEPENDENCIES| |$(tasks.build-images.results.JAVA_COMMUNITY_DEPENDENCIES[0])|
 ## Available results from tasks
 ### build-image-index:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/docker-build-multi-platform-oci-ta/patch.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/patch.yaml
@@ -19,24 +19,6 @@
 #     12  apply-tags
 #     13  push-dockerfile
 
-# Order of pipeline parameters
-# $ kustomize build pipelines/docker-build-oci-ta | yq ".spec.params.[].name" | nl -v 0
-#      0  git-url
-#      1  revision
-#      2  output-image
-#      3  path-context
-#      4  dockerfile
-#      5  rebuild
-#      6  skip-checks
-#      7  hermetic
-#      8  prefetch-input
-#      9  java
-#     10  image-expires-after
-#     11  build-source-image
-#     12  build-image-index
-#     13  build-args
-#     14  build-args-file
-
 # build-container
 - op: replace
   path: /spec/tasks/3/name
@@ -65,9 +47,27 @@
   path: /spec/tasks/4/runAfter
   value:
   - build-images
+
+# Order of pipeline parameters
+# $ kustomize build pipelines/docker-build-oci-ta | yq ".spec.params.[].name" | nl -v 0
+#      0  git-url
+#      1  revision
+#      2  output-image
+#      3  path-context
+#      4  dockerfile
+#      5  rebuild
+#      6  skip-checks
+#      7  hermetic
+#      8  prefetch-input
+#      9  image-expires-after
+#     10  build-source-image
+#     11  build-image-index
+#     12  build-args
+#     13  build-args-file
+
 # We want to always build the image index by default
 - op: replace
-  path: /spec/params/12/default  # build-image-index
+  path: /spec/params/11/default  # build-image-index
   value: "true"
 
 # Add a pipeline definition parameter to customize the build platforms
@@ -80,8 +80,3 @@
     default:
       - "linux/x86_64"
       - "linux/arm64"
-
-# Just use the first container built for the JAVA_COMMUNITY_DEPENDENCIES result
-- op: replace
-  path: /spec/results/4/value
-  value: $(tasks.build-images.results.JAVA_COMMUNITY_DEPENDENCIES[0])

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -10,7 +10,6 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.2:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-container:0.2:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|java| Java build| false| |
 |output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-container:0.2:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.2:PREFETCH_INPUT|
@@ -182,7 +181,6 @@
 |CHAINS-GIT_URL| |$(tasks.clone-repository.results.url)|
 |IMAGE_DIGEST| |$(tasks.build-image-index.results.IMAGE_DIGEST)|
 |IMAGE_URL| |$(tasks.build-image-index.results.IMAGE_URL)|
-|JAVA_COMMUNITY_DEPENDENCIES| |$(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)|
 ## Available results from tasks
 ### build-image-index:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -9,7 +9,7 @@
     "pipelines.openshift.io/runtime": "generic"
     "pipelines.openshift.io/strategy": "docker"
 # Remove unused parameters from the template
-# yq ".spec.params.[].name"  pipelines/template-build/template-build.yaml | nl -v 0
+# $ yq ".spec.params.[].name"  pipelines/template-build/template-build.yaml | nl -v 0
 #      0  git-url
 #      1  revision
 #      2  output-image
@@ -19,17 +19,14 @@
 #      6  skip-checks
 #      7  hermetic
 #      8  prefetch-input
-#      9  java
-#     10  image-expires-after
-#     11  build-source-image
-#     12  build-image-index
+#      9  image-expires-after
+#     10  build-source-image
+#     11  build-image-index
 
 - op: remove
-  path: /spec/params/12  # build-image-index
+  path: /spec/params/11  # build-image-index
 - op: remove
-  path: /spec/params/11  # build-source-image
-- op: remove
-  path: /spec/params/9  # java
+  path: /spec/params/10  # build-source-image
 - op: remove
   path: /spec/params/8  # prefetch-input
 - op: remove

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -10,7 +10,6 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.2:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.2:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|java| Java build| false| |
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.2:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.2:PREFETCH_INPUT|
@@ -180,7 +179,6 @@
 |CHAINS-GIT_URL| |$(tasks.clone-repository.results.url)|
 |IMAGE_DIGEST| |$(tasks.build-image-index.results.IMAGE_DIGEST)|
 |IMAGE_URL| |$(tasks.build-image-index.results.IMAGE_URL)|
-|JAVA_COMMUNITY_DEPENDENCIES| |$(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)|
 ## Available results from tasks
 ### build-image-index:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -66,9 +66,3 @@
       - $(params.build-args[*])
   - name: BUILD_ARGS_FILE
     value: "$(params.build-args-file)"
-
-- op: add
-  path: /spec/results/-
-  value:
-    name: JAVA_COMMUNITY_DEPENDENCIES
-    value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -8,7 +8,6 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.2:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|java| Java build| false| |
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.2:IMAGE ; build-image-index:0.1:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | |

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -8,7 +8,6 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.1:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|java| Java build| false| |
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:PATH_CONTEXT ; push-dockerfile:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input|

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -8,7 +8,6 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.1:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|java| Java build| false| |
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:PATH_CONTEXT ; push-dockerfile:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -8,7 +8,6 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
-|java| Java build| false| |
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT ; push-dockerfile:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input|

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -45,10 +45,6 @@ spec:
       name: prefetch-input
       type: string
       default: ""
-    - description: Java build
-      name: java
-      type: string
-      default: "false"
     - description: Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
       name: image-expires-after
       default: ""


### PR DESCRIPTION
This does not remove any of the java task dependencies but it will reduce a potential migration for new users that onboard. By removing the result, any users that onboard will have an easier migration.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
