### PR TITLE
check-repos: fix error message

### DIFF
--- a/.tekton/scripts/check-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/check-task-pipeline-bundle-repos.sh
@@ -67,7 +67,6 @@ done
 
 if [ -n "$has_missing_repo" ]; then
     echo "Please contact Build team - #forum-konflux-build that the missing repos should be created in:"
-    echo "- https://quay.io/organization/redhat-appstudio-tekton-catalog"
     echo "- https://quay.io/organization/konflux-ci"
     exit 1
 else


### PR DESCRIPTION
The script no longer checks the redhat-appstudio-tekton-catalog org (it's no longer necessary to create repos there).