### PR TITLE
feat: Update prefetch-dependencies to 0.2 to support sub-paths

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.2/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.2/README.md
@@ -1,0 +1,50 @@
+# prefetch-dependencies-oci-ta task
+
+Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+application source code are stored as a trusted artifact in the provided OCI repository.
+For additional info on Cachi2, see docs at
+https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+## Configuration
+
+Config file must be passed as a YAML string. For all available config options please check
+[available configuration parameters] page.
+
+Example of setting timeouts:
+
+```yaml
+params:
+  - name: config-file-content
+    value: |
+      ---
+      requests_timeout: 300
+      subprocess_timeout: 3600
+```
+
+[available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
+|input|Configures project packages that will have their dependencies prefetched.||true|
+|log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
+|ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
+|ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
+|subpaths|The subpaths which contains packages in the source folder, use ":" to separate.|""|false|
+
+## Results
+|name|description|
+|---|---|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -1,0 +1,282 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: prefetch-dependencies-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: |-
+    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    application source code are stored as a trusted artifact in the provided OCI repository.
+    For additional info on Cachi2, see docs at
+    https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+    ## Configuration
+
+    Config file must be passed as a YAML string. For all available config options please check
+    [available configuration parameters] page.
+
+    Example of setting timeouts:
+
+    ```yaml
+    params:
+      - name: config-file-content
+        value: |
+          ---
+          requests_timeout: 300
+          subprocess_timeout: 3600
+    ```
+
+    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+  params:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: config-file-content
+      description: |
+        Pass configuration to cachi2.
+        Note this needs to be passed as a YAML-formatted config dump, not as a file path!
+      type: string
+      default: ""
+    - name: dev-package-managers
+      description: |
+        Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk.
+      type: string
+      default: "false"
+    - name: input
+      description: Configures project packages that will have their dependencies
+        prefetched.
+      type: string
+    - name: log-level
+      description: Set cachi2 log level (debug, info, warning, error)
+      type: string
+      default: info
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: ""
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: subpaths
+      description: The subpaths which contains packages in the source folder,
+        use ":" to separate.
+      type: string
+      default: ""
+  results:
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  volumes:
+    - name: config
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  workspaces:
+    - name: git-basic-auth
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file or username and password.
+        These will be copied to the user's home before any cachi2 commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to bind a Secret to this Workspace over other volume types.
+      optional: true
+    - name: netrc
+      description: |
+        Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+        performing http(s) requests.
+      optional: true
+  stepTemplate:
+    env:
+      - name: CONFIG_FILE_CONTENT
+        value: $(params.config-file-content)
+    volumeMounts:
+      - mountPath: /mnt/config
+        name: config
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: skip-ta
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1726694542@sha256:f5d2c6a1e0c86e4234ea601552dbabb4ced0e013a1efcbfb439f1f6a7a9275b0
+      env:
+        - name: INPUT
+          value: $(params.input)
+        - name: SOURCE_ARTIFACT
+          value: $(params.SOURCE_ARTIFACT)
+      script: |
+        if [ -z "${INPUT}" ]; then
+          mkdir -p /var/workdir/source
+          mkdir -p /var/workdir/cachi2
+          echo "true" >/var/workdir/source/.skip-trusted-artifacts
+          echo "true" >/var/workdir/cachi2/.skip-trusted-artifacts
+          echo -n "${SOURCE_ARTIFACT}" >$(results.SOURCE_ARTIFACT.path)
+          echo -n "" >$(results.CACHI2_ARTIFACT.path)
+        fi
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:e0e457b6af10e44ff6b90208a9e69adc863a865e1c062c4cb84bf3846037d74d
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: sanitize-cachi2-config-file-with-yq
+      image: quay.io/konflux-ci/yq:latest@sha256:4ce1f9431020387eb6c33a28a46e079b0c28b97f916243d150e70a09e41ce6b4
+      script: |
+        if [ -n "${CONFIG_FILE_CONTENT}" ]; then
+          # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM
+          # impact of this configuration option will be:
+          # https://github.com/containerbuildsystem/cachi2/issues/577
+          yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}" >/mnt/config/config.yaml
+        fi
+    - name: generate-subpaths-json-args-with-jq
+      image: quay.io/konflux-ci/appstudio-utils@sha256:35624b7bf58c49d72ac373d1cf89c6c4f49c6daa5c821b158c212f09a453a944
+      env:
+        - name: INPUT
+          value: $(params.input)
+        - name: SUBPATHS
+          value: $(params.subpaths)
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        if [ -n "${SUBPATHS}" ]; then
+          IFS=':' read -ra spaths <<<"${SUBPATHS}"
+          for p in "${spaths[@]}"; do
+            jq -n --arg type "${INPUT}" --arg path "$p" \
+              '$ARGS.named'
+          done | jq -cn '.packages |= [inputs]' >/mnt/config/subpaths.json
+          if [ -f "/mnt/config/subpaths.json" ]; then
+            echo "Generated the subpaths json args for cachi2 fetch as below:"
+            echo "$(</mnt/config/subpaths.json)"
+          fi
+        fi
+    - name: prefetch-dependencies
+      image: quay.io/redhat-appstudio/cachi2:0.13.0@sha256:eb34cfe3fea20997eebd8164dc93eedb2fd7a60dc1fb4afcc1b1ff43df9d6667
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: INPUT
+          value: $(params.input)
+        - name: DEV_PACKAGE_MANAGERS
+          value: $(params.dev-package-managers)
+        - name: LOG_LEVEL
+          value: $(params.log-level)
+        - name: WORKSPACE_GIT_AUTH_BOUND
+          value: $(workspaces.git-basic-auth.bound)
+        - name: WORKSPACE_GIT_AUTH_PATH
+          value: $(workspaces.git-basic-auth.path)
+        - name: WORKSPACE_NETRC_BOUND
+          value: $(workspaces.netrc.bound)
+        - name: WORKSPACE_NETRC_PATH
+          value: $(workspaces.netrc.path)
+      script: |
+        if [ -z "${INPUT}" ]; then
+          # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
+          echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+          exit 0
+        fi
+
+        if [ -f /mnt/config/config.yaml ]; then
+          config_flag=--config-file=/mnt/config/config.yaml
+        else
+          config_flag=""
+        fi
+
+        if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
+          dev_pacman_flag=--dev-package-managers
+        else
+          dev_pacman_flag=""
+        fi
+
+        # Copied from https://github.com/konflux-ci/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml
+        if [ "${WORKSPACE_GIT_AUTH_BOUND}" = "true" ]; then
+          if [ -f "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" ]; then
+            cp "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" "${HOME}/.git-credentials"
+            cp "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" "${HOME}/.gitconfig"
+          # Compatibility with kubernetes.io/basic-auth secrets
+          elif [ -f "${WORKSPACE_GIT_AUTH_PATH}/username" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/password" ]; then
+            HOSTNAME=$(cd "/var/workdir/source" && git remote get-url origin | awk -F/ '{print $3}')
+            echo "https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME" >"${HOME}/.git-credentials"
+            echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" >"${HOME}/.gitconfig"
+          else
+            echo "Unknown git-basic-auth workspace format"
+            exit 1
+          fi
+          chmod 400 "${HOME}/.git-credentials"
+          chmod 400 "${HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
+          cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
+        fi
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        if [ -f /mnt/config/subpaths.json ]; then
+          subpaths=$(cat /mnt/config/subpaths.json)
+        else
+          subpaths=""
+        fi
+
+        if [ -z "$subpaths" ]; then
+          cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+            $dev_pacman_flag \
+            --source=/var/workdir/source \
+            --output=/var/workdir/cachi2/output \
+            "${INPUT}"
+        else
+          cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+            $dev_pacman_flag \
+            --source="/var/workdir/source" ''"$subpaths"'' \
+            --output="/var/workdir/cachi2/output"
+        fi
+
+        cachi2 --log-level="$LOG_LEVEL" generate-env /var/workdir/cachi2/output \
+          --format env \
+          --for-output-dir=/cachi2/output \
+          --output /var/workdir/cachi2/cachi2.env
+
+        cachi2 --log-level="$LOG_LEVEL" inject-files /var/workdir/cachi2/output \
+          --for-output-dir=/cachi2/output
+    - name: create-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:e0e457b6af10e44ff6b90208a9e69adc863a865e1c062c4cb84bf3846037d74d
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+        - $(results.CACHI2_ARTIFACT.path)=/var/workdir/cachi2
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)

--- a/task/prefetch-dependencies-oci-ta/0.2/recipe.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,52 @@
+---
+base: ../../prefetch-dependencies/0.2/prefetch-dependencies.yaml
+add:
+  - use-source
+  - create-source
+  - create-cachi2
+additionalSteps:
+  - at: 0
+    name: skip-ta
+    image: registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1726694542@sha256:f5d2c6a1e0c86e4234ea601552dbabb4ced0e013a1efcbfb439f1f6a7a9275b0
+    env:
+    - name: INPUT
+      value: $(params.input)
+    - name: SOURCE_ARTIFACT
+      value: $(params.SOURCE_ARTIFACT)
+    script: |
+      if [ -z "${INPUT}" ]; then
+        mkdir -p /var/workdir/source
+        mkdir -p /var/workdir/cachi2
+        echo "true" > /var/workdir/source/.skip-trusted-artifacts
+        echo "true" > /var/workdir/cachi2/.skip-trusted-artifacts
+        echo -n "${SOURCE_ARTIFACT}" > $(results.SOURCE_ARTIFACT.path)
+        echo -n "" > $(results.CACHI2_ARTIFACT.path)
+      fi
+description: |-
+    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    application source code are stored as a trusted artifact in the provided OCI repository.
+    For additional info on Cachi2, see docs at
+    https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+    ## Configuration
+
+    Config file must be passed as a YAML string. For all available config options please check
+    [available configuration parameters] page.
+
+    Example of setting timeouts:
+
+    ```yaml
+    params:
+      - name: config-file-content
+        value: |
+          ---
+          requests_timeout: 300
+          subprocess_timeout: 3600
+    ```
+
+    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+preferStepTemplate: true
+removeWorkspaces:
+  - source
+replacements:
+  workspaces.source.path: /var/workdir

--- a/task/prefetch-dependencies/0.2/README.md
+++ b/task/prefetch-dependencies/0.2/README.md
@@ -1,0 +1,40 @@
+# prefetch-dependencies task
+
+Task that uses Cachi2 to prefetch build dependencies.
+See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+This 0.2 version added a new parameter "subpaths" to let user specify sub paths of packages in the source
+
+## Configuration
+
+Config file must be passed as a YAML string. For all available config options please check [available configuration parameters] page.
+
+Example of setting timeouts:
+
+```yaml
+params:
+    - name: config-file-content
+      value: |
+         ---
+         requests_timeout: 300
+         subprocess_timeout: 3600
+```
+
+[available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|input|Configures project packages that will have their dependencies prefetched.||true|
+|dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
+|log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
+|config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|subpaths|The subpaths which contains packages in the source folder, use ":" to separate.|""|false|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace with the source code, cachi2 artifacts will be stored on the workspace as well|false|
+|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -1,0 +1,233 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, konflux"
+  name: prefetch-dependencies
+spec:
+  description: |-
+    Task that uses Cachi2 to prefetch build dependencies.
+    See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+    ## Configuration
+
+    Config file must be passed as a YAML string. For all available config options please check
+    [available configuration parameters] page.
+
+    Example of setting timeouts:
+
+    ```yaml
+    params:
+      - name: config-file-content
+        value: |
+          ---
+          requests_timeout: 300
+          subprocess_timeout: 3600
+    ```
+
+    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+  params:
+  - description: Configures project packages that will have their dependencies prefetched.
+    name: input
+    type: string
+  - description: >
+      Enable in-development package managers. WARNING: the behavior may change at any time without
+      notice. Use at your own risk.
+    name: dev-package-managers
+    default: "false"
+    type: string
+  - description: Set cachi2 log level (debug, info, warning, error)
+    name: log-level
+    default: "info"
+    type: string
+  - description: |
+      Pass configuration to cachi2.
+      Note this needs to be passed as a YAML-formatted config dump, not as a file path!
+    name: config-file-content
+    default: ""
+    type: string
+  - name: caTrustConfigMapName
+    type: string
+    description: The name of the ConfigMap to read CA bundle data from.
+    default: trusted-ca
+  - name: caTrustConfigMapKey
+    type: string
+    description: The name of the key in the ConfigMap that contains the CA bundle data.
+    default: ca-bundle.crt
+  - name: subpaths
+    type: string
+    description: The subpaths which contains packages in the source folder, use ":" to separate.
+    default: ""
+  stepTemplate:
+    env:
+      - name: CONFIG_FILE_CONTENT
+        value: $(params.config-file-content)
+    volumeMounts:
+      - name: config
+        mountPath: /mnt/config
+
+  steps:
+  - name: sanitize-cachi2-config-file-with-yq
+    image: quay.io/konflux-ci/yq:latest@sha256:4ce1f9431020387eb6c33a28a46e079b0c28b97f916243d150e70a09e41ce6b4
+    script: |
+      if [ -n "${CONFIG_FILE_CONTENT}" ]
+      then
+        # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM
+        # impact of this configuration option will be:
+        # https://github.com/containerbuildsystem/cachi2/issues/577
+        yq 'del(.goproxy_url)' <<< "${CONFIG_FILE_CONTENT}" > /mnt/config/config.yaml
+      fi
+
+  - name: generate-subpaths-json-args-with-jq
+    image: quay.io/konflux-ci/appstudio-utils@sha256:35624b7bf58c49d72ac373d1cf89c6c4f49c6daa5c821b158c212f09a453a944
+    env:
+    - name: INPUT
+      value: $(params.input)
+    - name: SUBPATHS
+      value: $(params.subpaths)
+    script: |
+      #!/usr/bin/env bash
+      set -e
+
+      if [ -n "${SUBPATHS}" ]
+      then
+        IFS=':' read -ra spaths <<< "${SUBPATHS}"
+        for p in "${spaths[@]}"
+        do
+          jq -n --arg type "${INPUT}" --arg path "$p" \
+            '$ARGS.named'
+        done | jq -cn '.packages |= [inputs]' > /mnt/config/subpaths.json
+        if [ -f "/mnt/config/subpaths.json" ]
+        then
+          echo "Generated the subpaths json args for cachi2 fetch as below:"
+          echo "$(</mnt/config/subpaths.json)"
+        fi
+      fi
+
+  - image: quay.io/redhat-appstudio/cachi2:0.13.0@sha256:eb34cfe3fea20997eebd8164dc93eedb2fd7a60dc1fb4afcc1b1ff43df9d6667
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    name: prefetch-dependencies
+    env:
+    - name: INPUT
+      value: $(params.input)
+    - name: DEV_PACKAGE_MANAGERS
+      value: $(params.dev-package-managers)
+    - name: LOG_LEVEL
+      value: $(params.log-level)
+    - name: WORKSPACE_GIT_AUTH_BOUND
+      value: $(workspaces.git-basic-auth.bound)
+    - name: WORKSPACE_GIT_AUTH_PATH
+      value: $(workspaces.git-basic-auth.path)
+    - name: WORKSPACE_NETRC_BOUND
+      value: $(workspaces.netrc.bound)
+    - name: WORKSPACE_NETRC_PATH
+      value: $(workspaces.netrc.path)
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    script: |
+      if [ -z "${INPUT}" ]
+      then
+        # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
+        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+        exit 0
+      fi
+
+      if [ -f /mnt/config/config.yaml ]; then
+        config_flag=--config-file=/mnt/config/config.yaml
+      else
+        config_flag=""
+      fi
+
+      if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
+        dev_pacman_flag=--dev-package-managers
+      else
+        dev_pacman_flag=""
+      fi
+
+      # Copied from https://github.com/konflux-ci/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml
+      if [ "${WORKSPACE_GIT_AUTH_BOUND}" = "true" ] ; then
+        if [ -f "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" ]; then
+          cp "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" "${HOME}/.git-credentials"
+          cp "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" "${HOME}/.gitconfig"
+        # Compatibility with kubernetes.io/basic-auth secrets
+        elif [ -f "${WORKSPACE_GIT_AUTH_PATH}/username" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/password" ]; then
+          HOSTNAME=$(cd "$(workspaces.source.path)/source" && git remote get-url origin | awk -F/ '{print $3}')
+          echo "https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
+          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
+        else
+          echo "Unknown git-basic-auth workspace format"
+          exit 1
+        fi
+        chmod 400 "${HOME}/.git-credentials"
+        chmod 400 "${HOME}/.gitconfig"
+      fi
+
+      if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
+        cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -f /mnt/config/subpaths.json ]; then
+        subpaths=$(cat /mnt/config/subpaths.json)
+      else
+        subpaths=""
+      fi
+
+      if [ -z "$subpaths" ]
+      then
+        cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+        $dev_pacman_flag \
+        --source=$(workspaces.source.path)/source \
+        --output=$(workspaces.source.path)/cachi2/output \
+        "${INPUT}"
+      else
+        cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+        $dev_pacman_flag \
+        --source="$(workspaces.source.path)/source" ''"$subpaths"'' \
+        --output="$(workspaces.source.path)/cachi2/output"
+      fi
+
+      cachi2 --log-level="$LOG_LEVEL" generate-env $(workspaces.source.path)/cachi2/output \
+      --format env \
+      --for-output-dir=/cachi2/output \
+      --output $(workspaces.source.path)/cachi2/cachi2.env
+
+      cachi2 --log-level="$LOG_LEVEL" inject-files $(workspaces.source.path)/cachi2/output \
+      --for-output-dir=/cachi2/output
+  workspaces:
+  - name: source
+    description: Workspace with the source code, cachi2 artifacts will be stored on the workspace as well
+  - name: git-basic-auth
+    description: |
+      A Workspace containing a .gitconfig and .git-credentials file or username and password.
+      These will be copied to the user's home before any cachi2 commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to bind a Secret to this Workspace over other volume types.
+    optional: true
+  - name: netrc
+    description: |
+      Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+      performing http(s) requests.
+    optional: true
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+    - name: config
+      emptyDir: {}


### PR DESCRIPTION
We're developing a new build pipeline to support build maven zip oci-artifacts, which needs cachi2 support to read multiple lockfiles of "generic" pkg type. This PR added that subpaths support.
