### PR TITLE
chore: add maven-zip-build/ta to main kustomization.yaml

### DIFF
--- a/pipelines/kustomization.yaml
+++ b/pipelines/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 - enterprise-contract.yaml
 - fbc-builder
 - tekton-bundle-builder
+- maven-zip-build
+- maven-zip-build-oci-ta


### PR DESCRIPTION
This is a missing part of maven-zip-build pipelines. They should be added to main kustomization.yaml to trigger the bundle build. Just added in this PR.