### PR TITLE
Remove oci-copy tasks' OWNERS files

### DIFF
--- a/task/oci-copy-oci-ta/OWNERS
+++ b/task/oci-copy-oci-ta/OWNERS
@@ -1,5 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - ralphbean
-reviewers:
-  - ralphbean

--- a/task/oci-copy/OWNERS
+++ b/task/oci-copy/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - ralphbean
-reviewers:
-  - ralphbean
-


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
