### PR TITLE
Stop using the github-app-token image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,6 @@
     {
       "matchPackageNames": [
         "quay.io/konflux-ci/pull-request-builds",
-        "quay.io/redhat-appstudio/github-app-token",
         "quay.io/konflux-ci/appstudio-utils",
         "quay.io/konflux-ci/buildah",
         "quay.io/konflux-ci/source-container-build",

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -141,8 +141,8 @@ spec:
         import time
         import base64
         import subprocess
-
-        import requests
+        import urllib.error
+        import urllib.request
 
         logging.basicConfig(level=logging.DEBUG, format="%(asctime)s:%(name)s:%(levelname)s:%(message)s")
         logger = logging.getLogger("updater")
@@ -153,6 +153,15 @@ spec:
 
         ORIGIN_REPO = os.environ["ORIGIN_REPO"]
         TARGET_GH_REPO = os.environ["TARGET_GH_REPO"]
+
+
+        class Response:
+            def __init__(self, content, status):
+                self.content = content
+                self.status = status
+
+            def json(self):
+                return json.loads(self.content)
 
 
         class GitHub():
@@ -209,10 +218,14 @@ spec:
                     headers.update({"Authorization": "Bearer " + self.token})
                 if not url.startswith("http"):
                     url = f"{GITHUB_API_URL}{url}"
-                return requests.request(method,
-                                        url,
-                                        headers=headers,
-                                        data=json.dumps(data))
+                req = urllib.request.Request(
+                    url, method=method, headers=headers, data=json.dumps(data).encode()
+                )
+                try:
+                    with urllib.request.urlopen(req) as resp:
+                        return Response(resp.read(), resp.status)
+                except urllib.error.HTTPError as e:
+                    return Response(e.read(), e.code)
 
             def create_mr(self):
                 repo_name = ORIGIN_REPO.split('/')[-1]

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -109,7 +109,7 @@ spec:
 
       # Based on https://github.com/tektoncd/catalog/tree/main/task/github-app-token/0.2/
     - name: create-mr
-      image: quay.io/redhat-appstudio/github-app-token@sha256:b4f2af12e9beea68055995ccdbdb86cfe1be97688c618117e5da2243dc1da18e
+      image: registry.access.redhat.com/ubi9/python-39:1-192.1722518946@sha256:0176b477075984d5a502253f951d2502f0763c551275f9585ac515b9f241d73d
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       volumeMounts:

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -140,9 +140,9 @@ spec:
         import os
         import time
         import base64
+        import subprocess
 
         import requests
-        from jwcrypto import jwk, jwt
 
         logging.basicConfig(level=logging.DEBUG, format="%(asctime)s:%(name)s:%(levelname)s:%(message)s")
         logger = logging.getLogger("updater")
@@ -158,30 +158,32 @@ spec:
         class GitHub():
             token = None
 
-            def __init__(self, private_key, app_id=None, installation_id=None):
-                if not isinstance(private_key, bytes):
-                    raise ValueError(f'"{private_key}" parameter must be byte-string')
-                self._private_key = private_key
+            def __init__(self, private_key_path, app_id=None, installation_id=None):
+                self._private_key_path = private_key_path
                 self.app_id = app_id
                 self.token = self._get_token(installation_id)
 
-            def _load_private_key(self, pem_key_bytes):
-                return jwk.JWK.from_pem(pem_key_bytes)
-
             def _app_token(self, expire_in=EXPIRE_MINUTES_AS_SECONDS):
-                key = self._load_private_key(self._private_key)
+                # based on https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app#example-using-bash-to-generate-a-jwt
                 now = int(time.time())
-                token = jwt.JWT(
-                    header={"alg": "RS256"},
-                    claims={
-                        "iat": now,
-                        "exp": now + expire_in,
-                        "iss": self.app_id
-                    },
-                    algs=["RS256"],
+
+                header_ = {"typ": "JWT", "alg": "RS256"}
+                header = base64.b64encode(json.dumps(header_).encode())
+
+                payload_ = {"iat": now, "exp": now + expire_in, "iss": self.app_id}
+                payload = base64.b64encode(json.dumps(payload_).encode())
+
+                header_payload = header + b"." + payload
+                proc = subprocess.run(
+                    ["openssl", "dgst", "-sha256", "-sign", self._private_key_path],
+                    input=header_payload,
+                    check=True,
+                    stdout=subprocess.PIPE,
                 )
-                token.make_signed_token(key)
-                return token.serialize()
+                signature = base64.b64encode(proc.stdout)
+
+                token = header_payload + b"." + signature
+                return token.decode()
 
             def _get_token(self, installation_id=None):
                 app_token = self._app_token()
@@ -301,8 +303,7 @@ spec:
 
 
         def main():
-            with open(os.environ['GITHUBAPP_KEY_PATH'], 'rb') as key_file:
-                key = key_file.read()
+            key_path = os.environ['GITHUBAPP_KEY_PATH']
 
             if os.environ.get('GITHUBAPP_APP_ID'):
                 app_id = os.environ['GITHUBAPP_APP_ID']
@@ -311,7 +312,7 @@ spec:
 
             print(f"Getting user token for application_id: {app_id}")
             github_app = GitHub(
-                key,
+                key_path,
                 app_id=app_id,
                 installation_id=os.environ.get('GITHUBAPP_INSTALLATION_ID'))
 

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -316,7 +316,11 @@ spec:
 
 
         def main():
-            key_path = os.environ['GITHUBAPP_KEY_PATH']
+            key_path = os.environ.get('GITHUBAPP_KEY_PATH')
+            if key_path is None:
+                raise ValueError("The GITHUBAPP_KEY_PATH environment variable is not set")
+            if not os.path.exists(key_path):
+                raise ValueError(f"The GITHUBAPP_KEY_PATH file ({key_path!r}) does not exist")
 
             if os.environ.get('GITHUBAPP_APP_ID'):
                 app_id = os.environ['GITHUBAPP_APP_ID']


### PR DESCRIPTION
[STONEBLD-2718](https://issues.redhat.com/browse/STONEBLD-2718)

The quay.io/redhat-appstudio/github-app-token image is highly suspect.

- It is a copy of quay.io/chmouel/github-app-token - an image in a
  personal namespace with unclear origins and content.
- It has not been updated for 4 years.
- It has 175 critical vlunerabilities according to quay.io.

Update the update-infra-deployments task to no longer depend on anything this
image provides and replace it with a generic python image.