### PR TITLE
Set useful SBOM name for rpm-ostree generated images

### DIFF
--- a/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
+++ b/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
@@ -234,7 +234,7 @@ spec:
         - mountPath: /var/lib/containers
           name: varlibcontainers
       script: |
-        syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json=/var/workdir/sbom-cyclonedx.json
+        syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json="/var/workdir/sbom-cyclonedx.json" --source-name "${IMAGE%:*}@$(cat "$(results.IMAGE_DIGEST.path)")"
       computeResources:
         limits:
           memory: 6Gi

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -217,7 +217,7 @@ spec:
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source
     script: |
-      syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json=$(workspaces.source.path)/sbom-cyclonedx.json --source-name "${IMAGE%:*}@$(cat "$(results.IMAGE_DIGEST.path)")"
+      syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json="$(workspaces.source.path)/sbom-cyclonedx.json" --source-name "${IMAGE%:*}@$(cat "$(results.IMAGE_DIGEST.path)")"
     volumeMounts:
       - mountPath: /var/lib/containers
         name: varlibcontainers

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -217,7 +217,7 @@ spec:
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source
     script: |
-      syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json=$(workspaces.source.path)/sbom-cyclonedx.json
+      syft oci-dir:/var/lib/containers/rhtap-final-image --output cyclonedx-json=$(workspaces.source.path)/sbom-cyclonedx.json --source-name "${IMAGE%:*}@$(cat "$(results.IMAGE_DIGEST.path)")"
     volumeMounts:
       - mountPath: /var/lib/containers
         name: varlibcontainers


### PR DESCRIPTION
Set SBOM name for rpm-ostree generated images to `registry/repository@digest`of the pushed image.

JIRA: [ISV-5322](https://issues.redhat.com//browse/ISV-5322)

