### PR TITLE
Add imageContentSources to eaas-create-ephemeral-cluster-hypershift-aws

### DIFF
--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/README.md
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/README.md
@@ -10,6 +10,7 @@ This StepAction provisions an ephemeral cluster using Hypershift with 3 worker n
 |instanceType|AWS EC2 instance type for worker nodes. Supported values: `m5.large`, `m5.xlarge`, `m5.2xlarge`, `m6g.large`, `m6g.xlarge`, `m6g.2xlarge`|m6g.large|false|
 |insecureSkipTLSVerify|Skip TLS verification when accessing the EaaS hub cluster. This should not be set to "true" in a production environment.|false|false|
 |timeout|How long to wait for cluster provisioning to complete.|30m|false|
+|imageContentSources|Alternate registry information containing a list of sources and their mirrors in yaml format. See: https://hypershift-docs.netlify.app/how-to/disconnected/image-content-sources|""|false|
 
 ## Results
 |name|description|

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
@@ -6,7 +6,7 @@ spec:
   description: >-
     This StepAction provisions an ephemeral cluster using Hypershift with 3 worker nodes in AWS.
     It does so by creating a ClusterTemplateInstance in a space on an EaaS cluster.
-  image: registry.redhat.io/openshift4/ose-cli@sha256:15da03b04318bcc842060b71e9dd6d6c2595edb4e8fdd11b0c6781eeb03ca182
+  image: quay.io/konflux-ci/appstudio-utils:5d8df82bdad43c3a71c9eb1a525a25e946777dc4@sha256:0901c58b85d6a05f75782bd8dd64b849a5b7d44f9f36c78a6ee33161278c96a4
   params:
     - name: eaasSpaceSecretRef
       type: string
@@ -32,6 +32,12 @@ spec:
       type: string
       default: 30m
       description: How long to wait for cluster provisioning to complete.
+    - name: imageContentSources
+      type: string
+      default: ""
+      description: >-
+        Alternate registry information containing a list of sources and their mirrors in yaml format.
+        See: https://hypershift-docs.netlify.app/how-to/disconnected/image-content-sources
   results:
     - name: clusterName
       description: The name of the generated ClusterTemplateInstance resource.
@@ -51,40 +57,45 @@ spec:
       value: "$(params.insecureSkipTLSVerify)"
     - name: TIMEOUT
       value: "$(params.timeout)"
+    - name: IMAGE_CONTENT_SOURCES
+      value: "$(params.imageContentSources)"
   script: |
     #!/bin/bash
     set -eo pipefail
 
     cat <<EOF > cti.yaml
+    ---
     apiVersion: clustertemplate.openshift.io/v1alpha1
     kind: ClusterTemplateInstance
     metadata:
       generateName: cluster-
     spec:
       clusterTemplateRef: hypershift-aws-cluster
-      parameters:
-        - name: instanceType
-          value: $INSTANCE_TYPE
-        - name: version
-          value: $VERSION
-        - name: timeout
-          value: $TIMEOUT
+      parameters: []
     EOF
+
+    yq -i '.spec.parameters += {"name": "instanceType", "value": strenv(INSTANCE_TYPE)}' cti.yaml
+    yq -i '.spec.parameters += {"name": "version", "value": strenv(VERSION)}' cti.yaml
+    yq -i '.spec.parameters += {"name": "timeout", "value": strenv(TIMEOUT)}' cti.yaml
+    yq -i '.spec.parameters += {"name": "imageContentSources", "value": strenv(IMAGE_CONTENT_SOURCES)}' cti.yaml
+
+    echo "Creating the following resource:"
+    cat cti.yaml
 
     trap 'rm -f "$KUBECONFIG"' EXIT
     echo "$KUBECONFIG_VALUE" > $KUBECONFIG
 
-    OC=(oc --insecure-skip-tls-verify="$INSECURE_SKIP_TLS_VERIFY")
-    CTI_NAME=$("${OC[@]}" create -f cti.yaml -o=jsonpath='{.metadata.name}')
+    KUBECTL=(kubectl --insecure-skip-tls-verify="$INSECURE_SKIP_TLS_VERIFY")
+    CTI_NAME=$("${KUBECTL[@]}" create -f cti.yaml -o=jsonpath='{.metadata.name}')
     echo "Created ClusterTemplateInstance $CTI_NAME"
     echo -n $CTI_NAME > $(step.results.clusterName.path)
 
     echo "Waiting for ClusterTemplateInstance to be ready ($TIMEOUT timeout)"
-    if "${OC[@]}" wait cti "$CTI_NAME" --for=jsonpath='{.status.phase}'=Ready --timeout="$TIMEOUT"; then
+    if "${KUBECTL[@]}" wait cti "$CTI_NAME" --for=jsonpath='{.status.phase}'=Ready --timeout="$TIMEOUT"; then
       echo "Successfully provisioned $CTI_NAME"
       exit 0
     else
-      "${OC[@]}" get cti "$CTI_NAME" -o yaml
+      "${KUBECTL[@]}" get cti "$CTI_NAME" -o yaml
       echo "Failed to provision $CTI_NAME"
       exit 1
     fi


### PR DESCRIPTION
The user may choose to pass the value as a quoted string with explicit newlines ("\n") or by using the "|" operator, among other options. A tool like `yq` is therefore necessary since basic variable expansion within a heredoc isn't adequate at preventing issues with malformed yaml.

As a result. the container image was changed to one which provides both the `yq` and `kubectl` binaries. This is a more upstream friendly image since it's publicly pullable.