### PR TITLE
fix: delete propagated kubeconfig

### DIFF
--- a/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+++ b/stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
@@ -78,7 +78,6 @@ spec:
     API_SERVER_URL=$("${OC[@]}" get cti "$CLUSTER_NAME" -o=jsonpath='{.status.apiServerURL}')
     echo "API Server URL: $API_SERVER_URL"
     echo -n "$API_SERVER_URL" > "$(step.results.apiServerURL.path)"
-    export KUBECONFIG=$CLUSTER_KUBECONFIG
-    CONSOLE_URL=https://$(oc get route console -n openshift-console -o go-template --template="{{.spec.host}}")
+    CONSOLE_URL=https://$(oc --kubeconfig "$CLUSTER_KUBECONFIG" get route console -n openshift-console -o go-template --template="{{.spec.host}}")
     echo "Console URL: $CONSOLE_URL"
     echo -n "$CONSOLE_URL" > "$(step.results.consoleURL.path)"


### PR DESCRIPTION
when getting ephemeral cluster credentials the kubeconfig file was assigned to the KUBECONFIG env var which is deleted before the script ends.

This change removes that assignment and instead explicitly mentions the kubeconfig path when it's used.
