### PR TITLE
renovate: update images in recipe.yaml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -207,6 +207,17 @@
       "depNameTemplate": "konflux-ci",
       "packageNameTemplate": "https://github.com/konflux-ci/konflux-ci",
       "datasourceTemplate": "git-refs"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^task/.*/recipe\\.yaml$"
+      ],
+      "matchStrings": [
+        "image: (?:['\"])?(?<depName>.*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})(?:['\"])?"
+      ],
+      "autoReplaceStringTemplate": "image: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
The task-generator/trusted-artifacts tools uses recipe.yaml files to generate tasks. These files may include an 'additionalSteps' attribute, which is a list of full Tekton step definitions.

These definitions include pinned image references. This clashes with Renovate updates - when Renovate updates the image reference in an *-oci-ta.yaml task, the TA generator reverts it back to the reference in recipe.yaml.

Fix by adding a custom regexManager for recipe.yaml files.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
