### PR TITLE
appstudio-utils: install zip

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -14,6 +14,7 @@ RUN dnf -y --setopt=tsflags=nodocs install \
     skopeo \
     make \
     golang \
+    zip \
     && dnf clean all
 
 COPY util-scripts /appstudio-utils/util-scripts


### PR DESCRIPTION
We will create a new build pipeline to create OCI-artifact for maven zip files, which will be used to release maven artifacts in RedHat Maven repository (maven.repository.redhat.com). It needs zip tool to create zip files, so add zip installation in this image for later use.