### PR TITLE
Improve buildah-remote-oci-ta size check

### DIFF
--- a/.github/workflows/temp-block-buildah.yaml
+++ b/.github/workflows/temp-block-buildah.yaml
@@ -10,23 +10,25 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
 
       - name: Check that the size of buildah-remote-oci-ta doesn't increase
-        env:
-          BASE: ${{ github.event.pull_request.base.sha }}
         run: |
           #!/bin/bash
           set -euo pipefail
 
           buildah_remote_oci_ta=task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
-          prev_size=$(git show "$BASE:$buildah_remote_oci_ta" | wc -c)
+          # 34172 is the largest that the file has ever been *and worked*.
+          # 34200 is known to be too large (see b2f800cc603ec0907ad2b3962d46919a535e158e,
+          # which had to be reverted). The actual limit is somewhere in between.
+          safe_size=34172
           current_size=$(wc -c < "$buildah_remote_oci_ta")
 
-          if [[ "$current_size" -gt "$prev_size" ]]; then
+          if [[ "$current_size" -gt "$safe_size" ]]; then
             cat << EOF >&2
-          This PR increases the size of $buildah_remote_oci_ta.
+          This PR increases the size of $buildah_remote_oci_ta beyond the known safe limit.
+
+          safe_size=$safe_size
+          current_size=$current_size
 
           Due to https://github.com/tektoncd/pipeline/issues/8388, this is risky;
           the resulting bundle may not be resolvable by Tekton.


### PR DESCRIPTION
The previous check wouldn't reward us for decreasing the file size - any PR that increased the size compared to the current 'main' would fail the check.

Instead, check the current size against largest known-safe size.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
