### PR TITLE
git-clone: Add configurable `short-commit` result

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -118,6 +118,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).git'|
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |submodules| Initialize and fetch git submodules.| true| |
@@ -226,6 +227,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-images:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
 ### init:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -115,6 +115,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).git'|
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |submodules| Initialize and fetch git submodules.| true| |
@@ -223,6 +224,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
 ### init:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -64,6 +64,7 @@
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
@@ -121,6 +122,7 @@
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -113,6 +113,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
@@ -220,6 +221,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -95,6 +95,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
@@ -171,6 +172,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/gitops-pull-request-rhtap/README.md
+++ b/pipelines/gitops-pull-request-rhtap/README.md
@@ -50,6 +50,7 @@
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
@@ -96,6 +97,7 @@
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| |
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
 ### verify-enterprise-contract:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -81,6 +81,7 @@
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
@@ -192,6 +193,7 @@
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -81,6 +81,7 @@
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
@@ -192,6 +193,7 @@
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -71,6 +71,7 @@
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
+|shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
@@ -159,6 +160,7 @@
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)

--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -17,6 +17,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
 |refspec|Refspec to fetch before checking out revision.|""|false|
 |revision|Revision to checkout. (branch, tag, sha, ref, etc...)|""|false|
+|shortCommitLength|Length of short commit SHA|7|false|
 |sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
 |sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
 |submodules|Initialize and fetch git submodules.|true|false|
@@ -30,6 +31,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
 |commit|The precise commit SHA that was fetched by this Task.|
 |commit-timestamp|The commit timestamp of the checkout|
+|short-commit|The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters|
 |url|The precise URL that was fetched by this Task.|
 
 ## Workspaces

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -66,6 +66,10 @@ spec:
       description: Revision to checkout. (branch, tag, sha, ref, etc...)
       type: string
       default: ""
+    - name: shortCommitLength
+      description: Length of short commit SHA
+      type: string
+      default: "7"
     - name: sparseCheckoutDirectories
       description: Define the directory patterns to match or exclude when
         performing a sparse checkout.
@@ -103,6 +107,9 @@ spec:
       description: The precise commit SHA that was fetched by this Task.
     - name: commit-timestamp
       description: The commit timestamp of the checkout
+    - name: short-commit
+      description: The commit SHA that was fetched by this Task limited to
+        params.shortCommitLength number of characters
     - name: url
       description: The precise URL that was fetched by this Task.
   volumes:
@@ -153,6 +160,8 @@ spec:
           value: $(params.submodules)
         - name: PARAM_DEPTH
           value: $(params.depth)
+        - name: PARAM_SHORT_COMMIT_LENGTH
+          value: $(params.shortCommitLength)
         - name: PARAM_SSL_VERIFY
           value: $(params.sslVerify)
         - name: PARAM_HTTP_PROXY
@@ -232,11 +241,13 @@ spec:
           -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
         cd "${CHECKOUT_DIR}"
         RESULT_SHA="$(git rev-parse HEAD)"
+        RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
         EXIT_CODE="$?"
         if [ "${EXIT_CODE}" != 0 ]; then
           exit "${EXIT_CODE}"
         fi
         printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
+        printf "%s" "${RESULT_SHA_SHORT}" >"$(results.short-commit.path)"
         printf "%s" "${PARAM_URL}" >"$(results.url.path)"
         printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
 

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -22,11 +22,13 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden the gitInitImage param with an image containing custom user configuration. |/tekton/home|false|
 |enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.|true|false|
 |fetchTags|Fetch all tags for the repo.|false|false|
+|shortCommitLength|Length of the returned short-commit|7|false|
 
 ## Results
 |name|description|
 |---|---|
 |commit|The precise commit SHA that was fetched by this Task.|
+|short-commit|The commit SHA that was fetched by this Task shortened to `shortCommitLength` number of characters||
 |url|The precise URL that was fetched by this Task.|
 
 ## Workspaces

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -33,6 +33,10 @@ spec:
     description: Perform a shallow clone, fetching only the most recent N commits.
     name: depth
     type: string
+  - name: shortCommitLength
+    description: Length of short commit SHA
+    type: string
+    default: "7"
   - default: "true"
     description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
     name: sslVerify
@@ -94,6 +98,8 @@ spec:
   results:
   - description: The precise commit SHA that was fetched by this Task.
     name: commit
+  - description: The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters
+    name: short-commit
   - description: The precise URL that was fetched by this Task.
     name: url
   - description: The commit timestamp of the checkout
@@ -113,6 +119,8 @@ spec:
       value: $(params.submodules)
     - name: PARAM_DEPTH
       value: $(params.depth)
+    - name: PARAM_SHORT_COMMIT_LENGTH
+      value: $(params.shortCommitLength)
     - name: PARAM_SSL_VERIFY
       value: $(params.sslVerify)
     - name: PARAM_SUBDIRECTORY
@@ -231,11 +239,13 @@ spec:
         -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
       cd "${CHECKOUT_DIR}"
       RESULT_SHA="$(git rev-parse HEAD)"
+      RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
       EXIT_CODE="$?"
       if [ "${EXIT_CODE}" != 0 ] ; then
         exit "${EXIT_CODE}"
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+      printf "%s" "${RESULT_SHA_SHORT}" > "$(results.short-commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
       printf "%s" "$(git log -1 --pretty=%ct)" > "$(results.commit-timestamp.path)"
 


### PR DESCRIPTION
It's helpful to have a short commit SHA for use in other tasks, such as `apply-tags`. The length of `short-commit` is also configurable, giving greater flexibility to the pipeline author.
