### PR TITLE
fix: adjust the cpu/mem values as per the step changed

### DIFF
--- a/task/buildah-min/0.2/patch.yaml
+++ b/task/buildah-min/0.2/patch.yaml
@@ -14,7 +14,7 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/cpu
   value: 100m
-# sbom-syft-generate step
+# push step
 - op: replace
   path: /spec/steps/1/computeResources/limits/memory
   value: 2Gi
@@ -23,24 +23,24 @@
   value: 512Mi
 - op: replace
   path: /spec/steps/1/computeResources/limits/cpu
-  value: 1
+  value: 500m
 - op: replace
   path: /spec/steps/1/computeResources/requests/cpu
-  value: 50m
-# analyse-dependencies-java-sbom step
+  value: 100m
+# sbom-syft-generate step
 - op: replace
   path: /spec/steps/2/computeResources/limits/memory
-  value: 256Mi
+  value: 2Gi
 - op: replace
   path: /spec/steps/2/computeResources/requests/memory
-  value: 128Mi
+  value: 512Mi
 - op: replace
   path: /spec/steps/2/computeResources/limits/cpu
-  value: 100m
+  value: 1
 - op: replace
   path: /spec/steps/2/computeResources/requests/cpu
-  value: 10m
-# prepare-sboms step
+  value: 50m
+# analyse-dependencies-java-sbom step
 - op: replace
   path: /spec/steps/3/computeResources/limits/memory
   value: 256Mi
@@ -53,29 +53,29 @@
 - op: replace
   path: /spec/steps/3/computeResources/requests/cpu
   value: 10m
-# inject-sbom-and-push step
+# prepare-sboms step
 - op: replace
   path: /spec/steps/4/computeResources/limits/memory
-  value: 2Gi
+  value: 256Mi
 - op: replace
   path: /spec/steps/4/computeResources/requests/memory
-  value: 512Mi
+  value: 128Mi
 - op: replace
   path: /spec/steps/4/computeResources/limits/cpu
-  value: 2
+  value: 100m
 - op: replace
   path: /spec/steps/4/computeResources/requests/cpu
-  value: 100m
+  value: 10m
 # upload-sbom step
 - op: replace
   path: /spec/steps/5/computeResources/limits/memory
-  value: 256Mi
+  value: 2Gi
 - op: replace
   path: /spec/steps/5/computeResources/requests/memory
-  value: 128Mi
+  value: 512Mi
 - op: replace
   path: /spec/steps/5/computeResources/limits/cpu
-  value: 100m
+  value: 2
 - op: replace
   path: /spec/steps/5/computeResources/requests/cpu
-  value: 10m
+  value: 100m


### PR DESCRIPTION
Due to recent step changes with [PR](https://github.com/konflux-ci/build-definitions/pull/1629/) in the `Buildah` task, our buildah-min task fails with `OOMKilled`, this PR will help address this issue
