### PR TITLE
feat: added new task export-image-tar

### DIFF
--- a/task/export-image-tar/0.1/README.md
+++ b/task/export-image-tar/0.1/README.md
@@ -1,0 +1,17 @@
+# export-image-tar task
+
+Given an input image save it as an oci-archive tar file, then push it as an oci artifact to a given output artifact location. This is useful for sharing images without the use of a registry, e.g. direct download.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|input-image|The input image that is to be saved as an oci-archive tar file||true|
+|tar-filename|The tar filename of the saved input image|image.tar|false|
+|dest-image-tag|The tag of the destination image when the tar file is loaded. Use this if you want to hide the source repository name, or if you have issues with digest missmatch which can happen sometimes with `podman save` and `podman load`|""|false|
+|output-artifact|The output url that points to the OCI artifact of the tar image||true|
+
+## Results
+|name|description|
+|---|---|
+|ARTIFACT_URL|Repository where the oci-archive tar artifact was pushed|
+|ARTIFACT_DIGEST|Digest of the oci-archive tar artifact just pushed|

--- a/task/export-image-tar/0.1/export-image-tar.yaml
+++ b/task/export-image-tar/0.1/export-image-tar.yaml
@@ -1,0 +1,79 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: export-image-tar
+spec:
+  params:
+    - name: input-image
+      type: string
+      description: The input image that is to be saved as an oci-archive tar file
+    - name: tar-filename
+      default: "image.tar"
+      description: The tar filename of the saved input image
+      type: string
+    - name: dest-image-tag
+      default: ""
+      description: The tag of the destination image when the tar file is loaded. Use this if you want to hide the source repository name, or if you have issues with digest missmatch which can happen sometimes with `podman save` and `podman load`
+      type: string
+    - name: output-artifact
+      type: string
+      description: The output url that points to the OCI artifact of the tar image
+  results:
+    - description: Digest of the tar artifact just pushed
+      name: ARTIFACT_DIGEST
+    - description: Image repository where the tar artifact was pushed
+      name: ARTIFACT_URL
+  steps:
+    - name: save-tar
+      image: registry.access.redhat.com/ubi9/podman:latest
+      script: |
+        podman --version
+
+        podman pull $(params.input-image)
+
+        echo "saving: $(params.tar-filename)"
+
+        # Check if dest-image-tag is not an empty string
+        if [[ -n "$(params.dest-image-tag)" ]]; then
+            # Tag the base image with the destination image tag
+            echo "tagging image: $(params.dest-image-tag)"
+            podman tag "$(params.input-image)" "$(params.dest-image-tag)"
+            
+            # Save the tagged image
+            podman save --format oci-archive -o "/mnt/artifacts/$(params.tar-filename)" "$(params.dest-image-tag)"
+        else
+            # Save the base image directly if no tag is provided
+            podman save --format oci-archive -o "/mnt/artifacts/$(params.tar-filename)" "$(params.input-image)"
+        fi
+
+        du -hs /mnt/artifacts/$(params.tar-filename)
+      securityContext:
+        # This is required for podman to work properly
+        capabilities:
+          add:
+            - SETFCAP
+      volumeMounts:
+        - mountPath: /mnt/artifacts
+          name: artifacts
+    - name: push-tar
+      image: quay.io/konflux-ci/oras:latest@sha256:9d6db5840c70e65fefe041201cc7ffe2d1661bd0582b590b54787213ccfd76e9
+      script: |
+        echo "selecting auth"
+        select-oci-auth "$(params.output-artifact)" > "$HOME/auth.json"
+
+        # push the tar using oras and caputre the Digest
+        echo "oras push tar: $(params.tar-filename)"
+        echo "output-artifact: $(params.output-artifact)"
+        cd /mnt/artifacts
+        ARTIFACT_DIGEST=$(oras push --registry-config "$HOME/auth.json" $(params.output-artifact) ./$(params.tar-filename):application/vnd.oci.image.layer.v1.tar 2>&1 | grep 'Digest:' | awk '{print $2}')
+
+        # Finally, record all that in our results
+        echo -n "$(params.output-artifact)" | tee /tekton/results/ARTIFACT_URL
+        echo -n "$ARTIFACT_DIGEST" | tee /tekton/results/ARTIFACT_DIGEST
+
+      volumeMounts:
+        - mountPath: /mnt/artifacts
+          name: artifacts
+  volumes:
+    - emptyDir: {}
+      name: artifacts

--- a/task/export-image-tar/OWNERS
+++ b/task/export-image-tar/OWNERS
@@ -1,0 +1,9 @@
+# See the OWNERS docs: https://go.k8s.io/owners
+approvers:
+  - ralphbean
+  - Jared-Sprague
+  - arewm
+reviewers:
+  - ralphbean
+  - Jared-Sprague
+  - arewm


### PR DESCRIPTION
This pull request is to add a new simple task for exporting images as oci-archive tar file and pushing as an oci artifact.  This is needed in some cases where images must be shared without the use of an image registry.
