### PR TITLE
fix: oci-copy task triggers unbounded var error when not using AWS creds

### DIFF
--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -135,7 +135,7 @@ spec:
           method="GET"
 
           curl_args=(--fail --silent --show-error)
-          if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
+          if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
             echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
             # This implements v4 auth https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
             path=$(echo "$url" | cut -d/ -f4-)
@@ -188,7 +188,7 @@ spec:
                 -H "Authorization: ${authorization}" \
                 --location "$url" \
                 -o "$file"
-          elif [ -n "${BEARER_TOKEN}" ]; then
+          elif [ -n "${BEARER_TOKEN:-}" ]; then
             echo "Found bearer token. Using it for authentication."
             curl "${curl_args[@]}" -H "Authorization: Bearer ${BEARER_TOKEN}" --location "$url" -o "$file"
           else

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -121,7 +121,7 @@ spec:
           method="GET"
 
           curl_args=(--fail --silent --show-error)
-          if [ -n "${AWS_ACCESS_KEY_ID}" ] && [ -n "${AWS_SECRET_ACCESS_KEY}" ]; then
+          if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
             echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
             # This implements v4 auth https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
             path=$(echo "$url" | cut -d/ -f4-)
@@ -174,7 +174,7 @@ spec:
                 -H "Authorization: ${authorization}" \
                 --location "$url" \
                 -o "$file"
-          elif [ -n "${BEARER_TOKEN}" ]; then
+          elif [ -n "${BEARER_TOKEN:-}" ]; then
             echo "Found bearer token. Using it for authentication."
             curl "${curl_args[@]}" -H "Authorization: Bearer ${BEARER_TOKEN}" --location "$url" -o "$file"
           else


### PR DESCRIPTION
Some build is failing because of this.

I think the problem is that set -u is set after the function definition but *before* the function is called

EDIT: I'm talking about this set: https://github.com/konflux-ci/build-definitions/blob/main/task/oci-copy/0.1/oci-copy.yaml#L186
Build is failing because of 
> /tekton/scripts/script-1-qxwgg: line 11: AWS_ACCESS_KEY_ID: unbound variable

When I'm not providing AWS creds
