### PR TITLE
fix(KONFLUX-6028): Stop fetching tags with skopeo inspect

### DIFF
--- a/task/apply-tags/0.1/apply-tags.yaml
+++ b/task/apply-tags/0.1/apply-tags.yaml
@@ -61,7 +61,7 @@ spec:
       script: |
         #!/bin/bash
 
-        ADDITIONAL_TAGS_FROM_IMAGE_LABEL=$(skopeo inspect --format '{{ index .Labels "konflux.additional-tags" }}' docker://$IMAGE)
+        ADDITIONAL_TAGS_FROM_IMAGE_LABEL=$(skopeo inspect --no-tags --format '{{ index .Labels "konflux.additional-tags" }}' "docker://$IMAGE")
 
         if [ -n "${ADDITIONAL_TAGS_FROM_IMAGE_LABEL}" ]; then
           IFS=', ' read -r -a tags_array <<< "$ADDITIONAL_TAGS_FROM_IMAGE_LABEL"

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -41,7 +41,7 @@ spec:
         echo "Determine if Image Already Exists"
         # Build the image when rebuild is set to true or image does not exist
         # The image check comes last to avoid unnecessary, slow API calls
-        if [ "$REBUILD" == "true" ] || [ "$SKIP_CHECKS" == "false" ] || ! skopeo inspect --raw docker://$IMAGE_URL &>/dev/null; then
+        if [ "$REBUILD" == "true" ] || [ "$SKIP_CHECKS" == "false" ] || ! skopeo inspect --no-tags --raw "docker://$IMAGE_URL" &>/dev/null; then
           echo -n "true" > $(results.build.path)
         else
           echo -n "false" > $(results.build.path)


### PR DESCRIPTION
By default, skopeo inspect will try to fetch all of the tags for a remote repository. This can take a lot of time if there are many present. Therefore, unless we need tags, we should use one of

* `skopeo inspect --raw`
* `skopeo inspect --no-tags`

as both of these will not try to list all tags.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
