### PR TITLE
Remove unnecessary pipeline tasks

### DIFF
--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -78,14 +78,6 @@
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| |
-### rpms-signature-scan:0.2 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
 ### show-sbom-rhdh:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -136,12 +128,6 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### rpms-signature-scan:0.2 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGES_PROCESSED| Images processed in the task.| |
-|RPMS_DATA| Information about signed and unsigned RPMs| |
-|TEST_OUTPUT| Tekton task test output.| |
 ### show-sbom-rhdh:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -115,24 +115,26 @@
   value: $(tasks.build-container.results.IMAGE_DIGEST)
 
 # Remove unused tasks
-# Example - yq .spec.tasks.[].name ../build-definitions/pipelines/template-build/template-build.yaml | nl -v 0
-# to compute offsets
-# 0  init
-# 1  clone-repository
-# 2  prefetch-dependencies
-# 3  build-container
-# 4  build-image-index
-# 5  build-source-image
-# 6  deprecated-base-image-check
-# 7  clair-scan
-# 8  ecosystem-cert-preflight-checks
-# 9  sast-snyk-check
-# 10  clamav-scan
-# 11  apply-tags
-# 12  push-dockerfile
+# kustomize build pipelines/template-build/ | yq ".spec.tasks.[].name" | nl -v 0
+#      0  init
+#      1  clone-repository
+#      2  prefetch-dependencies
+#      3  build-container
+#      4  build-image-index
+#      5  build-source-image
+#      6  deprecated-base-image-check
+#      7  clair-scan
+#      8  ecosystem-cert-preflight-checks
+#      9  sast-snyk-check
+#     10  clamav-scan
+#     11  apply-tags
+#     12  push-dockerfile
+#     13  rpms-signature-scan
 - op: replace
   path: /spec/tasks/3/runAfter/0
   value: clone-repository
+- op: remove
+  path: /spec/tasks/13  # rpms-signature-scan
 - op: remove
   path: /spec/tasks/12  # push-dockerfile
 - op: remove

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -116,14 +116,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKER_AUTH| unused, should be removed in next task version| | |
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |IMAGE_URL| Fully qualified image name.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### rpms-signature-scan:0.2 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -151,9 +143,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest ; inspect-image:0.1:IMAGE_DIGEST ; fbc-validate:0.1:IMAGE_DIGEST|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; inspect-image:0.1:IMAGE_DIGEST ; fbc-validate:0.1:IMAGE_DIGEST|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; apply-tags:0.1:IMAGE ; rpms-signature-scan:0.2:image-url ; inspect-image:0.1:IMAGE_URL ; fbc-validate:0.1:IMAGE_URL|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; apply-tags:0.1:IMAGE ; inspect-image:0.1:IMAGE_URL ; fbc-validate:0.1:IMAGE_URL|
 ### buildah:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -192,12 +184,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |BASE_IMAGE| Base image source image is built from.| fbc-validate:0.1:BASE_IMAGE|
 |BASE_IMAGE_REPOSITORY| Base image repository URL.| |
-|TEST_OUTPUT| Tekton task test output.| |
-### rpms-signature-scan:0.2 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGES_PROCESSED| Images processed in the task.| |
-|RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
 
 ## Workspaces

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -39,24 +39,26 @@
   - name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
 # Remove tasks
-# yq ".spec.params.[].name"  pipelines/template-build/template-build.yaml | nl -v 0
-# to compute offsets
-# 0  init
-# 1  clone-repository
-# 2  prefetch-dependencies
-# 3  build-container
-# 4  build-image-index
-# 5  build-source-image
-# 6  deprecated-base-image-check
-# 7  clair-scan
-# 8  ecosystem-cert-preflight-checks
-# 9  sast-snyk-check
-# 10  clamav-scan
-# 11  apply-tags
-# 12  push-dockerfile
+# yq ".spec.tasks.[].name"  pipelines/template-build/template-build.yaml | nl -v 0
+#      0  init
+#      1  clone-repository
+#      2  prefetch-dependencies
+#      3  build-container
+#      4  build-image-index
+#      5  build-source-image
+#      6  deprecated-base-image-check
+#      7  clair-scan
+#      8  ecosystem-cert-preflight-checks
+#      9  sast-snyk-check
+#     10  clamav-scan
+#     11  apply-tags
+#     12  push-dockerfile
+#     13  rpms-signature-scan
 - op: replace
   path: /spec/tasks/3/runAfter/0
   value: clone-repository
+- op: remove
+  path: /spec/tasks/13  # rpms-signature-scan
 - op: remove
   path: /spec/tasks/12  # push-dockerfile
 - op: remove

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -5,12 +5,12 @@
 |---|---|---|---|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-image-index:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; build-image-index:0.1:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
@@ -34,28 +34,6 @@
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
-### clair-scan:0.2 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|docker-auth| unused, should be removed in next task version.| | |
-|image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### clamav-scan:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|docker-auth| unused| | |
-|image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### ecosystem-cert-preflight-checks:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| Image url to scan.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### git-clone:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -94,30 +72,6 @@
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
-### push-dockerfile:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
-|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
-|DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| '$(params.dockerfile)'|
-|IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
-### rpms-signature-scan:0.2 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-snyk-check:0.2 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ARGS| Append arguments.| --all-projects --exclude=test*,vendor,deps| |
-|SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |
-|image-digest| Image digest to report findings for.| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### summary:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -145,25 +99,9 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| clair-scan:0.2:image-digest ; sast-snyk-check:0.2:image-digest ; clamav-scan:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| |
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.2:image-url ; clamav-scan:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
-### clair-scan:0.2 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGES_PROCESSED| Images processed in the task.| |
-|REPORTS| Mapping of image digests to report digests| |
-|SCAN_OUTPUT| Clair scan result.| |
-|TEST_OUTPUT| Tekton task test output.| |
-### clamav-scan:0.1 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGES_PROCESSED| Images processed in the task.| |
-|TEST_OUTPUT| Tekton task test output.| |
-### ecosystem-cert-preflight-checks:0.1 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|TEST_OUTPUT| Preflight pass or fail outcome.| |
+|IMAGE_URL| Image repository and tag where the built image was pushed| apply-tags:0.1:IMAGE|
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -175,20 +113,6 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### push-dockerfile:0.1 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
-### rpms-signature-scan:0.2 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGES_PROCESSED| Images processed in the task.| |
-|RPMS_DATA| Information about signed and unsigned RPMs| |
-|TEST_OUTPUT| Tekton task test output.| |
-### sast-snyk-check:0.2 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|TEST_OUTPUT| Tekton task test output.| |
 ### tkn-bundle:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -201,7 +125,7 @@
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.1:source ; sast-snyk-check:0.2:workspace ; push-dockerfile:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.1:source|
 ## Available workspaces from tasks
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -215,14 +139,6 @@
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
 |source| Workspace with the source code, cachi2 artifacts will be stored on the workspace as well| False| workspace|
-### push-dockerfile:0.1 task workspaces
-|name|description|optional|workspace from pipeline
-|---|---|---|---|
-|workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
-### sast-snyk-check:0.2 task workspaces
-|name|description|optional|workspace from pipeline
-|---|---|---|---|
-|workspace| | False| workspace|
 ### summary:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/tekton-bundle-builder/kustomization.yaml
+++ b/pipelines/tekton-bundle-builder/kustomization.yaml
@@ -4,50 +4,6 @@ resources:
 - ../template-build
 
 patches:
-# Use the template-build as a template replacing the Pipeline name and the
-# `build-container` step's task reference
-# Order of Tasks from the base template:
-# kustomize build pipelines/template-build/ | yq .spec.tasks.[].name | nl -v 0
-#      0  init
-#      1  clone-repository
-#      2  prefetch-dependencies
-#      3  build-container
-#      4  build-image-index
-#      5  build-source-image
-#      6  deprecated-base-image-check
-#      7  clair-scan
-#      8  ecosystem-cert-preflight-checks
-#      9  sast-snyk-check
-#     10  clamav-scan
-#     11  apply-tags
-#     12  push-dockerfile
-# Order of finally tasks from the base template:
-# kustomize build pipelines/template-build/ | yq .spec.finally.[].name | nl -v 0
-#      0  show-sbom
-#      1  show-summary
-- patch: |-
-    - op: replace
-      path: /metadata/name
-      value: tekton-bundle-builder
-    - op: replace
-      path: /spec/tasks/3/taskRef
-      value:
-        name: tkn-bundle
-        version: "0.1"
-    - op: add
-      path: /spec/tasks/3/params
-      value:
-      - name: IMAGE
-        value: $(params.output-image)
-      - name: CONTEXT
-        value: $(params.path-context)
-    # Remove tasks that assume a binary image
-    - op: remove
-      path: /spec/tasks/6  # deprecated-base-image-check
-    - op: remove
-      path: /spec/tasks/5  # build-source-image
-    - op: remove
-      path: /spec/finally/0  # show-sbom
+- path: patch.yaml
   target:
     kind: Pipeline
-    name: template-build

--- a/pipelines/tekton-bundle-builder/patch.yaml
+++ b/pipelines/tekton-bundle-builder/patch.yaml
@@ -1,0 +1,57 @@
+---
+- op: replace
+  path: /metadata/name
+  value: tekton-bundle-builder
+- op: replace
+  path: /spec/tasks/3/taskRef
+  value:
+    name: tkn-bundle
+    version: "0.1"
+# Use the template-build as a template replacing the Pipeline name and the
+# `build-container` step's task reference
+# Order of Tasks from the base template:
+# kustomize build pipelines/template-build/ | yq ".spec.tasks.[].name" | nl -v 0
+#      0  init
+#      1  clone-repository
+#      2  prefetch-dependencies
+#      3  build-container
+#      4  build-image-index
+#      5  build-source-image
+#      6  deprecated-base-image-check
+#      7  clair-scan
+#      8  ecosystem-cert-preflight-checks
+#      9  sast-snyk-check
+#     10  clamav-scan
+#     11  apply-tags
+#     12  push-dockerfile
+#     13  rpms-signature-scan
+# Order of finally tasks from the base template:
+# kustomize build pipelines/template-build/ | yq ".spec.finally.[].name" | nl -v 0
+#      0  show-sbom
+#      1  show-summary
+- op: add
+  path: /spec/tasks/3/params
+  value:
+  - name: IMAGE
+    value: $(params.output-image)
+  - name: CONTEXT
+    value: $(params.path-context)
+# Remove tasks that assume a binary image
+- op: remove
+  path: /spec/tasks/13  # rpms-signature-scan
+- op: remove
+  path: /spec/tasks/12  # push-dockerfile
+- op: remove
+  path: /spec/tasks/10  # clamav-scan
+- op: remove
+  path: /spec/tasks/9   # sast-snyk-check
+- op: remove
+  path: /spec/tasks/8   # ecosystem-cert-preflight-checks
+- op: remove
+  path: /spec/tasks/7   # clair-scan
+- op: remove
+  path: /spec/tasks/6   # deprecated-base-image-check
+- op: remove
+  path: /spec/tasks/5   # build-source-image
+- op: remove
+  path: /spec/finally/0  # show-sbom


### PR DESCRIPTION
In #1480, we added the rpms-signature-scan task to the pipeline template. This resulted in the task being added to multiple pipelines unnecessarily.

Also removed additional unnecessary tasks from the tekton bundle builder pipeline.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
