### PR TITLE
Include Image Index digest in PROCESSED_IMAGES

### DIFF
--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -113,9 +113,13 @@ spec:
           fi
         done
 
+        # If the image is an Image Index, also add the Image Index digest to the list.
+        if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
+          digests_processed+=("\"$IMAGE_DIGEST\"")
+        fi
+
         digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
 
-        # add the image_index to the processed digests list and store the result in a file
         images_processed=$(echo "${images_processed_template/\[%s]/[$digests_processed_string]}")
         echo "$images_processed" > /tekton/home/images-processed.json
     - name: conftest-vulnerabilities

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -145,6 +145,11 @@ spec:
             "note" : (if .result == "" or ($item.result == "SKIPPED" and .result == "SUCCESS") or ($item.result == "WARNING" and (.result == "SUCCESS" or .result == "SKIPPED")) or ($item.result == "FAILURE" and .result != "ERROR") or $item.result == "ERROR" then $item.note else .note end)
             })' /work/logs/clamscan-ec-test-*.json | tee $(results.TEST_OUTPUT.path)
 
+        # If the image is an Image Index, also add the Image Index digest to the list.
+        if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
+          digests_processed+=("\"$IMAGE_DIGEST\"")
+        fi
+
         digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
         echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee $(results.IMAGES_PROCESSED.path)
       volumeMounts:

--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -99,6 +99,12 @@ spec:
             digests_processed+=("\"$arch_sha\"")
           done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
         fi
+
+        # If the image is an Image Index, also add the Image Index digest to the list.
+        if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
+          digests_processed+=("\"$IMAGE_DIGEST\"")
+        fi
+
         digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
 
         if [ -n "${BASE_IMAGES_DIGESTS}" ];

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -84,6 +84,11 @@ spec:
         done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
       fi
 
+      # If the image is an Image Index, also add the Image Index digest to the list.
+      if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
+        digests_processed+=("\"$IMAGE_DIGEST\"")
+      fi
+
       # arrays to keep count of successful and failed checks
       successes=()
       failures=()

--- a/task/sbom-json-check/0.2/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.2/sbom-json-check.yaml
@@ -84,6 +84,11 @@ spec:
         done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
       fi
 
+      # If the image is an Image Index, also add the Image Index digest to the list.
+      if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
+        digests_processed+=("\"$IMAGE_DIGEST\"")
+      fi
+
       # arrays to keep count of successful and failed checks
       successes=()
       failures=()


### PR DESCRIPTION
In order to fix KFLUXBUGS-1616, we need to ensure the digest of the Image Index is also included in the list of PROCESSED_IMAGES. This will allow EC to verify the Image Index directly as well as the Image Manifests.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
