### PR TITLE
tasks: Use set -e in rpm-ostree task

### DIFF
--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -124,6 +124,8 @@ spec:
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/sh
       set -o verbose
+      set -eu
+      set -o pipefail
       cd $(workspaces.source.path)
       if [ -z "$CONFIG_FILE" ] ; then
         CONFIG_FILE_ARG=""


### PR DESCRIPTION
Related to https://gitlab.com/redhat/centos-stream/containers/bootc/-/merge_requests/248

Basically a while ago the rpm-ostree task was forked from the buildah task and we didn't inherit the later change to use `set -e` (as we should) on the inner shell script, meaning we had the default "blindly stumble forward when we hit an error" which is never what we want.

This would have helped focus the problem on cachi2, not selinux.
