### PR TITLE
update outdated konflux build slack channel

### DIFF
--- a/.tekton/scripts/check-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/check-task-pipeline-bundle-repos.sh
@@ -66,7 +66,7 @@ for pl_name in ${pl_names[@]}; do
 done
 
 if [ -n "$has_missing_repo" ]; then
-    echo "Please contact Build team - #forum-stonesoup-build that the missing repos should be created in:"
+    echo "Please contact Build team - #forum-konflux-build that the missing repos should be created in:"
     echo "- https://quay.io/organization/redhat-appstudio-tekton-catalog"
     echo "- https://quay.io/organization/konflux-ci"
     exit 1


### PR DESCRIPTION
- Message in the check-task-pipeline-bundle-repos script says to contact `#forum-stonesoup-build`
- This channel was renamed to `#forum-konflux-build`