### PR TITLE
task/git-clone*: add --short SHA to results

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -225,6 +225,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-images:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| |
 ### init:0.2 task results

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -222,6 +222,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| |
 ### init:0.2 task results

--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -120,6 +120,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA|
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -219,6 +219,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -170,6 +170,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/gitops-pull-request-rhtap/README.md
+++ b/pipelines/gitops-pull-request-rhtap/README.md
@@ -95,6 +95,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| |
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| |
 ### verify-enterprise-contract:0.1 task results

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -191,6 +191,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -191,6 +191,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -158,6 +158,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |commit| The precise commit SHA that was fetched by this Task.| build-image-index:0.1:COMMIT_SHA|
+|commit-short| The short commit SHA of the checkout| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -29,6 +29,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |---|---|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
 |commit|The precise commit SHA that was fetched by this Task.|
+|commit-short|The short commit SHA of the checkout|
 |commit-timestamp|The commit timestamp of the checkout|
 |url|The precise URL that was fetched by this Task.|
 

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -101,6 +101,8 @@ spec:
       type: string
     - name: commit
       description: The precise commit SHA that was fetched by this Task.
+    - name: commit-short
+      description: The short commit SHA of the checkout
     - name: commit-timestamp
       description: The commit timestamp of the checkout
     - name: url
@@ -239,6 +241,7 @@ spec:
         printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
         printf "%s" "${PARAM_URL}" >"$(results.url.path)"
         printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
+        printf "%s" "$(git rev-parse --short HEAD)" >"$(results.commit-short.path)"
 
         if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
           echo "Fetching tags"

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -11,23 +11,27 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |submodules|Initialize and fetch git submodules.|true|false|
 |depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
 |sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
-|subdirectory|Subdirectory inside the `output` Workspace to clone the repo into.|""|false|
+|subdirectory|Subdirectory inside the `output` Workspace to clone the repo into.|source|false|
 |sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
 |deleteExisting|Clean out the contents of the destination directory if it already exists before cloning.|true|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
 |noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
-|verbose|Log the commands that are executed during `git-clone`'s operation.|true|false|
+|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
 |gitInitImage|Deprecated. Has no effect. Will be removed in the future.|""|false|
-|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden the gitInitImage param with an image containing custom user configuration. |/tekton/home|false|
-|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.|true|false|
+|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
+|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
 |fetchTags|Fetch all tags for the repo.|false|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 
 ## Results
 |name|description|
 |---|---|
 |commit|The precise commit SHA that was fetched by this Task.|
 |url|The precise URL that was fetched by this Task.|
+|commit-timestamp|The commit timestamp of the checkout|
+|commit-short|The short commit SHA of the checkout|
 
 ## Workspaces
 |name|description|optional|

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -98,6 +98,8 @@ spec:
     name: url
   - description: The commit timestamp of the checkout
     name: commit-timestamp
+  - description: The short commit SHA of the checkout
+    name: commit-short
   steps:
   - name: clone
     env:
@@ -238,6 +240,7 @@ spec:
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
       printf "%s" "$(git log -1 --pretty=%ct)" > "$(results.commit-timestamp.path)"
+      printf "%s" "$(git rev-parse --short HEAD)" > "$(results.commit-short.path)"
 
       if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
         echo "Fetching tags"


### PR DESCRIPTION
add the short commit SHA of the default length (7 characters) to the results of the tasks and regen the readme