### PR TITLE
Revert "fix tektor linter issues"

### DIFF
--- a/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.1/buildah-oci-ta.yaml
@@ -113,17 +113,14 @@ spec:
     - name: YUM_REPOS_D_FETCHED
       description: Path in source workspace where dynamically-fetched repos
         are present
-      type: string
       default: fetched.repos.d
     - name: YUM_REPOS_D_SRC
       description: Path in the git repository in which yum repository files
         are stored
-      type: string
       default: repos.d
     - name: YUM_REPOS_D_TARGET
       description: Target path on the container in which yum repository files
         should be made available
-      type: string
       default: /etc/yum.repos.d
     - name: caTrustConfigMapKey
       description: The name of the key in the ConfigMap that contains the

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -113,17 +113,14 @@ spec:
     - name: YUM_REPOS_D_FETCHED
       description: Path in source workspace where dynamically-fetched repos
         are present
-      type: string
       default: fetched.repos.d
     - name: YUM_REPOS_D_SRC
       description: Path in the git repository in which yum repository files
         are stored
-      type: string
       default: repos.d
     - name: YUM_REPOS_D_TARGET
       description: Target path on the container in which yum repository files
         should be made available
-      type: string
       default: /etc/yum.repos.d
     - name: caTrustConfigMapKey
       description: The name of the key in the ConfigMap that contains the

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -113,16 +113,13 @@ spec:
   - default: fetched.repos.d
     description: Path in source workspace where dynamically-fetched repos are present
     name: YUM_REPOS_D_FETCHED
-    type: string
   - default: repos.d
     description: Path in the git repository in which yum repository files are stored
     name: YUM_REPOS_D_SRC
-    type: string
   - default: /etc/yum.repos.d
     description: Target path on the container in which yum repository files should
       be made available
     name: YUM_REPOS_D_TARGET
-    type: string
   - default: ca-bundle.crt
     description: The name of the key in the ConfigMap that contains the CA bundle
       data.

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -112,16 +112,13 @@ spec:
   - default: fetched.repos.d
     description: Path in source workspace where dynamically-fetched repos are present
     name: YUM_REPOS_D_FETCHED
-    type: string
   - default: repos.d
     description: Path in the git repository in which yum repository files are stored
     name: YUM_REPOS_D_SRC
-    type: string
   - default: /etc/yum.repos.d
     description: Target path on the container in which yum repository files should
       be made available
     name: YUM_REPOS_D_TARGET
-    type: string
   - default: ca-bundle.crt
     description: The name of the key in the ConfigMap that contains the CA bundle
       data.

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -63,16 +63,13 @@ spec:
   - default: repos.d
     description: Path in the git repository in which yum repository files are stored
     name: YUM_REPOS_D_SRC
-    type: string
   - default: fetched.repos.d
     description: Path in source workspace where dynamically-fetched repos are present
     name: YUM_REPOS_D_FETCHED
-    type: string
   - default: /etc/yum.repos.d
     description: Target path on the container in which yum repository files should
       be made available
     name: YUM_REPOS_D_TARGET
-    type: string
   - default: ""
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile
       is processed entirely to (and including) its last stage.

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -54,16 +54,13 @@ spec:
   - default: repos.d
     description: Path in the git repository in which yum repository files are stored
     name: YUM_REPOS_D_SRC
-    type: string
   - default: fetched.repos.d
     description: Path in source workspace where dynamically-fetched repos are present
     name: YUM_REPOS_D_FETCHED
-    type: string
   - default: /etc/yum.repos.d
     description: Target path on the container in which yum repository files should
       be made available
     name: YUM_REPOS_D_TARGET
-    type: string
   - default: ""
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile
       is processed entirely to (and including) its last stage.

--- a/task/buildah/0.1/buildah.yaml
+++ b/task/buildah/0.1/buildah.yaml
@@ -58,15 +58,12 @@ spec:
   - name: YUM_REPOS_D_SRC
     description: Path in the git repository in which yum repository files are stored
     default: repos.d
-    type: string
   - name: YUM_REPOS_D_FETCHED
     description: Path in source workspace where dynamically-fetched repos are present
     default: fetched.repos.d
-    type: string
   - name: YUM_REPOS_D_TARGET
     description: Target path on the container in which yum repository files should be made available
     default: /etc/yum.repos.d
-    type: string
   - name: TARGET_STAGE
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.
     type: string

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -49,15 +49,12 @@ spec:
   - name: YUM_REPOS_D_SRC
     description: Path in the git repository in which yum repository files are stored
     default: repos.d
-    type: string
   - name: YUM_REPOS_D_FETCHED
     description: Path in source workspace where dynamically-fetched repos are present
     default: fetched.repos.d
-    type: string
   - name: YUM_REPOS_D_TARGET
     description: Target path on the container in which yum repository files should be made available
     default: /etc/yum.repos.d
-    type: string
   - name: TARGET_STAGE
     description: Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.
     type: string

--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -14,14 +14,11 @@ spec:
   params:
     - name: image-digest
       description: Image digest to scan.
-      type: string
     - name: image-url
       description: Image URL.
-      type: string
     - name: docker-auth
       description: unused, should be removed in next task version.
       default: ""
-      type: string
     - name: ca-trust-config-map-name
       type: string
       description: The name of the ConfigMap to read CA bundle data from.

--- a/task/clair-scan/0.2/clair-scan.yaml
+++ b/task/clair-scan/0.2/clair-scan.yaml
@@ -14,14 +14,11 @@ spec:
   params:
     - name: image-digest
       description: Image digest to scan.
-      type: string
     - name: image-url
       description: Image URL.
-      type: string
     - name: docker-auth
       description: unused, should be removed in next task version.
       default: ""
-      type: string
     - name: ca-trust-config-map-name
       type: string
       description: The name of the ConfigMap to read CA bundle data from.

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -18,14 +18,11 @@ spec:
   params:
     - name: image-digest
       description: Image digest to scan.
-      type: string
     - name: image-url
       description: Image URL.
-      type: string
     - name: docker-auth
       description: unused
       default: ""
-      type: string
     - name: ca-trust-config-map-name
       type: string
       description: The name of the ConfigMap to read CA bundle data from.

--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -16,14 +16,11 @@ spec:
     - name: POLICY_DIR
       description: Path to directory containing Conftest policies.
       default: "/project/repository/"
-      type: string
     - name: POLICY_NAMESPACE
       description: Namespace for Conftest policy.
       default: "required_checks"
-      type: string
     - name: BASE_IMAGES_DIGESTS
       description: Digests of base build images.
-      type: string
 
   results:
     - name: PYXIS_HTTP_CODE

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -16,14 +16,11 @@ spec:
     - name: POLICY_DIR
       description: Path to directory containing Conftest policies.
       default: "/project/repository/"
-      type: string
     - name: POLICY_NAMESPACE
       description: Namespace for Conftest policy.
       default: "required_checks"
-      type: string
     - name: BASE_IMAGES_DIGESTS
       description: Digests of base build images.
-      type: string
 
   results:
     - name: PYXIS_HTTP_CODE

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -15,14 +15,11 @@ spec:
     - name: POLICY_DIR
       description: Path to directory containing Conftest policies.
       default: "/project/repository/"
-      type: string
     - name: POLICY_NAMESPACE
       description: Namespace for Conftest policy.
       default: "required_checks"
-      type: string
     - name: BASE_IMAGES_DIGESTS
       description: Digests of base build images.
-      type: string
 
   results:
     - name: PYXIS_HTTP_CODE

--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -16,21 +16,16 @@ spec:
     - name: POLICY_DIR
       description: Path to directory containing Conftest policies.
       default: "/project/repository/"
-      type: string
     - name: POLICY_NAMESPACE
       description: Namespace for Conftest policy.
       default: "required_checks"
-      type: string
     - name: BASE_IMAGES_DIGESTS
       description: Digests of base build images.
       default: ""
-      type: string
     - name: IMAGE_URL
       description: Fully qualified image name.
-      type: string
     - name: IMAGE_DIGEST
       description: Image digest.
-      type: string
     - name: CA_TRUST_CONFIG_MAP_NAME
       type: string
       description: The name of the ConfigMap to read CA bundle data from.

--- a/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
@@ -8,7 +8,6 @@ spec:
   params:
     - name: image-url
       description: Image url to scan.
-      type: string
     - name: ca-trust-config-map-name
       type: string
       description: The name of the ConfigMap to read CA bundle data from.

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -13,13 +13,10 @@ spec:
   params:
     - name: IMAGE_URL
       description: Fully qualified image name.
-      type: string
     - name: IMAGE_DIGEST
       description: Image digest.
-      type: string
     - name: BASE_IMAGE
       description: Fully qualified base image name.
-      type: string
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.

--- a/task/generate-labels/0.1/generate-labels.yaml
+++ b/task/generate-labels/0.1/generate-labels.yaml
@@ -32,7 +32,6 @@ spec:
   - name: source-date-epoch
     description: A standardised environment variable for build tools to consume in order to produce reproducible output.
     default: ""
-    type: string
   results:
     - name: labels
       description: The rendered labels, rendered from the provided templates

--- a/task/generate-odcs-compose/0.1/generate-odcs-compose.yaml
+++ b/task/generate-odcs-compose/0.1/generate-odcs-compose.yaml
@@ -8,11 +8,9 @@ spec:
     - name: COMPOSE_INPUTS
       description: relative path from workdir workspace to the compose inputs file
       default: compose_inputs.yaml
-      type: string
     - name: COMPOSE_OUTPUTS
       description: relative path from workdir workspace to store compose output files
       default: repos
-      type: string
   workspaces:
     - name: workdir
       description: |

--- a/task/generate-odcs-compose/0.2/generate-odcs-compose.yaml
+++ b/task/generate-odcs-compose/0.2/generate-odcs-compose.yaml
@@ -8,11 +8,9 @@ spec:
     - name: COMPOSE_INPUTS
       description: relative path from workdir workspace to the compose inputs file
       default: source/compose_inputs.yaml
-      type: string
     - name: COMPOSE_OUTPUTS
       description: relative path from workdir workspace to store compose output files
       default: fetched.repos.d
-      type: string
   workspaces:
     - name: workdir
       description: |

--- a/task/init/0.1/init.yaml
+++ b/task/init/0.1/init.yaml
@@ -13,27 +13,21 @@ spec:
   params:
     - name: image-url
       description: Image URL for build by PipelineRun
-      type: string
     - name: rebuild
       description: Rebuild the image if exists
       default: "false"
-      type: string
     - name: skip-checks
       description: Skip checks against built image
       default: "false"
-      type: string
     - name: skip-optional
       default: "true"
       description: Skip optional checks, set false if you want to run optional checks
-      type: string
     - name: pipelinerun-name
       description: unused, should be removed in next task version
       default: ""
-      type: string
     - name: pipelinerun-uid
       description: unused, should be removed in next task version
       default: ""
-      type: string
   results:
     - name: build
       description: Defines if the image in param image-url should be built

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -13,15 +13,12 @@ spec:
   params:
     - name: image-url
       description: Image URL for build by PipelineRun
-      type: string
     - name: rebuild
       description: Rebuild the image if exists
       default: "false"
-      type: string
     - name: skip-checks
       description: Skip checks against built image
       default: "false"
-      type: string
   results:
     - name: build
       description: Defines if the image in param image-url should be built

--- a/task/inspect-image/0.1/inspect-image.yaml
+++ b/task/inspect-image/0.1/inspect-image.yaml
@@ -15,7 +15,6 @@ spec:
   params:
     - name: IMAGE_URL
       description: Fully qualified image name.
-      type: string
     - name: IMAGE_DIGEST
       description: Image digest.
       type: string

--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -9,36 +9,29 @@ spec:
     - name: input-dir
       description: Directory to read cluster-ready operator manifests from
       default: deploy
-      type: string
     - name: channels
       description: Comma-separated list of channels the bundle belongs to
       default: alpha
-      type: string
     - name: kustomize-dir
       description: >
         Directory containing kustomize bases in a "bases" dir and a
         kustomization.yaml for operator-framework manifests
       default: ""
-      type: string
     - name: extra-service-accounts
       description: >
         Comma-seperated list of service account names, outside of the
         operator's Deployment account, that have bindings to {Cluster}Roles
         that should be added to the CSV
       default: ""
-      type: string
     - name: version
       description: Semantic version of the operator in the generated bundle
-      type: string
     - name: package-name
       description: Bundle's package name
-      type: string
     - name: additional-labels-file
       description: >
         A plain text file containing additional labels to append to the
         generated Dockerfile
       default: ""
-      type: string
   workspaces:
     - name: source
       description: Workspace with the source code

--- a/task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
+++ b/task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
@@ -8,7 +8,6 @@ spec:
   params:
     - name: bundle-image
       description: OLM bundle image to query
-      type: string
   results:
     - name: bundle-version
       description: olm.package version

--- a/task/opm-render-bundles/0.1/opm-render-bundles.yaml
+++ b/task/opm-render-bundles/0.1/opm-render-bundles.yaml
@@ -9,20 +9,15 @@ spec:
     - name: binary-image
       description: Base image in which to use for the catalog image
       default: registry.redhat.io/openshift4/ose-operator-registry:latest
-      type: string
     - name: bundle-images
       description: Comma separated list of bundles to add
-      type: string
     - name: operator-name
       description: Name of the Operator
-      type: string
     - name: operator-version
       description: Version of the Operator
-      type: string
     - name: default-channel
       description: The channel that subscriptions will default to if unspecified
       default: stable
-      type: string
   workspaces:
     - name: source
       description: Workspace with the source code

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -50,20 +50,16 @@ spec:
       description: |
         Pass configuration to cachi2.
         Note this needs to be passed as a YAML-formatted config dump, not as a file path!
-      type: string
       default: ""
     - name: dev-package-managers
       description: |
         Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk.
-      type: string
       default: "false"
     - name: input
       description: Configures project packages that will have their dependencies
         prefetched.
-      type: string
     - name: log-level
       description: Set cachi2 log level (debug, info, warning, error)
-      type: string
       default: info
     - name: ociArtifactExpiresAfter
       description: Expiration date for the trusted artifacts created in the

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -32,23 +32,19 @@ spec:
   params:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
-    type: string
   - description: >
       Enable in-development package managers. WARNING: the behavior may change at any time without
       notice. Use at your own risk.
     name: dev-package-managers
     default: "false"
-    type: string
   - description: Set cachi2 log level (debug, info, warning, error)
     name: log-level
     default: "info"
-    type: string
   - description: |
       Pass configuration to cachi2.
       Note this needs to be passed as a YAML-formatted config dump, not as a file path!
     name: config-file-content
     default: ""
-    type: string
   - name: caTrustConfigMapName
     type: string
     description: The name of the ConfigMap to read CA bundle data from.

--- a/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
@@ -24,7 +24,6 @@ spec:
       default: --all-projects --exclude=test*,vendor,deps
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
-      type: string
       default: snyk-secret
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with

--- a/task/sast-snyk-check-oci-ta/0.2/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.2/sast-snyk-check-oci-ta.yaml
@@ -29,7 +29,6 @@ spec:
       default: ""
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
-      type: string
       default: snyk-secret
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with

--- a/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml
@@ -48,7 +48,6 @@ spec:
       default: "false"
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
-      type: string
       default: snyk-secret
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -17,7 +17,6 @@ spec:
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
       default: snyk-secret
-      type: string
     - name: ARGS
       type: string
       description: Append arguments.

--- a/task/sast-snyk-check/0.2/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.2/sast-snyk-check.yaml
@@ -17,7 +17,6 @@ spec:
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
       default: snyk-secret
-      type: string
     - name: ARGS
       type: string
       description: Append arguments.

--- a/task/sast-snyk-check/0.3/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.3/sast-snyk-check.yaml
@@ -23,7 +23,6 @@ spec:
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
       default: snyk-secret
-      type: string
     - name: ARGS
       type: string
       description: Append arguments.

--- a/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+++ b/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
@@ -13,16 +13,13 @@ spec:
   params:
     - name: message
       description: Message to be sent
-      type: string
     - name: secret-name
       description: |
         Secret with at least one key where value is webhook URL for slack.
         eg. oc create secret generic my-secret --from-literal team1=https://hooks.slack.com/services/XXX/XXXXXX --from-literal team2=https://hooks.slack.com/services/YYY/YYYYYY
       default: slack-webhook-notification-secret
-      type: string
     - name: key-name
       description: Key in the key in secret which contains webhook URL for slack.
-      type: string
     - name: submodules
       type: array
       description: List of submodules name to dump. Git log since previous submodule commit will be added to the message. The previous submodule commit is found by looking at the previous commit in the repository that declares the submodules.

--- a/task/summary/0.1/summary.yaml
+++ b/task/summary/0.1/summary.yaml
@@ -13,18 +13,14 @@ spec:
   params:
     - name: pipelinerun-name
       description: pipeline-run to annotate
-      type: string
     - name: git-url
       description: Git URL
-      type: string
     - name: image-url
       description: Image URL
-      type: string
     - name: build-task-status
       description: State of build task in pipelineRun
       # Default Succeeded for backward compatibility
       default: Succeeded
-      type: string
   steps:
     - name: appstudio-summary
       image: registry.access.redhat.com/ubi9/ubi-minimal:9.4-1227.1726694542@sha256:f5d2c6a1e0c86e4234ea601552dbabb4ced0e013a1efcbfb439f1f6a7a9275b0

--- a/task/summary/0.2/summary.yaml
+++ b/task/summary/0.2/summary.yaml
@@ -13,18 +13,14 @@ spec:
   params:
     - name: pipelinerun-name
       description: pipeline-run to annotate
-      type: string
     - name: git-url
       description: Git URL
-      type: string
     - name: image-url
       description: Image URL
-      type: string
     - name: build-task-status
       description: State of build task in pipelineRun
       # Default Succeeded for backward compatibility
       default: Succeeded
-      type: string
   workspaces:
     - name: workspace
       description: The workspace where source code is included.

--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -13,37 +13,28 @@ spec:
   params:
     - name: SCRIPT
       description: Bash script for changing the infra-deployments
-      type: string
     - name: ORIGIN_REPO
       description: URL of github repository which was built by the Pipeline
-      type: string
     - name: REVISION
       description: Git reference which was built by the Pipeline
-      type: string
     - name: TARGET_GH_REPO
       description: GitHub repository of the infra-deployments code
       default: redhat-appstudio/infra-deployments
-      type: string
     - name: GIT_IMAGE
       description: Deprecated. Has no effect. Will be removed in the future.
       default: ""
-      type: string
     - name: SCRIPT_IMAGE
       description: Deprecated. Has no effect. Will be removed in the future.
       default: ""
-      type: string
     - name: shared-secret
       default: infra-deployments-pr-creator
       description: secret in the namespace which contains private key for the GitHub App
-      type: string
     - name: GITHUB_APP_ID
       description: ID of Github app used for updating PR
       default: "305606"
-      type: string
     - name: GITHUB_APP_INSTALLATION_ID
       description: Installation ID of Github app in the organization
       default: "35269675"
-      type: string
   volumes:
     - name: infra-deployments-pr-creator
       secret:


### PR DESCRIPTION
This reverts commit b2f800cc603ec0907ad2b3962d46919a535e158e.

The changes that were made here increased the size of the `buildah-remote-oci-ta` task. This seems to have exceeded the size for `tkn bundle` causing errors when Tekton was trying to resolve the task.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
