### PR TITLE
Remove rpm-ostree tasks' OWNERS files

### DIFF
--- a/task/rpm-ostree-oci-ta/OWNERS
+++ b/task/rpm-ostree-oci-ta/OWNERS
@@ -1,6 +1,0 @@
-
-#See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - cgwalters
-reviewers:
-  - cgwalters

--- a/task/rpm-ostree/OWNERS
+++ b/task/rpm-ostree/OWNERS
@@ -1,6 +1,0 @@
-
-#See the OWNERS docs: https://go.k8s.io/owners
-approvers:
-  - cgwalters
-reviewers:
-  - cgwalters


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
