### PR TITLE
Make EC verify task timeout infinite

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -85,6 +85,8 @@ spec:
       value: "$(tasks.verify.results.TEST_OUTPUT)"
   tasks:
     - name: verify
+      # Timeout 0 is unlimited. Here, rely on pipeline timeout to kill this task eventually.
+      timeout: 0
       params:
         - name: POLICY_CONFIGURATION
           value: "$(params.POLICY_CONFIGURATION)"


### PR DESCRIPTION
Before this change, users could use the TIMEOUT param to increase their timeout up from the 5m default, but they would hit a ceiling. If they increased their timeout past 2h, then a tekton default on timeout for the task itself would kick in.

