### PR TITLE
Remove build-vm-image tasks' OWNERS files

### DIFF
--- a/task/build-vm-image/OWNERS
+++ b/task/build-vm-image/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- arewm
-- brianwcook
-- ralphbean
-- scoheb


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
