### PR TITLE
Ensure that we know all image mainfests added to the index

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -85,7 +85,6 @@ spec:
         exit 2
       fi
 
-      image_manifests=""
       buildah manifest create "$IMAGE"
       for i in $@
       do
@@ -107,7 +106,6 @@ spec:
           exit 0
         fi
         echo "Adding $TOADD"
-        image_manifests="${image_manifests} ${TOADD},"
         buildah manifest add $IMAGE "docker://$TOADD" --all
       done
 
@@ -127,6 +125,14 @@ spec:
           echo "Failed to push image to registry after ${max_run} tries"
           exit 1
       fi
+
+      INDEX_REPOSITORY="$(echo "$IMAGE" | cut -d@ -f1 | cut -d: -f1)"
+      MANIFEST_DIGESTS=$(buildah manifest inspect "$IMAGE" | jq -er ".manifests[].digest")
+      image_manifests=""
+      for i in $MANIFEST_DIGESTS
+      do
+        image_manifests="${image_manifests} ${INDEX_REPOSITORY}@${i},"
+      done
 
       cat image-digest | tee $(results.IMAGE_DIGEST.path)
       echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"


### PR DESCRIPTION
Since we are passing --all to the buildah manifest add command, we enable all manifests referenced by an image index to be added to this index. If that happens, then we will only expose the digest of the image index and not all image manifests.

By post-processing the image index to identify all manifests, we can ensure that we have identified all image manifests referenced.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
