### PR TITLE
Improve listing changed files in a commit

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -148,6 +148,11 @@ spec:
                 value: "$(params.revision)"
               - name: GIT_URL
                 value: "$(params.git-url)"
+              - name: GITHUB_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: "{{ git_auth_secret }}"
+                    key: "git-provider-token"
               script: |
                 #!/bin/bash
                 set -euo pipefail

--- a/.tekton/scripts/build-acceptable-bundles.sh
+++ b/.tekton/scripts/build-acceptable-bundles.sh
@@ -7,10 +7,14 @@ set -o pipefail
 DATA_BUNDLE_REPO="${DATA_BUNDLE_REPO:-quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles}"
 mapfile -t BUNDLES < <(cat "$@")
 
+pr_number=$(gh search prs --repo konflux-ci/build-definitions --merged "${REVISION}" --json number --jq '.[].number')
+
+# changed files in a PR
+mapfile -t changed_files < <(gh pr view "https://github.com/konflux-ci/build-definitions/pull/${pr_number}" --json files --jq '.files.[].path')
 # store a list of changed task files
 task_records=()
 # loop over all changed files
-for path in $(git log -m -1 --name-only --pretty="format:" "${REVISION}"); do
+for path in "${changed_files[@]}"; do
     # check that the file modified is the task file
     if [[ "${path}" == task/*/*/*.yaml ]]; then
         IFS='/' read -r -a path_array <<< "${path}"
@@ -29,6 +33,11 @@ printf '%s\n' "${task_records[@]}"
 
 echo "Bundles to be added:"
 printf '%s\n' "${BUNDLES[@]}"
+
+if [[ -z ${task_records[*]} && -z ${BUNDLES[*]} ]]; then
+    echo Nothing to do...
+    exit 0
+fi
 
 # The OPA data bundle is tagged with the current timestamp. This has two main
 # advantages. First, it prevents the image from accidentally not having any tags,


### PR DESCRIPTION
We ended up with revision 3b215506e4ecc70c287785eeda9dbf8a4350b2fe for several Tasks in the acceptable bundles, seems that the `git log` method was also listing the files that were brought in by merging the main branch onto the pull request branch.

This switches to using GitHub CLI to search for a merged pull request that contains the top commit (`$REVISION`), and then lists the changed files in that pull request.

This version uses the GitHub Token from the `{{git_auth_secret}}` secret created by Pipelines as code.

This should contain only the list of files that were changed in the pull request and not any changed files in a merge commit.

Reference: https://issues.redhat.com/browse/EC-1015