### PR TITLE
push to a unique tag in buildah tasks

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -662,6 +662,15 @@ spec:
 
         buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
+        echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+        if ! retry buildah push \
+          --tls-verify="$TLSVERIFY" \
+          "$IMAGE" \
+          "docker://${IMAGE%:*}:$(context.taskRun.name)"; then
+          echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${max_run} tries"
+          exit 1
+        fi
+
         echo "Pushing to ${IMAGE}"
         if ! retry buildah push \
           --tls-verify="$TLSVERIFY" \

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -629,6 +629,19 @@ spec:
         #!/bin/bash
         set -e
 
+        retry() {
+          status=-1
+          max_run=5
+          sleep_sec=10
+
+          for run in $(seq 1 $max_run); do
+            status=0
+            [ "$run" -gt 1 ] && sleep $sleep_sec
+            "$@" && break || status=$?
+          done
+          return $status
+        }
+
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
         if [ -f "$ca_bundle" ]; then
           echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -649,20 +662,12 @@ spec:
 
         buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
-        status=-1
-        max_run=5
-        sleep_sec=10
-        for run in $(seq 1 $max_run); do
-          status=0
-          [ "$run" -gt 1 ] && sleep $sleep_sec
-          echo "Pushing sbom image to registry"
-          buildah push \
-            --tls-verify=$TLSVERIFY \
-            --digestfile /var/workdir/image-digest $IMAGE \
-            docker://$IMAGE && break || status=$?
-        done
-        if [ "$status" -ne 0 ]; then
-          echo "Failed to push sbom image to registry after ${max_run} tries"
+        echo "Pushing to ${IMAGE}"
+        if ! retry buildah push \
+          --tls-verify="$TLSVERIFY" \
+          --digestfile "/var/workdir/image-digest" "$IMAGE" \
+          "docker://$IMAGE"; then
+          echo "Failed to push sbom image to $IMAGE after ${max_run} tries"
           exit 1
         fi
 

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -747,6 +747,19 @@ spec:
         export IMAGE
       fi
 
+      retry() {
+        status=-1
+        max_run=5
+        sleep_sec=10
+
+        for run in $(seq 1 $max_run); do
+          status=0
+          [ "$run" -gt 1 ] && sleep $sleep_sec
+          "$@" && break || status=$?
+        done
+        return $status
+      }
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -767,20 +780,12 @@ spec:
 
       buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
-      status=-1
-      max_run=5
-      sleep_sec=10
-      for run in $(seq 1 $max_run); do
-        status=0
-        [ "$run" -gt 1 ] && sleep $sleep_sec
-        echo "Pushing sbom image to registry"
-        buildah push \
-          --tls-verify=$TLSVERIFY \
-          --digestfile /var/workdir/image-digest $IMAGE \
-          docker://$IMAGE && break || status=$?
-      done
-      if [ "$status" -ne 0 ]; then
-        echo "Failed to push sbom image to registry after ${max_run} tries"
+      echo "Pushing to ${IMAGE}"
+      if ! retry buildah push \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "/var/workdir/image-digest" "$IMAGE" \
+        "docker://$IMAGE"; then
+        echo "Failed to push sbom image to $IMAGE after ${max_run} tries"
         exit 1
       fi
 

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -780,6 +780,15 @@ spec:
 
       buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! retry buildah push \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)"; then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${max_run} tries"
+        exit 1
+      fi
+
       echo "Pushing to ${IMAGE}"
       if ! retry buildah push \
         --tls-verify="$TLSVERIFY" \

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -725,6 +725,19 @@ spec:
         export IMAGE
       fi
 
+      retry () {
+        status=-1
+        max_run=5
+        sleep_sec=10
+
+        for run in $(seq 1 $max_run); do
+          status=0
+          [ "$run" -gt 1 ] && sleep $sleep_sec
+          "$@" && break || status=$?
+        done
+        return $status
+      }
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -745,21 +758,14 @@ spec:
 
       buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
-      status=-1
-      max_run=5
-      sleep_sec=10
-      for run in $(seq 1 $max_run); do
-        status=0
-        [ "$run" -gt 1 ] && sleep $sleep_sec
-        echo "Pushing sbom image to registry"
-        buildah push \
-          --tls-verify=$TLSVERIFY \
-          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
-          docker://$IMAGE && break || status=$?
-      done
-      if [ "$status" -ne 0 ]; then
-          echo "Failed to push sbom image to registry after ${max_run} tries"
-          exit 1
+      echo "Pushing to ${IMAGE}"
+      if ! retry buildah push \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${max_run} tries"
+        exit 1
       fi
 
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -471,7 +471,6 @@ spec:
           VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/run/secrets/rhsm/ca/redhat-uep.pem)
         fi
 
-
       # was: if [ -d "$ACTIVATION_KEY_PATH" ]; then
       elif find /entitlement -name "*.pem" >> null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
@@ -757,6 +756,16 @@ spec:
       fi
 
       buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
+
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! retry buildah push \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${max_run} tries"
+        exit 1
+      fi
 
       echo "Pushing to ${IMAGE}"
       if ! retry buildah push \

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -574,6 +574,19 @@ spec:
       #!/bin/bash
       set -e
 
+      retry () {
+        status=-1
+        max_run=5
+        sleep_sec=10
+
+        for run in $(seq 1 $max_run); do
+          status=0
+          [ "$run" -gt 1 ] && sleep $sleep_sec
+          "$@" && break || status=$?
+        done
+        return $status
+      }
+
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -594,21 +607,14 @@ spec:
 
       buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
 
-      status=-1
-      max_run=5
-      sleep_sec=10
-      for run in $(seq 1 $max_run); do
-        status=0
-        [ "$run" -gt 1 ] && sleep $sleep_sec
-        echo "Pushing sbom image to registry"
-        buildah push \
-          --tls-verify=$TLSVERIFY \
-          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
-          docker://$IMAGE && break || status=$?
-      done
-      if [ "$status" -ne 0 ]; then
-          echo "Failed to push sbom image to registry after ${max_run} tries"
-          exit 1
+      echo "Pushing to ${IMAGE}"
+      if ! retry buildah push \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${max_run} tries"
+        exit 1
       fi
 
       cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -392,7 +392,6 @@ spec:
           VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/run/secrets/rhsm/ca/redhat-uep.pem)
         fi
 
-
       # was: if [ -d "$ACTIVATION_KEY_PATH" ]; then
       elif find /entitlement -name "*.pem" >> null; then
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
@@ -606,6 +605,16 @@ spec:
       fi
 
       buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
+
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! retry buildah push \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${max_run} tries"
+        exit 1
+      fi
 
       echo "Pushing to ${IMAGE}"
       if ! retry buildah push \


### PR DESCRIPTION
[KFLUXBUGS-1539](https://issues.redhat.com/browse/KFLUXBUGS-1539)
- Built image in buildah task is pushed to a location specified in the `IMAGE` param
- This location does not have to be unique when running multiple PipelineRuns on the
same revision
- A race condition can occur resulting in a failure
- Besides pushing to `IMAGE`, push to a tag named after the TaskRun name which
should be unique