### PR TITLE
fix(KFLUXBUGS-1601): use the base image name label to get its tag

### DIFF
--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -180,10 +180,18 @@ spec:
           TESTPASSED=false
         fi
 
-        # examines the BASE_IMAGE tag to derive the target OCP version
+        # examines the base_image_name tag to derive the target OCP version
         # assumes this is in the form
         # image-path:[v]major-digits.minor-digits[@sha...]
-        OCP_VER_FROM_BASE=$(echo "${BASE_IMAGE}" | sed -e "s/@.*$//" -e "s/^.*://")   # strips hash first due to greedy match
+        status=0
+        base_image_name=$(jq -r ".Labels.\"org.opencontainers.image.base.name\"" ../inspect-image/image_inspect.json) || status=$?
+        if [ $status -ne 0 ]; then
+          echo "Could not get labels from inspect-image/image_inspect.json. Make sure file exists and it contains this label: org.opencontainers.image.base.name"
+          TEST_OUTPUT="$(make_result_json -r ERROR)"
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+        OCP_VER_FROM_BASE=$(echo "${base_image_name}" | sed -e "s/@.*$//" -e "s/^.*://")   # strips hash first due to greedy match
         # extracts major digits and filters out any leading alphabetic characters, for e.g. 'v4' --> '4'
         OCP_VER_MAJOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 1 | sed "s/^[a-zA-Z]*//")
         OCP_VER_MINOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 2)
@@ -195,7 +203,7 @@ spec:
         fi
 
         if [ "${RUN_OCP_VERSION_VALIDATION}" == "false" ] ; then
-          echo "!WARNING! - unable to assess bundle metadata alignment with OCP version because we cannot extract version info from BASE_IMAGE: ${BASE_IMAGE}"
+          echo "!WARNING! - unable to assess bundle metadata alignment with OCP version because we cannot extract version info from base_image_name: ${base_image_name}"
         else
           OCP_BUNDLE_METADATA_THRESHOLD_MAJOR=4
           OCP_BUNDLE_METADATA_THRESHOLD_MINOR=17


### PR DESCRIPTION
* The BASE_IMAGE result from the inspect-image task is supposed to be referenced by digest and is supposed to be used as such in other checks within the fbc-validation task
* Switch to extracting the base image name from the org.opencontainers.image.base.name for the needs of getting the base image tag and deriving the OCP version from it

Signed-off-by: dirgim <kpavic@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
