### PR TITLE
Replace the hash tag with latest

### DIFF
--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -114,7 +114,7 @@ spec:
             | .name + "@" + $matched.digest
         ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
     - name: build
-      image: quay.io/konflux-ci/source-container-build:9ad131acf5154d2f280b7b46a1abc543952d325c@sha256:94271c32e4578208ac90308695d2b625d4e932d65f0cdd116b200c39228f5ece
+      image: quay.io/konflux-ci/source-container-build:latest@sha256:94271c32e4578208ac90308695d2b625d4e932d65f0cdd116b200c39228f5ece
       workingDir: /var/workdir
       env:
         - name: SOURCE_DIR

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -102,7 +102,7 @@ spec:
         ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
 
     - name: build
-      image: quay.io/konflux-ci/source-container-build:9ad131acf5154d2f280b7b46a1abc543952d325c@sha256:94271c32e4578208ac90308695d2b625d4e932d65f0cdd116b200c39228f5ece
+      image: quay.io/konflux-ci/source-container-build:latest@sha256:94271c32e4578208ac90308695d2b625d4e932d65f0cdd116b200c39228f5ece
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       computeResources:


### PR DESCRIPTION
Renovate PRs for this image are not created, the debug message says

DEBUG: Dependency quay.io/konflux-ci/source-container-build has unsupported/unversioned value 9ad131acf5154d2f280b7b46a1abc543952d325c (versioning=docker)

Replacing the hash tag with latest might work, as successfull PRs are created for images in this format, e.g.
https://github.com/konflux-ci/build-definitions/pull/1478/