### PR TITLE
fix RHTAPBUGS-1305 setup git credential helper for private repos

### DIFF
--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -82,7 +82,7 @@
 ### summary:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|build-task-status| State of build task in pipelineRun| Succeeded| '$(tasks.build-container.results.status)'|
+|build-task-status| State of build task in pipelineRun| Succeeded| '$(tasks.build-container.status)'|
 |git-url| Git URL| None| '$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)'|
 |image-url| Image URL| None| '$(params.output-image)'|
 |pipelinerun-name| pipeline-run to annotate| None| '$(context.pipelineRun.name)'|
@@ -135,6 +135,10 @@
 |git-auth| |True| clone-repository:0.1:basic-auth|
 |workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; build-container:0.1:source|
 ## Available workspaces from tasks
+### acs-deploy-check:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|gitops-auth| | True| |
 ### buildah-rhtap:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
@@ -149,3 +153,7 @@
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| The workspace where source code is included.| True| workspace|
+### update-deployment:0.1 task workspaces
+|name|description|optional|workspace from pipeline
+|---|---|---|---|
+|gitops-auth| | True| |

--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -18,6 +18,7 @@
 ### acs-deploy-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|gitops-auth-secret-name| Secret of basic-auth type containing credentials to clone the gitops repository. | gitops-auth-secret| |
 |gitops-repo-url| URL of gitops repository to check.| None| '$(params.git-url)-gitops'|
 |insecure-skip-tls-verify| When set to `"true"`, skip verifying the TLS certs of the Central endpoint. Defaults to `"false"`. | false| 'true'|
 |rox-secret-name| Secret containing the StackRox server endpoint and API token with CI permissions under rox-api-endpoint and rox-api-token keys. For example: rox-api-endpoint: rox.stackrox.io:443 ; rox-api-token: eyJhbGciOiJS... | None| '$(params.stackrox-secret)'|

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -106,7 +106,7 @@
   value: $(tasks.build-container.results.IMAGE_URL)
 - op: replace
   path: /spec/finally/1/params/3/value  # show-summary.params.build-task-status
-  value: $(tasks.build-container.results.status)
+  value: $(tasks.build-container.status)
 - op: replace
   path: /spec/results/0/value  # IMAGE_URL
   value: $(tasks.build-container.results.IMAGE_URL)

--- a/task/acs-deploy-check/0.1/acs-deploy-check.yaml
+++ b/task/acs-deploy-check/0.1/acs-deploy-check.yaml
@@ -84,8 +84,8 @@ spec:
             cp "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.gitconfig" "${HOME}/.gitconfig"
           # Compatibility with kubernetes.io/basic-auth secrets
           elif [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password" ]; then
-            HOSTNAME=$(echo $PARAM_GITOPS_REPO_URL | awk -F/ '{print $3}')
-            echo "https://$(cat ${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
+            HOSTNAME=$(echo "${PARAM_GITOPS_REPO_URL}" | awk -F/ '{print $3}')
+            echo "https://$(cat "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username"):$(cat "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password")@$HOSTNAME" > "${HOME}/.git-credentials"
             echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
           else
             echo "Unknown basic-auth workspace format"

--- a/task/acs-deploy-check/0.1/acs-deploy-check.yaml
+++ b/task/acs-deploy-check/0.1/acs-deploy-check.yaml
@@ -42,10 +42,9 @@ spec:
       secret:
         secretName: $(params.rox-secret-name)
         optional: true
-    - name: gitops-auth-secret
-      secret:
-        secretName: $(params.gitops-auth-secret-name)
-        optional: true
+  workspaces:
+    - name: gitops-auth
+      optional: true
   steps:
     - name: annotate-task
       image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
@@ -64,28 +63,36 @@ spec:
           mountPath: /workspace/repository
         - name: rox-secret
           mountPath: /rox-secret
-        - name: gitops-auth-secret
-          mountPath: /gitops-auth-secret
       workingDir: /workspace/repository
       env:
         - name: PARAM_INSECURE_SKIP_TLS_VERIFY
           value: $(params.insecure-skip-tls-verify)
         - name: PARAM_GITOPS_REPO_URL
           value: $(params.gitops-repo-url)
+        - name: WORKSPACE_GITOPS_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.gitops-auth.bound)
+        - name: WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH
+          value: $(workspaces.gitops-auth.path)
       script: |
         #!/usr/bin/env bash
         set +x
 
         # Check if credentials for cloning private repo are provided. Do nothing otherwise - probably public repo
-        if test -f /gitops-auth-secret/password ; then
-
-          password=$(cat /gitops-auth-secret/password)
-          if test -f /gitops-auth-secret/username ; then
-            username=$(cat /gitops-auth-secret/username)
-            HOSTNAME=$(echo "${PARAM_GITOPS_REPO_URL}" | awk -F/ '{print $3}')
-            echo "https://${username}:${password}@${HOSTNAME}" > "${HOME}/.git-credentials"
+        if [ "${WORKSPACE_GITOPS_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          if [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
+            cp "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.git-credentials" "${HOME}/.git-credentials"
+            cp "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.gitconfig" "${HOME}/.gitconfig"
+          # Compatibility with kubernetes.io/basic-auth secrets
+          elif [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password" ]; then
+            HOSTNAME=$(echo $PARAM_GITOPS_REPO_URL | awk -F/ '{print $3}')
+            echo "https://$(cat ${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
+            echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
+          else
+            echo "Unknown basic-auth workspace format"
+            exit 1
           fi
-          echo -e "[credential \"https://${HOSTNAME}\"]\n  helper = store" > "${HOME}/.gitconfig"
+          chmod 400 "${HOME}/.git-credentials"
+          chmod 400 "${HOME}/.gitconfig"
         fi
 
         # Check if rox API enpoint is configured

--- a/task/acs-deploy-check/0.1/acs-deploy-check.yaml
+++ b/task/acs-deploy-check/0.1/acs-deploy-check.yaml
@@ -30,12 +30,21 @@ spec:
       default: 'false'
       description: |
         When set to `"true"`, skip verifying the TLS certs of the Central endpoint. Defaults to `"false"`.
+    - name: gitops-auth-secret-name
+      type: string
+      default: gitops-auth-secret
+      description: |
+        Secret of basic-auth type containing credentials to clone the gitops repository.
   volumes:
     - name: repository
       emptyDir: {}
     - name: rox-secret
       secret:
         secretName: $(params.rox-secret-name)
+        optional: true
+    - name: gitops-auth-secret
+      secret:
+        secretName: $(params.gitops-auth-secret-name)
         optional: true
   steps:
     - name: annotate-task
@@ -55,6 +64,8 @@ spec:
           mountPath: /workspace/repository
         - name: rox-secret
           mountPath: /rox-secret
+        - name: gitops-auth-secret
+          mountPath: /gitops-auth-secret
       workingDir: /workspace/repository
       env:
         - name: PARAM_INSECURE_SKIP_TLS_VERIFY
@@ -64,6 +75,18 @@ spec:
       script: |
         #!/usr/bin/env bash
         set +x
+
+        # Check if credentials for cloning private repo are provided. Do nothing otherwise - probably public repo
+        if test -f /gitops-auth-secret/password ; then
+
+          password=$(cat /gitops-auth-secret/password)
+          if test -f /gitops-auth-secret/username ; then
+            username=$(cat /gitops-auth-secret/username)
+            HOSTNAME=$(echo "${PARAM_GITOPS_REPO_URL}" | awk -F/ '{print $3}')
+            echo "https://${username}:${password}@${HOSTNAME}" > "${HOME}/.git-credentials"
+          fi
+          echo -e "[credential \"https://${HOSTNAME}\"]\n  helper = store" > "${HOME}/.gitconfig"
+        fi
 
         # Check if rox API enpoint is configured
         if test -f /rox-secret/rox-api-endpoint ; then

--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -16,37 +16,38 @@ spec:
       default: gitops-auth-secret
       description: |
         Secret of basic-auth type containing credentials to commit into gitops repository.
-  volumes:
-    - name: gitops-auth-secret
-      secret:
-        secretName: $(params.gitops-auth-secret-name)
-        optional: true
+  workspaces:
+    - name: gitops-auth
+      optional: true
   steps:
     - name: patch-gitops
       image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-      volumeMounts:
-        - name: gitops-auth-secret
-          mountPath: /gitops-auth-secret
       env:
         - name: PARAM_GITOPS_REPO_URL
           value: $(params.gitops-repo-url)
         - name: PARAM_IMAGE
           value: $(params.image)
+        - name: WORKSPACE_GITOPS_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.gitops-auth.bound)
+        - name: WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH
+          value: $(workspaces.gitops-auth.path)
       script: |
-        if test -f /gitops-auth-secret/password ; then
-          gitops_repo_url=${PARAM_GITOPS_REPO_URL%'.git'}
-          remote_without_protocol=${gitops_repo_url#'https://'}
 
-          password=$(cat /gitops-auth-secret/password)
-          if test -f /gitops-auth-secret/username ; then
-            username=$(cat /gitops-auth-secret/username)
-            hostname=$(echo "${PARAM_GITOPS_REPO_URL}" | awk -F/ '{print $3}')
-            echo "https://${username}:${password}@${hostname}" > "${HOME}/.git-credentials"
-            origin_with_auth=https://${username}:${password}@${remote_without_protocol}.git
+        if [ "${WORKSPACE_GITOPS_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          if [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
+            cp "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.git-credentials" "${HOME}/.git-credentials"
+            cp "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.gitconfig" "${HOME}/.gitconfig"
+          # Compatibility with kubernetes.io/basic-auth secrets
+          elif [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password" ]; then
+            HOSTNAME=$(echo $PARAM_GITOPS_REPO_URL | awk -F/ '{print $3}')
+            echo "https://$(cat ${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
+            echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
           else
-            origin_with_auth=https://${password}@${remote_without_protocol}.git
+            echo "Unknown basic-auth workspace format"
+            exit 1
           fi
-           printf "[credential \"https://%s\"]\n  helper = store" "${hostname}" > "${HOME}/.gitconfig"
+          chmod 400 "${HOME}/.git-credentials"
+          chmod 400 "${HOME}/.gitconfig"
         else
           echo "git credentials to push into gitops repository ${PARAM_GITOPS_REPO_URL} is not configured."
           echo "gitops repository is not updated automatically."
@@ -59,6 +60,7 @@ spec:
         git config --global user.name "gitops-update"
 
         git clone ${PARAM_GITOPS_REPO_URL}
+        gitops_repo_url=${PARAM_GITOPS_REPO_URL%'.git'}
         gitops_repo_name=$(basename ${gitops_repo_url})
         cd ${gitops_repo_name}
 
@@ -70,7 +72,6 @@ spec:
 
         git add .
         git commit -m "Update '${component_name}' component image to: ${PARAM_IMAGE}"
-        git remote set-url origin $origin_with_auth
         git push 2> /dev/null || \
         {
           echo "Failed to push update to gitops repository: ${PARAM_GITOPS_REPO_URL}"

--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -40,11 +40,13 @@ spec:
           password=$(cat /gitops-auth-secret/password)
           if test -f /gitops-auth-secret/username ; then
             username=$(cat /gitops-auth-secret/username)
-            echo "https://${username}:${password})@${hostname}" > "${HOME}/.git-credentials"
+            hostname=$(echo "${PARAM_GITOPS_REPO_URL}" | awk -F/ '{print $3}')
+            echo "https://${username}:${password}@${hostname}" > "${HOME}/.git-credentials"
             origin_with_auth=https://${username}:${password}@${remote_without_protocol}.git
           else
             origin_with_auth=https://${password}@${remote_without_protocol}.git
           fi
+           printf "[credential \"https://%s\"]\n  helper = store" "${hostname}" > "${HOME}/.gitconfig"
         else
           echo "git credentials to push into gitops repository ${PARAM_GITOPS_REPO_URL} is not configured."
           echo "gitops repository is not updated automatically."

--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -39,9 +39,9 @@ spec:
             cp "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/.gitconfig" "${HOME}/.gitconfig"
           # Compatibility with kubernetes.io/basic-auth secrets
           elif [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password" ]; then
-            HOSTNAME=$(echo $PARAM_GITOPS_REPO_URL | awk -F/ '{print $3}')
-            echo "https://$(cat ${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
-            echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
+            HOSTNAME=$(echo "${PARAM_GITOPS_REPO_URL}" | awk -F/ '{print $3}')
+            echo "https://$(cat "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/username"):$(cat "${WORKSPACE_GITOPS_AUTH_DIRECTORY_PATH}/password")@$HOSTNAME" > "${HOME}/.git-credentials"
+            printf "[credential \"https://%s\"]\n helper = store" "${HOSTNAME}" > "${HOME}/.gitconfig"
           else
             echo "Unknown basic-auth workspace format"
             exit 1


### PR DESCRIPTION
update-deployment was using empty variable ${hostname} and it also wasn't setting up the ~/.gitconfig properly.

In acs-deploy-check, no credentials were being used whatsoever, so the gitops repo clone failed which caused failure of that task.