### PR TITLE
Move prefetch devs out of the larger build team

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -48,7 +48,12 @@ spec:
             value:
               - tasks := strings.any_prefix_match(input, ["task/", "hack/", ".tekton/"])
               - tasks_pipelines := strings.any_prefix_match(input, ["task/", "pipelines/", "hack/", ".tekton/"])
-              - e2e_tests := strings.any_prefix_match(input, ["task/", "pipelines/", "hack/", ".tekton/"])
+              - |
+                e2e_tests if {
+                  some file in input
+                  strings.any_prefix_match(file, ["task/", "pipelines/", "hack/", ".tekton/"])
+                  not endswith(file, "/OWNERS")
+                }
               - check_partner_tasks := strings.any_prefix_match(input, ["partners/", "hack/", ".tekton/"])
         runAfter:
           - build-appstudio-utils

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -9,9 +9,6 @@ aliases:
     - tisutisu
     - tnevrlka
     - MartinBasti
-    - eskultety
-    - brunoapimentel
-    - taylormadore
   integration-team:
     - dirgim
     - jsztuka

--- a/task/prefetch-dependencies-oci-ta/OWNERS
+++ b/task/prefetch-dependencies-oci-ta/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs: https://go.k8s.io/owners
 approvers:
   - build-team
+  - eskultety
+  - brunoapimentel
+  - taylormadore
 reviewers:
   - build-team
+  - eskultety
+  - brunoapimentel
+  - taylormadore

--- a/task/prefetch-dependencies/OWNERS
+++ b/task/prefetch-dependencies/OWNERS
@@ -1,5 +1,11 @@
 # See the OWNERS docs: https://go.k8s.io/owners
 approvers:
   - build-team
+  - eskultety
+  - brunoapimentel
+  - taylormadore
 reviewers:
   - build-team
+  - eskultety
+  - brunoapimentel
+  - taylormadore


### PR DESCRIPTION
They generally don't maintain anything in the build pipeline except for
the prefetch task.

Also: Don't run e2e-tests just for OWNERS changes (note that the e2e-tests _will_ trigger on this PR because it changes a file in `.tekton`)