### PR TITLE
extend the sast-coverity-check CI task to support buildful scanning

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -69,8 +69,8 @@
 # renovate groupName=integration
 /task/coverity-availability-check           @konflux-ci/integration-service-maintainers @kdudka
 /task/coverity-availability-check-oci-ta    @konflux-ci/integration-service-maintainers @kdudka
-/task/sast-coverity-check                   @konflux-ci/integration-service-maintainers @kdudka
-/task/sast-coverity-check-oci-ta            @konflux-ci/integration-service-maintainers @kdudka
+/task/sast-coverity-check                   @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @kdudka
+/task/sast-coverity-check-oci-ta            @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @kdudka
 /task/sast-shell-check                      @konflux-ci/integration-service-maintainers @kdudka
 /task/sast-shell-check-oci-ta               @konflux-ci/integration-service-maintainers @kdudka
 /task/sast-snyk-check                       @konflux-ci/integration-service-maintainers @kdudka

--- a/hack/generate-sast-tasks.sh
+++ b/hack/generate-sast-tasks.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o errtrace
+set -o nounset
+set -o pipefail
+set -o posix
+
+shopt -s globstar nullglob
+
+HACK_DIR="$(realpath "$(dirname "${BASH_SOURCE[0]}")")"
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+TASK_DIR="$(realpath "${ROOT_DIR}/task")"
+
+# sast-coverity-check of version 0.2 and newer uses kustomize to build the task
+# definition from the buildah task and a locally maintained patch.yaml
+for dir in "${TASK_DIR}/sast-coverity-check"/0.[2-9]; do (
+    cd "$dir" && kustomize build > sast-coverity-check.yaml
+) done

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -91,13 +91,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |docker-auth| unused| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### coverity-availability-check-oci-ta:0.1 task parameters
+### coverity-availability-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 ### deprecated-image-check:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -258,9 +256,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; coverity-availability-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; coverity-availability-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-remote-oci-ta:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -281,7 +279,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### coverity-availability-check-oci-ta:0.1 task results
+### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |STATUS| Tekton task simple status to be later checked| |
@@ -312,8 +310,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; coverity-availability-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; coverity-availability-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -7,18 +7,18 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.3:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.3:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.3:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.3:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.3:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-images:0.3:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-images:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-images:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-images:0.3:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-images:0.3:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-images:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-images:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.3:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-images:0.3:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -172,22 +172,45 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-coverity-check-oci-ta:0.1 task parameters
+### sast-coverity-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
+|ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
+|COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|
+|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
+|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
+|HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
+|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |KFP_GIT_URL| URL from repository to download known false positives files| | |
-|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
-|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|LABELS| Additional key=value labels that should be applied to the image| []| |
+|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
+|PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|PROJECT_NAME| | | |
+|RECORD_EXCLUDED| | false| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
+|SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
+|SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
+|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
+|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
+|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to report findings for.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|image-url| | None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-shell-check-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -256,9 +279,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-remote-oci-ta:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -299,7 +322,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
-|commit| The precise commit SHA that was fetched by this Task.| build-images:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit| The precise commit SHA that was fetched by this Task.| build-images:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
@@ -310,8 +333,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -322,7 +345,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-coverity-check-oci-ta:0.1 task results
+### sast-coverity-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -7,17 +7,17 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.3:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.3:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.3:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.3:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.3:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-container:0.3:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-container:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-container:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.3:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-container:0.3:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-container:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-container:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.3:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.3:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -169,22 +169,45 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-coverity-check-oci-ta:0.1 task parameters
+### sast-coverity-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
+|ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
+|COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|
+|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
+|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
+|HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
+|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |KFP_GIT_URL| URL from repository to download known false positives files| | |
-|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
-|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|LABELS| Additional key=value labels that should be applied to the image| []| |
+|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
+|PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|PROJECT_NAME| | | |
+|RECORD_EXCLUDED| | false| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
+|SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
+|SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
+|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
+|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
+|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to report findings for.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|image-url| | None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-shell-check-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -253,9 +276,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-oci-ta:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -296,7 +319,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
-|commit| The precise commit SHA that was fetched by this Task.| build-container:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit| The precise commit SHA that was fetched by this Task.| build-container:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
@@ -307,8 +330,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -319,7 +342,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-coverity-check-oci-ta:0.1 task results
+### sast-coverity-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -88,13 +88,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |docker-auth| unused| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### coverity-availability-check-oci-ta:0.1 task parameters
+### coverity-availability-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 ### deprecated-image-check:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -255,9 +253,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; coverity-availability-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; coverity-availability-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-oci-ta:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -278,7 +276,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### coverity-availability-check-oci-ta:0.1 task results
+### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |STATUS| Tekton task simple status to be later checked| |
@@ -309,8 +307,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; coverity-availability-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; coverity-availability-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/docker-build-oci-ta/patch.yaml
+++ b/pipelines/docker-build-oci-ta/patch.yaml
@@ -30,8 +30,8 @@
 #   8  ecosystem-cert-preflight-checks
 #   9  sast-snyk-check
 #  10  clamav-scan
-#  11  coverity-availability-check
-#  12  sast-coverity-check
+#  11  sast-coverity-check
+#  12  coverity-availability-check
 #  13  sast-shell-check
 #  14  sast-unicode-check
 #  15  apply-tags
@@ -147,23 +147,6 @@
     value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 - op: remove
   path: /spec/tasks/11/workspaces/0
-
-# coverity-availability-check
-- op: replace
-  path: /spec/tasks/12/taskRef/name
-  value: coverity-availability-check-oci-ta
-- op: add
-  path: /spec/tasks/12/params/-
-  value:
-    name: SOURCE_ARTIFACT
-    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-- op: add
-  path: /spec/tasks/12/params/-
-  value:
-    name: CACHI2_ARTIFACT
-    value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-- op: remove
-  path: /spec/tasks/12/workspaces/0
 
 # sast-shell-check
 - op: replace

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -7,17 +7,17 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.3:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.3:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.3:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.3:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.3:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-container:0.3:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.3:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-container:0.3:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.3:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.3:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -167,17 +167,40 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### sast-coverity-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
+|ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
+|COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|
+|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
-|COV_CAPTURE_ARGS| Arguments to be appended to the coverity capture command| | |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
+|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
+|HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
+|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |KFP_GIT_URL| URL from repository to download known false positives files| | |
-|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
-|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|LABELS| Additional key=value labels that should be applied to the image| []| |
+|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
+|PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|PROJECT_NAME| | | |
+|RECORD_EXCLUDED| | false| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
+|SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
+|SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
+|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
+|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
+|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|image-url| | None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-shell-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -287,7 +310,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
-|commit| The precise commit SHA that was fetched by this Task.| build-container:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|commit| The precise commit SHA that was fetched by this Task.| build-container:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
@@ -359,7 +382,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### sast-coverity-check:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|source| | False| workspace|
+|source| Workspace containing the source code to build.| False| workspace|
 ### sast-shell-check:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -86,7 +86,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |docker-auth| unused| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### coverity-availability-check:0.1 task parameters
+### coverity-availability-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
@@ -245,9 +245,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; coverity-availability-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; coverity-availability-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -268,7 +268,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### coverity-availability-check:0.1 task results
+### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |STATUS| Tekton task simple status to be later checked| |
@@ -334,16 +334,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.3:source ; build-source-image:0.1:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.1:workspace ; coverity-availability-check:0.1:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.3:source ; build-source-image:0.1:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.1:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
 ### buildah:0.3 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |source| Workspace containing the source code to build.| False| workspace|
-### coverity-availability-check:0.1 task workspaces
-|name|description|optional|workspace from pipeline
-|---|---|---|---|
-|workspace| | False| workspace|
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -334,7 +334,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.3:source ; build-source-image:0.1:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.3:source ; build-source-image:0.1:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
 ### buildah:0.3 task workspaces
 |name|description|optional|workspace from pipeline
@@ -359,7 +359,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### sast-coverity-check:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|workspace| | False| workspace|
+|source| | False| workspace|
 ### sast-shell-check:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -164,11 +164,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-coverity-check:0.1 task parameters
+### sast-coverity-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
 |COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
+|COV_CAPTURE_ARGS| Arguments to be appended to the coverity capture command| | |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |KFP_GIT_URL| URL from repository to download known false positives files| | |
@@ -176,7 +177,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to report findings for.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-shell-check:0.1 task parameters
 |name|description|default value|already set by|
@@ -245,9 +245,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -305,7 +305,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-coverity-check:0.1 task results
+### sast-coverity-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
@@ -334,7 +334,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.3:source ; build-source-image:0.1:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.1:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.3:source ; build-source-image:0.1:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
 ### buildah:0.3 task workspaces
 |name|description|optional|workspace from pipeline
@@ -356,7 +356,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
-### sast-coverity-check:0.1 task workspaces
+### sast-coverity-check:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -77,3 +77,51 @@
       - $(params.build-args[*])
   - name: BUILD_ARGS_FILE
     value: "$(params.build-args-file)"
+
+# FIXME: duplicate the "add" operations for sast-coverity-check, which is based on build-container
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: IMAGE
+    value: $(params.output-image)
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: DOCKERFILE
+    value: $(params.dockerfile)
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: CONTEXT
+    value: $(params.path-context)
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: HERMETIC
+    value: "$(params.hermetic)"
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: PREFETCH_INPUT
+    value: "$(params.prefetch-input)"
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: IMAGE_EXPIRES_AFTER
+    value: "$(params.image-expires-after)"
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: COMMIT_SHA
+    value: "$(tasks.clone-repository.results.commit)"
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: BUILD_ARGS
+    value:
+      - $(params.build-args[*])
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: BUILD_ARGS_FILE
+    value: "$(params.build-args-file)"

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -36,6 +36,9 @@
 #     17  rpms-signature-scan
 
 # build-container
+- op: test
+  path: /spec/tasks/3/name
+  value: build-container
 - op: replace
   path: /spec/tasks/3/taskRef
   value:
@@ -79,6 +82,9 @@
     value: "$(params.build-args-file)"
 
 # FIXME: duplicate the "add" operations for sast-coverity-check, which is based on build-container
+- op: test
+  path: /spec/tasks/11/name
+  value: sast-coverity-check
 - op: add
   path: /spec/tasks/11/params/-
   value:

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -26,13 +26,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PREFETCH_ROOT| The root directory of the artifacts under the prefetched directory. Will be kept in the maven zip as the top directory for all artifacts.| maven-repository| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-### coverity-availability-check-oci-ta:0.1 task parameters
+### coverity-availability-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 ### git-clone-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -151,11 +149,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### build-maven-zip-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-coverity-check:0.1:image-digest ; coverity-availability-check:0.1:image-digest ; sast-shell-check:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest|
 |IMAGE_REF| OCI-Artifact reference of the built OCI-Artifact| |
-|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.1:image-url ; coverity-availability-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
+|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### coverity-availability-check-oci-ta:0.1 task results
+### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |STATUS| Tekton task simple status to be later checked| |
@@ -177,8 +175,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-oci-artifact:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; coverity-availability-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; coverity-availability-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-oci-artifact:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT|
 ### sast-coverity-check-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -73,22 +73,45 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
-### sast-coverity-check-oci-ta:0.1 task parameters
+### sast-coverity-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
+|ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | |
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
+|COMMIT_SHA| The image is built from this commit.| | |
+|CONTEXT| Path to the directory to use as context.| .| |
 |COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| |
+|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
+|HERMETIC| Determines if build will be executed without network access.| false| |
+|IMAGE| Reference of the image buildah will produce.| None| |
+|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |KFP_GIT_URL| URL from repository to download known false positives files| | |
-|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
-|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|LABELS| Additional key=value labels that should be applied to the image| []| |
+|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | |
+|PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|PROJECT_NAME| | | |
+|RECORD_EXCLUDED| | false| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
+|SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
+|SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
+|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
+|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
+|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to report findings for.| None| '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
-|image-url| Image URL.| None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
+|image-url| | None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
 ### sast-shell-check-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -149,9 +172,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### build-maven-zip-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-shell-check:0.1:image-digest|
 |IMAGE_REF| OCI-Artifact reference of the built OCI-Artifact| |
-|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
+|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -175,9 +198,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-oci-artifact:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.1:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT|
-### sast-coverity-check-oci-ta:0.1 task results
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-oci-artifact:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT|
+### sast-coverity-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/maven-zip-build-oci-ta/patch.yaml
+++ b/pipelines/maven-zip-build-oci-ta/patch.yaml
@@ -90,21 +90,6 @@
 - op: remove
   path: /spec/tasks/4/workspaces/0
 
-# coverity-availability-check
-- op: replace
-  path: /spec/tasks/6/taskRef/name
-  value: coverity-availability-check-oci-ta
-- op: add
-  path: /spec/tasks/6/params/-
-  value:
-    name: SOURCE_ARTIFACT
-    value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-- op: add
-  path: /spec/tasks/6/params/-
-  value:
-    name: CACHI2_ARTIFACT
-    value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-
 # sast-coverity-check
 - op: replace
   path: /spec/tasks/5/taskRef/name
@@ -121,8 +106,6 @@
     value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 - op: remove
   path: /spec/tasks/5/workspaces/0
-- op: remove
-  path: /spec/tasks/6/workspaces/0
 
 # sast-shell-check
 - op: replace

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -70,20 +70,43 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
-### sast-coverity-check:0.1 task parameters
+### sast-coverity-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
+|ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | |
+|COMMIT_SHA| The image is built from this commit.| | |
+|CONTEXT| Path to the directory to use as context.| .| |
 |COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| |
+|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
+|HERMETIC| Determines if build will be executed without network access.| false| |
+|IMAGE| Reference of the image buildah will produce.| None| |
+|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |KFP_GIT_URL| URL from repository to download known false positives files| | |
-|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
-|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|LABELS| Additional key=value labels that should be applied to the image| []| |
+|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | |
+|PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|PROJECT_NAME| | | |
+|RECORD_EXCLUDED| | false| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
+|SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
+|SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
+|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
+|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
+|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to report findings for.| None| '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
-|image-url| Image URL.| None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
+|image-url| | None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
 ### sast-shell-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -145,9 +168,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### build-maven-zip:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-shell-check:0.1:image-digest|
 |IMAGE_REF| OCI-Artifact reference of the built OCI-Artifact| |
-|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
+|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -167,7 +190,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### sast-coverity-check:0.1 task results
+### sast-coverity-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
@@ -189,7 +212,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.1:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
 ## Available workspaces from tasks
 ### build-maven-zip:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -207,10 +230,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
 |source| Workspace with the source code, cachi2 artifacts will be stored on the workspace as well| False| workspace|
-### sast-coverity-check:0.1 task workspaces
+### sast-coverity-check:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|workspace| | False| workspace|
+|source| Workspace containing the source code to build.| False| workspace|
 ### sast-shell-check:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -25,7 +25,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PREFETCH_ROOT| The root directory of the artifacts under the prefetched directory. Will be kept in the maven zip as the top directory for all artifacts.| maven-repository| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-### coverity-availability-check:0.1 task parameters
+### coverity-availability-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
@@ -145,11 +145,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### build-maven-zip:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-coverity-check:0.1:image-digest ; coverity-availability-check:0.1:image-digest ; sast-shell-check:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-coverity-check:0.1:image-digest ; sast-shell-check:0.1:image-digest|
 |IMAGE_REF| OCI-Artifact reference of the built OCI-Artifact| |
-|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.1:image-url ; coverity-availability-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
+|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.1:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### coverity-availability-check:0.1 task results
+### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |STATUS| Tekton task simple status to be later checked| |
@@ -189,16 +189,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.1:workspace ; coverity-availability-check:0.1:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.1:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
 ## Available workspaces from tasks
 ### build-maven-zip:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |source| Workspace containing the source code to build.| False| workspace|
-### coverity-availability-check:0.1 task workspaces
-|name|description|optional|workspace from pipeline
-|---|---|---|---|
-|workspace| | False| workspace|
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/maven-zip-build/patch.yaml
+++ b/pipelines/maven-zip-build/patch.yaml
@@ -120,9 +120,6 @@
 # Replace the params set and runAfter of sast-coverity-check
 - op: replace
   path: /spec/tasks/5/params/0/value
-  value: "$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
-- op: replace
-  path: /spec/tasks/5/params/1/value
   value: "$(tasks.build-oci-artifact.results.IMAGE_URL)"
 # Replace the params set and runAfter of coverity-availability-check
 - op: replace

--- a/pipelines/maven-zip-build/patch.yaml
+++ b/pipelines/maven-zip-build/patch.yaml
@@ -126,12 +126,6 @@
   value: "$(tasks.build-oci-artifact.results.IMAGE_URL)"
 # Replace the params set and runAfter of coverity-availability-check
 - op: replace
-  path: /spec/tasks/6/params/0/value
-  value: "$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
-- op: replace
-  path: /spec/tasks/6/params/1/value
-  value: "$(tasks.build-oci-artifact.results.IMAGE_URL)"
-- op: replace
   path: /spec/tasks/6/runAfter
   value:
   - build-oci-artifact

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -91,20 +91,43 @@
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-coverity-check:0.1 task parameters
+### sast-coverity-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
+|ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
+|ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | |
+|COMMIT_SHA| The image is built from this commit.| | |
+|CONTEXT| Path to the directory to use as context.| .| |
 |COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| |
+|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
+|HERMETIC| Determines if build will be executed without network access.| false| |
+|IMAGE| Reference of the image buildah will produce.| None| |
+|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |KFP_GIT_URL| URL from repository to download known false positives files| | |
-|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
-|RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
+|LABELS| Additional key=value labels that should be applied to the image| []| |
+|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | |
+|PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
+|PROJECT_NAME| | | |
+|RECORD_EXCLUDED| | false| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
+|SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
+|SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
+|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
+|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
+|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to report findings for.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|image-url| | None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-unicode-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -143,9 +166,9 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| sast-coverity-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| sast-coverity-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| sast-coverity-check:0.2:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -170,7 +193,7 @@
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-coverity-check:0.1 task results
+### sast-coverity-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
@@ -190,7 +213,7 @@
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.1:source ; sast-coverity-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.1:source ; sast-coverity-check:0.2:source ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -208,10 +231,10 @@
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
-### sast-coverity-check:0.1 task workspaces
+### sast-coverity-check:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|workspace| | False| workspace|
+|source| Workspace containing the source code to build.| False| workspace|
 ### sast-unicode-check:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -250,10 +250,8 @@ spec:
         - coverity-availability-check
       taskRef:
         name: sast-coverity-check
-        version: "0.1"
+        version: "0.2"
       params:
-        - name: image-digest
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
       workspaces:

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -255,7 +255,7 @@ spec:
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
       workspaces:
-        - name: workspace
+        - name: source
           workspace: workspace
     - name: coverity-availability-check
       when:

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -268,15 +268,7 @@ spec:
         - build-image-index
       taskRef:
         name: coverity-availability-check
-        version: "0.1"
-      params:
-        - name: image-digest
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-        - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-      workspaces:
-        - name: workspace
-          workspace: workspace
+        version: "0.2"
     - name: sast-shell-check
       when:
         - input: $(params.skip-checks)

--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -293,14 +293,14 @@ spec:
           echo "Fetch Dockerfile from $DOCKERFILE"
           dockerfile_path=$(mktemp --suffix=-Dockerfile)
           http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-          if [ $http_code != 200 ]; then
+          if [ "$http_code" != 200 ]; then
             echo "No Dockerfile is fetched. Server responds $http_code"
             exit 1
           fi
           http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-          if [ $http_code = 200 ]; then
+          if [ "$http_code" = 200 ]; then
             echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-            mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+            mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
           fi
         else
           echo "Cannot find Dockerfile $DOCKERFILE"
@@ -376,7 +376,7 @@ spec:
           UNSHARE_ARGS+=("--net")
 
           for image in $BASE_IMAGES; do
-            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
           done
           echo "Build will be executed with network isolation"
         fi
@@ -429,14 +429,14 @@ spec:
 
         # if yum repofiles stored in git, copy them to mount point outside the source dir
         if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-          mkdir -p ${YUM_REPOS_D_FETCHED}
-          cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+          mkdir -p "${YUM_REPOS_D_FETCHED}"
+          cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
         fi
 
         # if anything in the repofiles mount point (either fetched or from git), mount it
         if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-          chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
-          mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+          chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+          mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
           VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
         fi
 
@@ -544,7 +544,7 @@ spec:
           cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
         fi
 
-        buildah mount $container | tee /shared/container_path
+        buildah mount "$container" | tee /shared/container_path
         # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
         find $(cat /shared/container_path) -xtype l -delete
         echo $container >/shared/container_name

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -327,14 +327,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ $http_code != 200 ]; then
+        if [ "$http_code" != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ $http_code = 200 ]; then
+        if [ "$http_code" = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -410,7 +410,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -463,14 +463,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p ${YUM_REPOS_D_FETCHED}
-        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+        mkdir -p "${YUM_REPOS_D_FETCHED}"
+        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
-        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -578,7 +578,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount $container | tee /shared/container_path
+      buildah mount "$container" | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container >/shared/container_name

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -309,14 +309,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ $http_code != 200 ]; then
+        if [ "$http_code" != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ $http_code = 200 ]; then
+        if [ "$http_code" = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -386,7 +386,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -439,14 +439,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p ${YUM_REPOS_D_FETCHED}
-        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+        mkdir -p "${YUM_REPOS_D_FETCHED}"
+        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
-        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -554,7 +554,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount $container | tee /shared/container_path
+      buildah mount "$container" | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -230,14 +230,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ $http_code != 200 ]; then
+        if [ "$http_code" != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ $http_code = 200 ]; then
+        if [ "$http_code" = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -307,7 +307,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -360,14 +360,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p ${YUM_REPOS_D_FETCHED}
-        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+        mkdir -p "${YUM_REPOS_D_FETCHED}"
+        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
-        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -475,7 +475,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount $container | tee /shared/container_path
+      buildah mount "$container" | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name

--- a/task/coverity-availability-check-oci-ta/0.2/MIGRATION.md
+++ b/task/coverity-availability-check-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,3 @@
+# Migration from 0.1 to 0.2
+
+Starting with version 0.2, the `coverity-availability-check-oci-ta` task is deprecated.  Please use `coverity-availability-check` instead.

--- a/task/coverity-availability-check-oci-ta/0.2/README.md
+++ b/task/coverity-availability-check-oci-ta/0.2/README.md
@@ -1,0 +1,3 @@
+# coverity-availability-check-oci-ta task
+
+The `coverity-availability-check-oci-ta` task is deprecated.  Please use `coverity-availability-check` instead.

--- a/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
+++ b/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
@@ -1,0 +1,1 @@
+../../coverity-availability-check/0.2/coverity-availability-check.yaml

--- a/task/coverity-availability-check/0.2/MIGRATION.md
+++ b/task/coverity-availability-check/0.2/MIGRATION.md
@@ -1,0 +1,45 @@
+# Migration from 0.1 to 0.2
+
+The workspace and parameters are no longer needed for this task.  They were in fact not needed in the 0.1 version already.
+
+## Action from users
+
+No action is needed.  Passing of the unused workspace (and parameters) for this task can optionally be removed like this:
+```diff
+--- a/.tekton/konflux-test-operator-pipelines-pull-request.yaml
++++ b/.tekton/konflux-test-operator-pipelines-pull-request.yaml
+@@ -448,32 +448,24 @@ spec:
+       workspaces:
+       - name: workspace
+         workspace: workspace
+     - name: coverity-availability-check
+-      params:
+-      - name: image-digest
+-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+-      - name: image-url
+-        value: $(tasks.build-image-index.results.IMAGE_URL)
+       runAfter:
+       - build-image-index
+       taskRef:
+         params:
+         - name: name
+           value: coverity-availability-check
+         - name: bundle
+-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.1
++          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2
+         - name: kind
+           value: task
+         resolver: bundles
+       when:
+       - input: $(params.skip-checks)
+         operator: in
+         values:
+         - "false"
+-      workspaces:
+-      - name: workspace
+-        workspace: workspace
+     - name: sast-shell-check
+       params:
+       - name: image-digest
+         value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+```

--- a/task/coverity-availability-check/0.2/README.md
+++ b/task/coverity-availability-check/0.2/README.md
@@ -1,0 +1,26 @@
+# coverity-availability-check task
+
+## Description:
+
+This task performs needed checks in order to use Coverity image in the pipeline. It will check for a Coverity license secret and an authentication secret for pulling the image.
+
+The characteristics of these tasks are:
+
+- It will check for a secret called "auth-token-coverity-image" where the authentication token for pulling Coverity image is pulled.
+- It will check for a secret called "cov-license" where the Coverity license is stored.
+
+> NOTE: If any of these tasks fails, the sast-coverity-task check won't be executed. The Coverity license can be used by Red Hat employees only and it needs to be protected such that external users cannot access the license.
+
+## Params:
+
+| name                        | description                                                                            | default value              | required |
+|-----------------------------|----------------------------------------------------------------------------------------|----------------------------|----------|
+| AUTH_TOKEN_COVERITY_IMAGE   | Name of secret which contains the authentication token for pulling the Coverity image  | auth-token-coverity-image  | yes      | 
+| COV_LICENSE                 | Name of secret which contains the Coverity license                                     | cov-license                | yes      |                                                                    
+
+## Results:
+
+| name        | description                                                                       |
+|-------------|-----------------------------------------------------------------------------------|
+| STATUS      | Tekton task simple status to be later checked by the sast-coverity-check task     |
+| TEST_OUTPUT | Tekton task test output.                                                          |

--- a/task/coverity-availability-check/0.2/coverity-availability-check.yaml
+++ b/task/coverity-availability-check/0.2/coverity-availability-check.yaml
@@ -1,0 +1,88 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: coverity-availability-check
+spec:
+  description: >-
+    This task performs needed checks in order to use Coverity image in the pipeline. It will check for a Coverity license secret and an authentication secret for pulling the image.
+  results:
+    - description: Tekton task result output.
+      name: TEST_OUTPUT
+    - description: Tekton task simple status to be later checked
+      name: STATUS
+  params:
+    - name: COV_LICENSE
+      description: Name of secret which contains the Coverity license
+      default: cov-license
+    - name: AUTH_TOKEN_COVERITY_IMAGE
+      description: Name of secret which contains the authentication token for pulling the Coverity image.
+      default: "auth-token-coverity-image"
+  volumes:
+    - name: cov-license
+      secret:
+        secretName: $(params.COV_LICENSE)
+        optional: true
+    - name: auth-token-coverity-image
+      secret:
+        secretName: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+        optional: true
+  steps:
+    - name: coverity-availability-check
+      image: quay.io/konflux-ci/konflux-test:v1.4.8@sha256:2224fabdb0a28a415d4af4c58ae53d7c4c53c83c315f12e07d1d7f48a80bfa70
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      volumeMounts:
+        - name: cov-license
+          mountPath: "/etc/secrets/cov"
+          readOnly: true
+        - name: auth-token-coverity-image
+          mountPath: "/etc/secrets/auth/config.json"
+          subPath: .dockerconfigjson
+      env:
+        - name: COV_LICENSE
+          value: $(params.COV_LICENSE)
+        - name: AUTH_TOKEN_COVERITY_IMAGE
+          value: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        # Checking Coverity license
+        COV_LICENSE_PATH=/etc/secrets/cov/cov-license
+        if [ -f "${COV_LICENSE_PATH}" ] && [ -s "${COV_LICENSE_PATH}" ]; then
+          echo "Coverity license detected!"
+        else
+          echo 'No license file for Coverity was detected. Coverity scan will not be executed...'
+          echo 'Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license'
+          note="Task $(context.task.name) failed: No license file for Coverity was detected. Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license"
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo -n "failed" | tee "$(results.STATUS.path)"
+          exit 0
+        fi
+
+        # Checking authentication token for downloading coverity image
+        AUTH_TOKEN_COVERITY_IMAGE_PATH=/etc/secrets/auth/config.json
+        if [ -f "${AUTH_TOKEN_COVERITY_IMAGE_PATH}" ] && [ -s "${AUTH_TOKEN_COVERITY_IMAGE_PATH}" ]; then
+          echo "Authentication token detected!"
+        else
+          echo 'No authentication token for downloading Coverity image detected. Coverity scan will not be executed...'
+          echo 'Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image'
+          note="Task $(context.task.name) failed: No authentication token for downloading Coverity image detected. Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image"
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo -n "failed" | tee "$(results.STATUS.path)"
+          exit 0
+        fi
+
+        note="Task $(context.task.name) completed: Coverity availability checks finished succesfully."
+        # shellcheck disable=SC2034
+        TEST_OUTPUT=$(make_result_json -r SUCCESS -s 1 -t "$note")
+        echo -n "success" | tee "$(results.STATUS.path)"
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"

--- a/task/sast-coverity-check-oci-ta/0.2/MIGRATION.md
+++ b/task/sast-coverity-check-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,70 @@
+# Migration from 0.1 to 0.2
+
+- The workspace has been renamed to `source` to make the interface compatible
+  with the `build-container` task.
+
+- The unused `IMAGE_DIGEST` parameter has been removed.
+
+- The `sast-coverity-check` task now supports buildful SAST scanning, too.
+
+## Action from users
+
+- The workspace for this task in the build pipeline should be renamed to `source`.
+- All parameters that are set for the `build-container` task now need to be set for `sast-coverity-check-oci-ta`, too.
+- The `IMAGE_DIGEST` parameter definition can optionally be removed for this task in the build pipeline.
+
+### Example
+```diff
+--- a/.tekton/konflux-test-ec-cli-pull-request.yaml
++++ b/.tekton/konflux-test-ec-cli-pull-request.yaml
+@@ -260,28 +260,45 @@ spec:
+       - input: $(tasks.init.results.build)
+         operator: in
+         values:
+         - "true"
+     - name: sast-coverity-check-oci-ta
+       params:
+-      - name: image-digest
+-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+       - name: image-url
+         value: $(tasks.build-image-index.results.IMAGE_URL)
++      - name: IMAGE
++        value: $(params.output-image)
++      - name: DOCKERFILE
++        value: $(params.dockerfile)
++      - name: CONTEXT
++        value: $(params.path-context)
++      - name: HERMETIC
++        value: $(params.hermetic)
++      - name: PREFETCH_INPUT
++        value: $(params.prefetch-input)
++      - name: IMAGE_EXPIRES_AFTER
++        value: $(params.image-expires-after)
++      - name: COMMIT_SHA
++        value: $(tasks.clone-repository.results.commit)
++      - name: BUILD_ARGS
++        value:
++        - $(params.build-args[*])
++      - name: BUILD_ARGS_FILE
++        value: $(params.build-args-file)
+       - name: SOURCE_ARTIFACT
+         value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+       - name: CACHI2_ARTIFACT
+         value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+       runAfter:
+         - coverity-availability-check
+       taskRef:
+         params:
+         - name: name
+           value: sast-coverity-check-oci-ta
+         - name: bundle
+-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.1
++          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.2
+         - name: kind
+           value: task
+         resolver: bundles
+       when:
+         - input: $(params.skip-checks)
+           operator: in
+
+```

--- a/task/sast-coverity-check-oci-ta/0.2/README.md
+++ b/task/sast-coverity-check-oci-ta/0.2/README.md
@@ -1,0 +1,49 @@
+# sast-coverity-check-oci-ta task
+
+Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Coverity.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
+|ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|COV_ANALYZE_ARGS|Arguments to be appended to the cov-analyze command|--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096|false|
+|COV_LICENSE|Name of secret which contains the Coverity license|cov-license|false|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+|IMAGE|Reference of the image buildah will produce.||true|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|IMP_FINDINGS_ONLY|Report only important findings. Default is true. To report all findings, specify "false"|true|false|
+|KFP_GIT_URL|URL from repository to download known false positives files|""|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
+|PROJECT_NAME||""|false|
+|RECORD_EXCLUDED||false|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|image-url|||true|
+
+## Results
+|name|description|
+|---|---|
+|TEST_OUTPUT|Tekton task test output.|
+

--- a/task/sast-coverity-check-oci-ta/0.2/recipe.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,13 @@
+---
+base: ../../sast-coverity-check/0.2/sast-coverity-check.yaml
+removeParams:
+  - BUILDER_IMAGE
+add:
+  - use-source
+  - use-cachi2
+removeWorkspaces:
+  - source
+replacements:
+  workspaces.source.path: /var/workdir
+regexReplacements:
+  "/workspace(/.*)": /var/workdir$1

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -268,7 +268,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: prepare
-      image: quay.io/redhat-services-prod/sast/coverity:202409.1
+      image: quay.io/redhat-services-prod/sast/coverity:202412.1
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /etc/secrets/cov
@@ -323,6 +323,11 @@ spec:
         # if current directory is "/", fallback to an empty temp directory
         [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
 
+        # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
+        if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
+          install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
+        fi
+
         # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
         /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
           -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
@@ -359,7 +364,7 @@ spec:
         # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
         cstrans-df-run --verbose /shared/cmd-wrap.sh <"$dockerfile_path" >/shared/Containerfile
     - name: build
-      image: quay.io/redhat-services-prod/sast/coverity:202409.1
+      image: quay.io/redhat-services-prod/sast/coverity:202412.1
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -688,7 +693,7 @@ spec:
           add:
             - SETFCAP
     - name: postprocess
-      image: quay.io/redhat-services-prod/sast/coverity:202409.1
+      image: quay.io/redhat-services-prod/sast/coverity:202412.1
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -1,0 +1,848 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sast-coverity-check-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: 0.2.1
+    build.appstudio.redhat.com/build_type: docker
+spec:
+  description: Scans source code for security vulnerabilities, including common
+    issues such as SQL injection, cross-site scripting (XSS), and code injection
+    attacks using Coverity.
+  params:
+    - name: ACTIVATION_KEY
+      description: Name of secret which contains subscription activation key
+      type: string
+      default: activation-key
+    - name: ADDITIONAL_SECRET
+      description: Name of a secret which will be made available to the build
+        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
+      type: string
+      default: does-not-exist
+    - name: ADD_CAPABILITIES
+      description: Comma separated list of extra capabilities to add when
+        running 'buildah build'
+      type: string
+      default: ""
+    - name: BUILD_ARGS
+      description: Array of --build-arg values ("arg=value" strings)
+      type: array
+      default: []
+    - name: BUILD_ARGS_FILE
+      description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      type: string
+      default: ""
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: COMMIT_SHA
+      description: The image is built from this commit.
+      type: string
+      default: ""
+    - name: CONTEXT
+      description: Path to the directory to use as context.
+      type: string
+      default: .
+    - name: COV_ANALYZE_ARGS
+      description: Arguments to be appended to the cov-analyze command
+      type: string
+      default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
+    - name: COV_LICENSE
+      description: Name of secret which contains the Coverity license
+      type: string
+      default: cov-license
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      type: string
+      default: ./Dockerfile
+    - name: ENTITLEMENT_SECRET
+      description: Name of secret which contains the entitlement certificates
+      type: string
+      default: etc-pki-entitlement
+    - name: HERMETIC
+      description: Determines if build will be executed without network access.
+      type: string
+      default: "false"
+    - name: IMAGE
+      description: Reference of the image buildah will produce.
+      type: string
+    - name: IMAGE_EXPIRES_AFTER
+      description: Delete image tag after specified time. Empty means to keep
+        the image tag. Time values could be something like 1h, 2d, 3w for
+        hours, days, and weeks, respectively.
+      type: string
+      default: ""
+    - name: IMP_FINDINGS_ONLY
+      description: Report only important findings. Default is true. To report
+        all findings, specify "false"
+      type: string
+      default: "true"
+    - name: KFP_GIT_URL
+      description: URL from repository to download known false positives files
+      type: string
+      default: ""
+    - name: LABELS
+      description: Additional key=value labels that should be applied to the
+        image
+      type: array
+      default: []
+    - name: PREFETCH_INPUT
+      description: In case it is not empty, the prefetched content should
+        be made available to the build.
+      type: string
+      default: ""
+    - name: PRIVILEGED_NESTED
+      description: Whether to enable privileged mode
+      type: string
+      default: "false"
+    - name: PROJECT_NAME
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      type: string
+      default: "false"
+    - name: SBOM_TYPE
+      description: 'Select the SBOM format to generate. Valid values: spdx,
+        cyclonedx. Note: the SBOM from the prefetch task - if there is one
+        - must be in the same format.'
+      type: string
+      default: cyclonedx
+    - name: SKIP_SBOM_GENERATION
+      description: Skip SBOM-related operations. This will likely cause EC
+        policies to fail if enabled
+      type: string
+      default: "false"
+    - name: SKIP_UNUSED_STAGES
+      description: Whether to skip stages in Containerfile that seem unused
+        by subsequent stages
+      type: string
+      default: "true"
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: SQUASH
+      description: Squash all new and previous layers added as a part of this
+        build, as per --squash
+      type: string
+      default: "false"
+    - name: STORAGE_DRIVER
+      description: Storage driver to configure for buildah
+      type: string
+      default: vfs
+    - name: TARGET_STAGE
+      description: Target stage in Dockerfile to build. If not specified,
+        the Dockerfile is processed entirely to (and including) its last stage.
+      type: string
+      default: ""
+    - name: TLSVERIFY
+      description: Verify the TLS on the registry endpoint (for push/pull
+        to a non-TLS registry)
+      type: string
+      default: "true"
+    - name: YUM_REPOS_D_FETCHED
+      description: Path in source workspace where dynamically-fetched repos
+        are present
+      default: fetched.repos.d
+    - name: YUM_REPOS_D_SRC
+      description: Path in the git repository in which yum repository files
+        are stored
+      default: repos.d
+    - name: YUM_REPOS_D_TARGET
+      description: Target path on the container in which yum repository files
+        should be made available
+      default: /etc/yum.repos.d
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: image-url
+      type: string
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+  volumes:
+    - name: activation-key
+      secret:
+        optional: true
+        secretName: $(params.ACTIVATION_KEY)
+    - name: additional-secret
+      secret:
+        optional: true
+        secretName: $(params.ADDITIONAL_SECRET)
+    - name: cov-license
+      secret:
+        optional: false
+        secretName: $(params.COV_LICENSE)
+    - name: etc-pki-entitlement
+      secret:
+        optional: true
+        secretName: $(params.ENTITLEMENT_SECRET)
+    - name: shared
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: varlibcontainers
+      emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    computeResources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    env:
+      - name: ACTIVATION_KEY
+        value: $(params.ACTIVATION_KEY)
+      - name: ADDITIONAL_SECRET
+        value: $(params.ADDITIONAL_SECRET)
+      - name: ADD_CAPABILITIES
+        value: $(params.ADD_CAPABILITIES)
+      - name: BUILDAH_FORMAT
+        value: oci
+      - name: BUILD_ARGS_FILE
+        value: $(params.BUILD_ARGS_FILE)
+      - name: CONTEXT
+        value: $(params.CONTEXT)
+      - name: ENTITLEMENT_SECRET
+        value: $(params.ENTITLEMENT_SECRET)
+      - name: HERMETIC
+        value: $(params.HERMETIC)
+      - name: IMAGE
+        value: $(params.IMAGE)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.IMAGE_EXPIRES_AFTER)
+      - name: PRIVILEGED_NESTED
+        value: $(params.PRIVILEGED_NESTED)
+      - name: SBOM_TYPE
+        value: $(params.SBOM_TYPE)
+      - name: SKIP_SBOM_GENERATION
+        value: $(params.SKIP_SBOM_GENERATION)
+      - name: SKIP_UNUSED_STAGES
+        value: $(params.SKIP_UNUSED_STAGES)
+      - name: SOURCE_CODE_DIR
+        value: source
+      - name: SQUASH
+        value: $(params.SQUASH)
+      - name: STORAGE_DRIVER
+        value: $(params.STORAGE_DRIVER)
+      - name: TARGET_STAGE
+        value: $(params.TARGET_STAGE)
+      - name: TLSVERIFY
+        value: $(params.TLSVERIFY)
+      - name: YUM_REPOS_D_FETCHED
+        value: $(params.YUM_REPOS_D_FETCHED)
+      - name: YUM_REPOS_D_SRC
+        value: $(params.YUM_REPOS_D_SRC)
+      - name: YUM_REPOS_D_TARGET
+        value: $(params.YUM_REPOS_D_TARGET)
+    volumeMounts:
+      - mountPath: /shared
+        name: shared
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    - name: prepare
+      image: quay.io/redhat-services-prod/sast/coverity:202409.1
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /etc/secrets/cov
+          name: cov-license
+          readOnly: true
+      env:
+        - name: COV_ANALYZE_ARGS
+          value: $(params.COV_ANALYZE_ARGS)
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
+      script: |
+        #!/bin/bash
+
+        # FIXME: Dockerfile discovery logic is copied from buildah task
+        SOURCE_CODE_DIR=source
+        if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+        elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+        elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+          echo "Fetch Dockerfile from $DOCKERFILE"
+          dockerfile_path=$(mktemp --suffix=-Dockerfile)
+          http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+          if [ "$http_code" != 200 ]; then
+            echo "No Dockerfile is fetched. Server responds $http_code"
+            exit 1
+          fi
+          http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+          if [ "$http_code" = 200 ]; then
+            echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+            mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          fi
+        else
+          echo "Cannot find Dockerfile $DOCKERFILE"
+          exit 1
+        fi
+
+        # install Coverity license file
+        install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
+
+        # pre-create directory for SAST scanning results
+        install -vm1777 -d /shared/sast-results
+
+        # create a wrapper script to instrument RUN lines
+        tee /shared/cmd-wrap.sh >&2 <<EOF
+        #!/bin/bash -x
+        id >&2
+
+        # use current directory as project directory by default
+        proj_dir=\$(pwd)
+
+        # if current directory is "/", fallback to an empty temp directory
+        [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
+
+        # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
+        /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
+          -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
+          - "\$@"
+
+        # always remove Coverity's intermediate directory so that it can be recreated with different ownership
+        trap 'rm -fr /tmp/idir' EXIT
+
+        # assign a unique file name for scan results
+        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+
+        # obtain capture stats to process them later on
+        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
+
+        # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
+        $(declare -p COV_ANALYZE_ARGS)
+
+        # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
+        /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
+
+        # export scan results and embed source code context into the scan results
+        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
+          > "\${json_file}"
+
+        # propagate the original exit code of the wrapped command
+        exit "\$(</tmp/idir/build-cmd-ec.txt)"
+        EOF
+        echo >&2
+
+        # make the wrapper script executable
+        chmod -v 0755 /shared/cmd-wrap.sh
+
+        # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
+        cstrans-df-run --verbose /shared/cmd-wrap.sh <"$dockerfile_path" >/shared/Containerfile
+    - name: build
+      image: quay.io/redhat-services-prod/sast/coverity:202409.1
+      args:
+        - --build-args
+        - $(params.BUILD_ARGS[*])
+        - --labels
+        - $(params.LABELS[*])
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+        - mountPath: /entitlement
+          name: etc-pki-entitlement
+        - mountPath: /activation-key
+          name: activation-key
+        - mountPath: /additional-secret
+          name: additional-secret
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: COMMIT_SHA
+          value: $(params.COMMIT_SHA)
+        - name: DOCKERFILE
+          value: /shared/Containerfile
+        - name: ADDITIONAL_VOLUME_MOUNTS
+          value: |-
+            /opt:/opt
+            /shared:/shared
+            /shared/license.dat:/opt/coverity/bin/license.dat
+            /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+        elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+        elif [ -e "$DOCKERFILE" ]; then
+          # Instrumented builds (SAST) use this custom dockerffile step as their base
+          dockerfile_path="$DOCKERFILE"
+        elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+          echo "Fetch Dockerfile from $DOCKERFILE"
+          dockerfile_path=$(mktemp --suffix=-Dockerfile)
+          http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+          if [ "$http_code" != 200 ]; then
+            echo "No Dockerfile is fetched. Server responds $http_code"
+            exit 1
+          fi
+          http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+          if [ "$http_code" = 200 ]; then
+            echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+            mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          fi
+        else
+          echo "Cannot find Dockerfile $DOCKERFILE"
+          exit 1
+        fi
+
+        dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
+        cp "$dockerfile_path" "$dockerfile_copy"
+
+        # Fixing group permission on /var/lib/containers
+        chown root:root /var/lib/containers
+
+        sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+        # Setting new namespace to run buildah - 2^32-2
+        echo 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid
+
+        build_args=()
+        if [ -n "${BUILD_ARGS_FILE}" ]; then
+          # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+          echo "Parsing ARGs from $BUILD_ARGS_FILE"
+          mapfile -t build_args < <(
+            # https://www.mankier.com/1/buildah-build#--build-arg-file
+            # delete lines that start with #
+            # delete blank lines
+            sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+          )
+        fi
+
+        LABELS=()
+        # Split `args` into two sets of arguments.
+        while [[ $# -gt 0 ]]; do
+          case $1 in
+          --build-args)
+            shift
+            # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+            # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+            # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              build_args+=("$1")
+              shift
+            done
+            ;;
+          --labels)
+            shift
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              LABELS+=("--label" "$1")
+              shift
+            done
+            ;;
+          *)
+            echo "unexpected argument: $1" >&2
+            exit 2
+            ;;
+          esac
+        done
+
+        BUILD_ARG_FLAGS=()
+        for build_arg in "${build_args[@]}"; do
+          BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+        done
+
+        dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
+        BASE_IMAGES=$(
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+        )
+
+        BUILDAH_ARGS=()
+        UNSHARE_ARGS=()
+
+        if [ "${HERMETIC}" == "true" ]; then
+          BUILDAH_ARGS+=("--pull=never")
+          UNSHARE_ARGS+=("--net")
+
+          for image in $BASE_IMAGES; do
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          done
+          echo "Build will be executed with network isolation"
+        fi
+
+        if [ -n "${TARGET_STAGE}" ]; then
+          BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+        fi
+
+        BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+        if [ "${PRIVILEGED_NESTED}" == "true" ]; then
+          BUILDAH_ARGS+=("--security-opt=label=disable")
+          BUILDAH_ARGS+=("--cap-add=all")
+          BUILDAH_ARGS+=("--device=/dev/fuse")
+        fi
+
+        if [ -n "${ADD_CAPABILITIES}" ]; then
+          BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+        fi
+
+        if [ "${SQUASH}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash")
+        fi
+
+        if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
+          BUILDAH_ARGS+=("--skip-unused-stages=false")
+        fi
+
+        VOLUME_MOUNTS=()
+
+        if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
+          cp -r "/var/workdir/cachi2" /tmp/
+          chmod -R go+rwX /tmp/cachi2
+          VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)
+          # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+          # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+          sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_copy"
+          echo "Prefetched content will be made available"
+
+          prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+          if [ -f "$prefetched_repo_for_my_arch" ]; then
+            echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+            mkdir -p "$YUM_REPOS_D_FETCHED"
+            cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          fi
+        fi
+
+        # if yum repofiles stored in git, copy them to mount point outside the source dir
+        if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+          mkdir -p "${YUM_REPOS_D_FETCHED}"
+          cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        fi
+
+        # if anything in the repofiles mount point (either fetched or from git), mount it
+        if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+          chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+          mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+          VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
+        fi
+
+        DEFAULT_LABELS=(
+          "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+          "--label" "architecture=$(uname -m)"
+          "--label" "vcs-type=git"
+        )
+        [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+        [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+        # Concatenate defaults and explicit labels. If a label appears twice, the last one wins.
+        LABELS=("${DEFAULT_LABELS[@]}" "${LABELS[@]}")
+
+        ACTIVATION_KEY_PATH="/activation-key"
+        ENTITLEMENT_PATH="/entitlement"
+
+        # 0. if hermetic=true, skip all subscription related stuff
+        # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+        # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+        # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+        # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+        #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+        #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
+
+        if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          mkdir -p /shared/rhsm/etc/pki/entitlement
+          mkdir -p /shared/rhsm/etc/pki/consumer
+
+          VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key
+            -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z
+            -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)
+          echo "Adding activation key to the build"
+
+          if ! grep -E "^[^#]*subscription-manager.[^#]*register" "$dockerfile_path"; then
+            # user is not running registration in the Containerfile: pre-register.
+            echo "Pre-registering with subscription manager."
+            subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+            trap 'subscription-manager unregister || true' EXIT
+
+            # copy generated certificates to /shared volume
+            cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement
+            cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer
+
+            # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+            VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)
+          fi
+
+        elif [ "${HERMETIC}" != "true" ] && find /entitlement -name "*.pem" >>null; then
+          cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+          VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
+          echo "Adding the entitlement to the build"
+        fi
+
+        if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
+          # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+          # Instrumented builds (SAST) use this step as their base and add some other tools.
+          while read -r volume_mount; do
+            VOLUME_MOUNTS+=("--volume=$volume_mount")
+          done <<<"$ADDITIONAL_VOLUME_MOUNTS"
+        fi
+
+        ADDITIONAL_SECRET_PATH="/additional-secret"
+        ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+        if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+          cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+          while read -r filename; do
+            echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+            BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+          done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+        fi
+
+        # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
+        declare IMAGE
+
+        buildah_cmd_array=(
+          buildah build
+          "${VOLUME_MOUNTS[@]}"
+          "${BUILDAH_ARGS[@]}"
+          "${LABELS[@]}"
+          --tls-verify="$TLSVERIFY" --no-cache
+          --ulimit nofile=4096:4096
+          -f "$dockerfile_copy" -t "$IMAGE" .
+        )
+        buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
+
+        if [ "${HERMETIC}" == "true" ]; then
+          # enabling loopback adapter enables Bazel builds to work in hermetic mode.
+          command="ip link set lo up && $buildah_cmd"
+        else
+          command="$buildah_cmd"
+        fi
+
+        # disable host subcription manager integration
+        find /usr/share/rhel/secrets -type l -exec unlink {} \;
+
+        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+
+        container=$(buildah from --pull-never "$IMAGE")
+
+        # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+        if [ -f "/tmp/cachi2/output/bom.json" ]; then
+          echo "Making copy of sbom-cachi2.json"
+          cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        fi
+
+        buildah mount "$container" | tee /shared/container_path
+        # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+        find $(cat /shared/container_path) -xtype l -delete
+        echo $container >/shared/container_name
+
+        touch /shared/base_images_digests
+        echo "Recording base image digests used"
+        for image in $BASE_IMAGES; do
+          base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+          # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
+          # if buildah did not use that particular image during build because it was skipped
+          if [ -n "$base_image_digest" ]; then
+            echo "$image $base_image_digest" | tee -a /shared/base_images_digests
+          fi
+        done
+      computeResources:
+        limits:
+          cpu: "16"
+          memory: 16Gi
+        requests:
+          cpu: "4"
+          memory: 4Gi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+    - name: postprocess
+      image: quay.io/redhat-services-prod/sast/coverity:202409.1
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: COV_ANALYZE_ARGS
+          value: $(params.COV_ANALYZE_ARGS)
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: IMP_FINDINGS_ONLY
+          value: $(params.IMP_FINDINGS_ONLY)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+      script: |
+        #!/bin/bash -e
+        # shellcheck source=/dev/null
+        set -o pipefail
+
+        . /usr/local/share/konflux-test/utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        # Installation of Red Hat certificates for cloning Red Hat internal repositories
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        if [ -z "$(ls /shared/sast-results/)" ]; then (
+          set +e
+          set -x
+
+          # fallback to buildless scan if we have no scan results from buildful
+          # shellcheck disable=SC2086
+          env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "/var/workdir"
+
+          /opt/coverity/bin/coverity list --dir=/tmp/idir >"/shared/sast-results/coverity-buildless-summary.txt"
+
+          # install Coverity license file
+          install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+          # shellcheck disable=SC2086
+          /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+          # export scan results
+          /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout |
+            csgrep --mode=json --embed-context=3 \
+              >/shared/sast-results/coverity-buildless.json
+        ); fi
+
+        # collect capture stats (FIXME: this doe not take findings deduplication into account)
+        set +e
+        for file in /shared/sast-results/*-summary.txt; do
+          ((SUCCEEDED += $(grep "^ *SUCCEEDED:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+          ((INCOMPLETE += $(grep "^ *INCOMPLETE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+          ((FAILED += $(grep "^ *FAILED:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+          ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+        done
+
+        # calculate the total number of files
+        ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
+
+        # calculate the ratio of successful files to total files
+        ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
+        set -e
+
+        # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
+        IMP_LEVEL=1
+        if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+          IMP_LEVEL=0
+        fi
+
+        # collect scan results
+        (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
+          --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+          --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+          --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+          --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") |
+          tee coverity-results-raw.json |
+          csgrep --mode=evtstat
+
+        # We check if the KFP_GIT_URL variable is set to apply the filters or not
+        if [[ -z "${KFP_GIT_URL}" ]]; then
+          echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+          mv coverity-results{-raw,}.json
+        else
+          echo "Filtering false positives in results files using csfilter-kfp..."
+          CMD=(
+            csfilter-kfp
+            --verbose
+            --kfp-git-url="${KFP_GIT_URL}"
+            --project-nvr="${PROJECT_NAME}"
+          )
+
+          if [ "${RECORD_EXCLUDED}" == "true" ]; then
+            CMD+=(--record-excluded="excluded-findings.json")
+          fi
+
+          "${CMD[@]}" coverity-results-raw.json |
+            tee coverity-results.json |
+            csgrep --mode=evtstat
+        fi
+
+        # convert the scan results into SARIF
+        csgrep --mode=sarif coverity-results.json >"/var/workdir/coverity-results.sarif"
+
+        if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
+          note="Task $(context.task.name) success: No finding was detected"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        else
+          TEST_OUTPUT=
+          parse_test_output "$(context.task.name)" sarif "/var/workdir/coverity-results.sarif" || true
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        fi
+
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+
+        # upload scan results
+        echo "Selecting auth for upload of scan results"
+        select-oci-auth "${IMAGE_URL}" >"${HOME}/auth.json"
+
+        upload_file() (
+          set -x
+          UPLOAD_FILE="$1"
+          MEDIA_TYPE="$2"
+          oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        )
+
+        echo "Attaching scan results to ${IMAGE_URL}"
+        upload_file "coverity-results.sarif" "application/sarif+json"
+
+        # upload excluded-findings.json if enabled
+        if [ -f "excluded-findings.json" ]; then
+          upload_file "excluded-findings.json" "application/json"
+        fi
+      computeResources:
+        limits:
+          cpu: "4"
+          memory: 4Gi
+        requests:
+          cpu: "2"
+          memory: 2Gi

--- a/task/sast-coverity-check/0.2/MIGRATION.md
+++ b/task/sast-coverity-check/0.2/MIGRATION.md
@@ -1,7 +1,60 @@
 # Migration from 0.1 to 0.2
 
+- The workspace has been renamed to `source` to make the interface compatible
+  with the `build-container` task.
+
 - The unused `IMAGE_DIGEST` parameter has been removed.
 
 ## Action from users
 
+- The workspace for this task in the build pipeline should be renamed to `source`.
 - The `IMAGE_DIGEST` parameter definition can optionally be removed for this task in the build pipeline.
+
+### Example
+```diff
+--- a/.tekton/konflux-test-operator-pipelines-pull-request.yaml
++++ b/.tekton/konflux-test-operator-pipelines-pull-request.yaml
+@@ -417,40 +417,38 @@ spec:
+       when:
+       - input: $(params.skip-checks)
+         operator: in
+         values:
+         - "false"
+     - name: sast-coverity-check
+       params:
+-      - name: image-digest
+-        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+       - name: image-url
+         value: $(tasks.build-image-index.results.IMAGE_URL)
+       runAfter:
+       - coverity-availability-check
+       taskRef:
+         params:
+         - name: name
+           value: sast-coverity-check
+         - name: bundle
+-          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.1@sha256:6d0bead975a9e9ce9dac98edb0a3c3908dbae3882df2775fc8760c6bb4f41f8c
++          value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check:0.2
+         - name: kind
+           value: task
+         resolver: bundles
+       when:
+       - input: $(params.skip-checks)
+         operator: in
+         values:
+         - "false"
+       - input: $(tasks.coverity-availability-check.results.STATUS)
+         operator: in
+         values:
+         - success
+       workspaces:
+-      - name: workspace
++      - name: source
+         workspace: workspace
+     - name: coverity-availability-check
+       runAfter:
+       - build-image-index
+       taskRef:
+         params:
+         - name: name
+```

--- a/task/sast-coverity-check/0.2/MIGRATION.md
+++ b/task/sast-coverity-check/0.2/MIGRATION.md
@@ -1,0 +1,7 @@
+# Migration from 0.1 to 0.2
+
+- The unused `IMAGE_DIGEST` parameter has been removed.
+
+## Action from users
+
+- The `IMAGE_DIGEST` parameter definition can optionally be removed for this task in the build pipeline.

--- a/task/sast-coverity-check/0.2/MIGRATION.md
+++ b/task/sast-coverity-check/0.2/MIGRATION.md
@@ -5,16 +5,19 @@
 
 - The unused `IMAGE_DIGEST` parameter has been removed.
 
+- The `sast-coverity-check` task now supports buildful SAST scanning, too.
+
 ## Action from users
 
 - The workspace for this task in the build pipeline should be renamed to `source`.
+- All parameters that are set for the `build-container` task now need to be set for `sast-coverity-check`, too.
 - The `IMAGE_DIGEST` parameter definition can optionally be removed for this task in the build pipeline.
 
 ### Example
 ```diff
 --- a/.tekton/konflux-test-operator-pipelines-pull-request.yaml
 +++ b/.tekton/konflux-test-operator-pipelines-pull-request.yaml
-@@ -417,40 +417,38 @@ spec:
+@@ -417,40 +417,57 @@ spec:
        when:
        - input: $(params.skip-checks)
          operator: in
@@ -26,6 +29,25 @@
 -        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
        - name: image-url
          value: $(tasks.build-image-index.results.IMAGE_URL)
++      - name: IMAGE
++        value: $(params.output-image)
++      - name: DOCKERFILE
++        value: $(params.dockerfile)
++      - name: CONTEXT
++        value: $(params.path-context)
++      - name: HERMETIC
++        value: $(params.hermetic)
++      - name: PREFETCH_INPUT
++        value: $(params.prefetch-input)
++      - name: IMAGE_EXPIRES_AFTER
++        value: $(params.image-expires-after)
++      - name: COMMIT_SHA
++        value: $(tasks.clone-repository.results.commit)
++      - name: BUILD_ARGS
++        value:
++        - $(params.build-args[*])
++      - name: BUILD_ARGS_FILE
++        value: $(params.build-args-file)
        runAfter:
        - coverity-availability-check
        taskRef:

--- a/task/sast-coverity-check/0.2/README.md
+++ b/task/sast-coverity-check/0.2/README.md
@@ -1,0 +1,46 @@
+# sast-coverity-check task
+
+## Description:
+
+The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST). In this task, we use the buildless mode, where Coverity has the ability to capture source code without the need of building the product.
+
+The documentation for this mode can be found here: https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
+
+The characteristics of these tasks are:
+
+- Perform buildless scanning with Coverity
+- The whole source code is scanned (by scanning `$(workspaces.source.path)` )
+- Only important findings are reported by default.  A parameter ( `IMP_FINDINGS_ONLY`) is provided to override this configuration.
+- The csdiff/v1 SARIF fingerprints are provided for all findings
+- A parameter ( `KFP_GIT_URL`) is provided to remove false positives providing a known false positives repository. By default, no repository is provided.
+
+> NOTE: This task is executed only if there is a Coverity license set up in the environment. Please check coverity-availability-check task for more information.
+
+## Params:
+
+| name                      | description                                                                                                                           | default value             | required |                                                                                                                   
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------------------------|----------|
+| COV_CAPTURE_ARGS          | Append arguments to the Coverity Capture CLI command                                                                                  | ""                        | no       |
+| COV_ANALYZE_ARGS          | Append arguments to the cov-analyze CLI command                                                                                       | ""                        | no       |
+| COV_LICENSE               | Name of secret which contains the Coverity license                                                                                    | cov-license               | no       |
+| AUTH_TOKEN_COVERITY_IMAGE | Name of secret which contains the authentication token for pulling the Coverity image                                                 | auth-token-coverity-image | no       |
+| IMP_FINDINGS_ONLY         | Report only important findings. Default is true. To report all findings, specify "false"                                              | true                      | no       |
+| KFP_GIT_URL               | Known False Positives git URL, optionally taking a revision delimited by #; If empty, filtering of known false positives is disabled. | ""                        | no       |
+| PROJECT_NAME              | Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.                       | ""                        | no       |
+| RECORD_EXCLUDED           | If set to `true`, excluded findings will be written to a file named `excluded-findings.json` for auditing purposes.                   | false                     | no       |
+
+## Results:
+
+| name              | description              |
+|-------------------|--------------------------|
+| TEST_OUTPUT       | Tekton task test output. |
+
+## Source repository for image:
+
+// TODO: Add reference to private repo for the container image once the task is migrated to repo
+
+
+## Additional links:
+
+* https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
+* https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/cli/topics/options_reference.html

--- a/task/sast-coverity-check/0.2/README.md
+++ b/task/sast-coverity-check/0.2/README.md
@@ -2,14 +2,13 @@
 
 ## Description:
 
-The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST). In this task, we use the buildless mode, where Coverity has the ability to capture source code without the need of building the product.
+The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST).
 
 The documentation for this mode can be found here: https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
 
 The characteristics of these tasks are:
 
-- Perform buildless scanning with Coverity
-- The whole source code is scanned (by scanning `$(workspaces.source.path)` )
+- Perform buildful scanning with Coverity
 - Only important findings are reported by default.  A parameter ( `IMP_FINDINGS_ONLY`) is provided to override this configuration.
 - The csdiff/v1 SARIF fingerprints are provided for all findings
 - A parameter ( `KFP_GIT_URL`) is provided to remove false positives providing a known false positives repository. By default, no repository is provided.
@@ -20,7 +19,6 @@ The characteristics of these tasks are:
 
 | name                      | description                                                                                                                           | default value             | required |                                                                                                                   
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------------------------|----------|
-| COV_CAPTURE_ARGS          | Append arguments to the Coverity Capture CLI command                                                                                  | ""                        | no       |
 | COV_ANALYZE_ARGS          | Append arguments to the cov-analyze CLI command                                                                                       | ""                        | no       |
 | COV_LICENSE               | Name of secret which contains the Coverity license                                                                                    | cov-license               | no       |
 | AUTH_TOKEN_COVERITY_IMAGE | Name of secret which contains the authentication token for pulling the Coverity image                                                 | auth-token-coverity-image | no       |

--- a/task/sast-coverity-check/0.2/kustomization.yaml
+++ b/task/sast-coverity-check/0.2/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../buildah/0.3
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Task

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -21,18 +21,46 @@
 ###################
 
 # Remove all buildah task steps except build
+
+# upload-sbom
+- op: test
+  path: /spec/steps/5/name
+  value: upload-sbom
 - op: remove
-  path: /spec/steps/5  # upload-sbom
+  path: /spec/steps/5
+
+# prepare-sboms
+- op: test
+  path: /spec/steps/4/name
+  value: prepare-sboms
 - op: remove
-  path: /spec/steps/4  # prepare-sboms
+  path: /spec/steps/4
+
+# sbom-syft-generate
+- op: test
+  path: /spec/steps/3/name
+  value: sbom-syft-generate
 - op: remove
-  path: /spec/steps/3  # sbom-syft-generate
+  path: /spec/steps/3
+
+# push
+- op: test
+  path: /spec/steps/2/name
+  value: push
 - op: remove
-  path: /spec/steps/2  # push
+  path: /spec/steps/2
+
+# icm
+- op: test
+  path: /spec/steps/1/name
+  value: icm
 - op: remove
-  path: /spec/steps/1  # icm
+  path: /spec/steps/1
 
 # Tune the build step (the only one left).
+- op: test
+  path: /spec/steps/0/name
+  value: build
 
 # Change build step image
 - op: replace
@@ -217,11 +245,17 @@
       cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile
 
 # Make the buildah task use the instrumented Dockerfile
+- op: test
+  path: /spec/steps/1/env/1/name
+  value: DOCKERFILE
 - op: replace
   path: /spec/steps/1/env/1/value  # steps -> build -> env -> DOCKERFILE
   value: /shared/Containerfile
 
 # Add postprocess step
+- op: test
+  path: /spec/steps/1/name
+  value: build
 - op: add
   path: /spec/steps/2
   value:

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -66,7 +66,7 @@
 - op: replace
   path: /spec/steps/0/image
   # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
-  value: quay.io/redhat-services-prod/sast/coverity:202409.1
+  value: quay.io/redhat-services-prod/sast/coverity:202412.1
 
 # Change build step resources
 - op: replace
@@ -153,7 +153,7 @@
   path: /spec/steps/0
   value:
     name: prepare
-    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    image: quay.io/redhat-services-prod/sast/coverity:202412.1
     workingDir: $(workspaces.source.path)
     env:
       - name: COV_ANALYZE_ARGS
@@ -208,6 +208,11 @@
       # if current directory is "/", fallback to an empty temp directory
       [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
 
+      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
+      if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
+        install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
+      fi
+
       # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
       /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
         -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
@@ -260,7 +265,7 @@
   path: /spec/steps/2
   value:
     name: postprocess
-    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    image: quay.io/redhat-services-prod/sast/coverity:202412.1
     computeResources:
       limits:
         memory: 4Gi

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -188,6 +188,12 @@
       # always remove Coverity's intermediate directory so that it can be recreated with different ownership
       trap 'rm -fr /tmp/idir' EXIT
 
+      # assign a unique file name for scan results
+      json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+
+      # obtain capture stats to process them later on
+      /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
+
       # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
       $(declare -p COV_ANALYZE_ARGS)
 
@@ -197,7 +203,7 @@
       # export scan results and embed source code context into the scan results
       /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
         | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
-        > \$(mktemp /shared/sast-results/\$\$-XXXX.json)
+        > "\${json_file}"
 
       # propagate the original exit code of the wrapped command
       exit "\$(</tmp/idir/build-cmd-ec.txt)"
@@ -278,6 +284,8 @@
         # shellcheck disable=SC2086
         env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
 
+        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
+
         # install Coverity license file
         install -vm0644 /{shared,opt/coverity/bin}/license.dat
 
@@ -290,6 +298,22 @@
           > /shared/sast-results/coverity-buildless.json
       ) fi
 
+      # collect capture stats (FIXME: this doe not take findings deduplication into account)
+      set +e
+      for file in /shared/sast-results/*-summary.txt; do
+        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+      done
+
+      # calculate the total number of files
+      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
+
+      # calculate the ratio of successful files to total files
+      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
+      set -e
+
       # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
       IMP_LEVEL=1
       if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
@@ -297,7 +321,11 @@
       fi
 
       # collect scan results
-      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*') \
+      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
+        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
         | tee coverity-results-raw.json \
         | csgrep --mode=evtstat
 

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -1,0 +1,359 @@
+# Task name
+- op: replace
+  path: /metadata/name
+  value: sast-coverity-check
+
+# Task description
+- op: replace
+  path: /spec/description
+  value: |-
+    Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Coverity.
+
+# Replace task results
+- op: replace
+  path: /spec/results
+  value:
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+
+###################
+# Task steps
+###################
+
+# Remove all buildah task steps except build
+- op: remove
+  path: /spec/steps/5  # upload-sbom
+- op: remove
+  path: /spec/steps/4  # prepare-sboms
+- op: remove
+  path: /spec/steps/3  # sbom-syft-generate
+- op: remove
+  path: /spec/steps/2  # push
+- op: remove
+  path: /spec/steps/1  # icm
+
+# Tune the build step (the only one left).
+
+# Change build step image
+- op: replace
+  path: /spec/steps/0/image
+  # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
+  value: quay.io/redhat-services-prod/sast/coverity:202409.1
+
+# Change build step resources
+- op: replace
+  path: /spec/steps/0/computeResources/limits/cpu
+  value: 16
+- op: replace
+  path: /spec/steps/0/computeResources/limits/memory
+  value: 16Gi
+- op: replace
+  path: /spec/steps/0/computeResources/requests/cpu
+  value: 4
+- op: replace
+  path: /spec/steps/0/computeResources/requests/memory
+  value: 4Gi
+
+# Additional parameters
+- op: add
+  path: /spec/params/-
+  value:
+    name: image-url
+    type: string
+- op: add
+  path: /spec/params/-
+  value:
+    name: COV_LICENSE
+    type: string
+    description: Name of secret which contains the Coverity license
+    default: "cov-license"
+- op: add
+  path: /spec/params/-
+  value:
+    name: PROJECT_NAME
+    type: string
+    default: ""
+- op: add
+  path: /spec/params/-
+  value:
+    name: RECORD_EXCLUDED
+    type: string
+    default: "false"
+- op: add
+  path: /spec/params/-
+  value:
+    description: Arguments to be appended to the cov-analyze command
+    name: COV_ANALYZE_ARGS
+    type: string
+    default: "--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096"
+- op: add
+  path: /spec/params/-
+  value:
+    name: IMP_FINDINGS_ONLY
+    type: string
+    description: Report only important findings. Default is true. To report all findings, specify "false"
+    default: "true"
+- op: add
+  path: /spec/params/-
+  value:
+    name: KFP_GIT_URL
+    type: string
+    description: URL from repository to download known false positives files
+    # FIXME: Red Hat internal projects will default to https://gitlab.cee.redhat.com/osh/known-false-positives.git when KONFLUX-4530 is resolved
+    default: ""
+
+# Additional volumes
+- op: add
+  path: /spec/volumes/-
+  value:
+    name: cov-license
+    secret:
+      secretName: $(params.COV_LICENSE)
+      optional: false
+- op: add
+  path: /spec/steps/0/env/-
+  value:
+    name: ADDITIONAL_VOLUME_MOUNTS
+    value: |-
+      /opt:/opt
+      /shared:/shared
+      /shared/license.dat:/opt/coverity/bin/license.dat
+      /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
+
+# Add prepare step
+- op: add
+  path: /spec/steps/0
+  value:
+    name: prepare
+    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    workingDir: $(workspaces.source.path)
+    env:
+      - name: COV_ANALYZE_ARGS
+        value: $(params.COV_ANALYZE_ARGS)
+      - name: DOCKERFILE
+        value: $(params.DOCKERFILE)
+    volumeMounts:
+      - name: cov-license
+        mountPath: "/etc/secrets/cov"
+        readOnly: true
+    script: |
+      #!/bin/bash
+
+      # FIXME: Dockerfile discovery logic is copied from buildah task
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      # install Coverity license file
+      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
+
+      # pre-create directory for SAST scanning results
+      install -vm1777 -d /shared/sast-results
+
+      # create a wrapper script to instrument RUN lines
+      tee /shared/cmd-wrap.sh >&2 << EOF
+      #!/bin/bash -x
+      id >&2
+
+      # use current directory as project directory by default
+      proj_dir=\$(pwd)
+
+      # if current directory is "/", fallback to an empty temp directory
+      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
+
+      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
+      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
+        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
+        - "\$@"
+
+      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
+      trap 'rm -fr /tmp/idir' EXIT
+
+      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
+      $(declare -p COV_ANALYZE_ARGS)
+
+      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
+      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
+
+      # export scan results and embed source code context into the scan results
+      /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+        | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
+        > \$(mktemp /shared/sast-results/\$\$-XXXX.json)
+
+      # propagate the original exit code of the wrapped command
+      exit "\$(</tmp/idir/build-cmd-ec.txt)"
+      EOF
+      echo >&2
+
+      # make the wrapper script executable
+      chmod -v 0755 /shared/cmd-wrap.sh
+
+      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
+      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile
+
+# Make the buildah task use the instrumented Dockerfile
+- op: replace
+  path: /spec/steps/1/env/1/value  # steps -> build -> env -> DOCKERFILE
+  value: /shared/Containerfile
+
+# Add postprocess step
+- op: add
+  path: /spec/steps/2
+  value:
+    name: postprocess
+    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    computeResources:
+      limits:
+        memory: 4Gi
+        cpu: 4
+      requests:
+        memory: 2Gi
+        cpu: 2
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: "/mnt/trusted-ca"
+        readOnly: true
+    env:
+      - name: IMAGE_URL
+        value: $(params.image-url)
+      - name: COV_ANALYZE_ARGS
+        value: $(params.COV_ANALYZE_ARGS)
+      - name: KFP_GIT_URL
+        value: $(params.KFP_GIT_URL)
+      - name: IMP_FINDINGS_ONLY
+        value: $(params.IMP_FINDINGS_ONLY)
+      - name: PROJECT_NAME
+        value: $(params.PROJECT_NAME)
+      - name: RECORD_EXCLUDED
+        value: $(params.RECORD_EXCLUDED)
+      - name: COMPONENT_LABEL
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.labels['appstudio.openshift.io/component']
+
+    workingDir: $(workspaces.source.path)
+    script: |
+      #!/bin/bash -e
+      # shellcheck source=/dev/null
+      set -o pipefail
+
+      . /usr/local/share/konflux-test/utils.sh
+      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
+      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+      # Installation of Red Hat certificates for cloning Red Hat internal repositories
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -z "$(ls /shared/sast-results/)" ]; then (
+        set +e
+        set -x
+
+        # fallback to buildless scan if we have no scan results from buildful
+        # shellcheck disable=SC2086
+        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
+
+        # install Coverity license file
+        install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+        # shellcheck disable=SC2086
+        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+        # export scan results
+        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+          | csgrep --mode=json --embed-context=3 \
+          > /shared/sast-results/coverity-buildless.json
+      ) fi
+
+      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
+      IMP_LEVEL=1
+      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+        IMP_LEVEL=0
+      fi
+
+      # collect scan results
+      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*') \
+        | tee coverity-results-raw.json \
+        | csgrep --mode=evtstat
+
+      # We check if the KFP_GIT_URL variable is set to apply the filters or not
+      if [[ -z "${KFP_GIT_URL}" ]]; then
+        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+        mv coverity-results{-raw,}.json
+      else
+        echo "Filtering false positives in results files using csfilter-kfp..."
+        CMD=(
+          csfilter-kfp
+          --verbose
+          --kfp-git-url="${KFP_GIT_URL}"
+          --project-nvr="${PROJECT_NAME}"
+        )
+
+        if [ "${RECORD_EXCLUDED}" == "true" ]; then
+          CMD+=(--record-excluded="excluded-findings.json")
+        fi
+
+        "${CMD[@]}" coverity-results-raw.json \
+          | tee coverity-results.json \
+          | csgrep --mode=evtstat
+      fi
+
+      # convert the scan results into SARIF
+      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+
+      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
+        note="Task $(context.task.name) success: No finding was detected"
+        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      else
+        TEST_OUTPUT=
+        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
+        note="Task $(context.task.name) failed: For details, check Tekton task log."
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      fi
+
+      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+
+      # upload scan results
+      echo "Selecting auth for upload of scan results"
+      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+
+      upload_file() (
+        set -x
+        UPLOAD_FILE="$1"
+        MEDIA_TYPE="$2"
+        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+      )
+
+      echo "Attaching scan results to ${IMAGE_URL}"
+      upload_file "coverity-results.sarif" "application/sarif+json"
+
+      # upload excluded-findings.json if enabled
+      if [ -f "excluded-findings.json" ]; then
+        upload_file "excluded-findings.json" "application/json"
+      fi

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -1,276 +1,794 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  labels:
-    app.kubernetes.io/version: "0.1"
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "konflux"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: 0.2.1
+    build.appstudio.redhat.com/build_type: docker
   name: sast-coverity-check
 spec:
-  description: >-
-    Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Coverity. At the moment, this task only uses the buildless mode, which does not build the project in order to analyze it.
-  results:
-    - description: Tekton task test output.
-      name: TEST_OUTPUT
+  description: Scans source code for security vulnerabilities, including common issues
+    such as SQL injection, cross-site scripting (XSS), and code injection attacks
+    using Coverity.
   params:
-    - description: Image URL.
-      name: image-url
-      type: string
-    - name: caTrustConfigMapName
-      type: string
-      description: The name of the ConfigMap to read CA bundle data from.
-      default: trusted-ca
-    - name: caTrustConfigMapKey
-      type: string
-      description: The name of the key in the ConfigMap that contains the CA bundle data.
-      default: ca-bundle.crt
-    - description: Arguments to be appended to the coverity capture command
-      name: COV_CAPTURE_ARGS
-      type: string
-      default: ""
-    - description: Arguments to be appended to the cov-analyze command
-      name: COV_ANALYZE_ARGS
-      type: string
-      default: "--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096"
-    - name: COV_LICENSE
-      description: Name of secret which contains the Coverity license
-      default: cov-license
-    - name: AUTH_TOKEN_COVERITY_IMAGE
-      description: Name of secret which contains the authentication token for pulling the Coverity image.
-      default: "auth-token-coverity-image"
-    - name: IMP_FINDINGS_ONLY
-      type: string
-      description: Report only important findings. Default is true. To report all findings, specify "false"
-      default: "true"
-    - name: KFP_GIT_URL
-      type: string
-      description: URL from repository to download known false positives files
-      # FIXME: Red Hat internal projects will default to https://gitlab.cee.redhat.com/osh/known-false-positives.git when KONFLUX-4530 is resolved
-      default: ""
-    - name: PROJECT_NAME
-      description: Name of the scanned project, used to find path exclusions.
-            By default, the Konflux component name will be used.
-      type: string
-      default: ""
-    - name: RECORD_EXCLUDED
-      type: string
-      description: Write excluded records in file. Useful for auditing (defaults to false).
-      default: "false"
-  volumes:
-    - name: cov-license
-      secret:
-        secretName: $(params.COV_LICENSE)
-        optional: false
-    - name: auth-token-coverity-image
-      secret:
-        secretName: $(params.AUTH_TOKEN_COVERITY_IMAGE)
-        optional: false
-    - name: trusted-ca
-      configMap:
-        name: $(params.caTrustConfigMapName)
-        items:
-          - key: $(params.caTrustConfigMapKey)
-            path: ca-bundle.crt
-        optional: true
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  - default: []
+    description: Additional key=value labels that should be applied to the image
+    name: LABELS
+    type: array
+  - default: "false"
+    description: Whether to enable privileged mode
+    name: PRIVILEGED_NESTED
+    type: string
+  - default: "false"
+    description: Skip SBOM-related operations. This will likely cause EC policies
+      to fail if enabled
+    name: SKIP_SBOM_GENERATION
+    type: string
+  - default: cyclonedx
+    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
+      Note: the SBOM from the prefetch task - if there is one - must be in the same
+      format.'
+    name: SBOM_TYPE
+    type: string
+  - name: image-url
+    type: string
+  - default: cov-license
+    description: Name of secret which contains the Coverity license
+    name: COV_LICENSE
+    type: string
+  - default: ""
+    name: PROJECT_NAME
+    type: string
+  - default: "false"
+    name: RECORD_EXCLUDED
+    type: string
+  - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
+    description: Arguments to be appended to the cov-analyze command
+    name: COV_ANALYZE_ARGS
+    type: string
+  - default: "true"
+    description: Report only important findings. Default is true. To report all findings,
+      specify "false"
+    name: IMP_FINDINGS_ONLY
+    type: string
+  - default: ""
+    description: URL from repository to download known false positives files
+    name: KFP_GIT_URL
+    type: string
+  results:
+  - description: Tekton task test output.
+    name: TEST_OUTPUT
+  stepTemplate:
+    computeResources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: SOURCE_CODE_DIR
+      value: source
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    - name: PRIVILEGED_NESTED
+      value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
+    - name: SBOM_TYPE
+      value: $(params.SBOM_TYPE)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
   steps:
-    - name: sast-coverity-check
-      # image: $(steps.secrets-check.results.image)
-      image: quay.io/redhat-user-workloads/sast-tenant/sast-scanner/coverity@sha256:d8e1266319d310443b183f8c14e083932b70f665fd72a61ff90b30e46b9398f0
-      computeResources:
-        requests:
-          memory: "16Gi"
-          cpu: "8"
-        limits:
-          memory: "32Gi"
-          cpu: "16"
-      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-      # the cluster will set imagePullPolicy to IfNotPresent
-      workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)
-      volumeMounts:
-        - name: cov-license
-          mountPath: "/etc/secrets/cov"
-          readOnly: true
-        - name: trusted-ca
-          mountPath: /mnt/trusted-ca
-          readOnly: true
-      env:
-        - name: COV_ANALYZE_ARGS
-          value: $(params.COV_ANALYZE_ARGS)
-        - name: COV_CAPTURE_ARGS
-          value: $(params.COV_CAPTURE_ARGS)
-        - name: KFP_GIT_URL
-          value: $(params.KFP_GIT_URL)
-        - name: COV_LICENSE
-          value: $(params.COV_LICENSE)
-        - name: IMP_FINDINGS_ONLY
-          value: $(params.IMP_FINDINGS_ONLY)
-        - name: PROJECT_NAME
-          value: $(params.PROJECT_NAME)
-        - name: RECORD_EXCLUDED
-          value: $(params.RECORD_EXCLUDED)
-        - name: COMPONENT_LABEL
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.labels['appstudio.openshift.io/component']
-      script: |
-        #!/usr/bin/env bash
-        set -eo pipefail
-        # shellcheck source=/dev/null
-        . /usr/local/share/konflux-test/utils.sh
-        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+  - env:
+    - name: COV_ANALYZE_ARGS
+      value: $(params.COV_ANALYZE_ARGS)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    name: prepare
+    script: |
+      #!/bin/bash
 
-        echo 'Starting Coverity buildless scan'
-
-        export HOME="/var/tmp/coverity/home"
-
-        if [[ -z "${PROJECT_NAME}" ]]; then
-          PROJECT_NAME=${COMPONENT_LABEL}
-        fi
-        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
-
-        COVERITY_DIR=/var/tmp/coverity/idir
-        COVERITY_RESULTS_FILE=$(workspaces.source.path)/coverity-buildless-results.json
-        COV_LICENSE_PATH=/etc/secrets/cov/cov-license
-        SOURCE_CODE_DIR=$(workspaces.source.path)
-
-        # Installing Coverity license
-        cp "$COV_LICENSE_PATH" /opt/coverity/bin/license.dat
-
-        # Installation of Red Hat certificates for cloning Red Hat internal repositories
-        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
-        if [ -f "$ca_bundle" ]; then
-          echo "INFO: Using mounted CA bundle: $ca_bundle"
-          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
-          update-ca-trust
-        fi
-
-        # Create configuration file for coverity buildless
-        echo -e 'capture:\n   build-command-inference: false' > "$SOURCE_CODE_DIR"/coverity.yml
-
-        set +e -x
-        # Buildless scan
-        # shellcheck disable=SC2086
-        env COV_HOST=konflux /opt/coverity/bin/coverity capture $COV_CAPTURE_ARGS --project-dir "$SOURCE_CODE_DIR" --dir "$COVERITY_DIR"
-        COV_CAPTURE_EXIT_CODE=$?
-        set -x
-
-        if [[ "$COV_CAPTURE_EXIT_CODE" -eq 0 ]]; then
-          echo "Coverity capture scan finished successfully"
-        else
-          echo "Coverity capture command failed with exit code ${COV_CAPTURE_EXIT_CODE}. Exiting..."
-          note="Task $(context.task.name) failed: For details, check Tekton task log."
-          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+      # FIXME: Dockerfile discovery logic is copied from buildah task
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
 
-        # Analysis phase
-        set -x
-        /opt/coverity/bin/cov-manage-emit --dir $COVERITY_DIR reset-host-name
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir="$COVERITY_DIR"
-        COV_ANALYZE_EXIT_CODE=$?
-        set +x
+      # install Coverity license file
+      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
 
-        if [[ "$COV_ANALYZE_EXIT_CODE" -eq 0 ]]; then
-          echo "cov-analyze scan finished successfully"
-        else
-          echo "cov-analyze scan failed with exit code ${COV_ANALYZE_EXIT_CODE}. Exiting..."
-          note="Task $(context.task.name) failed: For details, check Tekton task log."
-          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+      # pre-create directory for SAST scanning results
+      install -vm1777 -d /shared/sast-results
+
+      # create a wrapper script to instrument RUN lines
+      tee /shared/cmd-wrap.sh >&2 << EOF
+      #!/bin/bash -x
+      id >&2
+
+      # use current directory as project directory by default
+      proj_dir=\$(pwd)
+
+      # if current directory is "/", fallback to an empty temp directory
+      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
+
+      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
+      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
+        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
+        - "\$@"
+
+      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
+      trap 'rm -fr /tmp/idir' EXIT
+
+      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
+      $(declare -p COV_ANALYZE_ARGS)
+
+      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
+      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
+
+      # export scan results and embed source code context into the scan results
+      /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+        | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
+        > \$(mktemp /shared/sast-results/\$\$-XXXX.json)
+
+      # propagate the original exit code of the wrapped command
+      exit "\$(</tmp/idir/build-cmd-ec.txt)"
+      EOF
+      echo >&2
+
+      # make the wrapper script executable
+      chmod -v 0755 /shared/cmd-wrap.sh
+
+      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
+      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile
+    volumeMounts:
+    - mountPath: /etc/secrets/cov
+      name: cov-license
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - args:
+    - --build-args
+    - $(params.BUILD_ARGS[*])
+    - --labels
+    - $(params.LABELS[*])
+    computeResources:
+      limits:
+        cpu: 16
+        memory: 16Gi
+      requests:
+        cpu: 4
+        memory: 4Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: /shared/Containerfile
+    - name: ADDITIONAL_VOLUME_MOUNTS
+      value: |-
+        /opt:/opt
+        /shared:/shared
+        /shared/license.dat:/opt/coverity/bin/license.dat
+        /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
+    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    name: build
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        dockerfile_path="$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
-        set -e
-
-        /opt/coverity/bin/cov-format-errors --dir="$COVERITY_DIR" --json-output-v10 "$COVERITY_RESULTS_FILE"
-        # We parse the results, embed context, remove duplicates and store them in SARIF format.
-        IMP_LEVEL=1
-        if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
-          IMP_LEVEL=0
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
         fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
 
-        (cd "$SOURCE_CODE_DIR" && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --embed-context=3 "$COVERITY_RESULTS_FILE") \
-        | csgrep --mode=json --strip-path-prefix="$SOURCE_CODE_DIR"/source/ \
-        | csgrep --mode=json --strip-path-prefix="$HOME" \
-        > sast_coverity_buildless_check_all_findings.json
+      dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
+      cp "$dockerfile_path" "$dockerfile_copy"
 
-        echo "Results:"
-        (set -x && csgrep --mode=evtstat sast_coverity_buildless_check_all_findings.json)
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
 
-        # We check if the KFP_GIT_URL variable is set to apply the filters or not
-        if [[ -z "${KFP_GIT_URL}" ]]; then
-          echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
-          mv sast_coverity_buildless_check_all_findings.json filtered_sast_coverity_buildless_check_all_findings.json
-        else
-          echo "Filtering false positives in results files using csfilter-kfp..."
-          CMD=(
-            csfilter-kfp
-            --verbose
-            --kfp-git-url="${KFP_GIT_URL}"
-            --project-nvr="${PROJECT_NAME}"
-          )
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
 
-          if [ "${RECORD_EXCLUDED}" == "true" ]; then
-            CMD+=(--record-excluded="excluded-findings.json")
-          fi
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
 
-          "${CMD[@]}" sast_coverity_buildless_check_all_findings.json > filtered_sast_coverity_buildless_check_all_findings.json
-          status=$?
-          if [ "$status" -ne 0 ]; then
-            echo "Error: failed to filter known false positives" >&2
-            return 1
-          else
-            echo "Message: Succeed to filter known false positives" >&2
-          fi
+      build_args=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+        echo "Parsing ARGs from $BUILD_ARGS_FILE"
+        mapfile -t build_args < <(
+          # https://www.mankier.com/1/buildah-build#--build-arg-file
+          # delete lines that start with #
+          # delete blank lines
+          sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+        )
+      fi
 
-          echo "Results after filtering:"
-          (set -x $$ csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)
-        fi
+      LABELS=()
+      # Split `args` into two sets of arguments.
+      while [[ $# -gt 0 ]]; do
+          case $1 in
+              --build-args)
+                  shift
+                  # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+                  # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+                  # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
+                  while [[ $# -gt 0 && $1 != --* ]]; do build_args+=("$1"); shift; done
+                  ;;
+              --labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do LABELS+=("--label" "$1"); shift; done
+                  ;;
+              *)
+                  echo "unexpected argument: $1" >&2
+                  exit 2
+                  ;;
+          esac
+      done
 
-        csgrep --mode=sarif filtered_sast_coverity_buildless_check_all_findings.json > "$(workspaces.source.path)"/coverity-results.sarif
+      BUILD_ARG_FLAGS=()
+      for build_arg in "${build_args[@]}"; do
+        BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+      done
 
-        if [[ -z "$(csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)" ]]; then
-          note="Task $(context.task.name) success: No finding was detected"
-          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
-          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-        else
-          TEST_OUTPUT=
-          parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)"/coverity-results.sarif || true
-          note="Task $(context.task.name) failed: For details, check Tekton task log."
-          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-        fi
+      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
+      BASE_IMAGES=$(
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+      )
 
-        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
-    - name: upload
-      image: quay.io/konflux-ci/oras:latest@sha256:99737f436051e6d3866eb8a8706463c35abf72c87f05090ff42ff642f6729661
-      workingDir: $(workspaces.source.path)
-      env:
-        - name: IMAGE_URL
-          value: $(params.image-url)
-      script: |
-        #!/usr/bin/env bash
+      BUILDAH_ARGS=()
+      UNSHARE_ARGS=()
 
-        if [ -z "${IMAGE_URL}" ]; then
-          echo 'No image-url param provided. Skipping upload.'
-          exit 0
-        fi
-        UPLOAD_FILES="coverity-results.sarif excluded-findings.json"
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS+=("--net")
 
-        for UPLOAD_FILE in ${UPLOAD_FILES}; do
-          if [ ! -f "${UPLOAD_FILE}" ]; then
-            echo "No ${UPLOAD_FILE} exists. Skipping upload."
-            continue
-          fi
-          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
-            MEDIA_TYPE=application/json
-          else
-            MEDIA_TYPE=application/sarif+json
-          fi
-
-          echo "Selecting auth"
-          select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
-          echo "Attaching to ${IMAGE_URL}"
-          oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        for image in $BASE_IMAGES; do
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
         done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      if [ "${PRIVILEGED_NESTED}" == "true" ]; then
+        BUILDAH_ARGS+=("--security-opt=label=disable")
+        BUILDAH_ARGS+=("--cap-add=all")
+        BUILDAH_ARGS+=("--device=/dev/fuse")
+      fi
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      VOLUME_MOUNTS=()
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_copy"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p "${YUM_REPOS_D_FETCHED}"
+        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
+      fi
+
+      DEFAULT_LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      # Concatenate defaults and explicit labels. If a label appears twice, the last one wins.
+      LABELS=("${DEFAULT_LABELS[@]}" "${LABELS[@]}")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      # 0. if hermetic=true, skip all subscription related stuff
+      # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+      # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+      # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+      #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
+
+      if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir -p /shared/rhsm/etc/pki/entitlement
+        mkdir -p /shared/rhsm/etc/pki/consumer
+
+        VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key \
+                        -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z \
+                        -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)
+        echo "Adding activation key to the build"
+
+        if ! grep -E "^[^#]*subscription-manager.[^#]*register" "$dockerfile_path"; then
+          # user is not running registration in the Containerfile: pre-register.
+          echo "Pre-registering with subscription manager."
+          subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+          trap 'subscription-manager unregister || true' EXIT
+
+          # copy generated certificates to /shared volume
+          cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement
+          cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer
+
+          # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+          VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)
+        fi
+
+      elif [ "${HERMETIC}" != "true" ] && find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
+        echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
+        # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+        # Instrumented builds (SAST) use this step as their base and add some other tools.
+        while read -r volume_mount; do
+          VOLUME_MOUNTS+=("--volume=$volume_mount")
+        done <<< "$ADDITIONAL_VOLUME_MOUNTS"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
+      declare IMAGE
+
+      buildah_cmd_array=(
+          buildah build
+          "${VOLUME_MOUNTS[@]}"
+          "${BUILDAH_ARGS[@]}"
+          "${LABELS[@]}"
+          --tls-verify="$TLSVERIFY" --no-cache
+          --ulimit nofile=4096:4096
+          -f "$dockerfile_copy" -t "$IMAGE" .
+      )
+      buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
+
+      if [ "${HERMETIC}" == "true" ]; then
+        # enabling loopback adapter enables Bazel builds to work in hermetic mode.
+        command="ip link set lo up && $buildah_cmd"
+      else
+        command="$buildah_cmd"
+      fi
+
+      # disable host subcription manager integration
+      find /usr/share/rhel/secrets -type l -exec unlink {} \;
+
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+
+      container=$(buildah from --pull-never "$IMAGE")
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      touch /shared/base_images_digests
+      echo "Recording base image digests used"
+      for image in $BASE_IMAGES; do
+        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
+        # if buildah did not use that particular image during build because it was skipped
+        if [ -n "$base_image_digest" ]; then
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
+        fi
+      done
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        cpu: 4
+        memory: 4Gi
+      requests:
+        cpu: 2
+        memory: 2Gi
+    env:
+    - name: IMAGE_URL
+      value: $(params.image-url)
+    - name: COV_ANALYZE_ARGS
+      value: $(params.COV_ANALYZE_ARGS)
+    - name: KFP_GIT_URL
+      value: $(params.KFP_GIT_URL)
+    - name: IMP_FINDINGS_ONLY
+      value: $(params.IMP_FINDINGS_ONLY)
+    - name: PROJECT_NAME
+      value: $(params.PROJECT_NAME)
+    - name: RECORD_EXCLUDED
+      value: $(params.RECORD_EXCLUDED)
+    - name: COMPONENT_LABEL
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['appstudio.openshift.io/component']
+    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    name: postprocess
+    script: |
+      #!/bin/bash -e
+      # shellcheck source=/dev/null
+      set -o pipefail
+
+      . /usr/local/share/konflux-test/utils.sh
+      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
+      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+      # Installation of Red Hat certificates for cloning Red Hat internal repositories
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -z "$(ls /shared/sast-results/)" ]; then (
+        set +e
+        set -x
+
+        # fallback to buildless scan if we have no scan results from buildful
+        # shellcheck disable=SC2086
+        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
+
+        # install Coverity license file
+        install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+        # shellcheck disable=SC2086
+        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+        # export scan results
+        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+          | csgrep --mode=json --embed-context=3 \
+          > /shared/sast-results/coverity-buildless.json
+      ) fi
+
+      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
+      IMP_LEVEL=1
+      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+        IMP_LEVEL=0
+      fi
+
+      # collect scan results
+      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*') \
+        | tee coverity-results-raw.json \
+        | csgrep --mode=evtstat
+
+      # We check if the KFP_GIT_URL variable is set to apply the filters or not
+      if [[ -z "${KFP_GIT_URL}" ]]; then
+        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+        mv coverity-results{-raw,}.json
+      else
+        echo "Filtering false positives in results files using csfilter-kfp..."
+        CMD=(
+          csfilter-kfp
+          --verbose
+          --kfp-git-url="${KFP_GIT_URL}"
+          --project-nvr="${PROJECT_NAME}"
+        )
+
+        if [ "${RECORD_EXCLUDED}" == "true" ]; then
+          CMD+=(--record-excluded="excluded-findings.json")
+        fi
+
+        "${CMD[@]}" coverity-results-raw.json \
+          | tee coverity-results.json \
+          | csgrep --mode=evtstat
+      fi
+
+      # convert the scan results into SARIF
+      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+
+      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
+        note="Task $(context.task.name) success: No finding was detected"
+        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      else
+        TEST_OUTPUT=
+        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
+        note="Task $(context.task.name) failed: For details, check Tekton task log."
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      fi
+
+      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+
+      # upload scan results
+      echo "Selecting auth for upload of scan results"
+      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+
+      upload_file() (
+        set -x
+        UPLOAD_FILE="$1"
+        MEDIA_TYPE="$2"
+        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+      )
+
+      echo "Attaching scan results to ${IMAGE_URL}"
+      upload_file "coverity-results.sarif" "application/sarif+json"
+
+      # upload excluded-findings.json if enabled
+      if [ -f "excluded-findings.json" ]; then
+        upload_file "excluded-findings.json" "application/json"
+      fi
+    volumeMounts:
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  - name: cov-license
+    secret:
+      optional: false
+      secretName: $(params.COV_LICENSE)
   workspaces:
-    - name: source
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -275,6 +275,12 @@ spec:
       # always remove Coverity's intermediate directory so that it can be recreated with different ownership
       trap 'rm -fr /tmp/idir' EXIT
 
+      # assign a unique file name for scan results
+      json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+
+      # obtain capture stats to process them later on
+      /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
+
       # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
       $(declare -p COV_ANALYZE_ARGS)
 
@@ -284,7 +290,7 @@ spec:
       # export scan results and embed source code context into the scan results
       /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
         | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
-        > \$(mktemp /shared/sast-results/\$\$-XXXX.json)
+        > "\${json_file}"
 
       # propagate the original exit code of the wrapped command
       exit "\$(</tmp/idir/build-cmd-ec.txt)"
@@ -677,6 +683,8 @@ spec:
         # shellcheck disable=SC2086
         env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
 
+        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
+
         # install Coverity license file
         install -vm0644 /{shared,opt/coverity/bin}/license.dat
 
@@ -689,6 +697,22 @@ spec:
           > /shared/sast-results/coverity-buildless.json
       ) fi
 
+      # collect capture stats (FIXME: this doe not take findings deduplication into account)
+      set +e
+      for file in /shared/sast-results/*-summary.txt; do
+        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+      done
+
+      # calculate the total number of files
+      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
+
+      # calculate the ratio of successful files to total files
+      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
+      set -e
+
       # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
       IMP_LEVEL=1
       if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
@@ -696,7 +720,11 @@ spec:
       fi
 
       # collect scan results
-      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*') \
+      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
+        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
         | tee coverity-results-raw.json \
         | csgrep --mode=evtstat
 

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -1,0 +1,276 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: sast-coverity-check
+spec:
+  description: >-
+    Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Coverity. At the moment, this task only uses the buildless mode, which does not build the project in order to analyze it.
+  results:
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+  params:
+    - description: Image URL.
+      name: image-url
+      type: string
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+    - description: Arguments to be appended to the coverity capture command
+      name: COV_CAPTURE_ARGS
+      type: string
+      default: ""
+    - description: Arguments to be appended to the cov-analyze command
+      name: COV_ANALYZE_ARGS
+      type: string
+      default: "--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096"
+    - name: COV_LICENSE
+      description: Name of secret which contains the Coverity license
+      default: cov-license
+    - name: AUTH_TOKEN_COVERITY_IMAGE
+      description: Name of secret which contains the authentication token for pulling the Coverity image.
+      default: "auth-token-coverity-image"
+    - name: IMP_FINDINGS_ONLY
+      type: string
+      description: Report only important findings. Default is true. To report all findings, specify "false"
+      default: "true"
+    - name: KFP_GIT_URL
+      type: string
+      description: URL from repository to download known false positives files
+      # FIXME: Red Hat internal projects will default to https://gitlab.cee.redhat.com/osh/known-false-positives.git when KONFLUX-4530 is resolved
+      default: ""
+    - name: PROJECT_NAME
+      description: Name of the scanned project, used to find path exclusions.
+            By default, the Konflux component name will be used.
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      type: string
+      description: Write excluded records in file. Useful for auditing (defaults to false).
+      default: "false"
+  volumes:
+    - name: cov-license
+      secret:
+        secretName: $(params.COV_LICENSE)
+        optional: false
+    - name: auth-token-coverity-image
+      secret:
+        secretName: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+        optional: false
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  steps:
+    - name: sast-coverity-check
+      # image: $(steps.secrets-check.results.image)
+      image: quay.io/redhat-user-workloads/sast-tenant/sast-scanner/coverity@sha256:d8e1266319d310443b183f8c14e083932b70f665fd72a61ff90b30e46b9398f0
+      computeResources:
+        requests:
+          memory: "16Gi"
+          cpu: "8"
+        limits:
+          memory: "32Gi"
+          cpu: "16"
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - name: cov-license
+          mountPath: "/etc/secrets/cov"
+          readOnly: true
+        - name: trusted-ca
+          mountPath: /mnt/trusted-ca
+          readOnly: true
+      env:
+        - name: COV_ANALYZE_ARGS
+          value: $(params.COV_ANALYZE_ARGS)
+        - name: COV_CAPTURE_ARGS
+          value: $(params.COV_CAPTURE_ARGS)
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: COV_LICENSE
+          value: $(params.COV_LICENSE)
+        - name: IMP_FINDINGS_ONLY
+          value: $(params.IMP_FINDINGS_ONLY)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+      script: |
+        #!/usr/bin/env bash
+        set -eo pipefail
+        # shellcheck source=/dev/null
+        . /usr/local/share/konflux-test/utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        echo 'Starting Coverity buildless scan'
+
+        export HOME="/var/tmp/coverity/home"
+
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          PROJECT_NAME=${COMPONENT_LABEL}
+        fi
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        COVERITY_DIR=/var/tmp/coverity/idir
+        COVERITY_RESULTS_FILE=$(workspaces.workspace.path)/coverity-buildless-results.json
+        COV_LICENSE_PATH=/etc/secrets/cov/cov-license
+        SOURCE_CODE_DIR=$(workspaces.workspace.path)
+
+        # Installing Coverity license
+        cp "$COV_LICENSE_PATH" /opt/coverity/bin/license.dat
+
+        # Installation of Red Hat certificates for cloning Red Hat internal repositories
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # Create configuration file for coverity buildless
+        echo -e 'capture:\n   build-command-inference: false' > "$SOURCE_CODE_DIR"/coverity.yml
+
+        set +e -x
+        # Buildless scan
+        # shellcheck disable=SC2086
+        env COV_HOST=konflux /opt/coverity/bin/coverity capture $COV_CAPTURE_ARGS --project-dir "$SOURCE_CODE_DIR" --dir "$COVERITY_DIR"
+        COV_CAPTURE_EXIT_CODE=$?
+        set -x
+
+        if [[ "$COV_CAPTURE_EXIT_CODE" -eq 0 ]]; then
+          echo "Coverity capture scan finished successfully"
+        else
+          echo "Coverity capture command failed with exit code ${COV_CAPTURE_EXIT_CODE}. Exiting..."
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          exit 1
+        fi
+
+        # Analysis phase
+        set -x
+        /opt/coverity/bin/cov-manage-emit --dir $COVERITY_DIR reset-host-name
+        # shellcheck disable=SC2086
+        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir="$COVERITY_DIR"
+        COV_ANALYZE_EXIT_CODE=$?
+        set +x
+
+        if [[ "$COV_ANALYZE_EXIT_CODE" -eq 0 ]]; then
+          echo "cov-analyze scan finished successfully"
+        else
+          echo "cov-analyze scan failed with exit code ${COV_ANALYZE_EXIT_CODE}. Exiting..."
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          exit 1
+        fi
+        set -e
+
+        /opt/coverity/bin/cov-format-errors --dir="$COVERITY_DIR" --json-output-v10 "$COVERITY_RESULTS_FILE"
+        # We parse the results, embed context, remove duplicates and store them in SARIF format.
+        IMP_LEVEL=1
+        if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+          IMP_LEVEL=0
+        fi
+
+        (cd "$SOURCE_CODE_DIR" && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --embed-context=3 "$COVERITY_RESULTS_FILE") \
+        | csgrep --mode=json --strip-path-prefix="$SOURCE_CODE_DIR"/source/ \
+        | csgrep --mode=json --strip-path-prefix="$HOME" \
+        > sast_coverity_buildless_check_all_findings.json
+
+        echo "Results:"
+        (set -x && csgrep --mode=evtstat sast_coverity_buildless_check_all_findings.json)
+
+        # We check if the KFP_GIT_URL variable is set to apply the filters or not
+        if [[ -z "${KFP_GIT_URL}" ]]; then
+          echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+          mv sast_coverity_buildless_check_all_findings.json filtered_sast_coverity_buildless_check_all_findings.json
+        else
+          echo "Filtering false positives in results files using csfilter-kfp..."
+          CMD=(
+            csfilter-kfp
+            --verbose
+            --kfp-git-url="${KFP_GIT_URL}"
+            --project-nvr="${PROJECT_NAME}"
+          )
+
+          if [ "${RECORD_EXCLUDED}" == "true" ]; then
+            CMD+=(--record-excluded="excluded-findings.json")
+          fi
+
+          "${CMD[@]}" sast_coverity_buildless_check_all_findings.json > filtered_sast_coverity_buildless_check_all_findings.json
+          status=$?
+          if [ "$status" -ne 0 ]; then
+            echo "Error: failed to filter known false positives" >&2
+            return 1
+          else
+            echo "Message: Succeed to filter known false positives" >&2
+          fi
+
+          echo "Results after filtering:"
+          (set -x $$ csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)
+        fi
+
+        csgrep --mode=sarif filtered_sast_coverity_buildless_check_all_findings.json > "$(workspaces.workspace.path)"/coverity-results.sarif
+
+        if [[ -z "$(csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)" ]]; then
+          note="Task $(context.task.name) success: No finding was detected"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        else
+          TEST_OUTPUT=
+          parse_test_output "$(context.task.name)" sarif "$(workspaces.workspace.path)"/coverity-results.sarif || true
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        fi
+
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+    - name: upload
+      image: quay.io/konflux-ci/oras:latest@sha256:99737f436051e6d3866eb8a8706463c35abf72c87f05090ff42ff642f6729661
+      workingDir: $(workspaces.workspace.path)
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+      script: |
+        #!/usr/bin/env bash
+
+        if [ -z "${IMAGE_URL}" ]; then
+          echo 'No image-url param provided. Skipping upload.'
+          exit 0
+        fi
+        UPLOAD_FILES="coverity-results.sarif excluded-findings.json"
+
+        for UPLOAD_FILE in ${UPLOAD_FILES}; do
+          if [ ! -f "${UPLOAD_FILE}" ]; then
+            echo "No ${UPLOAD_FILE} exists. Skipping upload."
+            continue
+          fi
+          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+            MEDIA_TYPE=application/json
+          else
+            MEDIA_TYPE=application/sarif+json
+          fi
+
+          echo "Selecting auth"
+          select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+          echo "Attaching to ${IMAGE_URL}"
+          oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        done
+  workspaces:
+    - name: workspace

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -221,7 +221,7 @@ spec:
       value: $(params.COV_ANALYZE_ARGS)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    image: quay.io/redhat-services-prod/sast/coverity:202412.1
     name: prepare
     script: |
       #!/bin/bash
@@ -266,6 +266,11 @@ spec:
 
       # if current directory is "/", fallback to an empty temp directory
       [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
+
+      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
+      if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
+        install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
+      fi
 
       # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
       /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
@@ -330,7 +335,7 @@ spec:
         /shared:/shared
         /shared/license.dat:/opt/coverity/bin/license.dat
         /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    image: quay.io/redhat-services-prod/sast/coverity:202412.1
     name: build
     script: |
       #!/bin/bash
@@ -654,7 +659,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.labels['appstudio.openshift.io/component']
-    image: quay.io/redhat-services-prod/sast/coverity:202409.1
+    image: quay.io/redhat-services-prod/sast/coverity:202412.1
     name: postprocess
     script: |
       #!/bin/bash -e

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -86,7 +86,7 @@ spec:
           cpu: "16"
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
-      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)
       volumeMounts:
         - name: cov-license
           mountPath: "/etc/secrets/cov"
@@ -130,9 +130,9 @@ spec:
         echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
 
         COVERITY_DIR=/var/tmp/coverity/idir
-        COVERITY_RESULTS_FILE=$(workspaces.workspace.path)/coverity-buildless-results.json
+        COVERITY_RESULTS_FILE=$(workspaces.source.path)/coverity-buildless-results.json
         COV_LICENSE_PATH=/etc/secrets/cov/cov-license
-        SOURCE_CODE_DIR=$(workspaces.workspace.path)
+        SOURCE_CODE_DIR=$(workspaces.source.path)
 
         # Installing Coverity license
         cp "$COV_LICENSE_PATH" /opt/coverity/bin/license.dat
@@ -227,7 +227,7 @@ spec:
           (set -x $$ csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)
         fi
 
-        csgrep --mode=sarif filtered_sast_coverity_buildless_check_all_findings.json > "$(workspaces.workspace.path)"/coverity-results.sarif
+        csgrep --mode=sarif filtered_sast_coverity_buildless_check_all_findings.json > "$(workspaces.source.path)"/coverity-results.sarif
 
         if [[ -z "$(csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)" ]]; then
           note="Task $(context.task.name) success: No finding was detected"
@@ -235,7 +235,7 @@ spec:
           echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
         else
           TEST_OUTPUT=
-          parse_test_output "$(context.task.name)" sarif "$(workspaces.workspace.path)"/coverity-results.sarif || true
+          parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)"/coverity-results.sarif || true
           note="Task $(context.task.name) failed: For details, check Tekton task log."
           echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
         fi
@@ -243,7 +243,7 @@ spec:
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
     - name: upload
       image: quay.io/konflux-ci/oras:latest@sha256:99737f436051e6d3866eb8a8706463c35abf72c87f05090ff42ff642f6729661
-      workingDir: $(workspaces.workspace.path)
+      workingDir: $(workspaces.source.path)
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -273,4 +273,4 @@ spec:
           oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done
   workspaces:
-    - name: workspace
+    - name: source


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/OSH-750