### PR TITLE
Use Konflux-built Syft image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,12 +23,12 @@
         "quay.io/konflux-ci/source-container-build",
         "quay.io/redhat-appstudio/e2e-tests",
         "quay.io/redhat-appstudio/buildah",
-        "quay.io/redhat-appstudio/syft",
         "quay.io/redhat-appstudio/hacbs-jvm-build-request-processor",
         "quay.io/redhat-appstudio/build-definitions-source-image-build-utils",
         "quay.io/redhat-appstudio/cosign",
         "quay.io/redhat-appstudio/cachi2",
-        "quay.io/redhat-appstudio/sbom-utility-scripts-image"
+        "quay.io/redhat-appstudio/sbom-utility-scripts-image",
+        "registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9"
       ],
       "groupName": "build",
       "reviewers": ["mmorhun", "tkdchen", "rcerven", "mkosiarc", "brunoapimentel", "chmeliik"]

--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -253,11 +253,15 @@ if ! [[ $IS_LOCALHOST ]]; then
 		//sync back results
 		ret += "\n  rsync -ra \"$SSH_HOST:$BUILD_DIR/results/\" \"/tekton/results/\""
 
-		ret += "\n  buildah pull \"oci:konflux-final-image:$IMAGE\""
-		ret += "\nelse\n  bash " + containerScript
-		ret += "\nfi"
-		ret += "\nbuildah images"
-		ret += "\ncontainer=$(buildah from --pull-never \"$IMAGE\")\nbuildah mount \"$container\" | tee /shared/container_path\necho $container > /shared/container_name"
+		ret += `
+  buildah pull "oci:konflux-final-image:$IMAGE"
+else
+  bash ` + containerScript + `
+fi
+buildah images
+container=$(buildah from --pull-never "$IMAGE")
+buildah mount "$container" | tee /shared/container_path
+echo $container > /shared/container_name`
 
 		for _, i := range strings.Split(ret, "\n") {
 			if strings.HasSuffix(i, " ") {

--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -261,6 +261,8 @@ fi
 buildah images
 container=$(buildah from --pull-never "$IMAGE")
 buildah mount "$container" | tee /shared/container_path
+# delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+find $(cat /shared/container_path) -xtype l -delete
 echo $container > /shared/container_name`
 
 		for _, i := range strings.Split(ret, "\n") {

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -426,7 +426,7 @@ spec:
           add:
             - SETFCAP
     - name: sbom-syft-generate
-      image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+      image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
       workingDir: /var/workdir/source
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -396,6 +396,8 @@ spec:
 
         container=$(buildah from --pull-never $IMAGE)
         buildah mount $container | tee /shared/container_path
+        # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+        find $(cat /shared/container_path) -xtype l -delete
         echo $container >/shared/container_name
 
         # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
@@ -434,7 +436,6 @@ spec:
       script: |
         echo "Running syft on the source directory"
         syft dir:/var/workdir/source --output cyclonedx-json=/var/workdir/sbom-source.json
-        find $(cat /shared/container_path) -xtype l -delete
         echo "Running syft on the image filesystem"
         syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
     - name: analyse-dependencies-java-sbom

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -404,6 +404,8 @@ spec:
 
         container=$(buildah from --pull-never $IMAGE)
         buildah mount $container | tee /shared/container_path
+        # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+        find $(cat /shared/container_path) -xtype l -delete
         echo $container >/shared/container_name
 
         # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
@@ -442,7 +444,6 @@ spec:
       script: |
         echo "Running syft on the source directory"
         syft dir:/var/workdir/source --output cyclonedx-json=/var/workdir/sbom-source.json
-        find $(cat /shared/container_path) -xtype l -delete
         echo "Running syft on the image filesystem"
         syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
       computeResources:

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -434,7 +434,7 @@ spec:
           add:
             - SETFCAP
     - name: sbom-syft-generate
-      image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+      image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
       workingDir: /var/workdir/source
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -487,6 +487,8 @@ spec:
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
     securityContext:
       capabilities:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -511,7 +511,7 @@ spec:
       readOnly: true
     workingDir: /var/workdir
   - computeResources: {}
-    image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     name: sbom-syft-generate
     script: |
       echo "Running syft on the source directory"

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -420,6 +420,8 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container >/shared/container_name
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
@@ -512,7 +514,6 @@ spec:
     script: |
       echo "Running syft on the source directory"
       syft dir:/var/workdir/source --output cyclonedx-json=/var/workdir/sbom-source.json
-      find $(cat /shared/container_path) -xtype l -delete
       echo "Running syft on the image filesystem"
       syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
     volumeMounts:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -506,6 +506,8 @@ spec:
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
     securityContext:
       capabilities:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -536,7 +536,7 @@ spec:
       requests:
         cpu: 500m
         memory: 1Gi
-    image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     name: sbom-syft-generate
     script: |
       #!/bin/bash

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -439,6 +439,8 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container >/shared/container_name
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
@@ -543,7 +545,6 @@ spec:
       fi
       echo "Running syft on the source directory"
       syft dir:/var/workdir/source --output cyclonedx-json=/var/workdir/sbom-source.json
-      find $(cat /shared/container_path) -xtype l -delete
       echo "Running syft on the image filesystem"
       syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
     volumeMounts:

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -412,6 +412,8 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
@@ -505,7 +507,6 @@ spec:
     script: |
       echo "Running syft on the source directory"
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
-      find $(cat /shared/container_path) -xtype l -delete
       echo "Running syft on the image filesystem"
       syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
     volumeMounts:

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -504,7 +504,7 @@ spec:
       readOnly: true
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     name: sbom-syft-generate
     script: |
       echo "Running syft on the source directory"

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -480,6 +480,8 @@ spec:
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
     securityContext:
       capabilities:

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -518,7 +518,7 @@ spec:
       requests:
         cpu: 500m
         memory: 1Gi
-    image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     name: sbom-syft-generate
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -421,6 +421,8 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
@@ -525,7 +527,6 @@ spec:
       fi
       echo "Running syft on the source directory"
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
-      find $(cat /shared/container_path) -xtype l -delete
       echo "Running syft on the image filesystem"
       syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
     volumeMounts:

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -488,6 +488,8 @@ spec:
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
     securityContext:
       capabilities:

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -382,7 +382,7 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: sbom-syft-generate
-    image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     # Respect Syft configuration if the user has it in the root of their repository
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -343,6 +343,8 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
@@ -387,7 +389,6 @@ spec:
     script: |
       echo "Running syft on the source directory"
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
-      find $(cat /shared/container_path) -xtype l -delete
       echo "Running syft on the image filesystem"
       syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
     volumeMounts:

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -379,7 +379,7 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: sbom-syft-generate
-    image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     # Respect Syft configuration if the user has it in the root of their repository
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -341,6 +341,8 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
@@ -391,7 +393,6 @@ spec:
     script: |
       echo "Running syft on the source directory"
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
-      find $(cat /shared/container_path) -xtype l -delete
       echo "Running syft on the image filesystem"
       syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
     volumeMounts:

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -196,7 +196,7 @@ spec:
       name: ssh
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: sbom-syft-generate

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -194,7 +194,7 @@ spec:
       name: ssh
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: sbom-syft-generate

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -159,7 +159,7 @@ spec:
       name: gen-source
     workingDir: /gen-source
 
-  - image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: sbom-syft-generate

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -133,6 +133,8 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /workspace/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /workspace/container_path) -xtype l -delete
       echo $container > /workspace/container_name
     image: registry.access.redhat.com/ubi9/buildah:9.4-12@sha256:29402688af2b394a8400d946751520dbaea64759bbce2ef6928dc58ede6020e6
     name: build
@@ -166,7 +168,6 @@ spec:
     workingDir: $(workspaces.source.path)/source
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
-      find $(cat /workspace/container_path) -xtype l -delete
       syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -142,7 +142,7 @@ spec:
       name: gen-source
     workingDir: /gen-source
 
-  - image: quay.io/redhat-appstudio/syft:v0.105.1@sha256:1910b829997650c696881e5fc2fc654ddf3184c27edb1b2024e9cb2ba51ac431
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: sbom-syft-generate

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -117,6 +117,8 @@ spec:
 
       container=$(buildah from --pull-never $IMAGE)
       buildah mount $container | tee /workspace/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /workspace/container_path) -xtype l -delete
       echo $container > /workspace/container_name
     image: registry.access.redhat.com/ubi9/buildah:9.4-12@sha256:29402688af2b394a8400d946751520dbaea64759bbce2ef6928dc58ede6020e6
     name: build
@@ -149,7 +151,6 @@ spec:
     workingDir: $(workspaces.source.path)/source
     script: |
       syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
-      find $(cat /workspace/container_path) -xtype l -delete
       syft dir:$(cat /workspace/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
     volumeMounts:
     - mountPath: /var/lib/containers


### PR DESCRIPTION
[STONEBLD-2715](https://issues.redhat.com//browse/STONEBLD-2715)

Switch from quay.io/redhat-appstudio/syft to
registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9.

The latter is built and released via Konflux (from
https://github.com/redhat-appstudio/rh-syft/) and is a bit more up to
date.