### PR TITLE
Use `hermetic` param in FBC builder pipeline to configure `build-container` task

### DIFF
--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -11,7 +11,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.2:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| |
+|hermetic| Execute the build with network isolation| true| build-container:0.2:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.2:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.2:IMAGE ; build-image-index:0.1:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
@@ -50,7 +50,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
-|HERMETIC| Determines if build will be executed without network access.| false| 'true'|
+|HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | |

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -30,7 +30,7 @@
   - name: CONTEXT
     value: $(params.path-context)
   - name: HERMETIC
-    value: "true"
+    value: $(params.hermetic)
   - name: IMAGE_EXPIRES_AFTER
     value: "$(params.image-expires-after)"
   - name: COMMIT_SHA

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -16,6 +16,9 @@
     "pipelines.openshift.io/runtime": "fbc"
     "pipelines.openshift.io/strategy": "fbc"
 - op: replace
+  path: /spec/params/7/default
+  value: "true"
+- op: replace
   path: /spec/tasks/3/taskRef
   value:
     name: buildah


### PR DESCRIPTION
Fixes https://github.com/konflux-ci/build-definitions/issues/1426

Remove hardcoded `HERMETIC="true"` in `build-container` task for the FBC pipeline.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
