### PR TITLE
Add retries to registry operations in build-vm-image

### DIFF
--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -200,9 +200,9 @@ spec:
 
         mkdir output
         echo "PULLING BUILDER IMAGE"
-        time sudo podman pull --authfile=$BUILD_DIR/.docker/config.json $BOOTC_BUILDER_IMAGE
+        time sudo podman pull --authfile=$BUILD_DIR/.docker/config.json --retry 10 $BOOTC_BUILDER_IMAGE
         echo "PULLING IMAGE"
-        time sudo podman pull --authfile=$BUILD_DIR/.docker/config.json $SOURCE_IMAGE
+        time sudo podman pull --authfile=$BUILD_DIR/.docker/config.json --retry 10 $SOURCE_IMAGE
         echo "TAGGING IMAGE"
         time sudo podman tag $SOURCE_IMAGE $TAGGED_AS
         echo "RUNNING BUILD"
@@ -266,7 +266,7 @@ spec:
           # already compressed.
           buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
         fi
-        buildah manifest push --digestfile image-digest --authfile /.docker/config.json --all $OUTPUT_IMAGE
+        buildah manifest push --digestfile image-digest --authfile /.docker/config.json --retry 10 --all $OUTPUT_IMAGE
 
         # At this point, we have pushed an image index of length 1 to the registry.
         # Next, extract a reference to the image manifest and expose that, throwing away the image index.


### PR DESCRIPTION
We encountered transient 502 errors from quay today.

Add retries here to avoid task failure when we encounter flakiness.