### PR TITLE
subscription-manager pre-registration

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -229,7 +229,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -429,16 +429,34 @@ spec:
         ACTIVATION_KEY_PATH="/activation-key"
         ENTITLEMENT_PATH="/entitlement"
 
-        # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-        # when activation keys are used an empty directory on shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced container
-        # To use activation key file 'org' must exist, which means the key 'org' must exist in the key/value secret
+        # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+        # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+        # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+        # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+        #    to buildah but don't pre-register for backwards compatibility. In this case mount an empty directory on
+        #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced
+        #    container.
 
+        REGISTERED="false"
         if [ -e /activation-key/org ]; then
           cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
           mkdir /shared/rhsm-tmp
           VOLUME_MOUNTS+=(--volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z)
           echo "Adding activation key to the build"
 
+          if ! grep subscription-manager "$dockerfile_path" | grep -q register; then
+            # user is not running registration in the Containerfile: pre-register.
+            echo "Pre-registering with subscription manager."
+            subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+            REGISTERED=$?
+            # copy generated certificates to /shared/rhsm-tmp
+            cp /etc/pki/entitlement/*.pem /shared/rhsm-tmp
+
+            # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+            VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/run/secrets/rhsm/ca/redhat-uep.pem)
+          fi
+
+        # was: if [ -d "$ACTIVATION_KEY_PATH" ]; then
         elif find /entitlement -name "*.pem" >>null; then
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
@@ -496,6 +514,11 @@ spec:
 
         # Needed to generate base images SBOM
         echo "$BASE_IMAGES" >/shared/base_images_from_dockerfile
+
+        # unregister pod from subscription manager
+        if [ "$REGISTERED" == "0" ]; then
+          subscription-manager unregister
+        fi
       computeResources:
         limits:
           cpu: "4"
@@ -581,7 +604,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: inject-sbom-and-push
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -197,7 +197,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -230,7 +230,7 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: build
     script: |-
       #!/bin/bash
@@ -463,16 +463,34 @@ spec:
       ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
 
-      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used an empty directory on shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced container
-      # To use activation key file 'org' must exist, which means the key 'org' must exist in the key/value secret
+      # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+      # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+      # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+      #    to buildah but don't pre-register for backwards compatibility. In this case mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced
+      #    container.
 
+      REGISTERED="false"
       if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS+=(--volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z)
         echo "Adding activation key to the build"
 
+        if ! grep subscription-manager "$dockerfile_path" | grep -q register; then
+          # user is not running registration in the Containerfile: pre-register.
+          echo "Pre-registering with subscription manager."
+          subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+          REGISTERED=$?
+          # copy generated certificates to /shared/rhsm-tmp
+          cp /etc/pki/entitlement/*.pem /shared/rhsm-tmp
+
+          # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+          VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/run/secrets/rhsm/ca/redhat-uep.pem)
+        fi
+
+      # was: if [ -d "$ACTIVATION_KEY_PATH" ]; then
       elif find /entitlement -name "*.pem" >>null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
@@ -530,6 +548,11 @@ spec:
 
       # Needed to generate base images SBOM
       echo "$BASE_IMAGES" >/shared/base_images_from_dockerfile
+
+      # unregister pod from subscription manager
+      if [ "$REGISTERED" == "0" ]; then
+        subscription-manager unregister
+      fi
 
       buildah push "$IMAGE" "oci:konflux-final-image:$IMAGE"
       REMOTESSHEOF
@@ -701,7 +724,7 @@ spec:
       requests:
         cpu: "1"
         memory: 1Gi
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: inject-sbom-and-push
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -188,7 +188,7 @@ spec:
     - name: SKIP_UNUSED_STAGES
       value: $(params.SKIP_UNUSED_STAGES)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -212,7 +212,7 @@ spec:
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: build
     script: |-
       #!/bin/bash
@@ -439,16 +439,36 @@ spec:
       ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
 
-      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used an empty directory on shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced container
-      # To use activation key file 'org' must exist, which means the key 'org' must exist in the key/value secret
 
+      # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+      # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+      # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+      #    to buildah but don't pre-register for backwards compatibility. In this case mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced
+      #    container.
+
+      REGISTERED="false"
       if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS+=(--volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z)
         echo "Adding activation key to the build"
 
+        if ! grep subscription-manager "$dockerfile_path" | grep -q register; then
+          # user is not running registration in the Containerfile: pre-register.
+          echo "Pre-registering with subscription manager."
+          subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+          REGISTERED=$?
+          # copy generated certificates to /shared/rhsm-tmp
+          cp /etc/pki/entitlement/*.pem /shared/rhsm-tmp
+
+          # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+          VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/run/secrets/rhsm/ca/redhat-uep.pem)
+        fi
+
+
+      # was: if [ -d "$ACTIVATION_KEY_PATH" ]; then
       elif find /entitlement -name "*.pem" >> null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
@@ -506,6 +526,11 @@ spec:
 
       # Needed to generate base images SBOM
       echo "$BASE_IMAGES" > /shared/base_images_from_dockerfile
+
+      # unregister pod from subscription manager
+      if [ "$REGISTERED" == "0" ]; then
+        subscription-manager unregister
+      fi
 
       buildah push "$IMAGE" "oci:konflux-final-image:$IMAGE"
       REMOTESSHEOF
@@ -677,7 +702,7 @@ spec:
       requests:
         cpu: "1"
         memory: 1Gi
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: inject-sbom-and-push
     script: |
       #!/bin/bash

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -170,7 +170,7 @@ spec:
       value: $(params.SKIP_UNUSED_STAGES)
 
   steps:
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: build
     computeResources:
       limits:
@@ -360,16 +360,36 @@ spec:
       ACTIVATION_KEY_PATH="/activation-key"
       ENTITLEMENT_PATH="/entitlement"
 
-      # do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
-      # when activation keys are used an empty directory on shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced container
-      # To use activation key file 'org' must exist, which means the key 'org' must exist in the key/value secret
 
+      # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+      # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+      # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+      #    to buildah but don't pre-register for backwards compatibility. In this case mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced
+      #    container.
+
+      REGISTERED="false"
       if [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
         mkdir /shared/rhsm-tmp
         VOLUME_MOUNTS+=(--volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z)
         echo "Adding activation key to the build"
 
+        if ! grep subscription-manager "$dockerfile_path" | grep -q register; then
+          # user is not running registration in the Containerfile: pre-register.
+          echo "Pre-registering with subscription manager."
+          subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+          REGISTERED=$?
+          # copy generated certificates to /shared/rhsm-tmp
+          cp /etc/pki/entitlement/*.pem /shared/rhsm-tmp
+
+          # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+          VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/run/secrets/rhsm/ca/redhat-uep.pem)
+        fi
+
+
+      # was: if [ -d "$ACTIVATION_KEY_PATH" ]; then
       elif find /entitlement -name "*.pem" >> null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
@@ -427,6 +447,11 @@ spec:
 
       # Needed to generate base images SBOM
       echo "$BASE_IMAGES" > /shared/base_images_from_dockerfile
+
+      # unregister pod from subscription manager
+      if [ "$REGISTERED" == "0" ]; then
+        subscription-manager unregister
+      fi
 
     securityContext:
       capabilities:
@@ -524,7 +549,7 @@ spec:
       runAsUser: 0
 
   - name: inject-sbom-and-push
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:5cbd487022fb7ac476cbfdea25513b810f7e343ec48f89dc6a4e8c3c39fa37a2
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     computeResources:
       limits:
         memory: 4Gi


### PR DESCRIPTION
This add support for pre-registering with subscription-manager in the buildah tasks (0.2 only). When activation keys are provided the buildah-task container will register and then provide certs to the buildah env via volume mounts so that users do not need to add subscription-manager register commands to the Containerfiles. This makes downstreaming somewhat easier and addresses negative user feedback.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
