### PR TITLE
Remove ec-owned tasks' OWNERS files

### DIFF
--- a/task/tkn-bundle-oci-ta/OWNERS
+++ b/task/tkn-bundle-oci-ta/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - ec-team
-reviewers:
-  - ec-team

--- a/task/tkn-bundle/OWNERS
+++ b/task/tkn-bundle/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - ec-team
-reviewers:
-  - ec-team

--- a/task/verify-enterprise-contract/OWNERS
+++ b/task/verify-enterprise-contract/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - ec-team
-reviewers:
-  - ec-team


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
