### PR TITLE
Make EC strict mode configurable

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -71,6 +71,15 @@ spec:
       type: string
       description: PipelineRun ID
       default: "pr/$(context.pipelineRun.name)"
+    - name: STRICT
+      type: string
+      description: |
+        A boolean flag that determines whether the result of the test will mark the TaskRun as passing or not.
+        Swap to false to make the IntegrationTestScenario informative.
+
+        Setting to false is useful on specific conditions but will always mark the integration test as successful and
+        humans will tend to ignore the test results if they failed. Use with caution.
+      default: "true"
   results:
     - name: TEST_OUTPUT
       value: "$(tasks.verify.results.TEST_OUTPUT)"
@@ -83,12 +92,8 @@ spec:
           value: "$(params.SNAPSHOT)"
         - name: SSL_CERT_DIR
           value: "$(params.SSL_CERT_DIR)"
-        # It's confusing for users to see a passing taskrun that represents a failing EC test.
-        # For that reason let's have the taskrun fail when there are EC violations. Also, if
-        # this is set to false (IIUC), it's not possible to have the IntegrationTest gate the
-        # deploy to the devel environment work, which is what users expect to be able to do.
         - name: STRICT
-          value: "true"
+          value: "$(params.STRICT)"
         - name: PUBLIC_KEY
           value: "$(params.PUBLIC_KEY)"
         - name: IGNORE_REKOR


### PR DESCRIPTION
Allow modifying `STRICT`. This allows to mark an EC as informative and not gate changes on it.

This is useful for us while we iterate to fix all the violations without gating yet the pull requests