### PR TITLE
repo existence check: check all pipelines

### DIFF
--- a/.tekton/scripts/check-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/check-task-pipeline-bundle-repos.sh
@@ -59,7 +59,7 @@ done
 # pipelines
 pl_names=($(oc kustomize pipelines/ | yq -o json '.metadata.name' | jq -r))
 # Currently, only one pipeline for core services CI
-pl_names=($(oc kustomize pipelines/core-services/ | yq -o json '"core-services-" + .metadata.name' | jq -r))
+pl_names+=($(oc kustomize pipelines/core-services/ | yq -o json '"core-services-" + .metadata.name' | jq -r))
 for pl_name in ${pl_names[@]}; do
     if ! locate_in_all_namespaces pipeline "$pl_name"; then
         has_missing_repo=yes


### PR DESCRIPTION
The script had a bug (after 1a9375b67745b15eda6eee8bdf17713ac63a7600) that made it check only the "core-services" pipelines.
