### PR TITLE
Tagging appstudio-utils with latest

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -64,6 +64,17 @@ spec:
           - name: source
             workspace: workspace
 
+      - name: apply-additional-image-tags
+        params:
+          - name: IMAGE
+            value: $(tasks.build-container.results.IMAGE_REF)
+          - name: ADDITIONAL_TAGS
+            value: ["latest"]
+        runAfter:
+          - build-container
+        taskRef:
+          name: apply-tags
+
       - name: build-bundles
         params:
           - name: revision

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-event: "push"
     pipelinesascode.tekton.dev/on-target-branch: "main"
-    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml, task/apply-tags/0.1/apply-tags.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:


### PR DESCRIPTION
Using a floating tag so applications can use the latest utilities without updating the image tag.

https://issues.redhat.com/browse/EC-865
