### PR TITLE
Remove integration tasks' OWNERS files

### DIFF
--- a/task/clair-scan/OWNERS
+++ b/task/clair-scan/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/clamav-scan/OWNERS
+++ b/task/clamav-scan/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/coverity-availability-check-oci-ta/OWNERS
+++ b/task/coverity-availability-check-oci-ta/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-  - kdudka

--- a/task/coverity-availability-check/OWNERS
+++ b/task/coverity-availability-check/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-  - kdudka

--- a/task/deprecated-image-check/OWNERS
+++ b/task/deprecated-image-check/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/fbc-related-image-check/OWNERS
+++ b/task/fbc-related-image-check/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/fbc-validation/OWNERS
+++ b/task/fbc-validation/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/inspect-image/OWNERS
+++ b/task/inspect-image/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/sast-coverity-check-oci-ta/OWNERS
+++ b/task/sast-coverity-check-oci-ta/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-  - kdudka

--- a/task/sast-coverity-check/OWNERS
+++ b/task/sast-coverity-check/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-  - kdudka

--- a/task/sast-shell-check-oci-ta/OWNERS
+++ b/task/sast-shell-check-oci-ta/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-  - kdudka

--- a/task/sast-shell-check/OWNERS
+++ b/task/sast-shell-check/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-  - kdudka

--- a/task/sast-snyk-check-oci-ta/OWNERS
+++ b/task/sast-snyk-check-oci-ta/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/sast-snyk-check/OWNERS
+++ b/task/sast-snyk-check/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-  - kdudka

--- a/task/sast-unicode-check-oci-ta/OWNERS
+++ b/task/sast-unicode-check-oci-ta/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/sast-unicode-check/OWNERS
+++ b/task/sast-unicode-check/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-  - kdudka

--- a/task/sbom-json-check/OWNERS
+++ b/task/sbom-json-check/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team

--- a/task/validate-fbc/OWNERS
+++ b/task/validate-fbc/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - integration-team
-reviewers:
-  - integration-team
-


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
