### PR TITLE
chore(KFLUXVNGD-140): renovate to ignore tekton-tools tasks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -76,10 +76,8 @@
 # renovate groupName=preflight
 /task/ecosystem-cert-preflight-checks   @acornett21 @bcrochet @komish @skattoju
 
-# renovate groupName=eaas
+# maitained in tekton-tools, thus should be ignored by renovate
 /task/provision-env-with-ephemeral-namespace    @amisstea @avi-biton @gbenhaim @omeramsc @yftacherzog
-
-# renovate groupName=rpm-tasks
 /task/generate-odcs-compose @amisstea @avi-biton @gbenhaim @yftacherzog
 /task/rpms-signature-scan   @amisstea @avi-biton @gbenhaim @yftacherzog
 /task/verify-signed-rpms    @amisstea @avi-biton @gbenhaim @yftacherzog

--- a/renovate.json
+++ b/renovate.json
@@ -136,8 +136,7 @@
         "stepactions/eaas-get-ephemeral-cluster-credentials/**",
         "stepactions/eaas-get-latest-openshift-version-by-prefix/**",
         "stepactions/eaas-get-supported-ephemeral-cluster-versions/**",
-        "task/eaas-provision-space/**",
-        "task/provision-env-with-ephemeral-namespace/**"
+        "task/eaas-provision-space/**"
       ]
     },
     {
@@ -170,12 +169,15 @@
       ]
     },
     {
-      "groupName": "rpm-tasks",
+      "groupName": "tekton-tools-tasks",
+      "description": "Updated and verified in tekton-tools so should be ignored here",
       "matchFileNames": [
         "task/generate-odcs-compose/**",
         "task/rpms-signature-scan/**",
-        "task/verify-signed-rpms/**"
-      ]
+        "task/verify-signed-rpms/**",
+        "task/provision-env-with-ephemeral-namespace/**"
+      ],
+      "enabled": false
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
The tasks that are maintained in tekton-tools are tracked by mintmaker there and have additional specific test cases there.

We should let mintmaker update them rather than have renovate update them here. The updated tasks are then automatically mirrored to this repo.
