### PR TITLE
Trigger an update to the build-image-index task

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -100,7 +100,7 @@ spec:
           TOADD="${TOADD_REPOSITORY}@${TOADD_DIGEST}"
         fi
         if [[ "$ALWAYS_BUILD_INDEX" != "true" ]]; then
-          echo "Skipping image index generation. Returning results for $TOADD"
+          echo "Skipping image index generation. Returning results for $TOADD."
           echo -n "${TOADD_URL}" > "$(results.IMAGE_URL.path)"
           echo -n "${TOADD_DIGEST}" > "$(results.IMAGE_DIGEST.path)"
           echo -n "${TOADD}" > "$(results.IMAGES.path)"


### PR DESCRIPTION
This task was never added to the trusted tasks.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
