### PR TITLE
oci-copy produced SBOM has a better name

### DIFF
--- a/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.1/oci-copy-oci-ta.yaml
@@ -305,6 +305,12 @@ spec:
             "specVersion": "1.5",
             "version": 1,
             "components": []
+            "metadata": {
+              "component": {
+                "type": "file",
+                "name": "${IMAGE%:*}@$(cat "$(results.IMAGE_DIGEST.path)")"
+              }
+            }
         }
         EOL
 

--- a/task/oci-copy/0.1/oci-copy.yaml
+++ b/task/oci-copy/0.1/oci-copy.yaml
@@ -284,6 +284,12 @@ spec:
             "specVersion": "1.5",
             "version": 1,
             "components": []
+            "metadata": {
+              "component": {
+                "type": "file",
+                "name": "${IMAGE%:*}@$(cat "$(results.IMAGE_DIGEST.path)")"
+              }
+            }
         }
         EOL
 


### PR DESCRIPTION
This enhances the name for the oci-copy produced SBOM, to be `registry/repository@digest `

JIRA: [ISV-5323](https://issues.redhat.com//browse/ISV-5323)