### PR TITLE
set strict mode for buildah build step

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -256,7 +256,7 @@ spec:
           value: $(params.DOCKERFILE)
       script: |
         #!/bin/bash
-        set -e
+        set -euo pipefail
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
         if [ -f "$ca_bundle" ]; then
           echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -293,7 +293,7 @@ spec:
         dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
         cp "$dockerfile_path" "$dockerfile_copy"
 
-        if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+        if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
           sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
           touch /var/lib/containers/java
         fi
@@ -475,7 +475,7 @@ spec:
           echo "Adding the entitlement to the build"
         fi
 
-        if [ -n "$ADDITIONAL_VOLUME_MOUNTS" ]; then
+        if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
           # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
           # This is primarily used in instrumented builds for SAST scanning and analyzing.
           # Instrumented builds use this step as their base and add some other tools.

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -289,7 +289,7 @@ spec:
 
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/bash
-      set -e
+      set -euo pipefail
       cd /var/workdir
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
@@ -327,7 +327,7 @@ spec:
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
 
-      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
         sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
         touch /var/lib/containers/java
       fi
@@ -509,7 +509,7 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      if [ -n "$ADDITIONAL_VOLUME_MOUNTS" ]; then
+      if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
         # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
         # This is primarily used in instrumented builds for SAST scanning and analyzing.
         # Instrumented builds use this step as their base and add some other tools.

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -271,7 +271,7 @@ spec:
 
       cat >scripts/script-build.sh <<'REMOTESSHEOF'
       #!/bin/bash
-      set -e
+      set -euo pipefail
       cd $(workspaces.source.path)
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
@@ -309,7 +309,7 @@ spec:
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
 
-      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
         sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
         touch /var/lib/containers/java
       fi
@@ -486,7 +486,7 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      if [ -n "$ADDITIONAL_VOLUME_MOUNTS" ]; then
+      if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
         # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
         # This is primarily used in instrumented builds for SAST scanning and analyzing.
         # Instrumented builds use this step as their base and add some other tools.

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -193,7 +193,7 @@ spec:
 
     script: |
       #!/bin/bash
-      set -e
+      set -euo pipefail
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -230,7 +230,7 @@ spec:
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
 
-      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
         sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
         touch /var/lib/containers/java
       fi
@@ -407,7 +407,7 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
-      if [ -n "$ADDITIONAL_VOLUME_MOUNTS" ]; then
+      if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
         # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
         # This is primarily used in instrumented builds for SAST scanning and analyzing.
         # Instrumented builds use this step as their base and add some other tools.


### PR DESCRIPTION
[KFLUXBUGS-1681](https://issues.redhat.com/browse/KFLUXBUGS-1681)

- Failure of dockerfile-json parsing is not handled and buildah attempts to build
the image, leading to confusing errors
- Fail the build immediately if an error in a pipeline occurs

Previously
![image](https://github.com/user-attachments/assets/0235b554-ed80-4baf-8b53-20aedb456616)

After the change
![image](https://github.com/user-attachments/assets/06d592e6-97b7-45bb-8ca6-fa9e74b54e38)