### PR TITLE
Expose the git repositories cloned to Chains

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -235,6 +235,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### git-clone-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
+|CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-images:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -232,6 +232,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### git-clone-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
+|CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |

--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -120,6 +120,8 @@
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
+|CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -230,6 +230,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
+|CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -172,6 +172,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
+|CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.2:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |

--- a/pipelines/gitops-pull-request-rhtap/README.md
+++ b/pipelines/gitops-pull-request-rhtap/README.md
@@ -95,6 +95,8 @@
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
+|CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -106,6 +106,8 @@
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
+|CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |

--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -28,6 +28,8 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 ## Results
 |name|description|
 |---|---|
+|CHAINS-GIT_COMMIT|The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|CHAINS-GIT_URL|The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
 |commit|The precise commit SHA that was fetched by this Task.|
 |commit-timestamp|The commit timestamp of the checkout|

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -99,6 +99,12 @@ spec:
       type: string
       default: "false"
   results:
+    - name: CHAINS-GIT_COMMIT
+      description: The precise commit SHA that was fetched by this Task. This
+        result uses Chains type hinting to include in the provenance.
+    - name: CHAINS-GIT_URL
+      description: The precise URL that was fetched by this Task. This result
+        uses Chains type hinting to include in the provenance.
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -247,8 +253,10 @@ spec:
           exit "${EXIT_CODE}"
         fi
         printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
+        printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"
         printf "%s" "${RESULT_SHA_SHORT}" >"$(results.short-commit.path)"
         printf "%s" "${PARAM_URL}" >"$(results.url.path)"
+        printf "%s" "${PARAM_URL}" >"$(results.CHAINS-GIT_URL.path)"
         printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
 
         if [ "${PARAM_FETCH_TAGS}" = "true" ]; then

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -10,26 +10,31 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |refspec|Refspec to fetch before checking out revision.|""|false|
 |submodules|Initialize and fetch git submodules.|true|false|
 |depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
+|shortCommitLength|Length of short commit SHA|7|false|
 |sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
-|subdirectory|Subdirectory inside the `output` Workspace to clone the repo into.|""|false|
+|subdirectory|Subdirectory inside the `output` Workspace to clone the repo into.|source|false|
 |sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
 |deleteExisting|Clean out the contents of the destination directory if it already exists before cloning.|true|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
 |noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
-|verbose|Log the commands that are executed during `git-clone`'s operation.|true|false|
+|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
 |gitInitImage|Deprecated. Has no effect. Will be removed in the future.|""|false|
-|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user or have overridden the gitInitImage param with an image containing custom user configuration. |/tekton/home|false|
-|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.|true|false|
+|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
+|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
 |fetchTags|Fetch all tags for the repo.|false|false|
-|shortCommitLength|Length of the returned short-commit|7|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 
 ## Results
 |name|description|
 |---|---|
 |commit|The precise commit SHA that was fetched by this Task.|
-|short-commit|The commit SHA that was fetched by this Task shortened to `shortCommitLength` number of characters||
+|short-commit|The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters|
 |url|The precise URL that was fetched by this Task.|
+|commit-timestamp|The commit timestamp of the checkout|
+|CHAINS-GIT_URL|The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|CHAINS-GIT_COMMIT|The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
 
 ## Workspaces
 |name|description|optional|

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -104,6 +104,10 @@ spec:
     name: url
   - description: The commit timestamp of the checkout
     name: commit-timestamp
+  - description: The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.
+    name: CHAINS-GIT_URL
+  - description: The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.
+    name: CHAINS-GIT_COMMIT
   steps:
   - name: clone
     env:
@@ -245,8 +249,10 @@ spec:
         exit "${EXIT_CODE}"
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+      printf "%s" "${RESULT_SHA}" > "$(results.CHAINS-GIT_COMMIT.path)"
       printf "%s" "${RESULT_SHA_SHORT}" > "$(results.short-commit.path)"
       printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+      printf "%s" "${PARAM_URL}" > "$(results.CHAINS-GIT_URL.path)"
       printf "%s" "$(git log -1 --pretty=%ct)" > "$(results.commit-timestamp.path)"
 
       if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then


### PR DESCRIPTION
Previously, we only exposed the git references cloned using the Pipeline results. If a trusted git clone task was used more than once then the generated attestation wouldn't have the information from both.

By exposing the metadata with the git type hinting on the task, any occurance of these trusted tasks should result in the provenance including the repositories.

https://tekton.dev/docs/chains/slsa-provenance/#git-results

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
