### PR TITLE
fix(KFLUXBUGS-1693): remove fail-unsigned param from task

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -153,12 +153,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
-### rpms-signature-scan:0.1 task parameters
+### rpms-signature-scan:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|fail-unsigned| [true \ false] If true fail if unsigned RPMs were found| false| |
 |image-digest| Image digest to scan| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-container.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
@@ -252,7 +251,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
-### rpms-signature-scan:0.1 task results
+### rpms-signature-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -150,12 +150,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
-### rpms-signature-scan:0.1 task parameters
+### rpms-signature-scan:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|fail-unsigned| [true \ false] If true fail if unsigned RPMs were found| false| |
 |image-digest| Image digest to scan| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-container.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
@@ -201,9 +200,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.1:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.2:image-url|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
@@ -249,7 +248,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
-### rpms-signature-scan:0.1 task results
+### rpms-signature-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -78,12 +78,11 @@
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| |
-### rpms-signature-scan:0.1 task parameters
+### rpms-signature-scan:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|fail-unsigned| [true \ false] If true fail if unsigned RPMs were found| false| |
 |image-digest| Image digest to scan| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-container.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
@@ -123,8 +122,8 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of the base images used for build| |
-|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.1:image-digest ; acs-image-check:0.1:image-digest ; acs-image-scan:0.1:image-digest|
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; rpms-signature-scan:0.1:image-url ; update-deployment:0.1:image|
+|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.2:image-digest ; acs-image-check:0.1:image-digest ; acs-image-scan:0.1:image-digest|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; rpms-signature-scan:0.2:image-url ; update-deployment:0.1:image|
 |SBOM_BLOB_URL| Link to the SBOM layer pushed to the registry as part of an OCI artifact.| |
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -137,7 +136,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### rpms-signature-scan:0.1 task results
+### rpms-signature-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -145,12 +145,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
-### rpms-signature-scan:0.1 task parameters
+### rpms-signature-scan:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|fail-unsigned| [true \ false] If true fail if unsigned RPMs were found| false| |
 |image-digest| Image digest to scan| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-container.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
@@ -199,9 +198,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.1:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.2:image-url|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
@@ -241,7 +240,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
-### rpms-signature-scan:0.1 task results
+### rpms-signature-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -115,12 +115,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKER_AUTH| unused, should be removed in next task version| | |
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |IMAGE_URL| Fully qualified image name.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### rpms-signature-scan:0.1 task parameters
+### rpms-signature-scan:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|fail-unsigned| [true \ false] If true fail if unsigned RPMs were found| false| |
 |image-digest| Image digest to scan| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-container.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
@@ -157,9 +156,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.1:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.2:image-url|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
@@ -193,7 +192,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BASE_IMAGE| Base image source image is built from.| fbc-validate:0.1:BASE_IMAGE|
 |BASE_IMAGE_REPOSITORY| Base image repository URL.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### rpms-signature-scan:0.1 task results
+### rpms-signature-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/java-builder/README.md
+++ b/pipelines/java-builder/README.md
@@ -113,12 +113,11 @@
 |IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
-### rpms-signature-scan:0.1 task parameters
+### rpms-signature-scan:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|fail-unsigned| [true \ false] If true fail if unsigned RPMs were found| false| |
 |image-digest| Image digest to scan| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-container.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
@@ -213,7 +212,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
-### rpms-signature-scan:0.1 task results
+### rpms-signature-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
@@ -223,9 +222,9 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of the base images used for build| |
-|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.1:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.2:image-url|
 |JAVA_COMMUNITY_DEPENDENCIES| The Java dependencies that came from community sources such as Maven central.| |
 |SBOM_JAVA_COMPONENTS_COUNT| The counting of Java components by publisher in JSON format| |
 ### sast-snyk-check:0.2 task results

--- a/pipelines/nodejs-builder/README.md
+++ b/pipelines/nodejs-builder/README.md
@@ -113,12 +113,11 @@
 |IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
-### rpms-signature-scan:0.1 task parameters
+### rpms-signature-scan:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|fail-unsigned| [true \ false] If true fail if unsigned RPMs were found| false| |
 |image-digest| Image digest to scan| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-container.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
@@ -213,7 +212,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
-### rpms-signature-scan:0.1 task results
+### rpms-signature-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
@@ -223,9 +222,9 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of the base images used for build| |
-|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.1:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.2:image-url|
 ### sast-snyk-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -103,12 +103,11 @@
 |IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
-### rpms-signature-scan:0.1 task parameters
+### rpms-signature-scan:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|fail-unsigned| [true \ false] If true fail if unsigned RPMs were found| false| |
 |image-digest| Image digest to scan| None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-container.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
@@ -180,7 +179,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
-### rpms-signature-scan:0.1 task results
+### rpms-signature-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
@@ -193,9 +192,9 @@
 ### tkn-bundle:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image| |
-|IMAGE_URL| Image repository and tag where the built image was pushed with tag only| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.1:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed with tag only| build-image-index:0.1:IMAGES ; rpms-signature-scan:0.2:image-url|
 
 ## Workspaces
 |name|description|optional|used in tasks

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -274,7 +274,7 @@ spec:
         - build-container
       taskRef:
         name: rpms-signature-scan
-        version: "0.1"
+        version: "0.2"
       params:
       - name: image-url
         value: $(tasks.build-container.results.IMAGE_URL)

--- a/task/rpms-signature-scan/0.2/MIGRATION.md
+++ b/task/rpms-signature-scan/0.2/MIGRATION.md
@@ -1,0 +1,5 @@
+# Migration from 0.1 to 0.2
+The parameter `fail-unsigned` used by `rpms-signature-scan` task was removed.
+
+## Action from users
+Remove the `fail-unsigned` parameter from the `rpms-signature-scan` task in your pipeline

--- a/task/rpms-signature-scan/0.2/README.md
+++ b/task/rpms-signature-scan/0.2/README.md
@@ -1,0 +1,34 @@
+# rpms-signature-scan.yaml task
+
+## Description:
+This tasks scans RPMs in an image and provide information about RPMs signatures.
+
+The RPM's signature keys as well as the unsigned RPMs are saved into the `RPMS_DATA` 
+result path and they are processed by EC to detemine whether the task should fail
+or not.
+
+The task will fail in case one or more image have failed the scan
+
+## Params:
+
+| Name                     | Description                                                            | Defaults      | Required |
+|--------------------------|------------------------------------------------------------------------|---------------|----------|
+| image-url                | Image URL                                                              |               | true     |
+| image-digest             | Image digest to scan.                                                  |               | true     |
+| workdir                  | Directory for storing temporary files                                  | /tmp          | false    |
+| ca-trust-config-map-name | The name of the ConfigMap to read CA bundle data from.                 | trusted-ca    | false    |
+| ca-trust-config-map-key  | The name of the key in the ConfigMap that contains the CA bundle data. | ca-bundle.crt | false    |
+
+## Results:
+
+| Name              | Description                  |
+|-------------------|------------------------------|
+| TEST_OUTPUT       | Tekton task test output      |
+| RPMS_DATA         | RPMs scanner results         |
+| IMAGES_PROCESSED  | Images processed in the task |
+
+## Source repository for image:
+https://github.com/redhat-appstudio/tools
+
+## Source repository for task:
+https://github.com/redhat-appstudio/tekton-tools

--- a/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
+++ b/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: rpms-signature-scan
+spec:
+  params:
+    - name: image-url
+      type: string
+      description: Image URL
+    - name: image-digest
+      type: string
+      description: Image digest to scan
+    - name: workdir
+      type: string
+      default: /tmp
+      description: |
+        Directory that will be used for storing temporary
+        files produced by this task.
+    - name: ca-trust-config-map-name
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: ca-trust-config-map-key
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+    - name: RPMS_DATA
+      description: Information about signed and unsigned RPMs
+    - name: IMAGES_PROCESSED
+      description: Images processed in the task.
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        name: $(params.ca-trust-config-map-name)
+        items:
+          - key: $(params.ca-trust-config-map-key)
+            path: ca-bundle.crt
+        optional: true
+  steps:
+    - name: rpms-signature-scan
+      image: quay.io/redhat-appstudio/tools@sha256:ee86a2f62b9a20cabba648e26dd972bd679a1e7f9ea6725943316a24d218899f
+      volumeMounts:
+        - name: workdir
+          mountPath: "$(params.workdir)"
+        - name: trusted-ca
+          mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
+      env:
+        - name: IMAGE_URL
+          value: "$(params.image-url)"
+        - name: IMAGE_DIGEST
+          value: "$(params.image-digest)"
+        - name: WORKDIR
+          value: "$(params.workdir)"
+      script: |
+        #!/bin/bash
+        set -ex
+        set -o pipefail
+
+        rpm_verifier \
+          --image-url "${IMAGE_URL}" \
+          --image-digest "${IMAGE_DIGEST}" \
+          --workdir "${WORKDIR}" \
+    - name: output-results
+      image: quay.io/redhat-appstudio/konflux-test:v1.4.7@sha256:cf6808a3bd605630a5d9f20595ff7c43f8645c00381219d32f5a11e88fe37072
+      volumeMounts:
+        - name: workdir
+          mountPath: "$(params.workdir)"
+      env:
+        - name: WORKDIR
+          value: "$(params.workdir)"
+      script: |
+        #!/bin/bash
+        set -ex
+
+        source /utils.sh
+        status=$(cat "${WORKDIR}"/status)
+        rpms_data=$(cat "${WORKDIR}"/results)
+        images_processed=$(cat "${WORKDIR}"/images_processed)
+        if [ "$status" == "ERROR" ]; then
+          note="Task $(context.task.name) failed to scan images. Refer to Tekton task output for details"
+        else
+          note="Task $(context.task.name) completed successfully"
+        fi
+
+        TEST_OUTPUT=$(make_result_json -r "$status" -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        echo "${rpms_data}" | tee "$(results.RPMS_DATA.path)"
+        echo "${images_processed}" | tee "$(results.IMAGES_PROCESSED.path)"


### PR DESCRIPTION
The fail-unsigned parameter was removed from the task.
The task will only fail if the scanner fails, otherwise it will end successfully providing the RPMS_DATA result with the signature keys and the number of unsigned RPMs.
EC will process the result and determine whether it should pass or fail.

- Bumping to v0.2
- Update task
- Add MIGRATION.md
- Update template version

