### PR TITLE
Use revision when pull_request_number is missing

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -40,8 +40,8 @@ spec:
         taskRef:
           name: task-switchboard
         params:
-          - name: pr_number
-            value: "{{ pull_request_number }}"
+          - name: revision
+            value: $(params.revision)
           - name: utils_image
             value: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
           - name: expressions

--- a/.tekton/tasks/task-switchboard.yaml
+++ b/.tekton/tasks/task-switchboard.yaml
@@ -12,7 +12,7 @@ spec:
   description: "Computes a set of expressions based on the changed files in the
   pipeline, used to determine which tasks to run"
   params:
-    - name: pr_number
+    - name: revision
       type: string
     - name: utils_image
       type: string
@@ -46,8 +46,10 @@ spec:
 
         ec opa check --v1-compatible "${rules}"
 
+        pr_number=$(gh search prs --repo konflux-ci/build-definitions "$(params.revision)" --json number --jq '.[].number')
+
         ec opa eval --v1-compatible --data "${rules}" --input \
-        <(gh pr view "https://github.com/konflux-ci/build-definitions/pull/$(params.pr_number)" --json files --jq '[.files.[].path']) \
+        <(gh pr view "https://github.com/konflux-ci/build-definitions/pull/${pr_number}" --json files --jq '[.files.[].path']) \
         'data[_]' \
         | jq '[.result.[].expressions.[].value | to_entries | .[] | select(.value == true) | .key]' \
         | tee "$(results.bindings.path)"


### PR DESCRIPTION
It seems that the `pull_request_number` might not be defined when running checks on a PR in merge queue. So if the value is empty we can try looking up the pull request number by searching for the commit that contained it.