### PR TITLE
Ensure rpms-signature-scan emits expected result

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -13,12 +13,14 @@ sources:
         - ssh-directory
         - netrc
       required_task_results:
-        # Certain EC rules rely on the presence of this result when validating an image.
+        # Certain EC rules rely on the presence of these results when validating an image.
         - task: clair-scan
           result: CLAIR_SCAN_RESULT
           version: "0.1"
         - task: clair-scan
           result: SCAN_OUTPUT
+        - task: rpms-signature-scan
+          result: RPMS_DATA
     config:
       include:
         - kind


### PR DESCRIPTION
Because some EC policy rules rely on the existence of the RPMS_DATA result, this commit adds a check to ensure future modifications of the `rpms-signature-scan` Task continues to define the result.

Ref: https://issues.redhat.com/browse/EC-846

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
