### PR TITLE
CI: don't ignore build-and-push failures

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -155,6 +155,8 @@ spec:
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
+                set -e
+
                 QUAY_NAMESPACE=konflux-ci \
                 TEST_REPO_NAME=pull-request-builds \
                 BUILD_TAG=$(params.revision) \


### PR DESCRIPTION
Fail the pipeline when build-and-push.sh fails, don't proceed to the e2e-tests (which would fail anyway)