### PR TITLE
fix(KFLUXBUGS-1666): Only analyze build context for dependencies

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -195,6 +195,8 @@ spec:
         value: $(params.IMAGE_EXPIRES_AFTER)
       - name: SKIP_UNUSED_STAGES
         value: $(params.SKIP_UNUSED_STAGES)
+      - name: SOURCE_CODE_DIR
+        value: source
       - name: SQUASH
         value: $(params.SQUASH)
       - name: STORAGE_DRIVER
@@ -251,7 +253,6 @@ spec:
           update-ca-trust
         fi
 
-        SOURCE_CODE_DIR=source
         if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
           dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
         elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
@@ -459,9 +460,9 @@ spec:
           name: shared
       script: |
         echo "Running syft on the source directory"
-        syft dir:/var/workdir/source --output cyclonedx-json=/var/workdir/sbom-source.json
+        syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="/var/workdir/sbom-source.json"
         echo "Running syft on the image filesystem"
-        syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
+        syft dir:"$(cat /shared/container_path)" --output cyclonedx-json="/var/workdir/sbom-image.json"
       computeResources:
         limits:
           cpu: "2"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -176,6 +176,8 @@ spec:
       value: $(params.IMAGE_EXPIRES_AFTER)
     - name: SKIP_UNUSED_STAGES
       value: $(params.SKIP_UNUSED_STAGES)
+    - name: SOURCE_CODE_DIR
+      value: source
     - name: SQUASH
       value: $(params.SQUASH)
     - name: STORAGE_DRIVER
@@ -286,7 +288,6 @@ spec:
         update-ca-trust
       fi
 
-      SOURCE_CODE_DIR=source
       if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
@@ -494,6 +495,7 @@ spec:
           -e IMAGE="$IMAGE" \
           -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
           -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
+          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
           -e SQUASH="$SQUASH" \
           -e STORAGE_DRIVER="$STORAGE_DRIVER" \
           -e TARGET_STAGE="$TARGET_STAGE" \
@@ -562,9 +564,9 @@ spec:
         export IMAGE
       fi
       echo "Running syft on the source directory"
-      syft dir:/var/workdir/source --output cyclonedx-json=/var/workdir/sbom-source.json
+      syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="/var/workdir/sbom-source.json"
       echo "Running syft on the image filesystem"
-      syft dir:$(cat /shared/container_path) --output cyclonedx-json=/var/workdir/sbom-image.json
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json="/var/workdir/sbom-image.json"
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -149,6 +149,8 @@ spec:
       value: $(params.STORAGE_DRIVER)
     - name: HERMETIC
       value: $(params.HERMETIC)
+    - name: SOURCE_CODE_DIR
+      value: source
     - name: CONTEXT
       value: $(params.CONTEXT)
     - name: DOCKERFILE
@@ -268,7 +270,6 @@ spec:
         update-ca-trust
       fi
 
-      SOURCE_CODE_DIR=source
       if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
@@ -467,6 +468,7 @@ spec:
           -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
           -e STORAGE_DRIVER="$STORAGE_DRIVER" \
           -e HERMETIC="$HERMETIC" \
+          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
           -e CONTEXT="$CONTEXT" \
           -e DOCKERFILE="$DOCKERFILE" \
           -e IMAGE="$IMAGE" \
@@ -544,9 +546,9 @@ spec:
         export IMAGE
       fi
       echo "Running syft on the source directory"
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image filesystem"
-      syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json="$(workspaces.source.path)/sbom-image.json"
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -130,6 +130,8 @@ spec:
       value: $(params.STORAGE_DRIVER)
     - name: HERMETIC
       value: $(params.HERMETIC)
+    - name: SOURCE_CODE_DIR
+      value: source
     - name: CONTEXT
       value: $(params.CONTEXT)
     - name: DOCKERFILE
@@ -188,7 +190,6 @@ spec:
         update-ca-trust
       fi
 
-      SOURCE_CODE_DIR=source
       if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
@@ -408,9 +409,9 @@ spec:
         cpu: 500m
     script: |
       echo "Running syft on the source directory"
-      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image filesystem"
-      syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json="$(workspaces.source.path)/sbom-image.json"
     volumeMounts:
     - mountPath: /var/lib/containers
       name: varlibcontainers


### PR DESCRIPTION
When generating the SBOM, we do not constrain the source analysis to the build context. This can result in many additional dependencies being included than should be.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
