### PR TITLE
The buildah task does not support IMAGE_REF

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -67,7 +67,7 @@ spec:
       - name: apply-additional-image-tags
         params:
           - name: IMAGE
-            value: $(tasks.build-container.results.IMAGE_REF)
+            value: $(tasks.build-container.results.IMAGE_URL)
           - name: ADDITIONAL_TAGS
             value: ["latest"]
         runAfter:


### PR DESCRIPTION
The IMAGE_REF result is not supported in this version. Using IMAGE_URL instead. This will fix the CI issue on push.
