### PR TITLE
Removes unused workdir volume form oci-copy Task

### DIFF
--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -55,8 +55,6 @@ spec:
       emptyDir: {}
     - name: workdir
       emptyDir: {}
-    - name: workdir
-      emptyDir: {}
   stepTemplate:
     env:
       - name: IMAGE

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -318,8 +318,6 @@ spec:
   volumes:
     - emptyDir: {}
       name: varlibcontainers
-    - emptyDir: {}
-      name: workdir
   workspaces:
     - description: Workspace containing the source artifacts to copy
       name: source


### PR DESCRIPTION
There is no volumeMount for workdir in the oci-copy task, and it's presence in the volumes causes duplicate volumes in the oci-copy-oci-ta Task.

This could also be resolved by making the generator aware of duplicate volumes and volumeMounts. Let's do that if it indeed does become an issue.