### PR TITLE
Deprecate buildah task resource variations

### DIFF
--- a/task/buildah-10gb/0.1/patch.yaml
+++ b/task/buildah-10gb/0.1/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 8Gi
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-10gb/0.2/patch.yaml
+++ b/task/buildah-10gb/0.2/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 8Gi
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-20gb/0.1/patch.yaml
+++ b/task/buildah-20gb/0.1/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 16Gi
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-20gb/0.2/patch.yaml
+++ b/task/buildah-20gb/0.2/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 16Gi
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-24gb/0.1/patch.yaml
+++ b/task/buildah-24gb/0.1/patch.yaml
@@ -13,3 +13,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/cpu
   value: "10"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-24gb/0.2/patch.yaml
+++ b/task/buildah-24gb/0.2/patch.yaml
@@ -13,3 +13,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/cpu
   value: "10"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-6gb/0.1/patch.yaml
+++ b/task/buildah-6gb/0.1/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 4Gi
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-6gb/0.2/patch.yaml
+++ b/task/buildah-6gb/0.2/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 4Gi
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-8gb/0.1/patch.yaml
+++ b/task/buildah-8gb/0.1/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 6Gi
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"

--- a/task/buildah-8gb/0.2/patch.yaml
+++ b/task/buildah-8gb/0.2/patch.yaml
@@ -7,3 +7,9 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/memory
   value: 6Gi
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+  value: "2025-01-21T00:00:00Z"
+- op: add
+  path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+  value: "Instead of using this task, switch to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah) and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/"


### PR DESCRIPTION
Since it's possible to set task resources from pipeline run in Konflux ([docs](https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/)), we are deprecation `buildah-*gb` tasks.
