### PR TITLE
task/operator-sdk-generate-bundle: allow for supplying additional labels

### DIFF
--- a/task/operator-sdk-generate-bundle/0.1/README.md
+++ b/task/operator-sdk-generate-bundle/0.1/README.md
@@ -11,6 +11,7 @@ Generate an OLM bundle using the operator-sdk
 |extra-service-accounts|Comma-seperated list of service account names, outside of the operator's Deployment account, that have bindings to {Cluster}Roles that should be added to the CSV |""|false|
 |version|Semantic version of the operator in the generated bundle||true|
 |package-name|Bundle's package name||true|
+|additional-labels-file|A plain text file containing additional labels to append to the generated Dockerfile |""|false|
 
 ## Workspaces
 |name|description|optional|

--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -27,6 +27,11 @@ spec:
       description: Semantic version of the operator in the generated bundle
     - name: package-name
       description: Bundle's package name
+    - name: additional-labels-file
+      description: >
+        A plain text file containing additional labels to append to the
+        generated Dockerfile
+      default: ""
   workspaces:
     - name: source
       description: Workspace with the source code
@@ -36,19 +41,35 @@ spec:
       workingDir: $(workspaces.source.path)/source
       securityContext:
         runAsUser: 0
-      args:
-        - generate
-        - bundle
-        - --overwrite
-        - --channels
-        - $(params.channels)
-        - --input-dir
-        - $(params.input-dir)
-        - --version
-        - $(params.version)
-        - --package
-        - $(params.package-name)
-        - --kustomize-dir
-        - $(params.kustomize-dir)
-        - --extra-service-accounts
-        - $(params.extra-service-accounts)
+      env:
+        - name: CHANNELS
+          value: $(params.channels)
+        - name: INPUT_DIR
+          value: $(params.input-dir)
+        - name: VERSION
+          value: $(params.version)
+        - name: PACKAGE_NAME
+          value: $(params.package-name)
+        - name: KUSTOMIZE_DIR
+          value: $(params.kustomize-dir)
+        - name: EXTRA_SERVICE_ACCOUNTS
+          value: $(params.extra-service-accounts)
+        - name: ADDITIONAL_LABELS_FILE
+          value: $(params.additional-labels-file)
+      script: |
+        #!/usr/bin/env bash
+
+        set -xe
+
+        operator-sdk generate bundle \
+          --overwrite \
+          --channels "${CHANNELS}" \
+          --input-dir "${INPUT_DIR}" \
+          --version "${VERSION}" \
+          --package "${PACKAGE_NAME}" \
+          --kustomize-dir "${KUSTOMIZE_DIR}" \
+          --extra-service-accounts "${EXTRA_SERVICE_ACCOUNTS}"
+
+        if [ -f "${ADDITIONAL_LABELS_FILE}" ]; then
+          cat "${ADDITIONAL_LABELS_FILE}" >> bundle.Dockerfile
+        fi


### PR DESCRIPTION
in order to comply with the required labels check, the generated dockerfile needs to have labels amended to it. By providing an additional file with this data, it can be appended in order to pass the compliance check.

```
❯ cat -p config/metadata/additional-labels.txt
LABEL com.redhat.component="openshift-osd-example-operator" \
      description="A sample operator used for testing SREP tooling" \
      distribution-scope="public" \
      io.k8s.description="A sample operator used for testing SREP tooling" \
      name="openshift/osd-example-operator" \
      release="v0.0.0" \
      url="https://github.com/openshift/osd-example-operator" \
      vendor="Red Hat" \
      version="v0.0.0"
```

Below is the summarized output of running the task locally

```
...

[generate-bundle : operator-sdk-generate-bundle] + operator-sdk generate bundle --overwrite --channels stable --input-dir deploy --version 4.16.0-abcdef8 --package osd-example-operator --kustomize-dir config/manifests --extra-service-accounts osd-example-admin
[generate-bundle : operator-sdk-generate-bundle] Generating bundle version 4.16.0-abcdef8
[generate-bundle : operator-sdk-generate-bundle] Generating bundle manifests
[generate-bundle : operator-sdk-generate-bundle] Bundle manifests generated successfully in bundle
[generate-bundle : operator-sdk-generate-bundle] Generating bundle metadata
[generate-bundle : operator-sdk-generate-bundle] time="2024-09-05T12:18:35Z" level=warning msg="ClusterServiceVersion validation: [OperationFailed] provided API should have an example annotation"
[generate-bundle : operator-sdk-generate-bundle] time="2024-09-05T12:18:35Z" level=info msg="Creating bundle.Dockerfile"
[generate-bundle : operator-sdk-generate-bundle] time="2024-09-05T12:18:35Z" level=info msg="Creating bundle/metadata/annotations.yaml"
[generate-bundle : operator-sdk-generate-bundle] time="2024-09-05T12:18:35Z" level=info msg="Bundle metadata generated successfully"
[generate-bundle : operator-sdk-generate-bundle] + '[' -f config/metadata/additional-labels.txt ']'
[generate-bundle : operator-sdk-generate-bundle] + cat config/metadata/additional-labels.txt

[build-container : build] Adding the entitlement to the build
[build-container : build] STEP 1/13: FROM scratch
[build-container : build] STEP 2/13: LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
[build-container : build] STEP 3/13: LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
[build-container : build] STEP 4/13: LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
[build-container : build] STEP 5/13: LABEL operators.operatorframework.io.bundle.package.v1=osd-example-operator
[build-container : build] STEP 6/13: LABEL operators.operatorframework.io.bundle.channels.v1=stable
[build-container : build] STEP 7/13: LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.31.0-ocp
[build-container : build] STEP 8/13: LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
[build-container : build] STEP 9/13: LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
[build-container : build] STEP 10/13: COPY bundle/manifests /manifests/
[build-container : build] STEP 11/13: COPY bundle/metadata /metadata/
[build-container : build] STEP 12/13: LABEL com.redhat.component="openshift-osd-example-operator"       description="A sample operator used for testing SREP tooling"       distribution-scope="public"       io.k8s.description="A sample operator used for testing SREP tooling"       name="openshift/osd-example-operator"       release="v0.0.0"       url="https://github.com/openshift/osd-example-operator"       vendor="Red Hat"       version="v0.0.0"
[build-container : build] STEP 13/13: LABEL "build-date"="2024-09-05T12:18:44" "architecture"="x86_64" "vcs-type"="git" "vcs-ref"="35e2cca6f77a24308697957e9994a0c54b687674"
[build-container : build] COMMIT quay.io/redhat-user-workloads/oeo-cicada-tenant/osd-example-operator/bundle:on-pr-test
[build-container : build] --> 0506c4e76f56
[build-container : build] Successfully tagged quay.io/redhat-user-workloads/oeo-cicada-tenant/osd-example-operator/bundle:on-pr-test
[build-container : build] 0506c4e76f5687c1a3b564859f504029bdbdcc0328854e64cd22132752bc6be8
[build-container : build] /var/lib/containers/storage/vfs/dir/6b665e0e17d0fa80753efbb5415cd920f5d7086675212ef0d0ff6aa2c69b6c81
...
```
