### PR TITLE
buildah: restore exclusion of "FROM oci-archive:"

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -310,7 +310,7 @@ spec:
 
         BASE_IMAGES=$(
           dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_path" |
-            jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName'
+            jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)'
         )
 
         BUILDAH_ARGS=()

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -345,7 +345,7 @@ spec:
 
       BASE_IMAGES=$(
         dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_path" |
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName'
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)'
       )
 
       BUILDAH_ARGS=()

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -327,7 +327,7 @@ spec:
 
       BASE_IMAGES=$(
         dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_path" |
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName'
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)'
       )
 
       BUILDAH_ARGS=()

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -247,7 +247,7 @@ spec:
 
       BASE_IMAGES=$(
         dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_path" |
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName'
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)'
       )
 
       BUILDAH_ARGS=()


### PR DESCRIPTION
Commit f12435b933 (Replace grep base images parsing with dockerfile-json) accidentally reverted fdc3d9c57cc (buildah: Don't include oci-archive: FROM lines in BASE_IMAGES)

Original commit message:

    In certain cases, we might have a FROM line which is from an archive
    exported by a pevious build stage; when we are pre-pulling images
    for a hermetic build, skip these images.

    (Even if the oci-archive wasn't generated during the build, there's
    no point in pre-pulling a local URL.)

See https://github.com/konflux-ci/build-definitions/pull/1158

