### PR TITLE
chore(deps): update quay.io/redhat-appstudio/cachi2 docker to v0.13.0

### DIFF
--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -490,7 +490,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: merge-cachi2-sbom
-      image: quay.io/redhat-appstudio/cachi2:0.11.0@sha256:1051a8e55f4b6dddb5591ac103644e1d45b2367cffe50ba900418939aace0fb2
+      image: quay.io/redhat-appstudio/cachi2:0.13.0@sha256:eb34cfe3fea20997eebd8164dc93eedb2fd7a60dc1fb4afcc1b1ff43df9d6667
       workingDir: /var/workdir
       script: |
         if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -578,7 +578,7 @@ spec:
       runAsUser: 0
     workingDir: /var/workdir
   - computeResources: {}
-    image: quay.io/redhat-appstudio/cachi2:0.11.0@sha256:1051a8e55f4b6dddb5591ac103644e1d45b2367cffe50ba900418939aace0fb2
+    image: quay.io/redhat-appstudio/cachi2:0.13.0@sha256:eb34cfe3fea20997eebd8164dc93eedb2fd7a60dc1fb4afcc1b1ff43df9d6667
     name: merge-cachi2-sbom
     script: |
       if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -571,7 +571,7 @@ spec:
       runAsUser: 0
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: quay.io/redhat-appstudio/cachi2:0.11.0@sha256:1051a8e55f4b6dddb5591ac103644e1d45b2367cffe50ba900418939aace0fb2
+    image: quay.io/redhat-appstudio/cachi2:0.13.0@sha256:eb34cfe3fea20997eebd8164dc93eedb2fd7a60dc1fb4afcc1b1ff43df9d6667
     name: merge-cachi2-sbom
     script: |
       if [ -f "sbom-cachi2.json" ]; then

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -450,7 +450,7 @@ spec:
       runAsUser: 0
 
   - name: merge-cachi2-sbom
-    image: quay.io/redhat-appstudio/cachi2:0.11.0@sha256:1051a8e55f4b6dddb5591ac103644e1d45b2367cffe50ba900418939aace0fb2
+    image: quay.io/redhat-appstudio/cachi2:0.13.0@sha256:eb34cfe3fea20997eebd8164dc93eedb2fd7a60dc1fb4afcc1b1ff43df9d6667
     script: |
       if [ -f "sbom-cachi2.json" ]; then
         echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"


### PR DESCRIPTION
Renovate bot has ignored v0.12.0 for some reason and it didn't open an update to v0.13.0 either. Bump it manually.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
