### PR TITLE
Update sbom-utility-scripts image to latest

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -163,7 +163,7 @@ spec:
         add:
           - SETFCAP
 
-  - image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:53a3041dff341b7fd1765b9cc2c324625d19e804b2eaff10a6e6d9dcdbde3a91
+  - image: quay.io/redhat-appstudio/sbom-utility-scripts-image:latest@sha256:3b219e0610c06401bb5bd355a4bdfeb7f6700f2bef66f89316739d4aae96c89d
     name: create-sbom
     computeResources:
       limits:

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -587,7 +587,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: prepare-sboms
-      image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:53a3041dff341b7fd1765b9cc2c324625d19e804b2eaff10a6e6d9dcdbde3a91
+      image: quay.io/redhat-appstudio/sbom-utility-scripts-image:latest@sha256:3b219e0610c06401bb5bd355a4bdfeb7f6700f2bef66f89316739d4aae96c89d
       workingDir: /var/workdir
       script: |
         echo "Merging contents of sbom-source.json and sbom-image.json into sbom-cyclonedx.json"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -701,7 +701,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:53a3041dff341b7fd1765b9cc2c324625d19e804b2eaff10a6e6d9dcdbde3a91
+    image: quay.io/redhat-appstudio/sbom-utility-scripts-image:latest@sha256:3b219e0610c06401bb5bd355a4bdfeb7f6700f2bef66f89316739d4aae96c89d
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -678,7 +678,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:53a3041dff341b7fd1765b9cc2c324625d19e804b2eaff10a6e6d9dcdbde3a91
+    image: quay.io/redhat-appstudio/sbom-utility-scripts-image:latest@sha256:3b219e0610c06401bb5bd355a4bdfeb7f6700f2bef66f89316739d4aae96c89d
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -530,7 +530,7 @@ spec:
       runAsUser: 0
 
   - name: prepare-sboms
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:53a3041dff341b7fd1765b9cc2c324625d19e804b2eaff10a6e6d9dcdbde3a91
+    image: quay.io/redhat-appstudio/sbom-utility-scripts-image:latest@sha256:3b219e0610c06401bb5bd355a4bdfeb7f6700f2bef66f89316739d4aae96c89d
     computeResources:
       limits:
         memory: 512Mi

--- a/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
+++ b/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
@@ -241,7 +241,7 @@ spec:
         requests:
           memory: 6Gi
     - name: merge-cachi2-sbom
-      image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:53a3041dff341b7fd1765b9cc2c324625d19e804b2eaff10a6e6d9dcdbde3a91
+      image: quay.io/redhat-appstudio/sbom-utility-scripts-image:latest@sha256:3b219e0610c06401bb5bd355a4bdfeb7f6700f2bef66f89316739d4aae96c89d
       workingDir: /var/workdir
       script: |
         cachi2_sbom=./cachi2/output/bom.json

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -222,7 +222,7 @@ spec:
       - mountPath: /var/lib/containers
         name: varlibcontainers
   - name: merge-cachi2-sbom
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:53a3041dff341b7fd1765b9cc2c324625d19e804b2eaff10a6e6d9dcdbde3a91
+    image: quay.io/redhat-appstudio/sbom-utility-scripts-image:latest@sha256:3b219e0610c06401bb5bd355a4bdfeb7f6700f2bef66f89316739d4aae96c89d
     script: |
       cachi2_sbom=./cachi2/output/bom.json
       if [ -f "$cachi2_sbom" ]; then


### PR DESCRIPTION
In https://github.com/konflux-ci/build-definitions/pull/1552, Renovate downgraded the sbom-utility-scripts image to an older version. Upgrade it again.

It is not entirely clear *why* Renovate did that. Attempt to avoid this by using an explicit 'latest' tag and by making sure the sbom-utility-scripts image 'latest' tag will really point to the latest tag (https://github.com/konflux-ci/build-tasks-dockerfiles/pull/172).

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
