### PR TITLE
Rename CI task that builds appstudio-utils image

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -54,13 +54,13 @@ spec:
             workspace: workspace
       - name: sast-unicode-check
         runAfter:
-          - build-container
+          - build-appstudio-utils
         taskRef:
           name: sast-unicode-check
         workspaces:
           - name: workspace
             workspace: workspace
-      - name: build-container
+      - name: build-appstudio-utils
         runAfter:
           - task-lint-check
         params:
@@ -75,7 +75,7 @@ spec:
             workspace: workspace
       - name: check-partner-tasks
         runAfter:
-          - build-container
+          - build-appstudio-utils
         taskSpec:
           steps:
             - name: check-task-structure
@@ -131,7 +131,7 @@ spec:
           - name: e2e_test_namespace
             value: $(params.e2e_test_namespace)
         runAfter:
-          - build-container
+          - build-appstudio-utils
         workspaces:
           - name: source
             workspace: workspace

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -62,7 +62,7 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
-      - name: build-container
+      - name: build-appstudio-utils
         params:
           - name: IMAGE
             value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
@@ -79,11 +79,11 @@ spec:
       - name: apply-additional-image-tags
         params:
           - name: IMAGE
-            value: $(tasks.build-container.results.IMAGE_URL)
+            value: $(tasks.build-appstudio-utils.results.IMAGE_URL)
           - name: ADDITIONAL_TAGS
             value: ["latest"]
         runAfter:
-          - build-container
+          - build-appstudio-utils
         taskRef:
           name: apply-tags
 
@@ -92,7 +92,7 @@ spec:
           - name: revision
             value: "$(params.revision)"
         runAfter:
-          - build-container
+          - build-appstudio-utils
           - ec-task-checks
         workspaces:
           - name: source


### PR DESCRIPTION
The original name build-container does not reflect what the task does.