### PR TITLE
chore(RHTAPWATCH-1248): Provide admin user/pwd combo for ephemeral clusters

### DIFF
--- a/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+++ b/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
@@ -4,7 +4,7 @@ metadata:
   name: eaas-get-ephemeral-cluster-credentials
 spec:
   description: >-
-    This StepAction queries the EaaS hub cluster to get the kubeconfig for an ephemeral cluster
+    This StepAction queries the EaaS hub cluster to get the kubeconfig, username, and password for an ephemeral cluster
     by name. Credentials are stored in a mounted volume that must be provided as a param.
   image: registry.redhat.io/openshift4/ose-cli@sha256:15da03b04318bcc842060b71e9dd6d6c2595edb4e8fdd11b0c6781eeb03ca182
   params:
@@ -26,11 +26,19 @@ spec:
   results:
     - name: kubeconfig
       description: Relative path to the kubeconfig in the mounted volume
+    - name: username
+      description: The username for the cluster
+    - name: passwordPath
+      description: Relative path to the password file in the mounted volume
+    - name: apiServerURL
+      description: API server URL of the cluster
   env:
     - name: CLUSTER_NAME
       value: "$(params.clusterName)"
     - name: CLUSTER_KUBECONFIG
       value: "/credentials/$(params.clusterName)-kubeconfig"
+    - name: CLUSTER_PASSWORD
+      value: "/credentials/$(params.clusterName)-password"
     - name: KUBECONFIG
       value: /tmp/eaas-kubeconfig
     - name: KUBECONFIG_VALUE
@@ -56,3 +64,15 @@ spec:
     "${OC[@]}" get secret $SECRET -o go-template --template="{{.data.kubeconfig|base64decode}}" > $CLUSTER_KUBECONFIG
     echo "Wrote kubeconfig to $CLUSTER_KUBECONFIG"
     echo -n $(basename $CLUSTER_KUBECONFIG) > $(step.results.kubeconfig.path)
+
+    ADMIN_PASSWORD_SECRET=$("${OC[@]}" get cti "$CLUSTER_NAME" -o=jsonpath='{.status.adminPassword.name}')
+    echo "Found admin password secret: $ADMIN_PASSWORD_SECRET"
+    USERNAME=$("${OC[@]}" get secret "$ADMIN_PASSWORD_SECRET" -o go-template --template="{{.data.username | base64decode}}")
+    "${OC[@]}" get secret "$ADMIN_PASSWORD_SECRET" -o go-template --template="{{.data.password | base64decode}}" > "$CLUSTER_PASSWORD"
+    echo "Retrieved username"
+    echo "Wrote password to $CLUSTER_PASSWORD"
+    echo -n "$USERNAME" > "$(step.results.username.path)"
+    echo -n "$(basename "$CLUSTER_PASSWORD")" > "$(step.results.passwordPath.path)"
+    API_SERVER_URL=$("${OC[@]}" get cti "$CLUSTER_NAME" -o=jsonpath='{.status.apiServerURL}')
+    echo "API Server URL: $API_SERVER_URL"
+    echo -n "$API_SERVER_URL" > "$(step.results.apiServerURL.path)"


### PR DESCRIPTION
- Add admin username and password in the credentials volume
- Add `APIserverURL` and `ConsoleURL` status field values from the CTI in the results