### PR TITLE
Modify buildah task to allow creating SAST scan tasks via kustomize

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -188,8 +188,6 @@ spec:
         value: $(params.BUILD_ARGS_FILE)
       - name: CONTEXT
         value: $(params.CONTEXT)
-      - name: DOCKERFILE
-        value: $(params.DOCKERFILE)
       - name: ENTITLEMENT_SECRET
         value: $(params.ENTITLEMENT_SECRET)
       - name: HERMETIC
@@ -251,6 +249,8 @@ spec:
       env:
         - name: COMMIT_SHA
           value: $(params.COMMIT_SHA)
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
       script: |
         #!/bin/bash
         set -e
@@ -265,6 +265,10 @@ spec:
           dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
         elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
           dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+        elif [ -e "$DOCKERFILE" ]; then
+          # Custom Dockerfile location is mainly used for instrumented builds for SAST scanning and analyzing.
+          # Instrumented builds use this step as their base and also need to provide modified Dockerfile.
+          dockerfile_path="$DOCKERFILE"
         elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
           echo "Fetch Dockerfile from $DOCKERFILE"
           dockerfile_path=$(mktemp --suffix=-Dockerfile)
@@ -461,6 +465,15 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
           echo "Adding the entitlement to the build"
+        fi
+
+        if [ -n "$ADDITIONAL_VOLUME_MOUNTS" ]; then
+          # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+          # This is primarily used in instrumented builds for SAST scanning and analyzing.
+          # Instrumented builds use this step as their base and add some other tools.
+          while read -r volume_mount; do
+            VOLUME_MOUNTS+=("--volume=$volume_mount")
+          done <<<"$ADDITIONAL_VOLUME_MOUNTS"
         fi
 
         ADDITIONAL_SECRET_PATH="/additional-secret"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -168,8 +168,6 @@ spec:
       value: $(params.BUILD_ARGS_FILE)
     - name: CONTEXT
       value: $(params.CONTEXT)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
     - name: ENTITLEMENT_SECRET
       value: $(params.ENTITLEMENT_SECRET)
     - name: HERMETIC
@@ -230,6 +228,8 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: build
     script: |-
@@ -299,6 +299,10 @@ spec:
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        # Custom Dockerfile location is mainly used for instrumented builds for SAST scanning and analyzing.
+        # Instrumented builds use this step as their base and also need to provide modified Dockerfile.
+        dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
@@ -497,6 +501,15 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      if [ -n "$ADDITIONAL_VOLUME_MOUNTS" ]; then
+        # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+        # This is primarily used in instrumented builds for SAST scanning and analyzing.
+        # Instrumented builds use this step as their base and add some other tools.
+        while read -r volume_mount; do
+          VOLUME_MOUNTS+=("--volume=$volume_mount")
+        done <<<"$ADDITIONAL_VOLUME_MOUNTS"
+      fi
+
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
@@ -568,7 +581,6 @@ spec:
           -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
           -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
           -e CONTEXT="$CONTEXT" \
-          -e DOCKERFILE="$DOCKERFILE" \
           -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
           -e HERMETIC="$HERMETIC" \
           -e IMAGE="$IMAGE" \
@@ -583,6 +595,7 @@ spec:
           -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
           -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
           -e COMMIT_SHA="$COMMIT_SHA" \
+          -e DOCKERFILE="$DOCKERFILE" \
           -v "$BUILD_DIR/volumes/shared:/shared:Z" \
           -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
           -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -157,8 +157,6 @@ spec:
       value: source
     - name: CONTEXT
       value: $(params.CONTEXT)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
     - name: IMAGE
       value: $(params.IMAGE)
     - name: TLSVERIFY
@@ -212,6 +210,8 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: build
     script: |-
@@ -281,6 +281,10 @@ spec:
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        # Custom Dockerfile location is mainly used for instrumented builds for SAST scanning and analyzing.
+        # Instrumented builds use this step as their base and also need to provide modified Dockerfile.
+        dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
@@ -475,6 +479,15 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      if [ -n "$ADDITIONAL_VOLUME_MOUNTS" ]; then
+        # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+        # This is primarily used in instrumented builds for SAST scanning and analyzing.
+        # Instrumented builds use this step as their base and add some other tools.
+        while read -r volume_mount; do
+          VOLUME_MOUNTS+=("--volume=$volume_mount")
+        done <<< "$ADDITIONAL_VOLUME_MOUNTS"
+      fi
+
       ADDITIONAL_SECRET_PATH="/additional-secret"
       ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
       if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
@@ -545,7 +558,6 @@ spec:
           -e HERMETIC="$HERMETIC" \
           -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
           -e CONTEXT="$CONTEXT" \
-          -e DOCKERFILE="$DOCKERFILE" \
           -e IMAGE="$IMAGE" \
           -e TLSVERIFY="$TLSVERIFY" \
           -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
@@ -561,6 +573,7 @@ spec:
           -e SQUASH="$SQUASH" \
           -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
           -e COMMIT_SHA="$COMMIT_SHA" \
+          -e DOCKERFILE="$DOCKERFILE" \
           -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
           -v "$BUILD_DIR/volumes/shared:/shared:Z" \
           -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -138,8 +138,6 @@ spec:
       value: source
     - name: CONTEXT
       value: $(params.CONTEXT)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
     - name: IMAGE
       value: $(params.IMAGE)
     - name: TLSVERIFY
@@ -182,6 +180,8 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
     args:
       - --build-args
       - $(params.BUILD_ARGS[*])
@@ -202,6 +202,10 @@ spec:
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        # Custom Dockerfile location is mainly used for instrumented builds for SAST scanning and analyzing.
+        # Instrumented builds use this step as their base and also need to provide modified Dockerfile.
+        dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
@@ -394,6 +398,15 @@ spec:
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
         echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "$ADDITIONAL_VOLUME_MOUNTS" ]; then
+        # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+        # This is primarily used in instrumented builds for SAST scanning and analyzing.
+        # Instrumented builds use this step as their base and add some other tools.
+        while read -r volume_mount; do
+          VOLUME_MOUNTS+=("--volume=$volume_mount")
+        done <<< "$ADDITIONAL_VOLUME_MOUNTS"
       fi
 
       ADDITIONAL_SECRET_PATH="/additional-secret"


### PR DESCRIPTION
We need to modify buildah task in order to be able to create SAST scanning tasks that has identical build logic with the original buildah task, but also have ability to:
- override the image used for the build step
- override the computeResources requirements for the task
- modify Dockerfile prior to running the buildah build
- specify additional volume mounts for the buildah build
- process the captured data after the container build
- prevent the resulting image from being used as the task result
Also
- The instrumented build-container SAST task will be provided with the same inputs as the original build-container task
- The instrumented build-container SAST task will be able to upload the SAST scanning results to image registry

SAST scan tasks can be created using the following kustomize file:
```yaml
# Task name
- op: replace
  path: /metadata/name
  value: buildah-sast

# Task description
- op: replace
  path: /spec/description
  value: |-
    Buildah sast task builds source code to do SAST analysis.

# Replace task results
- op: replace
  path: /spec/results
  value:
    - description: Short summary of SAST scan results.
      name: SCAN_OUTPUT
    - description: Tekton task test output.
      name: TEST_OUTPUT
    - description: SAST scanning results artifact URL.
      name: SAST_RESULT_URL

###################
# Task steps
###################

# Remove all buildah task steps except build
- op: remove
  path: /spec/steps/5 # upload-sbom
- op: remove
  path: /spec/steps/4 # inject-sbom-and-push
- op: remove
  path: /spec/steps/3 # prepare-sboms
- op: remove
  path: /spec/steps/2 # analyse-dependencies-java-sbom
- op: remove
  path: /spec/steps/1 # sbom-syft-generate

# Tune the build step (the only one left).

  # Change build step image
- op: replace
  path: /spec/steps/0/image
  # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
  value: quay.io/konflux-ci/buildah-task:latest

  # Change build step resources
- op: replace
  path: /spec/steps/0/computeResources/limits/memory
  value: 10Gi
- op: replace
  path: /spec/steps/0/computeResources/requests/memory
  value: 5Gi

  # Replace Dockerfile location to not to change the original one
- op: replace
  path: /spec/steps/0/env/1/value
  value: /tekton/home/sast.Dockerfile

  # Additional volumes
- op: add
  path: /spec/steps/0/env/-
  value:
    name: ADDITIONAL_VOLUME_MOUNTS
    value: >-
       /tekton/home/sast-scan-results:/sast-scan-results

# Add prepare and postprocess steps
  # Prepare step
- op: add
  path: /spec/steps/0
  value:
    name: prepare
    image: quay.io/konflux-ci/buildah-task:latest
    computeResources:
      limits:
        memory: 1Gi
        cpu: '1'
      requests:
        memory: 0.5Gi
        cpu: '0.5'
    env:
    - name: DOCKERFILE
      value: $(params.DOCKERFILE)
    workingDir: $(workspaces.source.path)
    script: |
      # Dockerfile discovery logic is copied from buildah task
      SOURCE_CODE_DIR=source
      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
      elif [ -e "$DOCKERFILE" ]; then
        dockerfile_path="$DOCKERFILE"
      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
        echo "Fetch Dockerfile from $DOCKERFILE"
        dockerfile_path=$(mktemp --suffix=-Dockerfile)
        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
        if [ "$http_code" != 200 ]; then
          echo "No Dockerfile is fetched. Server responds $http_code"
          exit 1
        fi
        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
        if [ "$http_code" = 200 ]; then
          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
        fi
      else
        echo "Cannot find Dockerfile $DOCKERFILE"
        exit 1
      fi

      cp "$dockerfile_path" /tekton/home/sast.Dockerfile
      dockerfile_path=/tekton/home/sast.Dockerfile

      # Modify Dockerfile
      sed -i '1 i\ARG NEW_ARG=default-value' "$dockerfile_path"

      echo 'Modified Dockerfile:'
      cat "$dockerfile_path"

      # Prepare directory for the SAST scan results
      mkdir /tekton/home/sast-scan-results

  # Postprocess step
- op: add
  path: /spec/steps/2
  value:
    name: postprocess
    image: quay.io/konflux-ci/buildah-task:latest
    computeResources:
      limits:
        memory: 1Gi
        cpu: '1'
      requests:
        memory: 0.5Gi
        cpu: '0.5'
    workingDir: $(workspaces.source.path)
    script: |
      ls -l /tekton/home/sast-scan-results
      echo 'Postprocessing SAST results'

      # buildah push quay.io/results-image
      echo "buildah push quay.io/org/results-image"
```
[Example PR could be found here](https://github.com/konflux-ci/build-definitions/pull/1488/).

Then, the SAST task can be used in the pipeline by just copying original `buildah` task definition and replacing the task bundle, for example:
```yaml
...
    - name: build-container-sast
      params:
      - name: IMAGE
        value: $(params.output-image)
      - name: DOCKERFILE
        value: $(params.dockerfile)
      - name: CONTEXT
        value: $(params.path-context)
      - name: HERMETIC
        value: $(params.hermetic)
      - name: PREFETCH_INPUT
        value: $(params.prefetch-input)
      - name: IMAGE_EXPIRES_AFTER
        value: $(params.image-expires-after)
      - name: COMMIT_SHA
        value: $(tasks.clone-repository.results.commit)
      - name: BUILD_ARGS
        value:
        - $(params.build-args[*])
      - name: BUILD_ARGS_FILE
        value: $(params.build-args-file)
      runAfter:
      - prefetch-dependencies
      taskRef:
        params:
        - name: name
          value: buildah-sast
        - name: bundle
          value: quay.io/org/sast-task-bundle:tag@sha1234abcd
        - name: kind
          value: task
        resolver: bundles
      when:
      - input: $(tasks.init.results.build)
        operator: in
        values:
        - "true"
      workspaces:
      - name: source
        workspace: workspace
...
```