### PR TITLE
feat(KONFLUX-5670): Define computeResources for prefetch-dependencies and create-trusted-artifact steps

### DIFF
--- a/task-generator/trusted-artifacts/go.mod
+++ b/task-generator/trusted-artifacts/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/tektoncd/pipeline v0.66.0
 	github.com/zregvart/tkn-fmt v0.0.0-20240614122620-a2995427266c
 	k8s.io/api v0.30.1
+	k8s.io/apimachinery v0.30.1
 	mvdan.cc/sh/v3 v3.10.0
 	sigs.k8s.io/kustomize/api v0.18.0
 	sigs.k8s.io/kustomize/kyaml v0.18.1
@@ -87,7 +88,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/apimachinery v0.30.1 // indirect
 	k8s.io/client-go v0.30.1 // indirect
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240521193020-835d969ad83a // indirect

--- a/task-generator/trusted-artifacts/golden/git-clone/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/git-clone/ta.yaml
@@ -255,6 +255,13 @@ spec:
     env:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.ociArtifactExpiresAfter)
+    computeResources:
+      limits:
+        cpu: "1"
+        memory: 3Gi
+      requests:
+        cpu: "1"
+        memory: 3Gi
     volumeMounts:
       - name: workdir
         mountPath: /var/workdir

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -152,6 +152,13 @@ spec:
     env:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.ociArtifactExpiresAfter)
+    computeResources:
+      limits:
+        cpu: "1"
+        memory: 3Gi
+      requests:
+        cpu: "1"
+        memory: 3Gi
     args:
       - create
       - --store

--- a/task-generator/trusted-artifacts/ta.go
+++ b/task-generator/trusted-artifacts/ta.go
@@ -12,6 +12,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	core "k8s.io/api/core/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 )
 
 var (
@@ -334,6 +335,16 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 				},
 			},
 			Args: args,
+			ComputeResources: core.ResourceRequirements{
+				Requests: core.ResourceList{
+					core.ResourceCPU:    resource.MustParse("1"),
+					core.ResourceMemory: resource.MustParse("3Gi"),
+				},
+				Limits: core.ResourceList{
+					core.ResourceCPU:    resource.MustParse("1"),
+					core.ResourceMemory: resource.MustParse("3Gi"),
+				},
+			},
 		}
 
 		if task.Spec.StepTemplate == nil && !recipe.PreferStepTemplate {

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -310,3 +310,10 @@ spec:
       env:
         - name: IMAGE_EXPIRES_AFTER
           value: $(params.ociArtifactExpiresAfter)
+      computeResources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -394,6 +394,13 @@ spec:
 
         cachi2 --log-level="$LOG_LEVEL" inject-files /var/workdir/cachi2/output \
           --for-output-dir=/cachi2/output
+      computeResources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
     - name: unregister-rhsm
       image: quay.io/redhat-appstudio/cachi2:0.16.0@sha256:55415cd8ded149f5d56d3fca46d93125b86b41e07ae5d3c03caa240b7b93b7d8
       script: |
@@ -417,3 +424,10 @@ spec:
       env:
         - name: IMAGE_EXPIRES_AFTER
           value: $(params.ociArtifactExpiresAfter)
+      computeResources:
+        limits:
+          cpu: "1"
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -255,6 +255,13 @@ spec:
         readOnly: true
       - mountPath: /activation-key
         name: activation-key
+    computeResources:
+      limits:
+        cpu: '1'
+        memory: 3Gi
+      requests:
+        cpu: '1'
+        memory: 3Gi
     script: |
       #!/bin/bash
 


### PR DESCRIPTION
OK, I was trying to reproduce the issue [KONFLUX-5951](https://issues.redhat.com//browse/KONFLUX-5951) and was able to do so with Gomod Cachi2 configured. I do not know what caused that issue, but noticed that for me all of 50 concurrent prefetch-dependencies pods were running on the same node!

I have picked 1 CPU and 3 GiB of memory as a `request` (and in an effort to slowly migrate to model where we have requests == limits), used the same for `limits`. This is why I used these numbers (graphs from _stone-prd-rh01_):

![image](https://github.com/user-attachments/assets/9bcf0940-a2ce-41ac-95d2-0f44662db13c)
... looks like steps `step-prefetch-dependencies` and `step-create-trusted-artifact` can take about 2 GB (including cache and so)

![image](https://github.com/user-attachments/assets/c07f7b65-23bb-40a8-8285-ed0190011e12)
... RSS memory is of-course smaller

![image](https://github.com/user-attachments/assets/b91a745d-9309-45bb-ad63-725c15e65f8d)
... regarding CPU it takes about 1 CPU across all containers

![image](https://github.com/user-attachments/assets/97113874-766a-42fe-98e8-0d61eb7fdf08)
... again, only containers `step-prefetch-dependencies` and `step-create-trusted-artifact` seems to be bigger players here