### PR TITLE
Pass buildah build arguments to remote VM

### DIFF
--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -240,7 +240,7 @@ if ! [[ $IS_LOCALHOST ]]; then
 			env += "    -e " + e.Name + "=\"$" + e.Name + "\" \\\n"
 		}
 		podmanArgs += "    -v \"$BUILD_DIR/scripts:/scripts:Z\" \\\n"
-		ret += "\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run " + env + "" + podmanArgs + "    --user=0  --rm  \"$BUILDER_IMAGE\" /" + containerScript
+		ret += "\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run " + env + "" + podmanArgs + "    --user=0  --rm  \"$BUILDER_IMAGE\" /" + containerScript + ` "$@"`
 
 		// Sync the contents of the workspaces back so subsequent tasks can use them
 		for _, workspace := range task.Spec.Workspaces {
@@ -256,7 +256,7 @@ if ! [[ $IS_LOCALHOST ]]; then
 		ret += `
   buildah pull "oci:konflux-final-image:$IMAGE"
 else
-  bash ` + containerScript + `
+  bash ` + containerScript + ` "$@"
 fi
 buildah images
 container=$(buildah from --pull-never "$IMAGE")

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -476,13 +476,13 @@ spec:
           -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
         buildah pull "oci:konflux-final-image:$IMAGE"
       else
-        bash scripts/script-build.sh
+        bash scripts/script-build.sh "$@"
       fi
       buildah images
       container=$(buildah from --pull-never "$IMAGE")

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -491,13 +491,13 @@ spec:
           -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
         buildah pull "oci:konflux-final-image:$IMAGE"
       else
-        bash scripts/script-build.sh
+        bash scripts/script-build.sh "$@"
       fi
       buildah images
       container=$(buildah from --pull-never "$IMAGE")

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -469,13 +469,13 @@ spec:
           -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
         buildah pull "oci:konflux-final-image:$IMAGE"
       else
-        bash scripts/script-build.sh
+        bash scripts/script-build.sh "$@"
       fi
       buildah images
       container=$(buildah from --pull-never "$IMAGE")

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -473,13 +473,13 @@ spec:
           -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
         buildah pull "oci:konflux-final-image:$IMAGE"
       else
-        bash scripts/script-build.sh
+        bash scripts/script-build.sh "$@"
       fi
       buildah images
       container=$(buildah from --pull-never "$IMAGE")


### PR DESCRIPTION
### How to test the PR

1. Create a source repo that builds an image that consumes build args
```
FROM alpine
ARG ARG1="test1"
ARG ARG2="test2"
RUN echo "arg1=${ARG1}" && echo "${ARG1}" > /arg1.txt
RUN echo "arg2=${ARG2}" && echo "${ARG2}" > /arg2.txt
```
2. Onboard a component with multi platform build.
3. Add `build-args` pipeline param:
```yaml
spec:
  params:
    - name: build-args
      value: ["ARG1=val1", "ARG2=val2"]
```
5. Wait build finished and check the resulting arm image