### PR TITLE
Optionally skip SBOM generation

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -62,6 +62,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -59,6 +59,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -58,6 +58,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -62,6 +62,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |

--- a/task/buildah-oci-ta/0.2/README.md
+++ b/task/buildah-oci-ta/0.2/README.md
@@ -24,6 +24,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -86,6 +86,11 @@ spec:
       description: Whether to enable privileged mode
       type: string
       default: "false"
+    - name: SKIP_SBOM_GENERATION
+      description: Skip SBOM-related operations. This will likely cause EC
+        policies to fail if enabled
+      type: string
+      default: "false"
     - name: SKIP_UNUSED_STAGES
       description: Whether to skip stages in Containerfile that seem unused
         by subsequent stages
@@ -209,6 +214,8 @@ spec:
         value: $(params.IMAGE_EXPIRES_AFTER)
       - name: PRIVILEGED_NESTED
         value: $(params.PRIVILEGED_NESTED)
+      - name: SKIP_SBOM_GENERATION
+        value: $(params.SKIP_SBOM_GENERATION)
       - name: SKIP_UNUSED_STAGES
         value: $(params.SKIP_UNUSED_STAGES)
       - name: SOURCE_CODE_DIR
@@ -643,6 +650,10 @@ spec:
         - mountPath: /shared
           name: shared
       script: |
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
         echo "Running syft on the source directory"
         syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="/var/workdir/sbom-source.json"
         echo "Running syft on the image filesystem"
@@ -674,6 +685,10 @@ spec:
       image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
       workingDir: /var/workdir
       script: |
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
         echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
         python3 /scripts/merge_syft_sboms.py
 
@@ -718,6 +733,10 @@ spec:
           readOnly: true
       script: |
         #!/bin/bash
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
 
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
         if [ -f "$ca_bundle" ]; then

--- a/task/buildah-oci-ta/0.3/README.md
+++ b/task/buildah-oci-ta/0.3/README.md
@@ -23,6 +23,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -85,6 +85,11 @@ spec:
       description: Whether to enable privileged mode
       type: string
       default: "false"
+    - name: SKIP_SBOM_GENERATION
+      description: Skip SBOM-related operations. This will likely cause EC
+        policies to fail if enabled
+      type: string
+      default: "false"
     - name: SKIP_UNUSED_STAGES
       description: Whether to skip stages in Containerfile that seem unused
         by subsequent stages
@@ -202,6 +207,8 @@ spec:
         value: $(params.IMAGE_EXPIRES_AFTER)
       - name: PRIVILEGED_NESTED
         value: $(params.PRIVILEGED_NESTED)
+      - name: SKIP_SBOM_GENERATION
+        value: $(params.SKIP_SBOM_GENERATION)
       - name: SKIP_UNUSED_STAGES
         value: $(params.SKIP_UNUSED_STAGES)
       - name: SOURCE_CODE_DIR
@@ -629,6 +636,10 @@ spec:
         - mountPath: /shared
           name: shared
       script: |
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
         echo "Running syft on the source directory"
         syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="/var/workdir/sbom-source.json"
         echo "Running syft on the image filesystem"
@@ -637,6 +648,10 @@ spec:
       image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
       workingDir: /var/workdir
       script: |
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
         echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
         python3 /scripts/merge_syft_sboms.py
 
@@ -681,6 +696,10 @@ spec:
           readOnly: true
       script: |
         #!/bin/bash
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
 
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
         if [ -f "$ca_bundle" ]; then

--- a/task/buildah-remote-oci-ta/0.2/README.md
+++ b/task/buildah-remote-oci-ta/0.2/README.md
@@ -21,7 +21,9 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
@@ -34,6 +36,7 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |PLATFORM|The platform to build on||true|
+|IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -85,6 +85,11 @@ spec:
     description: Whether to enable privileged mode
     name: PRIVILEGED_NESTED
     type: string
+  - default: "false"
+    description: Skip SBOM-related operations. This will likely cause EC policies
+      to fail if enabled
+    name: SKIP_SBOM_GENERATION
+    type: string
   - default: "true"
     description: Whether to skip stages in Containerfile that seem unused by subsequent
       stages
@@ -188,6 +193,8 @@ spec:
       value: $(params.IMAGE_EXPIRES_AFTER)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
     - name: SKIP_UNUSED_STAGES
       value: $(params.SKIP_UNUSED_STAGES)
     - name: SOURCE_CODE_DIR
@@ -618,6 +625,7 @@ spec:
           -e IMAGE="$IMAGE" \
           -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
           -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
+          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
           -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
           -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
           -e SQUASH="$SQUASH" \
@@ -761,6 +769,10 @@ spec:
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Running syft on the source directory"
       syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="/var/workdir/sbom-source.json"
       echo "Running syft on the image filesystem"
@@ -816,6 +828,10 @@ spec:
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
       python3 /scripts/merge_syft_sboms.py
 
@@ -856,11 +872,15 @@ spec:
     name: upload-sbom
     script: |
       #!/bin/bash
-
       if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"

--- a/task/buildah-remote-oci-ta/0.3/README.md
+++ b/task/buildah-remote-oci-ta/0.3/README.md
@@ -22,6 +22,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -84,6 +84,11 @@ spec:
     description: Whether to enable privileged mode
     name: PRIVILEGED_NESTED
     type: string
+  - default: "false"
+    description: Skip SBOM-related operations. This will likely cause EC policies
+      to fail if enabled
+    name: SKIP_SBOM_GENERATION
+    type: string
   - default: "true"
     description: Whether to skip stages in Containerfile that seem unused by subsequent
       stages
@@ -181,6 +186,8 @@ spec:
       value: $(params.IMAGE_EXPIRES_AFTER)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
     - name: SKIP_UNUSED_STAGES
       value: $(params.SKIP_UNUSED_STAGES)
     - name: SOURCE_CODE_DIR
@@ -606,6 +613,7 @@ spec:
           -e IMAGE="$IMAGE" \
           -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
           -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
+          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
           -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
           -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
           -e SQUASH="$SQUASH" \
@@ -743,6 +751,10 @@ spec:
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Running syft on the source directory"
       syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="/var/workdir/sbom-source.json"
       echo "Running syft on the image filesystem"
@@ -768,6 +780,10 @@ spec:
       if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
+      fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
       echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
       python3 /scripts/merge_syft_sboms.py
@@ -809,11 +825,15 @@ spec:
     name: upload-sbom
     script: |
       #!/bin/bash
-
       if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"

--- a/task/buildah-remote/0.2/README.md
+++ b/task/buildah-remote/0.2/README.md
@@ -31,7 +31,10 @@ When prefetch-dependencies task was activated it is using its artifacts to run b
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
 |STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |PLATFORM|The platform to build on||true|
+|IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -123,6 +123,11 @@ spec:
     description: Whether to enable privileged mode
     name: PRIVILEGED_NESTED
     type: string
+  - default: "false"
+    description: Skip SBOM-related operations. This will likely cause EC policies
+      to fail if enabled
+    name: SKIP_SBOM_GENERATION
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -197,6 +202,8 @@ spec:
       value: $(params.SKIP_UNUSED_STAGES)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     - name: PLATFORM
@@ -603,6 +610,7 @@ spec:
           -e SQUASH="$SQUASH" \
           -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
           -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
+          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
           -e COMMIT_SHA="$COMMIT_SHA" \
           -e DOCKERFILE="$DOCKERFILE" \
           -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
@@ -739,6 +747,10 @@ spec:
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image filesystem"
@@ -794,6 +806,10 @@ spec:
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
       python3 /scripts/merge_syft_sboms.py
 
@@ -834,11 +850,15 @@ spec:
     name: upload-sbom
     script: |
       #!/bin/bash
-
       if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"

--- a/task/buildah-remote/0.3/README.md
+++ b/task/buildah-remote/0.3/README.md
@@ -31,6 +31,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |PLATFORM|The platform to build on||true|
 |IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
 

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -122,6 +122,11 @@ spec:
     description: Whether to enable privileged mode
     name: PRIVILEGED_NESTED
     type: string
+  - default: "false"
+    description: Skip SBOM-related operations. This will likely cause EC policies
+      to fail if enabled
+    name: SKIP_SBOM_GENERATION
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -190,6 +195,8 @@ spec:
       value: $(params.SKIP_UNUSED_STAGES)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     - name: PLATFORM
@@ -591,6 +598,7 @@ spec:
           -e SQUASH="$SQUASH" \
           -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
           -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
+          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
           -e COMMIT_SHA="$COMMIT_SHA" \
           -e DOCKERFILE="$DOCKERFILE" \
           -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
@@ -721,6 +729,10 @@ spec:
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image filesystem"
@@ -746,6 +758,10 @@ spec:
       if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
+      fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
       echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
       python3 /scripts/merge_syft_sboms.py
@@ -787,11 +803,15 @@ spec:
     name: upload-sbom
     script: |
       #!/bin/bash
-
       if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"

--- a/task/buildah/0.2/README.md
+++ b/task/buildah/0.2/README.md
@@ -6,49 +6,45 @@ When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup
 When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
 
 ## Parameters
-| name                 | description                                                                                                                                                        | default value       | required |
-| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------- | -------- |
-| IMAGE                | Reference of the image buildah will produce.                                                                                                                       |                     | true     |
-| DOCKERFILE           | Path to the Dockerfile to build.                                                                                                                                   | ./Dockerfile        | false    |
-| CONTEXT              | Path to the directory to use as context.                                                                                                                           | .                   | false    |
-| TLSVERIFY            | Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)                                                                                      | true                | false    |
-| HERMETIC             | Determines if build will be executed without network access.                                                                                                       | false               | false    |
-| PREFETCH_INPUT       | In case it is not empty, the prefetched content should be made available to the build.                                                                             | ""                  | false    |
-| IMAGE_EXPIRES_AFTER  | Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively. | ""                  | false    |
-| COMMIT_SHA           | The image is built from this commit.                                                                                                                               | ""                  | false    |
-| YUM_REPOS_D_SRC      | Path in the git repository in which yum repository files are stored                                                                                                | repos.d             | false    |
-| YUM_REPOS_D_FETCHED  | Path in source workspace where dynamically-fetched repos are present                                                                                               | fetched.repos.d     | false    |
-| YUM_REPOS_D_TARGET   | Target path on the container in which yum repository files should be made available                                                                                | /etc/yum.repos.d    | false    |
-| TARGET_STAGE         | Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.                                     | ""                  | false    |
-| ENTITLEMENT_SECRET   | Name of secret which contains the entitlement certificates                                                                                                         | etc-pki-entitlement | false    |
-| ACTIVATION_KEY       | Name of secret which contains subscription activation key                                                                                                          | activation-key      | false    |
-| ADDITIONAL_SECRET    | Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET                                        | does-not-exist      | false    |
-| BUILD_ARGS           | Array of --build-arg values ("arg=value" strings)                                                                                                                  | []                  | false    |
-| BUILD_ARGS_FILE      | Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file                                                                  | ""                  | false    |
-| caTrustConfigMapName | The name of the ConfigMap to read CA bundle data from.                                                                                                             | trusted-ca          | false    |
-| caTrustConfigMapKey  | The name of the key in the ConfigMap that contains the CA bundle data.                                                                                             | ca-bundle.crt       | false    |
-| ADD_CAPABILITIES     | Comma separated list of extra capabilities to add when running 'buildah build'                                                                                     | ""                  | false    |
-| SQUASH               | Squash all new and previous layers added as a part of this build, as per --squash                                                                                  | false               | false    |
-| STORAGE_DRIVER       | Storage driver to configure for buildah                                                                                                                            | vfs                 | false    |
-| SKIP_UNUSED_STAGES   | Whether to skip stages in Containerfile that seem unused by subsequent stages                                                                                      | true                | false    |
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image buildah will produce.||true|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+|PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 
 ## Results
-| name                        | description                                                                       |
-| --------------------------- | --------------------------------------------------------------------------------- |
-| IMAGE_DIGEST                | Digest of the image just built                                                    |
-| IMAGE_URL                   | Image repository and tag where the built image was pushed                         |
-| IMAGE_REF                   | Image reference of the built image                                                |
-| SBOM_BLOB_URL               | Reference of SBOM blob digest to enable digest-based verification from provenance |
-| SBOM_JAVA_COMPONENTS_COUNT  | The counting of Java components by publisher in JSON format                       |
-| JAVA_COMMUNITY_DEPENDENCIES | The Java dependencies that came from community sources such as Maven central.     |
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_URL|Image repository and tag where the built image was pushed|
+|IMAGE_REF|Image reference of the built image|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+|SBOM_JAVA_COMPONENTS_COUNT|The counting of Java components by publisher in JSON format|
+|JAVA_COMMUNITY_DEPENDENCIES|The Java dependencies that came from community sources such as Maven central.|
 
 ## Workspaces
-| name   | description                                    | optional |
-| ------ | ---------------------------------------------- | -------- |
-| source | Workspace containing the source code to build. | false    |
-
-
-## Changes in 0.2.1
-- Added image reference to the SBOM output file.
-- Re-arranged steps to push image first and then generate and push SBOM file.
-- Remove SBOM file stored in the image under `/root/buildinfo/content_manifests/`
+|name|description|optional|
+|---|---|---|
+|source|Workspace containing the source code to build.|false|

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -111,6 +111,10 @@ spec:
     description: Whether to enable privileged mode
     type: string
     default: "false"
+  - name: SKIP_SBOM_GENERATION
+    description: Skip SBOM-related operations. This will likely cause EC policies to fail if enabled
+    type: string
+    default: "false"
 
   results:
   - description: Digest of the image just built
@@ -179,6 +183,8 @@ spec:
       value: $(params.SKIP_UNUSED_STAGES)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
 
   steps:
   - image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
@@ -582,6 +588,10 @@ spec:
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source
     script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image filesystem"
@@ -625,6 +635,10 @@ spec:
         memory: 256Mi
         cpu: 100m
     script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
       python3 /scripts/merge_syft_sboms.py
 
@@ -659,6 +673,10 @@ spec:
     image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
     script: |
       #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
@@ -674,7 +692,6 @@ spec:
       sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
-
     computeResources:
       limits:
         memory: 512Mi

--- a/task/buildah/0.3/README.md
+++ b/task/buildah/0.3/README.md
@@ -31,6 +31,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -110,6 +110,10 @@ spec:
     description: Whether to enable privileged mode
     type: string
     default: "false"
+  - name: SKIP_SBOM_GENERATION
+    description: Skip SBOM-related operations. This will likely cause EC policies to fail if enabled
+    type: string
+    default: "false"
 
   results:
   - description: Digest of the image just built
@@ -173,6 +177,8 @@ spec:
       value: $(params.SKIP_UNUSED_STAGES)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
 
   steps:
   - image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
@@ -568,6 +574,10 @@ spec:
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source
     script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image filesystem"
@@ -588,6 +598,10 @@ spec:
         memory: 256Mi
         cpu: 100m
     script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
       echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"
       python3 /scripts/merge_syft_sboms.py
 
@@ -622,6 +636,10 @@ spec:
     image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
     script: |
       #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then


### PR DESCRIPTION
Since we can require SBOMs to be present with EC policies, we can enable
users to optionally speed up their builds by not analyzing repositories
to generate build-time SBOMs.

While we may have a partial SBOM from the prefetched data, we should
just not upload an SBOM at all in order to simplify decisions (i.e.
removing the need to decide if the SBOM is full or partial).
