### PR TITLE
Remove opm tasks' OWNERS files

### DIFF
--- a/task/operator-sdk-generate-bundle/OWNERS
+++ b/task/operator-sdk-generate-bundle/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-- jbpratt
-- gurnben
-reviewers:
-- jbpratt
-- gurnben

--- a/task/opm-get-bundle-version/OWNERS
+++ b/task/opm-get-bundle-version/OWNERS
@@ -1,6 +1,0 @@
-approvers:
-- jbpratt
-- gurnben
-reviewers:
-- jbpratt
-- gurnben

--- a/task/opm-render-bundles/OWNERS
+++ b/task/opm-render-bundles/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-- jbpratt
-- gurnben
-reviewers:
-- jbpratt
-- gurnben


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
