### PR TITLE
Add cachi2 artifact to rpm-ostree OCI-TA Task

### DIFF
--- a/task/rpm-ostree-oci-ta/0.2/README.md
+++ b/task/rpm-ostree-oci-ta/0.2/README.md
@@ -6,6 +6,7 @@ RPM Ostree (Trusted Artifacts variant).
 |name|description|default value|required|
 |---|---|---|---|
 |BUILDER_IMAGE|The location of the rpm-ostree builder image.|quay.io/redhat-user-workloads/project-sagano-tenant/ostree-builder/ostree-builder-fedora-38:d124414a81d17f31b1d734236f55272a241703d7|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
 |COMMIT_SHA|The image is built from this commit.|""|false|
 |CONFIG_FILE|The relative path of the file used to configure the rpm-ostree tool found in source control. See https://github.com/coreos/rpm-ostree/blob/main/docs/container.md#adding-container-image-configuration|""|false|
 |CONTEXT|Path to the directory to use as context.|.|false|

--- a/task/rpm-ostree-oci-ta/0.2/recipe.yaml
+++ b/task/rpm-ostree-oci-ta/0.2/recipe.yaml
@@ -2,6 +2,7 @@
 base: ../../rpm-ostree/0.2/rpm-ostree.yaml
 add:
   - use-source
+  - use-cachi2
 preferStepTemplate: true
 removeWorkspaces:
   - source

--- a/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
+++ b/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
@@ -17,6 +17,11 @@ spec:
       description: The location of the rpm-ostree builder image.
       type: string
       default: quay.io/redhat-user-workloads/project-sagano-tenant/ostree-builder/ostree-builder-fedora-38:d124414a81d17f31b1d734236f55272a241703d7
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
     - name: COMMIT_SHA
       description: The image is built from this commit.
       type: string
@@ -103,6 +108,7 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: build
       image: quay.io/redhat-appstudio/multi-platform-runner:01c7670e81d5120347cf0ad13372742489985e5f@sha256:246adeaaba600e207131d63a7f706cffdcdc37d8f600c56187123ec62823ff44
       workingDir: /var/workdir


### PR DESCRIPTION
We also need to restore the cachi2 TA artifact.

Reference: https://issues.redhat.com/browse/EC-924
