### PR TITLE
buildah: resolve BUILD_ARGS in base images

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -286,9 +286,35 @@ spec:
         # Setting new namespace to run buildah - 2^32-2
         echo 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid
 
+        build_args=()
+        if [ -n "${BUILD_ARGS_FILE}" ]; then
+          # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+          echo "Parsing ARGs from $BUILD_ARGS_FILE"
+          mapfile -t build_args < <(
+            # https://www.mankier.com/1/buildah-build#--build-arg-file
+            # delete lines that start with #
+            # delete blank lines
+            sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+          )
+        fi
+        # Append BUILD_ARGS
+        # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+        # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+        # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE - they take precedence.
+        build_args+=("$@")
+
+        BUILD_ARG_FLAGS=()
+        for build_arg in "${build_args[@]}"; do
+          BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+        done
+
+        BASE_IMAGES=$(
+          dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_path" |
+            jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName'
+        )
+
         BUILDAH_ARGS=()
 
-        BASE_IMAGES=$(dockerfile-json "$dockerfile_path" | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName')
         if [ "${HERMETIC}" == "true" ]; then
           BUILDAH_ARGS+=("--pull=never")
           UNSHARE_ARGS="--net"
@@ -302,13 +328,7 @@ spec:
           BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
         fi
 
-        if [ -n "${BUILD_ARGS_FILE}" ]; then
-          BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
-        fi
-
-        for build_arg in "$@"; do
-          BUILDAH_ARGS+=("--build-arg=$build_arg")
-        done
+        BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
         if [ -n "${ADD_CAPABILITIES}" ]; then
           BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -321,9 +321,35 @@ spec:
       # Setting new namespace to run buildah - 2^32-2
       echo 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid
 
+      build_args=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+        echo "Parsing ARGs from $BUILD_ARGS_FILE"
+        mapfile -t build_args < <(
+          # https://www.mankier.com/1/buildah-build#--build-arg-file
+          # delete lines that start with #
+          # delete blank lines
+          sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+        )
+      fi
+      # Append BUILD_ARGS
+      # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+      # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+      # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE - they take precedence.
+      build_args+=("$@")
+
+      BUILD_ARG_FLAGS=()
+      for build_arg in "${build_args[@]}"; do
+        BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+      done
+
+      BASE_IMAGES=$(
+        dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_path" |
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName'
+      )
+
       BUILDAH_ARGS=()
 
-      BASE_IMAGES=$(dockerfile-json "$dockerfile_path" | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName')
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
@@ -337,13 +363,7 @@ spec:
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
       fi
 
-      if [ -n "${BUILD_ARGS_FILE}" ]; then
-        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
-      fi
-
-      for build_arg in "$@"; do
-        BUILDAH_ARGS+=("--build-arg=$build_arg")
-      done
+      BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
       if [ -n "${ADD_CAPABILITIES}" ]; then
         BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -303,9 +303,35 @@ spec:
       # Setting new namespace to run buildah - 2^32-2
       echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
 
+      build_args=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+        echo "Parsing ARGs from $BUILD_ARGS_FILE"
+        mapfile -t build_args < <(
+          # https://www.mankier.com/1/buildah-build#--build-arg-file
+          # delete lines that start with #
+          # delete blank lines
+          sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+        )
+      fi
+      # Append BUILD_ARGS
+      # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+      # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+      # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE - they take precedence.
+      build_args+=("$@")
+
+      BUILD_ARG_FLAGS=()
+      for build_arg in "${build_args[@]}"; do
+        BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+      done
+
+      BASE_IMAGES=$(
+        dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_path" |
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName'
+      )
+
       BUILDAH_ARGS=()
 
-      BASE_IMAGES=$(dockerfile-json "$dockerfile_path" | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName')
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
@@ -319,13 +345,7 @@ spec:
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
       fi
 
-      if [ -n "${BUILD_ARGS_FILE}" ]; then
-        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
-      fi
-
-      for build_arg in "$@"; do
-        BUILDAH_ARGS+=("--build-arg=$build_arg")
-      done
+      BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
       if [ -n "${ADD_CAPABILITIES}" ]; then
         BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -223,8 +223,25 @@ spec:
       # Setting new namespace to run buildah - 2^32-2
       echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
 
+      build_args=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+        echo "Parsing ARGs from $BUILD_ARGS_FILE"
+        mapfile -t build_args < <(
+          # https://www.mankier.com/1/buildah-build#--build-arg-file
+          # delete lines that start with #
+          # delete blank lines
+          sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+        )
+      fi
+      # Append BUILD_ARGS
+      # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+      # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+      # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE - they take precedence.
+      build_args+=("$@")
+
       BUILD_ARG_FLAGS=()
-      for build_arg in "$@"; do
+      for build_arg in "${build_args[@]}"; do
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
@@ -246,10 +263,6 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
-      fi
-
-      if [ -n "${BUILD_ARGS_FILE}" ]; then
-        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
       fi
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -223,9 +223,18 @@ spec:
       # Setting new namespace to run buildah - 2^32-2
       echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
 
+      BUILD_ARG_FLAGS=()
+      for build_arg in "$@"; do
+        BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+      done
+
+      BASE_IMAGES=$(
+        dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_path" |
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName'
+      )
+
       BUILDAH_ARGS=()
 
-      BASE_IMAGES=$(dockerfile-json "$dockerfile_path" | jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName')
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS="--net"
@@ -243,9 +252,7 @@ spec:
         BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
       fi
 
-      for build_arg in "$@"; do
-        BUILDAH_ARGS+=("--build-arg=$build_arg")
-      done
+      BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
       if [ -n "${ADD_CAPABILITIES}" ]; then
         BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")


### PR DESCRIPTION
It is possible to use a build arg to specify the base image for a stage:

    ARG BASE_IMAGE=foo

    FROM $BASE_IMAGE

    ...

Pass --build-arg values to dockerfile-json to make sure we resolve the
base images properly.
