### PR TITLE
Remove exceptions for step images

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -28,8 +28,3 @@ sources:
         - results
         - step_image_registries
         - trusted_artifacts
-      exclude:
-        # https://issues.redhat.com/browse/KFLUXBUGS-1111
-        - step_image_registries.step_images_permitted:generate-odcs-compose/noversion
-        # https://issues.redhat.com/browse/KFLUXBUGS-1110
-        - step_image_registries.step_images_permitted:verify-signed-rpms/noversion


### PR DESCRIPTION
Since [KFLUXBUGS-1111](https://issues.redhat.com//browse/KFLUXBUGS-1111) and [KFLUXBUGS-1110](https://issues.redhat.com//browse/KFLUXBUGS-1110) have been resolved an exception for the EC `step_image_registries.step_images_permitted` policy rules is no longer needed.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
