### PR TITLE
Remove eaas tasks' OWNERS files

### DIFF
--- a/stepactions/eaas-copy-secrets-to-ephemeral-cluster/OWNERS
+++ b/stepactions/eaas-copy-secrets-to-ephemeral-cluster/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- amisstea
-- omeramsc
-- avi-biton
-- yftacherzog
-- hmariset

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/OWNERS
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- amisstea
-- omeramsc
-- avi-biton
-- yftacherzog
-- hmariset

--- a/stepactions/eaas-get-ephemeral-cluster-credentials/OWNERS
+++ b/stepactions/eaas-get-ephemeral-cluster-credentials/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- amisstea
-- omeramsc
-- avi-biton
-- yftacherzog
-- hmariset

--- a/stepactions/eaas-get-latest-openshift-version-by-prefix/OWNERS
+++ b/stepactions/eaas-get-latest-openshift-version-by-prefix/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- amisstea
-- omeramsc
-- avi-biton
-- yftacherzog
-- hmariset

--- a/stepactions/eaas-get-supported-ephemeral-cluster-versions/OWNERS
+++ b/stepactions/eaas-get-supported-ephemeral-cluster-versions/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- amisstea
-- omeramsc
-- avi-biton
-- yftacherzog
-- hmariset

--- a/task/eaas-provision-space/OWNERS
+++ b/task/eaas-provision-space/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- amisstea
-- omeramsc
-- avi-biton
-- yftacherzog
-- hmariset

--- a/task/provision-env-with-ephemeral-namespace/OWNERS
+++ b/task/provision-env-with-ephemeral-namespace/OWNERS
@@ -1,8 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- gbenhaim
-- omeramsc
-- amisstea
-- avi-biton
-- yftacherzog


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
