### PR TITLE
Fix renovate.json groupings

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -27,18 +27,6 @@
       ]
     },
     {
-      "matchPackageNames": [
-        "quay.io/konflux-ci/pull-request-builds",
-        "quay.io/konflux-ci/buildah",
-        "quay.io/konflux-ci/source-container-build",
-        "quay.io/redhat-appstudio/e2e-tests",
-        "quay.io/redhat-appstudio/buildah",
-        "quay.io/redhat-appstudio/hacbs-jvm-build-request-processor",
-        "quay.io/redhat-appstudio/build-definitions-source-image-build-utils",
-        "quay.io/redhat-appstudio/cachi2",
-        "quay.io/redhat-appstudio/sbom-utility-scripts-image",
-        "registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9"
-      ],
       "groupName": "build",
       "matchFileNames": [
         "task/acs-deploy-check/**",
@@ -80,12 +68,6 @@
       ]
     },
     {
-      "matchPackagePrefixes": [
-        "quay.io/enterprise-contract/"
-      ],
-      "matchPackageNames": [
-        "registry.redhat.io/openshift-pipelines/pipelines-cli-tkn-rhel8"
-      ],
       "groupName": "ec",
       "matchFileNames": [
         "task/tkn-bundle-oci-ta/**",
@@ -94,11 +76,6 @@
       ]
     },
     {
-      "matchPackageNames": [
-        "quay.io/konflux-ci/konflux-test",
-        "quay.io/redhat-appstudio/clair-in-ci",
-        "quay.io/konflux-ci/clamav-db"
-      ],
       "groupName": "integration",
       "matchFileNames": [
         "task/clair-scan/**",
@@ -122,9 +99,6 @@
       ]
     },
     {
-      "matchPackageNames": [
-        "quay.io/opdev/preflight"
-      ],
       "groupName": "preflight",
       "matchFileNames": [
         "task/ecosystem-cert-preflight-checks/**"
@@ -132,11 +106,8 @@
     },
     {
       "groupName": "github-actions",
-      "matchManagers": [
-        "github-actions"
-      ],
       "matchFileNames": [
-        ".github/workflows/**"
+        ".github/**"
       ],
       "schedule": [
         "on sunday"


### PR DESCRIPTION
https://docs.renovatebot.com/configuration-options/#packagerules

> If multiple matchers are included in one package rule, *all of them*
> must match.

Remove the extraneous matchers that are breaking the groupings

Tested with

    $ podman run --rm -ti -v "$PWD:$PWD:z" -w "$PWD" --user=0 \
        -e LOG_LEVEL=debug \
        -e RENOVATE_PLATFORM=local \
        ghcr.io/renovatebot/renovate |
            grep 'Returning .* branch'

      DEBUG: Returning 15 branch(es) (repository=local)

In main, this returns 24 branches instead.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
