### PR TITLE
fix: remove duplicate workdir volume

### DIFF
--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -55,8 +55,6 @@ spec:
       emptyDir: {}
     - name: workdir
       emptyDir: {}
-    - name: workdir
-      emptyDir: {}
   stepTemplate:
     env:
       - name: IMAGE


### PR DESCRIPTION
- The oci-copy-oci-ta task fails during configuration because of the duplicate volume, so local tests run
via `./hack/test-builds.sh` do not start
- Remove the duplicate workdir volume so tests can be run

