### PR TITLE
feat(KONFLUX-4136): add new reduce-snapshot task

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -59,16 +59,43 @@ spec:
       type: string
       description: The name of the key in the ConfigMap that contains the CA bundle data.
       default: "ca-bundle.crt"
+    - name: SINGLE_COMPONENT
+      type: string
+      description: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
+      default: "false"
+    - name: PIPELINERUN_ID
+      type: string
+      description: PipelineRun ID
+      default: "$(context.pipelineRun.name)"
   results:
     - name: TEST_OUTPUT
       value: "$(tasks.verify.results.TEST_OUTPUT)"
   tasks:
+    - name: reduce-snapshot-to-single-component
+      params:
+        - name: SNAPSHOT
+          value: "$(params.SNAPSHOT)"
+        - name: SINGLE_COMPONENT
+          value: "$(params.SINGLE_COMPONENT)"
+        - name: PIPELINERUN_ID
+          value: "$(params.PIPELINERUN_ID)"
+      taskRef:
+        resolver: "git"
+        params:
+          - name: url
+            # temp
+            value: https://github.com/scoheb/build-definitions
+          - name: revision
+            # temp
+            value: reduce-snapshot
+          - name: pathInRepo
+            value: task/reduce-snapshot-to-single-component/0.1/reduce-snapshot-to-single-component.yaml
     - name: verify
       params:
         - name: POLICY_CONFIGURATION
           value: "$(params.POLICY_CONFIGURATION)"
         - name: IMAGES
-          value: "$(params.SNAPSHOT)"
+          value: "$(tasks.reduce-snapshot-to-single-component.results.SNAPSHOT)"
         - name: SSL_CERT_DIR
           value: "$(params.SSL_CERT_DIR)"
         # It's confusing for users to see a passing taskrun that represents a failing EC test.
@@ -96,3 +123,5 @@ spec:
             value: verify-enterprise-contract
           - name: kind
             value: task
+      runAfter:
+        - reduce-snapshot-to-single-component

--- a/task/reduce-snapshot-to-single-component/0.1/README.md
+++ b/task/reduce-snapshot-to-single-component/0.1/README.md
@@ -1,0 +1,20 @@
+# reduce-snapshot-to-single-component task
+
+This task is designed to reduce the Snapshot that is passed to the Enterprise Contract verify task. 
+
+If activated via the SINGLE_COMPONENT parameter, then the Snapshot is filtered to only contain the Component which caused the Snapshot to be built.
+
+The use case for this reduction is based on the desire to have components that are built to be quickly released
+regardless of any other Components within the Snapshot and Application. 
+
+## Parameters
+| name            | description                                                                              | default value | required   |
+|-----------------|------------------------------------------------------------------------------------------|---------------|------------|
+| SNAPSHOT        | Snapshot to possibly reduce                                                              |               | true       |
+| SINGLE_COMPONENT | Reduce the Snapshot to only the component whose build caused the Snapshot to be created  | false         | false      |
+| PIPELINERUN_ID  | Name of current PipelineRun.                                                             |               | true       |
+
+## Results
+| name     | description        |
+|----------|--------------------|
+| SNAPSHOT | Resulting Snapshot |

--- a/task/reduce-snapshot-to-single-component/0.1/reduce-snapshot-to-single-component.yaml
+++ b/task/reduce-snapshot-to-single-component/0.1/reduce-snapshot-to-single-component.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: reduce-snapshot-to-single-component
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.0.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+spec:
+  description: Reduce a snapshot to contain the single component that the snapshot was created for.
+  params:
+    - name: SNAPSHOT
+      description: Snapshot to possibly reduce
+      type: string
+    - name: SINGLE_COMPONENT
+      description: Reduce the Snapshot to only the component whose build caused the Snapshot to be created
+      type: string
+      default: false
+    - name: PIPELINERUN_ID
+      description: Name of current PipelineRun.
+      type: string
+  results:
+    - name: SNAPSHOT
+      description: Reduced Snapshot if SINGLE_COMPONENT == true otherwise the original Snapshot
+  steps:
+    - name: reduce-snapshot-to-single-component
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+      env:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: SINGLE_COMPONENT
+          value: $(params.SINGLE_COMPONENT)
+        - name: PIPELINERUN_ID
+          value: $(params.PIPELINERUN_ID)
+      script: |
+        #!/usr/bin/env bash
+        set -eu
+
+        echo "Single Component mode? ${SINGLE_COMPONENT}"
+        if [ "${SINGLE_COMPONENT}" == "true" ]; then
+          SNAPSHOT_CREATION_TYPE=$(oc get "pr/$PIPELINERUN_ID" -ojson | jq -rec '.metadata.labels."test.appstudio.openshift.io/type" // ""')
+          SNAPSHOT_CREATION_COMPONENT=$(oc get "pr/$PIPELINERUN_ID" -ojson | jq -rec '.metadata.labels."appstudio.openshift.io/component" // ""')
+
+          echo "SNAPSHOT_CREATION_TYPE: ${SNAPSHOT_CREATION_TYPE}"
+          echo "SNAPSHOT_CREATION_COMPONENT: ${SNAPSHOT_CREATION_COMPONENT}"
+          if [ "${SNAPSHOT_CREATION_TYPE}" == "component" ] && [ "${SNAPSHOT_CREATION_COMPONENT}" != "" ]; then
+            echo "Single Component mode is ${SINGLE_COMPONENT} and Snapshot type is component"
+            REDUCED_SNAPSHOT=$(echo "${SNAPSHOT}" | jq --arg component "${SNAPSHOT_CREATION_COMPONENT}" \
+                'del(.components[] | select(.name != $component))')
+            echo "Reducing Snapshot to:"
+            echo "$REDUCED_SNAPSHOT" | jq .
+            SNAPSHOT=$(echo "$REDUCED_SNAPSHOT" | tr -d ' ' | tr -d '\n')
+          fi
+        fi
+
+        echo "$SNAPSHOT" | tee -a "$(results.SNAPSHOT.path)"

--- a/task/reduce-snapshot-to-single-component/OWNERS
+++ b/task/reduce-snapshot-to-single-component/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - integration-team
+reviewers:
+  - integration-team


### PR DESCRIPTION
- This task, **reduce-snapshot-to-single-component** does nothing by default.
- If turned on, it will create a new single component Snapshot
  based on which component caused the Snapshot to be built.
