### PR TITLE
DNM: debug build-bundles task

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -151,6 +151,7 @@ spec:
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
+                set -e
                 QUAY_NAMESPACE=konflux-ci \
                 TEST_REPO_NAME=pull-request-builds \
                 BUILD_TAG=$(params.revision) \

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e -o pipefail
+set -x
 
 VCS_URL=https://github.com/konflux-ci/build-definitions
 VCS_REF=$(git rev-parse HEAD)


### PR DESCRIPTION
# Description

investigation of this issue in build-bundles task
```
step-build-bundles

*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
Error: invalid input format for param parameter:  runs script in 'SCRIPT' parameter
*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
Error: invalid input format for param parameter:  runs script in 'SCRIPT' parameter
*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
Error: invalid input format for param parameter:  runs script in 'SCRIPT' parameter
*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
Error: invalid input format for param parameter:  runs script in 'SCRIPT' parameter
*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
Error: invalid input format for param parameter:  runs script in 'SCRIPT' parameter
*Warning*: This is an experimental command, it's usage and behavior can change in the next release(s)
Error: invalid input format for param parameter:  runs script in 'SCRIPT' parameter
/tekton/scripts/script-0-64ghn: line 10: bundle_values.env: No such file or directory
```