### PR TITLE
fix ocp major version extraction from base image tag

### DIFF
--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -190,7 +190,7 @@ spec:
 
         RUN_OCP_VERSION_VALIDATION="false"
         digits_regex='^[0-9]*$'
-        if [[ ${OCP_VER_MAJOR} =~ digits_regex ]] && [[ ${OCP_VER_MINOR} =~ digits_regex ]] ; then
+        if [[ ${OCP_VER_MAJOR} =~ $digits_regex ]] && [[ ${OCP_VER_MINOR} =~ $digits_regex ]] ; then
           RUN_OCP_VERSION_VALIDATION="true"
         fi
 

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -180,48 +180,63 @@ spec:
           TESTPASSED=false
         fi
 
-        OCP_VER_FROM_BASE=$(echo "${BASE_IMAGE}" | sed "s/@.*$//" | sed "s/^.*://")   # strips hash first due to greedy match
-        OCP_VER_MAJOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 1)
+        # examines the BASE_IMAGE tag to derive the target OCP version
+        # assumes this is in the form
+        # image-path:[v]major-digits.minor-digits[@sha...]
+        OCP_VER_FROM_BASE=$(echo "${BASE_IMAGE}" | sed -e "s/@.*$//" -e "s/^.*://")   # strips hash first due to greedy match
+        # extracts major digits and filters out any leading alphabetic characters, for e.g. 'v4' --> '4'
+        OCP_VER_MAJOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 1 | sed "s/^[a-zA-Z]*//")
         OCP_VER_MINOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 2)
-        OCP_BUNDLE_METADATA_THRESHOLD_MAJOR=4
-        OCP_BUNDLE_METADATA_THRESHOLD_MINOR=17
-        OCP_BUNDLE_METADATA_FORMAT="olm.bundle.object"
 
-        if [[ "${OCP_VER_MAJOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MAJOR}" ]] && [[ "${OCP_VER_MINOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MINOR}" ]]; then
-           OCP_BUNDLE_METADATA_FORMAT="olm.csv.metadata"
+        RUN_OCP_VERSION_VALIDATION="false"
+        digits_regex='^[0-9]*$'
+        if [[ ${OCP_VER_MAJOR} =~ digits_regex ]] && [[ ${OCP_VER_MINOR} =~ digits_regex ]] ; then
+          RUN_OCP_VERSION_VALIDATION="true"
         fi
 
-        # enforce the presence of either olm.csv.metadata or olm.bundle.object based on OCP version
-        if [[ "${OCP_BUNDLE_METADATA_FORMAT}" = "olm.csv.metadata" ]]; then
-          if ! jq -en 'reduce( inputs | select(.schema == "olm.bundle" and .properties[].type == "olm.bundle.object")) as $_ (0;.+1) == 0' ${OPM_RENDERED_CATALOG}; then
-            echo "!FAILURE! - olm.bundle.object bundle properties are not permitted in a FBC fragment for OCP version ${OCP_VER_MAJOR}.${OCP_VER_MINOR}. Fragments must move to olm.csv.metadata bundle metadata."
-          failure_num=$((failure_num + 1))
-            TESTPASSED=false
-          fi
+        if [ "${RUN_OCP_VERSION_VALIDATION}" == "false" ] ; then
+          echo "!WARNING! - unable to assess bundle metadata alignment with OCP version because we cannot extract version info from BASE_IMAGE: ${BASE_IMAGE}"
         else
-          if ! jq -en 'reduce( inputs | select(.schema == "olm.bundle" and .properties[].type == "olm.csv.metadata")) as $_ (0;.+1) == 0' ${OPM_RENDERED_CATALOG}; then
-            echo "!FAILURE! - olm.csv.metadata bundle properties are not permitted in a FBC fragment for OCP version ${OCP_VER_MAJOR}.${OCP_VER_MINOR}. Fragments must only use olm.bundle.object bundle metadata."
-          failure_num=$((failure_num + 1))
-            TESTPASSED=false
-          fi
-        fi
+          OCP_BUNDLE_METADATA_THRESHOLD_MAJOR=4
+          OCP_BUNDLE_METADATA_THRESHOLD_MINOR=17
+          OCP_BUNDLE_METADATA_FORMAT="olm.bundle.object"
 
-        # enforce that each bundle has the OCP-version-appropriate bundle metadata.
-        BUNDLE_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema=="olm.bundle"))' ${OPM_RENDERED_CATALOG})
-        BUNDLE_BO_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema == "olm.bundle" and .properties[].type == "olm.bundle.object"))' ${OPM_RENDERED_CATALOG})
-        BUNDLE_CM_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema == "olm.bundle" and .properties[].type == "olm.csv.metadata"))' ${OPM_RENDERED_CATALOG})
-
-        if [[ "${OCP_BUNDLE_METADATA_FORMAT}" = "olm.csv.metadata" ]]; then
-          if [[ "${BUNDLE_COUNT}" -ne "${BUNDLE_CM_COUNT}" ]]; then
-            echo "!FAILURE! - every olm.bundle object in the fragment must have a corresponding olm.csv.metadata bundle property"
-          failure_num=$((failure_num + 1))
-            TESTPASSED=false
+          if [[ "${OCP_VER_MAJOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MAJOR}" ]] && [[ "${OCP_VER_MINOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MINOR}" ]]; then
+             OCP_BUNDLE_METADATA_FORMAT="olm.csv.metadata"
           fi
-        else
-          if [[ "${BUNDLE_BO_COUNT}" -lt "${BUNDLE_COUNT}" ]]; then
-            echo "!FAILURE! - every olm.bundle object in the fragment must have at least one olm.bundle.object bundle property"
-          failure_num=$((failure_num + 1))
-            TESTPASSED=false
+
+          # enforce the presence of either olm.csv.metadata or olm.bundle.object based on OCP version
+          if [[ "${OCP_BUNDLE_METADATA_FORMAT}" = "olm.csv.metadata" ]]; then
+            if ! jq -en 'reduce( inputs | select(.schema == "olm.bundle" and .properties[].type == "olm.bundle.object")) as $_ (0;.+1) == 0' ${OPM_RENDERED_CATALOG}; then
+              echo "!FAILURE! - olm.bundle.object bundle properties are not permitted in a FBC fragment for OCP version ${OCP_VER_MAJOR}.${OCP_VER_MINOR}. Fragments must move to olm.csv.metadata bundle metadata."
+            failure_num=$((failure_num + 1))
+              TESTPASSED=false
+            fi
+          else
+            if ! jq -en 'reduce( inputs | select(.schema == "olm.bundle" and .properties[].type == "olm.csv.metadata")) as $_ (0;.+1) == 0' ${OPM_RENDERED_CATALOG}; then
+              echo "!FAILURE! - olm.csv.metadata bundle properties are not permitted in a FBC fragment for OCP version ${OCP_VER_MAJOR}.${OCP_VER_MINOR}. Fragments must only use olm.bundle.object bundle metadata."
+            failure_num=$((failure_num + 1))
+              TESTPASSED=false
+            fi
+          fi
+
+          # enforce that each bundle has the OCP-version-appropriate bundle metadata.
+          BUNDLE_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema=="olm.bundle"))' ${OPM_RENDERED_CATALOG})
+          BUNDLE_BO_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema == "olm.bundle" and .properties[].type == "olm.bundle.object"))' ${OPM_RENDERED_CATALOG})
+          BUNDLE_CM_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema == "olm.bundle" and .properties[].type == "olm.csv.metadata"))' ${OPM_RENDERED_CATALOG})
+
+          if [[ "${OCP_BUNDLE_METADATA_FORMAT}" = "olm.csv.metadata" ]]; then
+            if [[ "${BUNDLE_COUNT}" -ne "${BUNDLE_CM_COUNT}" ]]; then
+              echo "!FAILURE! - every olm.bundle object in the fragment must have a corresponding olm.csv.metadata bundle property"
+            failure_num=$((failure_num + 1))
+              TESTPASSED=false
+            fi
+          else
+            if [[ "${BUNDLE_BO_COUNT}" -lt "${BUNDLE_COUNT}" ]]; then
+              echo "!FAILURE! - every olm.bundle object in the fragment must have at least one olm.bundle.object bundle property"
+            failure_num=$((failure_num + 1))
+              TESTPASSED=false
+            fi
           fi
         fi
 


### PR DESCRIPTION
OCP major version extraction was failing for base images with reference like `registry.redhat.io/openshift4/ose-operator-registry-rhel9@sha256:56e5c57b9d94bcadad6ff0cd47d157d35affc4bfd2c23a2ac948eee1cac3b8a3`. 

This changes behavior to test the OCP version major/minor elements which were extracted from the BASE_IMAGE supplied to the task.  If those elements are not numeric, then it will print a warning, e.g. 

```
!WARNING! - unable to assess bundle metadata alignment with OCP version because we cannot extract version info from BASE_IMAGE: brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9@sha256:a3314d6dab5509fdd445ec81fb430eba7453fb56d674566fc6ef9354bc31bb3a
```


