### PR TITLE
fix: extract region from aws s3 urls

### DIFF
--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -142,7 +142,13 @@ spec:
             echo "Bucket path is $path"
             date="$(date -u '+%Y%m%dT%H%M%SZ')"
             host=$(echo -n "$url" | awk -F '/' '{print $3}')
-            region=$(echo -n "$host" | awk -F '.' '{print $2}')
+            if [[ "$host" == *.amazonaws.com ]]; then
+              # AWS Style
+              region=$(echo -n "$host" | awk -F '.' '{print $3}')
+            else
+              # IBM Cloud style
+              region=$(echo -n "$host" | awk -F '.' '{print $2}')
+            fi
 
             # This e3b0c44 digest is digest of the empty string. No request body.
             payload_digest=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -128,7 +128,13 @@ spec:
             echo "Bucket path is $path"
             date="$(date -u '+%Y%m%dT%H%M%SZ')"
             host=$(echo -n "$url" | awk -F '/' '{print $3}')
-            region=$(echo -n "$host" | awk -F '.' '{print $2}')
+            if [[ "$host" == *.amazonaws.com ]] ; then
+              # AWS Style
+              region=$(echo -n "$host" | awk -F '.' '{print $3}')
+            else
+              # IBM Cloud style
+              region=$(echo -n "$host" | awk -F '.' '{print $2}')
+            fi
 
             # This e3b0c44 digest is digest of the empty string. No request body.
             payload_digest=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855


### PR DESCRIPTION
It turns out that IBM Cloud and AWS s3 bucket urls are constructed differently, and the region is in a different place in the string.

Add a conditional here to catch AWS-style urls.
