### PR TITLE
deprecate images using BASE_IMAGES_DIGESTS result

### DIFF
--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -4,6 +4,7 @@ kind: Task
 metadata:
   name: buildah-oci-ta
   annotations:
+    build.appstudio.redhat.com/expires-on: "2024-11-13T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2024-11-13T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2024-11-13T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -7,6 +7,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, konflux"
+    build.appstudio.redhat.com/expires-on: 2024-11-13T00:00:00Z
   name: buildah
 spec:
   description: |-

--- a/task/rpm-ostree/0.1/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.1/rpm-ostree.yaml
@@ -4,6 +4,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
+    build.appstudio.redhat.com/expires-on: 2024-11-13T00:00:00Z
   labels:
     app.kubernetes.io/version: "0.1"
     build.appstudio.redhat.com/build_type: rpm-ostree

--- a/task/s2i-java/0.1/s2i-java.yaml
+++ b/task/s2i-java/0.1/s2i-java.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/version: "0.1"
     build-definition.include: add-sbom-and-push
     build.appstudio.redhat.com/build_type: "java"
+    build.appstudio.redhat.com/expires-on: 2024-11-13T00:00:00Z
   annotations:
     tekton.dev/displayName: s2i java
     tekton.dev/pipelines.minVersion: "0.19"

--- a/task/s2i-nodejs/0.1/s2i-nodejs.yaml
+++ b/task/s2i-nodejs/0.1/s2i-nodejs.yaml
@@ -8,6 +8,7 @@ metadata:
     tekton.dev/displayName: s2i nodejs
     tekton.dev/pipelines.minVersion: "0.19"
     tekton.dev/tags: s2i, nodejs, workspace
+    build.appstudio.redhat.com/expires-on: 2024-11-13T00:00:00Z
   name: s2i-nodejs
 spec:
   description: |


### PR DESCRIPTION
[STONEBLD-2747](https://issues.redhat.com/browse/STONEBLD-2747)
- Results with BASE_IMAGES_DIGESTS are too large and cause builds to hit the Tekton result size
limit
- Deprecate all tasks using the result so they will be unsupported after 2024-11-13T00:00:00Z
