### PR TITLE
Remove rpm-related tasks' OWNERS files

### DIFF
--- a/task/generate-odcs-compose/OWNERS
+++ b/task/generate-odcs-compose/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- gbenhaim
-- avi-biton
-- amisstea
-- yftacherzog

--- a/task/rpms-signature-scan/OWNERS
+++ b/task/rpms-signature-scan/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- gbenhaim
-- avi-biton
-- amisstea
-- yftacherzog

--- a/task/verify-signed-rpms/OWNERS
+++ b/task/verify-signed-rpms/OWNERS
@@ -1,7 +1,0 @@
-# See the OWNERS docs: https://go.k8s.io/owners
-
-approvers:
-- gbenhaim
-- avi-biton
-- amisstea
-- yftacherzog


### PR DESCRIPTION
We use CODEOWNERS instead now.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
