### PR TITLE
sast-coverity-check: added stats for Coverity scans

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.1/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.1/sast-coverity-check-oci-ta.yaml
@@ -95,7 +95,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:52f1391e6f1c472fd10bb838f64fae2ed3320c636f536014978a5ddbdfc6b3af
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -241,7 +241,32 @@ spec:
           (set -x && csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)
         fi
 
-        csgrep --mode=sarif filtered_sast_coverity_buildless_check_all_findings.json >"/var/workdir"/coverity-results.sarif
+        # Generation of stats
+        /opt/coverity/bin/coverity list --dir "$COVERITY_DIR" >coverity_list_command.txt
+
+        # Parse the summary statistics using grep
+        SUCCEEDED=$(grep "SUCCEEDED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        INCOMPLETE=$(grep "INCOMPLETE:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        FAILED=$(grep "FAILED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        IGNORED=$(grep "IGNORED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        LINES_OF_CODE=$(grep "LINES OF CODE:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+
+        # Calculate the total number of files
+        TOTAL_FILES=$((SUCCEEDED + INCOMPLETE + FAILED + IGNORED))
+
+        # Calculate the ratio of successful files to total files
+        if [ "$TOTAL_FILES" -ne 0 ]; then
+          COVERAGE_RATIO=$((SUCCEEDED * 100 / TOTAL_FILES))
+        else
+          COVERAGE_RATIO="0"
+        fi
+
+        csgrep --mode=sarif --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+          --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+          --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+          --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}"
+        filtered_sast_coverity_buildless_check_all_findings.json \
+          >"/var/workdir"/coverity-results.sarif
 
         if [[ -z "$(csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)" ]]; then
           note="Task $(context.task.name) success: No finding was detected"

--- a/task/sast-coverity-check/0.1/README.md
+++ b/task/sast-coverity-check/0.1/README.md
@@ -13,6 +13,7 @@ The characteristics of these tasks are:
 - Only important findings are reported by default.  A parameter ( `IMP_FINDINGS_ONLY`) is provided to override this configuration.
 - The csdiff/v1 SARIF fingerprints are provided for all findings
 - A parameter ( `KFP_GIT_URL`) is provided to remove false positives providing a known false positives repository. By default, no repository is provided.
+- The stats of the scan are embedded into the result's SARIF file
 
 > NOTE: This task is executed only if there is a Coverity license set up in the environment. Please check coverity-availability-check task for more information.
 

--- a/task/sast-coverity-check/0.1/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.1/sast-coverity-check.yaml
@@ -224,7 +224,32 @@ spec:
           (set -x && csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)
         fi
 
-        csgrep --mode=sarif filtered_sast_coverity_buildless_check_all_findings.json > "$(workspaces.workspace.path)"/coverity-results.sarif
+        # Generation of stats
+        /opt/coverity/bin/coverity list --dir "$COVERITY_DIR" > coverity_list_command.txt
+
+        # Parse the summary statistics using grep
+        SUCCEEDED=$(grep "SUCCEEDED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        INCOMPLETE=$(grep "INCOMPLETE:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        FAILED=$(grep "FAILED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        IGNORED=$(grep "IGNORED:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+        LINES_OF_CODE=$(grep "LINES OF CODE:" "coverity_list_command.txt" | grep -oE '[0-9]+')
+
+        # Calculate the total number of files
+        TOTAL_FILES=$((SUCCEEDED + INCOMPLETE + FAILED + IGNORED))
+
+        # Calculate the ratio of successful files to total files
+        if [ "$TOTAL_FILES" -ne 0 ]; then
+            COVERAGE_RATIO=$((SUCCEEDED * 100 / TOTAL_FILES))
+        else
+            COVERAGE_RATIO="0"
+        fi
+
+        csgrep --mode=sarif --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}"
+        filtered_sast_coverity_buildless_check_all_findings.json \
+        > "$(workspaces.workspace.path)"/coverity-results.sarif
 
         if [[ -z "$(csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)" ]]; then
           note="Task $(context.task.name) success: No finding was detected"


### PR DESCRIPTION
Solves: https://issues.redhat.com/browse/OSH-769

Adding the stats to Coverity scans in the result's SARIF file of successful scans.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
