### PR TITLE
Don't push unnecessary things to redhat-appstudio-tekton-catalog

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -169,28 +169,6 @@ spec:
                 - $(workspaces.source.path)/pipeline-bundle-list-konflux-ci
                 - $(workspaces.source.path)/task-bundle-list-appstudio
                 - $(workspaces.source.path)/pipeline-bundle-list-appstudio
-            - name: copy-acceptable-bundle-to-appstudio
-              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
-              workingDir: $(workspaces.source.path)/source
-              script: |
-                #!/bin/bash
-                set -euo pipefail
-
-                DATA_BUNDLE_REPO=quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles
-                DATA_BUNDLE_TAG=$(<acceptable_bundle_tag)
-                DATA_BUNDLE_RH_APPSTUDIO=quay.io/redhat-appstudio-tekton-catalog/data-acceptable-bundles
-
-                skopeo copy \
-                  "docker://$DATA_BUNDLE_REPO:$DATA_BUNDLE_TAG" \
-                  "docker://$DATA_BUNDLE_RH_APPSTUDIO:$DATA_BUNDLE_TAG"
-
-                skopeo copy \
-                  "docker://$DATA_BUNDLE_REPO:$DATA_BUNDLE_TAG" \
-                  "docker://$DATA_BUNDLE_RH_APPSTUDIO:latest"
-              volumeMounts:
-                - mountPath: /root/.docker/config.json
-                  subPath: .dockerconfigjson
-                  name: quay-secret
           volumes:
           - name: quay-secret
             secret:

--- a/.tekton/scripts/check-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/check-task-pipeline-bundle-repos.sh
@@ -8,7 +8,6 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPTDIR/../.."
 
 CATALOG_NAMESPACES=(
-    redhat-appstudio-tekton-catalog
     konflux-ci/tekton-catalog
 )
 

--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -224,6 +224,11 @@ if [ -n "$ENABLE_SOURCE_BUILD" ]; then
     done
 fi
 
+if [ "$QUAY_NAMESPACE" == redhat-appstudio-tekton-catalog ]; then
+    echo "NOTE: not pushing any pipelines to $QUAY_NAMESPACE; the namespace is deprecated"
+    exit 0
+fi
+
 # Build Pipeline bundle with pipelines pointing to newly built task bundles
 for pipeline_yaml in "$generated_pipelines_dir"/*.yaml "$core_services_pipelines_dir"/*.yaml
 do


### PR DESCRIPTION
[STONEBLD-2720](https://issues.redhat.com//browse/STONEBLD-2720)

* Stop pushing task bundles for new tasks (those that didn't exist before this PR got merged)
* Stop pushing pipeline bundles
  * Related PRs:
    * https://github.com/konflux-ci/ci-helper-app/pull/55
    * https://github.com/konflux-ci/quality-dashboard/pull/340
    * https://github.com/redhat-appstudio/managed-gitops/pull/812
    * https://github.com/containerbuildsystem/cachi2/pull/661
    * https://github.com/openshift-pipelines/pipeline-service-exporter/pull/73
    * https://github.com/konflux-ci/docs/pull/137
  * These don't need to be merged before this PR gets merged. If they're not merged, the worst that can happen is that the affected services will use an outdated build pipeline.

* Stop pushing data-acceptable-bundles
  * one related MR in an internal gitlab instance