### PR TITLE
Remove maven tasks' OWNERS files

### DIFF
--- a/task/build-maven-zip-oci-ta/OWNERS
+++ b/task/build-maven-zip-oci-ta/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - spmm-team
-reviewers:
-  - spmm-team

--- a/task/build-maven-zip/OWNERS
+++ b/task/build-maven-zip/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - spmm-team
-reviewers:
-  - spmm-team


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
