### PR TITLE
replace cosign image with appstudio-utils

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,7 +25,6 @@
         "quay.io/redhat-appstudio/buildah",
         "quay.io/redhat-appstudio/hacbs-jvm-build-request-processor",
         "quay.io/redhat-appstudio/build-definitions-source-image-build-utils",
-        "quay.io/redhat-appstudio/cosign",
         "quay.io/redhat-appstudio/cachi2",
         "quay.io/redhat-appstudio/sbom-utility-scripts-image",
         "registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9"

--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -315,16 +315,10 @@ spec:
           yq -oj -i '.components += [ {"purl": "'$purl'", "type": "file", "name": "'$OCI_FILENAME'", "hashes": [{"alg": "SHA-256", "content": "'$OCI_ARTIFACT_DIGEST'"}], "externalReferences": [{"type": "distribution", "url": "'$OCI_SOURCE'"}]} ]' sbom-cyclonedx.json
         done
     - name: upload-sbom
-      image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-      args:
-        - attach
-        - sbom
-        - --sbom
-        - sbom-cyclonedx.json
-        - --type
-        - cyclonedx
-        - $(params.IMAGE)
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       workingDir: /var/workdir
+      script: |
+        cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
     - name: report-sbom-url
       image: quay.io/konflux-ci/yq:latest@sha256:f758d9a25bc88cc114bfb6137fd4d649db427de5a4217e818b8466ad5bf9255c
       workingDir: /var/workdir

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -295,16 +295,10 @@ spec:
         done
       workingDir: $(workspaces.source.path)
     - name: upload-sbom
-      image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-      args:
-        - attach
-        - sbom
-        - --sbom
-        - sbom-cyclonedx.json
-        - --type
-        - cyclonedx
-        - $(params.IMAGE)
+      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       workingDir: $(workspaces.source.path)
+      script: |
+        cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
     - name: report-sbom-url
       image: quay.io/konflux-ci/yq:latest@sha256:f758d9a25bc88cc114bfb6137fd4d649db427de5a4217e818b8466ad5bf9255c
       script: |

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -281,20 +281,11 @@ spec:
     - mountPath: /var/lib/containers
       name: varlibcontainers
     workingDir: $(workspaces.source.path)
-  - args:
-    - attach
-    - sbom
-    - --sbom
-    - sbom-cyclonedx.json
-    - --type
-    - cyclonedx
-    - $(params.IMAGE)
-    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    name: upload-sbom
-    computeResources: {}
+  - name: upload-sbom
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     workingDir: $(workspaces.source.path)
+    script: |
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
   volumes:
   - emptyDir: {}
     name: varlibcontainers

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -276,20 +276,11 @@ spec:
     - mountPath: /var/lib/containers
       name: varlibcontainers
     workingDir: $(workspaces.source.path)
-  - args:
-    - attach
-    - sbom
-    - --sbom
-    - sbom-cyclonedx.json
-    - --type
-    - cyclonedx
-    - $(params.IMAGE)
-    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    name: upload-sbom
-    computeResources: {}
+  - name: upload-sbom
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     workingDir: $(workspaces.source.path)
+    script: |
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
   volumes:
   - emptyDir: {}
     name: varlibcontainers

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -273,17 +273,9 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: upload-sbom
-    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    args:
-      - attach
-      - sbom
-      - --sbom
-      - sbom-cyclonedx.json
-      - --type
-      - cyclonedx
-      - $(params.IMAGE)
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
+    script: |
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
     workingDir: $(workspaces.source.path)
 
   volumes:

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -240,18 +240,10 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: upload-sbom
-    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    args:
-      - attach
-      - sbom
-      - --sbom
-      - sbom-cyclonedx.json
-      - --type
-      - cyclonedx
-      - $(params.IMAGE)
+    image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
     workingDir: $(workspaces.source.path)
+    script: |
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
 
   volumes:
   - emptyDir: {}


### PR DESCRIPTION
redhat-appstudio/cosign image is getting deprecated due to migration to konflux-ci, replace with konflux-ci/appstudio-utils image

[STONEBLD-2717](https://issues.redhat.com/browse/STONEBLD-2717), related previous reverted attempt https://github.com/konflux-ci/build-definitions/pull/1344

This PR has been tested by running `./hack/test-builds.sh` locally and checking that pipelines pass and SBOMs are pushed to the Quay namespace.