### PR TITLE
Propagate oci-ta Pipelines to e2e-tests

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -143,6 +143,10 @@ spec:
           results:
           - name: custom-docker-build-bundle
             description: "custom bundle for docker-build pipeline"
+          - name: custom-docker-build-oci-ta-bundle
+            description: "custom bundle for docker-build-oci-ta pipeline"
+          - name: custom-docker-build-multi-platform-oci-ta-bundle
+            description: "custom bundle for docker-build-multi-platform-oci-ta"
           - name: custom-fbc-builder-bundle
             description: "custom bundle for fbc-builder pipeline"
           steps:
@@ -160,8 +164,10 @@ spec:
                 ENABLE_HERMETIC_BUILD=1 \
                 hack/build-and-push.sh
                 eval "source bundle_values.env"
-                echo -n $CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE | tee $(results.custom-docker-build-bundle.path)
-                echo -n $CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE | tee $(results.custom-fbc-builder-bundle.path)
+                echo -n "$CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE" | tee "$(results.custom-docker-build-bundle.path)"
+                echo -n "$CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE" | tee "$(results.custom-docker-build-oci-ta-bundle.path)"
+                echo -n "$CUSTOM_DOCKER_BUILD_MULTI_PLATFORM_OCI_TA_PIPELINE_BUNDLE" | tee "$(results.custom-docker-build-multi-platform-oci-ta-bundle.path)"
+                echo -n "$CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE" | tee "$(results.custom-fbc-builder-bundle.path)"
           workspaces:
             - name: source
       - name: e2e-tests
@@ -176,6 +182,10 @@ spec:
             value: "{{ revision }}"
           - name: docker-build-bundle
             value: "$(tasks.build-bundles.results.custom-docker-build-bundle)"
+          - name: docker-build-oci-ta-bundle
+            value: "$(tasks.build-bundles.results.custom-docker-build-oci-ta-bundle)"
+          - name: docker-build-multi-platform-oci-ta-bundle
+            value: "$(tasks.build-bundles.results.custom-docker-build-multi-platform-oci-ta-bundle)"
           - name: fbc-builder-bundle
             value: "$(tasks.build-bundles.results.custom-fbc-builder-bundle)"
         runAfter:

--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -22,6 +22,10 @@ spec:
       type: string
     - name: docker-build-bundle
       type: string
+    - name: docker-build-oci-ta-bundle
+      type: string
+    - name: docker-build-multi-platform-oci-ta-bundle
+      type: string
     - name: fbc-builder-bundle
       type: string
   steps:
@@ -67,5 +71,9 @@ spec:
         value: $(params.ec_pipelines_repo_revision)
       - name: CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE
         value: "$(params.docker-build-bundle)"
+      - name: CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE
+        value: "$(params.docker-build-oci-ta-bundle)"
+      - name: CUSTOM_DOCKER_BUILD_OCI_MULTI_PLATFORM_TA_PIPELINE_BUNDLE
+        value: "$(params.docker-build-multi-platform-oci-ta-bundle)"
       - name: CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE
         value: "$(params.fbc-builder-bundle)"

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -91,7 +91,7 @@ if [ "$SKIP_BUILD" == "" ]; then
     echo "Using $QUAY_NAMESPACE to push results "
     docker build -t "$APPSTUDIO_UTILS_IMG" "$SCRIPTDIR/../appstudio-utils/"
     docker push "$APPSTUDIO_UTILS_IMG"
-    
+
     # This isn't needed during PR testing
     if [[ "$BUILD_TAG" != "latest" && -z "$TEST_REPO_NAME" ]]; then
         # tag with latest
@@ -223,6 +223,8 @@ do
         save_ref "$pipeline_bundle" "$OUTPUT_PIPELINE_BUNDLE_LIST"
 
     [ "$pipeline_name" == "docker-build" ] && docker_pipeline_bundle=$pipeline_bundle
+    [ "$pipeline_name" == "docker-build-oci-ta" ] && docker_oci_ta_pipeline_bundle=$pipeline_bundle
+    [ "$pipeline_name" == "docker-build-multi-platform-oci-ta" ] && docker_multi_platform_oci_ta_pipeline_bundle=$pipeline_bundle
     [ "$pipeline_name" == "fbc-builder" ] && fbc_pipeline_bundle=$pipeline_bundle
     [ "$pipeline_name" == "nodejs-builder" ] && nodejs_pipeline_bundle=$pipeline_bundle
     [ "$pipeline_name" == "java-builder" ] && java_pipeline_bundle=$pipeline_bundle
@@ -233,5 +235,10 @@ do
 done
 
 if [ "$SKIP_INSTALL" == "" ]; then
-    printf "export CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE=$docker_pipeline_bundle\nexport CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE=$fbc_pipeline_bundle" > bundle_values.env
+    rm -f bundle_values.env
+
+    echo "export CUSTOM_DOCKER_BUILD_PIPELINE_BUNDLE=$docker_pipeline_bundle" >> bundle_values.env
+    echo "export CUSTOM_DOCKER_BUILD_OCI_TA_PIPELINE_BUNDLE=$docker_oci_ta_pipeline_bundle" >> bundle_values.env
+    echo "export CUSTOM_DOCKER_BUILD_MULTI_PLATFORM_OCI_TA_PIPELINE_BUNDLE=$docker_multi_platform_oci_ta_pipeline_bundle" >> bundle_values.env
+    echo "export CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE=$fbc_pipeline_bundle" >> bundle_values.env
 fi


### PR DESCRIPTION
This commit passes new environment variables to the e2e tests containing references to the oci-ta build Pipelines. This allows us to test those Pipelines.

Ref: [EC-715](https://issues.redhat.com//browse/EC-715)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
