### PR TITLE
Add new `step_images` rule to policy

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -27,4 +27,5 @@ sources:
         - kind
         - results
         - step_image_registries
+        - step_images
         - trusted_artifacts


### PR DESCRIPTION
The rule checks that Task step image is accessible.

Reference: https://issues.redhat.com/browse/EC-912