### PR TITLE
Enable Task results check via EC

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -12,9 +12,14 @@ sources:
         - basic-auth
         - ssh-directory
         - netrc
+      required_task_results:
+        # Certain EC rules rely on the presence of this result when validating an image.
+        - task: clair-scan
+          result: CLAIR_SCAN_RESULT
     config:
       include:
         - kind
+        - results
         - step_image_registries
         - trusted_artifacts
       exclude:


### PR DESCRIPTION
Since certain EC policy rules rely on the existence of certain Task results, e.g. CLAIR_SCAN_RESULT, let's verify that these are defined during CI.

Ref: https://issues.redhat.com/browse/EC-794

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
