### PR TITLE
apply-tags: Tag multi-arch images as expected

### DIFF
--- a/task/apply-tags/0.1/apply-tags.yaml
+++ b/task/apply-tags/0.1/apply-tags.yaml
@@ -47,7 +47,7 @@ spec:
           IMAGE_WITHOUT_TAG=$(echo "$IMAGE" | sed 's/:[^:]*$//')
           for tag in "$@"; do
             echo "Applying tag $tag"
-            skopeo copy docker://$IMAGE docker://$IMAGE_WITHOUT_TAG:$tag
+            skopeo copy --multi-arch all docker://"$IMAGE" docker://"$IMAGE_WITHOUT_TAG:$tag"
           done
         else
           echo "No additional tags parameter specified"
@@ -70,7 +70,7 @@ spec:
           for tag in "${tags_array[@]}"
           do
               echo "Applying tag $tag"
-              skopeo copy docker://$IMAGE docker://$IMAGE_WITHOUT_TAG:$tag
+              skopeo copy --multi-arch all docker://"$IMAGE" docker://"$IMAGE_WITHOUT_TAG:$tag"
           done
         else
           echo "No additional tags specified in the image labels"

--- a/task/apply-tags/0.1/apply-tags.yaml
+++ b/task/apply-tags/0.1/apply-tags.yaml
@@ -47,7 +47,7 @@ spec:
           IMAGE_WITHOUT_TAG=$(echo "$IMAGE" | sed 's/:[^:]*$//')
           for tag in "$@"; do
             echo "Applying tag $tag"
-            skopeo copy --multi-arch all docker://"$IMAGE" docker://"$IMAGE_WITHOUT_TAG:$tag"
+            skopeo copy --multi-arch index-only docker://"$IMAGE" docker://"$IMAGE_WITHOUT_TAG:$tag"
           done
         else
           echo "No additional tags parameter specified"
@@ -70,7 +70,7 @@ spec:
           for tag in "${tags_array[@]}"
           do
               echo "Applying tag $tag"
-              skopeo copy --multi-arch all docker://"$IMAGE" docker://"$IMAGE_WITHOUT_TAG:$tag"
+              skopeo copy --multi-arch index-only docker://"$IMAGE" docker://"$IMAGE_WITHOUT_TAG:$tag"
           done
         else
           echo "No additional tags specified in the image labels"


### PR DESCRIPTION
When copying an image manifest, `skopeo` by default only copies the image matching the architecture of the system running `skopeo`. It does not copy the image manifest as expected.

In my testing, adding the `--multi-arch all` flag on single architecture images works without error.
