### PR TITLE
Add buildah-sast task prototype

### DIFF
--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -412,10 +412,12 @@ spec:
         BUILDAH_ARGS+=("--skip-unused-stages=false")
       fi
 
+      VOLUME_MOUNTS="$VOLUME_MOUNTS_FROM_ENV"
+
       if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
         cp -r "/var/workdir/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
-        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/cachi2:/cachi2"
         # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
         # for each RUN ... line insert the cachi2.env command *after* any options like --mount
         sed -E -i \

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -157,8 +157,6 @@ spec:
       value: source
     - name: CONTEXT
       value: $(params.CONTEXT)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
     - name: IMAGE
       value: $(params.IMAGE)
     - name: TLSVERIFY
@@ -212,6 +210,8 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
     name: build
     script: |-
@@ -281,6 +281,8 @@ spec:
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
@@ -388,10 +390,12 @@ spec:
         BUILDAH_ARGS+=("--skip-unused-stages=false")
       fi
 
+      VOLUME_MOUNTS="$VOLUME_MOUNTS_FROM_ENV"
+
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
-        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/cachi2:/cachi2"
         # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
         # for each RUN ... line insert the cachi2.env command *after* any options like --mount
         sed -E -i \
@@ -504,7 +508,6 @@ spec:
           -e HERMETIC="$HERMETIC" \
           -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
           -e CONTEXT="$CONTEXT" \
-          -e DOCKERFILE="$DOCKERFILE" \
           -e IMAGE="$IMAGE" \
           -e TLSVERIFY="$TLSVERIFY" \
           -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
@@ -520,6 +523,7 @@ spec:
           -e SQUASH="$SQUASH" \
           -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
           -e COMMIT_SHA="$COMMIT_SHA" \
+          -e DOCKERFILE="$DOCKERFILE" \
           -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
           -v "$BUILD_DIR/volumes/shared:/shared:Z" \
           -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \

--- a/task/buildah-sast-oci-ta/0.2/README.md
+++ b/task/buildah-sast-oci-ta/0.2/README.md
@@ -1,0 +1,41 @@
+# buildah-sast-oci-ta task
+
+Buildah SAST scanning task
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
+|ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+|IMAGE|Reference of the image buildah will produce.||true|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+
+## Results
+|name|description|
+|---|---|
+|SAST_RESULT_URL|SAST scanning results artifact URL.|
+|SCAN_OUTPUT|Short summary of SAST scan results.|
+|TEST_OUTPUT|Tekton task test output.|
+

--- a/task/buildah-sast-oci-ta/0.2/buildah-sast-oci-ta.yaml
+++ b/task/buildah-sast-oci-ta/0.2/buildah-sast-oci-ta.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: buildah-oci-ta
+  name: buildah-sast-oci-ta
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
@@ -10,11 +10,7 @@ metadata:
     app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: docker
 spec:
-  description: |-
-    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
-    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
-    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
-    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
+  description: Buildah SAST scanning task
   params:
     - name: ACTIVATION_KEY
       description: Name of secret which contains subscription activation key
@@ -132,22 +128,12 @@ spec:
       type: string
       default: trusted-ca
   results:
-    - name: IMAGE_DIGEST
-      description: Digest of the image just built
-    - name: IMAGE_REF
-      description: Image reference of the built image
-    - name: IMAGE_URL
-      description: Image repository and tag where the built image was pushed
-    - name: JAVA_COMMUNITY_DEPENDENCIES
-      description: The Java dependencies that came from community sources
-        such as Maven central.
-    - name: SBOM_BLOB_URL
-      description: Reference of SBOM blob digest to enable digest-based verification
-        from provenance
-      type: string
-    - name: SBOM_JAVA_COMPONENTS_COUNT
-      description: The counting of Java components by publisher in JSON format
-      type: string
+    - name: SAST_RESULT_URL
+      description: SAST scanning results artifact URL.
+    - name: SCAN_OUTPUT
+      description: Short summary of SAST scan results.
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
   volumes:
     - name: activation-key
       secret:
@@ -226,8 +212,60 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    - name: prepare
+      image: quay.io/konflux-ci/buildah-task:latest
+      workingDir: /var/workdir
+      env:
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
+      script: |
+        set -x
+        # Dockerfile discovery logic is copied from buildah task
+        SOURCE_CODE_DIR=source
+        if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+        elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+        elif [ -e "$DOCKERFILE" ]; then
+          dockerfile_path="$DOCKERFILE"
+        elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+          echo "Fetch Dockerfile from $DOCKERFILE"
+          dockerfile_path=$(mktemp --suffix=-Dockerfile)
+          http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+          if [ "$http_code" != 200 ]; then
+            echo "No Dockerfile is fetched. Server responds $http_code"
+            exit 1
+          fi
+          http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+          if [ "$http_code" = 200 ]; then
+            echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+            mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          fi
+        else
+          echo "Cannot find Dockerfile $DOCKERFILE"
+          exit 1
+        fi
+
+        cp "$dockerfile_path" /tekton/home/sast.Dockerfile
+        dockerfile_path=/tekton/home/sast.Dockerfile
+
+        # Modify Dockerfile
+        sed -i '1 i\ARG NEW_ARG=default-value' "$dockerfile_path"
+
+        echo 'Modified Dockerfile:'
+        cat "$dockerfile_path"
+
+        # Prepare directory for the SAST scan results
+        mkdir /tekton/home/sast-scan-results
+      computeResources:
+        limits:
+          cpu: "1"
+          memory: 1Gi
+        requests:
+          cpu: 500m
+          memory: 512Mi
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+      image: quay.io/konflux-ci/buildah-task:latest
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -250,7 +288,9 @@ spec:
         - name: COMMIT_SHA
           value: $(params.COMMIT_SHA)
         - name: DOCKERFILE
-          value: $(params.DOCKERFILE)
+          value: /tekton/home/sast.Dockerfile
+        - name: VOLUME_MOUNTS_FROM_ENV
+          value: --volume /tekton/home/sast-scan-results:/sast-scan-results
       script: |
         #!/bin/bash
         set -e
@@ -487,181 +527,27 @@ spec:
       computeResources:
         limits:
           cpu: "4"
-          memory: 8Gi
+          memory: 10Gi
         requests:
           cpu: "1"
-          memory: 2Gi
+          memory: 5Gi
       securityContext:
         capabilities:
           add:
             - SETFCAP
-    - name: sbom-syft-generate
-      image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
-      workingDir: /var/workdir/source
-      volumeMounts:
-        - mountPath: /var/lib/containers
-          name: varlibcontainers
-        - mountPath: /shared
-          name: shared
+    - name: postprocess
+      image: quay.io/konflux-ci/buildah-task:latest
+      workingDir: /var/workdir
       script: |
-        echo "Running syft on the source directory"
-        syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="/var/workdir/sbom-source.json"
-        echo "Running syft on the image filesystem"
-        syft dir:"$(cat /shared/container_path)" --output cyclonedx-json="/var/workdir/sbom-image.json"
+        ls -l /tekton/home/sast-scan-results
+        echo 'Postprocessing SAST results'
+
+        # buildah push quay.io/results-image
+        echo "buildah push quay.io/org/results-image"
       computeResources:
         limits:
-          cpu: "2"
-          memory: 4Gi
+          cpu: "1"
+          memory: 1Gi
         requests:
           cpu: 500m
-          memory: 1Gi
-    - name: analyse-dependencies-java-sbom
-      image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
-      volumeMounts:
-        - mountPath: /var/lib/containers
-          name: varlibcontainers
-        - mountPath: /shared
-          name: shared
-      script: |
-        if [ -f /var/lib/containers/java ]; then
-          /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s /var/workdir/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
-          sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
-        else
-          touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
-        fi
-      computeResources:
-        limits:
-          cpu: 200m
           memory: 512Mi
-        requests:
-          cpu: 100m
-          memory: 256Mi
-      securityContext:
-        runAsUser: 0
-    - name: prepare-sboms
-      image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:53a3041dff341b7fd1765b9cc2c324625d19e804b2eaff10a6e6d9dcdbde3a91
-      workingDir: /var/workdir
-      script: |
-        echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
-        python3 /scripts/merge_syft_sboms.py
-
-        if [ -f "sbom-cachi2.json" ]; then
-          echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
-          python3 /scripts/merge_cachi2_sboms.py sbom-cachi2.json sbom-cyclonedx.json >sbom-temp.json
-          mv sbom-temp.json sbom-cyclonedx.json
-        fi
-
-        echo "Creating sbom-purl.json"
-        python3 /scripts/create_purl_sbom.py
-
-        echo "Adding base images data to sbom-cyclonedx.json"
-        python3 /scripts/base_images_sbom_script.py \
-          --sbom=sbom-cyclonedx.json \
-          --base-images-from-dockerfile=/shared/base_images_from_dockerfile \
-          --base-images-digests=/shared/base_images_digests
-      computeResources:
-        limits:
-          cpu: 200m
-          memory: 512Mi
-        requests:
-          cpu: 100m
-          memory: 256Mi
-      securityContext:
-        runAsUser: 0
-    - name: inject-sbom-and-push
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
-      workingDir: /var/workdir
-      volumeMounts:
-        - mountPath: /var/lib/containers
-          name: varlibcontainers
-        - mountPath: /mnt/trusted-ca
-          name: trusted-ca
-          readOnly: true
-      script: |
-        #!/bin/bash
-        set -e
-
-        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
-        if [ -f "$ca_bundle" ]; then
-          echo "INFO: Using mounted CA bundle: $ca_bundle"
-          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
-          update-ca-trust
-        fi
-
-        base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
-        base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
-        container=$(buildah from --pull-never $IMAGE)
-        buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
-        buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
-
-        BUILDAH_ARGS=()
-        if [ "${SQUASH}" == "true" ]; then
-          BUILDAH_ARGS+=("--squash")
-        fi
-
-        buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
-
-        status=-1
-        max_run=5
-        sleep_sec=10
-        for run in $(seq 1 $max_run); do
-          status=0
-          [ "$run" -gt 1 ] && sleep $sleep_sec
-          echo "Pushing sbom image to registry"
-          buildah push \
-            --tls-verify=$TLSVERIFY \
-            --digestfile /var/workdir/image-digest $IMAGE \
-            docker://$IMAGE && break || status=$?
-        done
-        if [ "$status" -ne 0 ]; then
-            echo "Failed to push sbom image to registry after ${max_run} tries"
-            exit 1
-        fi
-
-        cat "/var/workdir"/image-digest | tee $(results.IMAGE_DIGEST.path)
-        echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-        {
-          echo -n "${IMAGE}@"
-          cat "/var/workdir/image-digest"
-        } >"$(results.IMAGE_REF.path)"
-
-        # Remove tag from IMAGE while allowing registry to contain a port number.
-        sbom_repo="${IMAGE%:*}"
-        sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
-        # The SBOM_BLOB_URL is created by `cosign attach sbom`.
-        echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
-      computeResources:
-        limits:
-          cpu: "4"
-          memory: 4Gi
-        requests:
-          cpu: "1"
-          memory: 1Gi
-      securityContext:
-        capabilities:
-          add:
-            - SETFCAP
-        runAsUser: 0
-    - name: upload-sbom
-      image: quay.io/konflux-ci/appstudio-utils:ab6b0b8e40e440158e7288c73aff1cf83a2cc8a9@sha256:24179f0efd06c65d16868c2d7eb82573cce8e43533de6cea14fec3b7446e0b14
-      workingDir: /var/workdir
-      volumeMounts:
-        - mountPath: /mnt/trusted-ca
-          name: trusted-ca
-          readOnly: true
-      script: |
-        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
-        if [ -f "$ca_bundle" ]; then
-          echo "INFO: Using mounted CA bundle: $ca_bundle"
-          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
-          update-ca-trust
-        fi
-
-        cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
-      computeResources:
-        limits:
-          cpu: 200m
-          memory: 512Mi
-        requests:
-          cpu: 100m
-          memory: 256Mi

--- a/task/buildah-sast-oci-ta/0.2/recipe.yaml
+++ b/task/buildah-sast-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,15 @@
+---
+base: ../../buildah-sast/0.2/kustomization.yaml
+removeParams:
+  - BUILDER_IMAGE
+add:
+  - use-source
+  - use-cachi2
+removeWorkspaces:
+  - source
+replacements:
+  workspaces.source.path: /var/workdir
+regexReplacements:
+  "/workspace(/.*)": /var/workdir$1
+description: |-
+    Buildah SAST scanning task

--- a/task/buildah-sast-oci-ta/OWNERS
+++ b/task/buildah-sast-oci-ta/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - kdudka
+reviewers:
+  - kdudka

--- a/task/buildah-sast/0.2/kustomization.yaml
+++ b/task/buildah-sast/0.2/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../buildah/0.2
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Task

--- a/task/buildah-sast/0.2/patch.yaml
+++ b/task/buildah-sast/0.2/patch.yaml
@@ -1,0 +1,145 @@
+# Task name
+- op: replace
+  path: /metadata/name
+  value: buildah-sast
+
+# Task description
+- op: replace
+  path: /spec/description
+  value: |-
+    Buildah sast task builds source code to do SAST analysis.
+
+# Replace task results
+- op: replace
+  path: /spec/results
+  value:
+    - description: Short summary of SAST scan results.
+      name: SCAN_OUTPUT
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+    - description: SAST scanning results artifact URL.
+      name: SAST_RESULT_URL
+
+###################
+# Task steps
+###################
+
+# Remove all buildah task steps except build
+- op: remove
+  path: /spec/steps/5 # upload-sbom
+- op: remove
+  path: /spec/steps/4 # inject-sbom-and-push
+- op: remove
+  path: /spec/steps/3 # prepare-sboms
+- op: remove
+  path: /spec/steps/2 # analyse-dependencies-java-sbom
+- op: remove
+  path: /spec/steps/1 # sbom-syft-generate
+
+# Tune the build step (the only one left).
+
+  # Change build step image
+- op: replace
+  path: /spec/steps/0/image
+  # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
+  value: quay.io/konflux-ci/buildah-task:latest
+
+  # Change build step resources
+- op: replace
+  path: /spec/steps/0/computeResources/limits/memory
+  value: 10Gi
+- op: replace
+  path: /spec/steps/0/computeResources/requests/memory
+  value: 5Gi
+
+  # Replace Dockerfile location
+- op: replace
+  path: /spec/steps/0/env/1/value
+  value: /tekton/home/sast.Dockerfile
+
+  # Additional volumes
+- op: add
+  path: /spec/steps/0/env/-
+  value:
+    name: VOLUME_MOUNTS_FROM_ENV
+    value: >-
+      --volume /tekton/home/sast-scan-results:/sast-scan-results
+
+# Add prepare and postprocess steps
+  # Prepare step
+- op: add
+  path: /spec/steps/0
+  value:
+    name: prepare
+    image: quay.io/konflux-ci/buildah-task:latest
+    computeResources:
+      limits:
+        memory: 1Gi
+        cpu: '1'
+      requests:
+        memory: 0.5Gi
+        cpu: '0.5'
+    env:
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    workingDir: $(workspaces.source.path)
+    script: |
+      set -x
+      # Dockerfile discovery logic is copied from buildah task
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        dockerfile_path="$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      cp "$dockerfile_path" /tekton/home/sast.Dockerfile
+      dockerfile_path=/tekton/home/sast.Dockerfile
+
+      # Modify Dockerfile
+      sed -i '1 i\ARG NEW_ARG=default-value' "$dockerfile_path"
+
+      echo 'Modified Dockerfile:'
+      cat "$dockerfile_path"
+
+      # Prepare directory for the SAST scan results
+      mkdir /tekton/home/sast-scan-results
+
+  # Postprocess step
+- op: add
+  path: /spec/steps/2
+  value:
+    name: postprocess
+    image: quay.io/konflux-ci/buildah-task:latest
+    computeResources:
+      limits:
+        memory: 1Gi
+        cpu: '1'
+      requests:
+        memory: 0.5Gi
+        cpu: '0.5'
+    workingDir: $(workspaces.source.path)
+    script: |
+      ls -l /tekton/home/sast-scan-results
+      echo 'Postprocessing SAST results'
+
+      # buildah push quay.io/results-image
+      echo "buildah push quay.io/org/results-image"

--- a/task/buildah-sast/OWNERS
+++ b/task/buildah-sast/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - kdudka
+reviewers:
+  - kdudka

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -138,8 +138,6 @@ spec:
       value: source
     - name: CONTEXT
       value: $(params.CONTEXT)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
     - name: IMAGE
       value: $(params.IMAGE)
     - name: TLSVERIFY
@@ -182,6 +180,8 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
     args:
       - --build-args
       - $(params.BUILD_ARGS[*])
@@ -202,6 +202,8 @@ spec:
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
@@ -309,10 +311,12 @@ spec:
         BUILDAH_ARGS+=("--skip-unused-stages=false")
       fi
 
+      VOLUME_MOUNTS="$VOLUME_MOUNTS_FROM_ENV"
+
       if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
         cp -r "$(workspaces.source.path)/cachi2" /tmp/
         chmod -R go+rwX /tmp/cachi2
-        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/cachi2:/cachi2"
         # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
         # for each RUN ... line insert the cachi2.env command *after* any options like --mount
         sed -E -i \


### PR DESCRIPTION
This PR brings a prototype of buildah-sats scan task. The goal is to keep build with sast scanning as close to the original build as possible while providing mechanisms to instrument the build with needed sast scan tooling.
This includes:
- Ability to override the image used for the build step
- Ability to override the computeResources requirements for the task
- Ability to modify Dockerfile prior to running the buildah build
- Ability to specify additional volume mounts for the buildah build
- Ability to process the captured data after the container build
- Ability to prevent the resulting image from being used as the task result
- The instrumented build-container task will be provided with the same inputs as the original build-container task
- The instrumented build-container task will be able to upload the SAST scanning results to image registry

