### PR TITLE
Guard Task execution via changed files

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -5,7 +5,7 @@ metadata:
   name: build-definitions-pull-request
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || !body.pull_request.draft) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/"))
-    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.2/sast-snyk-check.yaml, task/sast-unicode-check/0.1/sast-unicode-check.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.2/sast-snyk-check.yaml, task/sast-unicode-check/0.1/sast-unicode-check.yaml, .tekton/tasks/task-switchboard.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:
@@ -36,7 +36,27 @@ spec:
             value: $(params.revision)
           - name: depth
             value: "0"
+      - name: task-switchboard
+        taskRef:
+          name: task-switchboard
+        params:
+          - name: pr_number
+            value: "{{ pull_request_number }}"
+          - name: utils_image
+            value: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
+          - name: expressions
+            value:
+              - tasks := strings.any_prefix_match(input, ["task/", "hack/", ".tekton/"])
+              - tasks_pipelines := strings.any_prefix_match(input, ["task/", "pipelines/", "hack/", ".tekton/"])
+              - e2e_tests := strings.any_prefix_match(input, ["task/", "pipelines/", "hack/", ".tekton/"])
+              - check_partner_tasks := strings.any_prefix_match(input, ["partners/", "hack/", ".tekton/"])
+        runAfter:
+          - build-appstudio-utils
       - name: task-lint-check
+        when:
+          - input: "tasks"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
         runAfter:
           - fetch-repository
         taskRef:
@@ -62,7 +82,7 @@ spec:
             workspace: workspace
       - name: build-appstudio-utils
         runAfter:
-          - task-lint-check
+          - fetch-repository
         params:
           - name: IMAGE
             value: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
@@ -74,6 +94,10 @@ spec:
           - name: source
             workspace: workspace
       - name: check-partner-tasks
+        when:
+          - input: "check_partner_tasks"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
         runAfter:
           - build-appstudio-utils
         taskSpec:
@@ -125,13 +149,15 @@ spec:
           - name: source
             workspace: workspace
       - name: build-bundles
+        when:
+          - input: "tasks_pipelines"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
         params:
           - name: revision
             value: "{{ revision }}"
           - name: e2e_test_namespace
             value: $(params.e2e_test_namespace)
-        runAfter:
-          - build-appstudio-utils
         workspaces:
           - name: source
             workspace: workspace
@@ -174,6 +200,10 @@ spec:
           workspaces:
             - name: source
       - name: e2e-tests
+        when:
+          - input: "e2e_tests"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
         params:
           - name: e2e_test_namespace
             value: $(params.e2e_test_namespace)
@@ -198,6 +228,10 @@ spec:
         # Added a timeout due to https://issues.redhat.com/browse/STONEBLD-2265
         timeout: "2h"
       - name: check-task-pipeline-repo-existence
+        when:
+          - input: "tasks_pipelines"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
         runAfter:
           - build-bundles
         taskSpec:
@@ -214,6 +248,10 @@ spec:
           - name: source
             workspace: workspace
       - name: ec-task-checks
+        when:
+          - input: "tasks_pipelines"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
         runAfter:
           - fetch-repository
         taskRef:
@@ -222,6 +260,10 @@ spec:
           - name: source
             workspace: workspace
       - name: check-task-migration-md
+        when:
+          - input: "tasks"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
         runAfter:
           - fetch-repository
         taskSpec:
@@ -250,6 +292,10 @@ spec:
             workspace: workspace
     finally:
       - name: e2e-cleanup
+        when:
+          - input: "e2e_tests"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
         params:
           - name: e2e_test_namespace
             value: $(params.e2e_test_namespace)

--- a/.tekton/tasks/task-switchboard.yaml
+++ b/.tekton/tasks/task-switchboard.yaml
@@ -1,0 +1,53 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: task-switchboard
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/displayName: Task Switchboard
+    tekton.dev/platforms: "linux/amd64"
+spec:
+  description: "Computes a set of expressions based on the changed files in the
+  pipeline, used to determine which tasks to run"
+  params:
+    - name: pr_number
+      type: string
+    - name: utils_image
+      type: string
+    - name: expressions
+      type: array
+  results:
+    - name: bindings
+      type: array
+  steps:
+    - name: evaluate
+      image: $(params.utils_image)
+      env:
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: "{{ git_auth_secret }}"
+              key: "git-provider-token"
+      args:
+        - "$(params.expressions[*])"
+      script: |
+        #!/bin/bash
+        set -o errexit
+        set -o nounset
+        set -o pipefail
+
+        rules="$(mktemp -d)"
+        trap 'rm -rf "${rules}"' EXIT
+        for ((i=1; i<=$#; ++i)); do
+            printf "package rule\n%s\n" "${!i}" > "${rules}/$i.rego"
+        done
+
+        ec opa check --v1-compatible "${rules}"
+
+        ec opa eval --v1-compatible --data "${rules}" --input \
+        <(gh pr view "https://github.com/konflux-ci/build-definitions/pull/$(params.pr_number)" --json files --jq '[.files.[].path']) \
+        'data[_]' \
+        | jq '[.result.[].expressions.[].value | to_entries | .[] | select(.value == true) | .key]' \
+        | tee "$(results.bindings.path)"

--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -8,6 +8,7 @@ RUN curl -L https://github.com/tektoncd/cli/releases/download/v0.32.2/tkn_0.32.2
 RUN curl -L https://github.com/sigstore/rekor/releases/download/v0.5.0/rekor-cli-linux-amd64 -o /usr/bin/rekor-cli && chmod +x /usr/bin/rekor-cli
 RUN curl -L https://github.com/open-policy-agent/conftest/releases/download/v0.32.0/conftest_0.32.0_Linux_x86_64.tar.gz | tar -xz --no-same-owner -C /usr/bin
 RUN curl -L https://github.com/enterprise-contract/ec-cli/releases/download/snapshot/ec_linux_amd64 -o /usr/bin/ec && chmod +x /usr/bin/ec && ec version
+RUN curl -L https://github.com/cli/cli/releases/download/v2.60.1/gh_2.60.1_linux_amd64.tar.gz | tar -xz  -C /usr/bin --wildcards "gh_*/bin/gh" --strip-components=2 --no-same-owner
 
 RUN dnf -y --setopt=tsflags=nodocs install \
     git \

--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi
 
-RUN curl -L https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -o /usr/bin/jq && chmod +x /usr/bin/jq
+RUN curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -o /usr/bin/jq && chmod +x /usr/bin/jq
 RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
 RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.9/openshift-client-linux.tar.gz | tar -xz -C /usr/bin/
 RUN curl -L https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign


### PR DESCRIPTION
The new Task in `.tekton/tasks/changed-dirs.yaml` produces a list of changed directories for a particular pull request as an array result. Given this result guards can be done, e.g. using CEL expressions to limit when a Task on the Pipeline needs to run.
This way we can skip expensive Tasks that are unrelated to the change done in the pull request.

Similar to work in #1188 and #524, with the distinction that the PipelineRun is executed, only potentially not in full.