### PR TITLE
Revert "replace multi-platform-runner image with buildah"

### DIFF
--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -113,7 +113,7 @@ spec:
         echo "declare TAGGED_AS=${TAGGED_AS}" >> /var/workdir/vars
 
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:1301e1a87a44898ab73e5dff8f6ac7499be4cb64eb7300e25d7a20ae266c87d3
+      image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
       computeResources:
         limits:
           memory: 512Mi

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -89,7 +89,7 @@ spec:
   - env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1301e1a87a44898ab73e5dff8f6ac7499be4cb64eb7300e25d7a20ae266c87d3
+    image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build
@@ -227,7 +227,7 @@ spec:
     workingDir: $(workspaces.source.path)
     securityContext:
       runAsUser: 0
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:1301e1a87a44898ab73e5dff8f6ac7499be4cb64eb7300e25d7a20ae266c87d3
+  - image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: inject-sbom-and-push

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -87,7 +87,7 @@ spec:
   - env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1301e1a87a44898ab73e5dff8f6ac7499be4cb64eb7300e25d7a20ae266c87d3
+    image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build
@@ -225,7 +225,7 @@ spec:
     workingDir: $(workspaces.source.path)
     securityContext:
       runAsUser: 0
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:1301e1a87a44898ab73e5dff8f6ac7499be4cb64eb7300e25d7a20ae266c87d3
+  - image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: inject-sbom-and-push


### PR DESCRIPTION
This reverts commit 79b11ef741cec77d707f5670315f7d7b68322d9c. (#1348)

This change broke the ostree tasks due to the updated buildah version. This updated version includes
https://github.com/containers/common/commit/08fc0b450 which prevents the task from being able to use an OCI archive as desired.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
