### PR TITLE
sast-unicode: added SME to the OWNERS file

### DIFF
--- a/task/sast-unicode-check/OWNERS
+++ b/task/sast-unicode-check/OWNERS
@@ -3,3 +3,4 @@ approvers:
   - integration-team
 reviewers:
   - integration-team
+  - kdudka


### PR DESCRIPTION
As suggested by the Konflux team, updated the OWNERS file to add members from the SAST scanning.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
