### PR TITLE
fix(STONEINTG-1073): increase db copy timeout

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -96,7 +96,7 @@ spec:
               exit 0
             fi
 
-            timeout=1200  # 20 minutes
+            timeout=2400  # 40 minutes
             interval=20  # interval between checks in seconds
             elapsed=0
 


### PR DESCRIPTION
This should resolve the intermittent issue that users are experiencing with their build pipelines.
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
