### PR TITLE
ci: migrate yamllint to GitHub Actions

### DIFF
--- a/.github/workflows/check-buildah-remote.yaml
+++ b/.github/workflows/check-buildah-remote.yaml
@@ -7,9 +7,9 @@ jobs:
     name: Check Buildah Remote
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4
       - name: Install Go
-        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32  # v5
         with:
           go-version-file: './task-generator/remote/go.mod'
       - name: Check buildah remote

--- a/.github/workflows/checkton.yaml
+++ b/.github/workflows/checkton.yaml
@@ -1,5 +1,5 @@
 name: Checkton
-on:
+"on":
   pull_request:
     branches: [main]
 
@@ -23,12 +23,12 @@ jobs:
           find-copies-harder: true
           exclude-regex: ^task-generator
 
-      # Currently, code scanning alerts annoyingly stay open even if you fix them.
-      # Don't upload SARIF until https://github.com/orgs/community/discussions/132787 is resolved.
+          # Currently, code scanning alerts annoyingly stay open even if you fix them.
+          # Don't upload SARIF until https://github.com/orgs/community/discussions/132787 is resolved.
 
-      # - name: Upload SARIF file
-      #   uses: github/codeql-action/upload-sarif@v3
-      #   with:
-      #     sarif_file: ${{ steps.checkton.outputs.sarif }}
-      #     # Avoid clashing with ShellCheck
-      #     category: checkton
+          # - name: Upload SARIF file
+          #   uses: github/codeql-action/upload-sarif@v3
+          #   with:
+          #     sarif_file: ${{ steps.checkton.outputs.sarif }}
+          #     # Avoid clashing with ShellCheck
+          #     category: checkton

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -1,5 +1,5 @@
 name: Validate PR - golang CI
-on:
+"on":
   pull_request:
     branches: [main]
 jobs:

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -1,0 +1,12 @@
+---
+name: yamllint
+"on":
+  pull_request:
+    branches: [main]
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint YAML files
+        run: yamllint .

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -5,8 +5,7 @@ metadata:
   name: build-definitions-pull-request
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || !body.pull_request.draft) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
-    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/yaml-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.2/sast-snyk-check.yaml]"
-    pipelinesascode.tekton.dev/task-2: "yaml-lint"
+    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.2/sast-snyk-check.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:
@@ -37,17 +36,14 @@ spec:
             value: $(params.revision)
           - name: depth
             value: "0"
-      - name: yaml-lint-check
+      - name: task-lint-check
         runAfter:
           - fetch-repository
         taskRef:
-          name: yaml-lint
+          name: task-lint
         workspaces:
           - name: shared-workspace
             workspace: workspace
-        params:
-        - name: args
-          value: [".", "-c", "/workspace/shared-workspace/source/.yamllint"]
       - name: sast-snyk-check
         runAfter:
           - fetch-repository
@@ -58,7 +54,7 @@ spec:
             workspace: workspace
       - name: build-container
         runAfter:
-          - yaml-lint-check
+          - task-lint-check
         params:
           - name: IMAGE
             value: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}

--- a/.tekton/tasks/task-lint.yaml
+++ b/.tekton/tasks/task-lint.yaml
@@ -1,18 +1,18 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: yaml-lint
+  name: task-lint
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/categories: Code Quality
     tekton.dev/tags: linter
-    tekton.dev/displayName: "YAML linter"
+    tekton.dev/displayName: "Task Linter"
     tekton.dev/platforms: "linux/amd64"
 spec:
   description: >-
-    This task can be used to perform lint check on YAML files
+    A task for performing static analysis on Tekton tasks
   workspaces:
     - name: shared-workspace
       description: A workspace that contains the fetched git repository.
@@ -22,15 +22,6 @@ spec:
       description: extra args needs to append
       default: ["--help"]
   steps:
-    - name: lint-yaml-files
-      image: docker.io/cytopia/yamllint:1.26@sha256:1bf8270a671a2e5f2fea8ac2e80164d627e0c5fa083759862bbde80628f942b2  # tag: 1.23
-      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-      # the cluster will set imagePullPolicy to IfNotPresent
-      workingDir: $(workspaces.shared-workspace.path)/source
-      command:
-        - yamllint
-      args:
-        - $(params.args)
     - name: ensure-params-not-in-script
       image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting

--- a/partners/README.md
+++ b/partners/README.md
@@ -20,7 +20,6 @@ Send a pull request to the [build-definitions](https://github.com/konflux-ci/bui
 ### How to debug the CI failures in my submitted Task?
 
 Check the logs of the `check-partner-tasks` Task in the `build-definitions-pull-request` PR check.
-If you see the Task `yaml-lint-check` has failed, then your Task YAML contains yaml-lint errors.
 
 ### Checks
 


### PR DESCRIPTION
[STONEBLD-2791](https://issues.redhat.com/browse/STONEBLD-2791)
- Container image used in yaml-lint task is outdated and using it causes rate-limiting issues with docker.io
- Remove the yaml-lint task to task-lint and remove yamllint part
- Create a GitHub Action that runs yamllint
- Fix yamllint warnings
  - Double quote the `on` keyword
`on` -> `"on"`
  - Fix comment indentation

Tested locally by using `act`. Added random things to random YAMLs in order to make the lint fail and it indeed failed.