### PR TITLE
feat: Add support for specific GCP format for build-vm-image task

### DIFF
--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -21,7 +21,7 @@ spec:
       type: string
     - name: IMAGE_TYPE
       type: string
-      description: The type of VM image to build, valid values are iso, qcow2, raw and vhd
+      description: The type of VM image to build, valid values are iso, qcow2, gce, vhd and raw
     - name: BIB_CONFIG_FILE
       default: bib.yaml
       type: string
@@ -261,6 +261,10 @@ spec:
           echo -e "Found vhd image."
           pigz /output/vpc/disk.vhd
           buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.vhd.gzip $OUTPUT_IMAGE /output/vpc/disk.vhd.gz
+        elif [ -f "/output/gce/image.tar.gz" ]; then
+          echo -e "Found gce image."
+          # already compressed.
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
         fi
         buildah manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE
 


### PR DESCRIPTION
Add supporty for specific GCP disk image format in build-vm-image task

Original support from BIB was made in this PR: https://github.com/osbuild/bootc-image-builder/pull/646

Edit: I also checked the release pipeline, it should be ok to have a .tgz: https://github.com/hacbs-release/app-interface-deployments/blob/main/internal-services/catalog/pulp-push-disk-images-task.yaml#L180-L182 