### PR TITLE
task/opm-render-bundles: add v to entry name

### DIFF
--- a/task/opm-render-bundles/0.1/opm-render-bundles.yaml
+++ b/task/opm-render-bundles/0.1/opm-render-bundles.yaml
@@ -60,7 +60,7 @@ spec:
         package: "${OPERATOR_NAME}"
         name: "${DEFAULT_CHANNEL}"
         entries:
-          - name: ${OPERATOR_NAME}.${OPERATOR_VERSION}
+          - name: ${OPERATOR_NAME}.v${OPERATOR_VERSION}
             skipRange: ">=0.0.1 <${OPERATOR_VERSION}"
         EOF
 


### PR DESCRIPTION
the entry should have a v in the name according to the skiprange docs

https://olm.operatorframework.io/docs/concepts/olm-architecture/operator-catalog/creating-an-update-graph/#skiprange
