### PR TITLE
feat(STONEINTG-947): migrate the clamav db to konflux-ci repo

### DIFF
--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -224,7 +224,7 @@ spec:
   # provides latest virus database for clamscan only
   # does not execute anything
   sidecars:
-    - image: quay.io/redhat-appstudio/clamav-db:v1  # explicit floating tag, daily updates, per arch call this is exempt for now for use of image digest
+    - image: quay.io/konflux-ci/clamav-db:v1  # explicit floating tag, daily updates, per arch call this is exempt for now for use of image digest
       imagePullPolicy: Always
       name: database
       script: |


### PR DESCRIPTION
Integration team migrating the quay  repo of Clamav DB to  Konflux-ci orq , 
in this PR we redirect the task and renovate to the new repo 

for more details review  [STONEINTG-947](https://issues.redhat.com/browse/STONEINTG-947)