### PR TITLE
feat: introduce content manifest with content sets

### DIFF
--- a/task/buildah-min/0.2/patch.yaml
+++ b/task/buildah-min/0.2/patch.yaml
@@ -14,45 +14,19 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/cpu
   value: 100m
-# icm step
+# icm, push, and sbom-syft-generate steps
 - op: replace
-  path: /spec/steps/1/computeResources/limits/memory
+  path: /spec/stepTemplate/computeResources/limits/memory
   value: 2Gi
 - op: replace
-  path: /spec/steps/1/computeResources/requests/memory
+  path: /spec/stepTemplate/computeResources/requests/memory
   value: 512Mi
 - op: replace
-  path: /spec/steps/1/computeResources/limits/cpu
+  path: /spec/stepTemplate/computeResources/limits/cpu
   value: 500m
 - op: replace
-  path: /spec/steps/1/computeResources/requests/cpu
+  path: /spec/stepTemplate/computeResources/requests/cpu
   value: 100m
-# push step
-- op: replace
-  path: /spec/steps/2/computeResources/limits/memory
-  value: 2Gi
-- op: replace
-  path: /spec/steps/2/computeResources/requests/memory
-  value: 512Mi
-- op: replace
-  path: /spec/steps/2/computeResources/limits/cpu
-  value: 500m
-- op: replace
-  path: /spec/steps/2/computeResources/requests/cpu
-  value: 100m
-# sbom-syft-generate step
-- op: replace
-  path: /spec/steps/3/computeResources/limits/memory
-  value: 2Gi
-- op: replace
-  path: /spec/steps/3/computeResources/requests/memory
-  value: 512Mi
-- op: replace
-  path: /spec/steps/3/computeResources/limits/cpu
-  value: 1
-- op: replace
-  path: /spec/steps/3/computeResources/requests/cpu
-  value: 50m
 # analyse-dependencies-java-sbom step
 - op: replace
   path: /spec/steps/4/computeResources/limits/memory

--- a/task/buildah-min/0.2/patch.yaml
+++ b/task/buildah-min/0.2/patch.yaml
@@ -14,7 +14,7 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/cpu
   value: 100m
-# push step
+# icm step
 - op: replace
   path: /spec/steps/1/computeResources/limits/memory
   value: 2Gi
@@ -27,7 +27,7 @@
 - op: replace
   path: /spec/steps/1/computeResources/requests/cpu
   value: 100m
-# sbom-syft-generate step
+# push step
 - op: replace
   path: /spec/steps/2/computeResources/limits/memory
   value: 2Gi
@@ -36,24 +36,24 @@
   value: 512Mi
 - op: replace
   path: /spec/steps/2/computeResources/limits/cpu
-  value: 1
+  value: 500m
 - op: replace
   path: /spec/steps/2/computeResources/requests/cpu
-  value: 50m
-# analyse-dependencies-java-sbom step
+  value: 100m
+# sbom-syft-generate step
 - op: replace
   path: /spec/steps/3/computeResources/limits/memory
-  value: 256Mi
+  value: 2Gi
 - op: replace
   path: /spec/steps/3/computeResources/requests/memory
-  value: 128Mi
+  value: 512Mi
 - op: replace
   path: /spec/steps/3/computeResources/limits/cpu
-  value: 100m
+  value: 1
 - op: replace
   path: /spec/steps/3/computeResources/requests/cpu
-  value: 10m
-# prepare-sboms step
+  value: 50m
+# analyse-dependencies-java-sbom step
 - op: replace
   path: /spec/steps/4/computeResources/limits/memory
   value: 256Mi
@@ -66,16 +66,29 @@
 - op: replace
   path: /spec/steps/4/computeResources/requests/cpu
   value: 10m
-# upload-sbom step
+# prepare-sboms step
 - op: replace
   path: /spec/steps/5/computeResources/limits/memory
-  value: 2Gi
+  value: 256Mi
 - op: replace
   path: /spec/steps/5/computeResources/requests/memory
-  value: 512Mi
+  value: 128Mi
 - op: replace
   path: /spec/steps/5/computeResources/limits/cpu
-  value: 2
+  value: 100m
 - op: replace
   path: /spec/steps/5/computeResources/requests/cpu
+  value: 10m
+# upload-sbom step
+- op: replace
+  path: /spec/steps/6/computeResources/limits/memory
+  value: 2Gi
+- op: replace
+  path: /spec/steps/6/computeResources/requests/memory
+  value: 512Mi
+- op: replace
+  path: /spec/steps/6/computeResources/limits/cpu
+  value: 2
+- op: replace
+  path: /spec/steps/6/computeResources/requests/cpu
   value: 100m

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -175,6 +175,13 @@ spec:
     - name: workdir
       emptyDir: {}
   stepTemplate:
+    computeResources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
     env:
       - name: ACTIVATION_KEY
         value: $(params.ACTIVATION_KEY)
@@ -438,9 +445,8 @@ spec:
         # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
         # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
         # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
-        #    to buildah but don't pre-register for backwards compatibility. In this case mount an empty directory on
-        #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced
-        #    container.
+        #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+        #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
 
         if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
           cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
@@ -558,13 +564,6 @@ spec:
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers
-      computeResources:
-        limits:
-          cpu: "4"
-          memory: 4Gi
-        requests:
-          cpu: "1"
-          memory: 1Gi
       securityContext:
         capabilities:
           add:
@@ -618,13 +617,6 @@ spec:
           echo -n "${IMAGE}@"
           cat "/var/workdir/image-digest"
         } >"$(results.IMAGE_REF.path)"
-      computeResources:
-        limits:
-          cpu: "4"
-          memory: 4Gi
-        requests:
-          cpu: "1"
-          memory: 1Gi
       securityContext:
         capabilities:
           add:
@@ -643,13 +635,6 @@ spec:
         syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="/var/workdir/sbom-source.json"
         echo "Running syft on the image filesystem"
         syft dir:"$(cat /shared/container_path)" --output cyclonedx-json="/var/workdir/sbom-image.json"
-      computeResources:
-        limits:
-          cpu: "2"
-          memory: 4Gi
-        requests:
-          cpu: 500m
-          memory: 1Gi
     - name: analyse-dependencies-java-sbom
       image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
       volumeMounts:

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -518,15 +518,51 @@ spec:
         unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 
         container=$(buildah from --pull-never "$IMAGE")
+
+        # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+        if [ -f "/tmp/cachi2/output/bom.json" ]; then
+          echo "Making copy of sbom-cachi2.json"
+          cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+
+          # Inject a content sets file for backwards compatibility
+          # This is only possible for images built hermetically with prefetch
+          base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
+          base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
+          cat >content-sets.json <<EOF
+          {
+              "metadata": {
+                  "icm_version": 1,
+                  "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
+                  "image_layer_index": 0
+              },
+              "from_dnf_hint": true,
+              "content_sets": []
+          }
+
+        EOF
+
+          while IFS='' read -r content_set; do
+            jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json >content-sets.json.tmp
+            mv content-sets.json.tmp content-sets.json
+          done <<<"$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
+
+          echo "Writing to /root/buildinfo/content_manifests/content-sets.json"
+          buildah copy "$container" content-sets.json /root/buildinfo/content_manifests/
+          buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$container"
+
+          BUILDAH_ARGS=()
+          if [ "${SQUASH}" == "true" ]; then
+            BUILDAH_ARGS+=("--squash")
+          fi
+
+          buildah commit "${BUILDAH_ARGS[@]}" "$container" "$IMAGE"
+          # End content sets backwards compatibility
+        fi
+
         buildah mount $container | tee /shared/container_path
         # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
         find $(cat /shared/container_path) -xtype l -delete
         echo $container >/shared/container_name
-
-        # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
-        if [ -f "/tmp/cachi2/output/bom.json" ]; then
-          cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-        fi
 
         touch /shared/base_images_digests
         for image in $BASE_IMAGES; do

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -273,8 +273,7 @@ spec:
         elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
           dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
         elif [ -e "$DOCKERFILE" ]; then
-          # Custom Dockerfile location is mainly used for instrumented builds for SAST scanning and analyzing.
-          # Instrumented builds use this step as their base and also need to provide modified Dockerfile.
+          # Instrumented builds (SAST) use this custom dockerffile step as their base
           dockerfile_path="$DOCKERFILE"
         elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
           echo "Fetch Dockerfile from $DOCKERFILE"
@@ -330,7 +329,7 @@ spec:
             shift
             # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
             # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
-            # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE - they take precedence.
+            # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
             while [[ $# -gt 0 && $1 != --* ]]; do
               build_args+=("$1")
               shift
@@ -480,8 +479,7 @@ spec:
 
         if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
           # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
-          # This is primarily used in instrumented builds for SAST scanning and analyzing.
-          # Instrumented builds use this step as their base and add some other tools.
+          # Instrumented builds (SAST) use this step as their base and add some other tools.
           while read -r volume_mount; do
             VOLUME_MOUNTS+=("--volume=$volume_mount")
           done <<<"$ADDITIONAL_VOLUME_MOUNTS"

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -557,7 +557,7 @@ spec:
           add:
             - SETFCAP
     - name: icm
-      image: quay.io/rbean/testing:icm-injection-scripts
+      image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
       args:
         - $(params.IMAGE)
       workingDir: /var/workdir

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -523,40 +523,6 @@ spec:
         if [ -f "/tmp/cachi2/output/bom.json" ]; then
           echo "Making copy of sbom-cachi2.json"
           cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-
-          # Inject a content sets file for backwards compatibility
-          # This is only possible for images built hermetically with prefetch
-          base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
-          base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
-          cat >content-sets.json <<EOF
-          {
-              "metadata": {
-                  "icm_version": 1,
-                  "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
-                  "image_layer_index": 0
-              },
-              "from_dnf_hint": true,
-              "content_sets": []
-          }
-
-        EOF
-
-          while IFS='' read -r content_set; do
-            jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json >content-sets.json.tmp
-            mv content-sets.json.tmp content-sets.json
-          done <<<"$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
-
-          echo "Writing to /root/buildinfo/content_manifests/content-sets.json"
-          buildah copy "$container" content-sets.json /root/buildinfo/content_manifests/
-          buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$container"
-
-          BUILDAH_ARGS=()
-          if [ "${SQUASH}" == "true" ]; then
-            BUILDAH_ARGS+=("--squash")
-          fi
-
-          buildah commit "${BUILDAH_ARGS[@]}" "$container" "$IMAGE"
-          # End content sets backwards compatibility
         fi
 
         buildah mount $container | tee /shared/container_path
@@ -580,6 +546,25 @@ spec:
         requests:
           cpu: "1"
           memory: 2Gi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+    - name: icm
+      image: quay.io/rbean/testing:icm-injection-scripts
+      args:
+        - $(params.IMAGE)
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      computeResources:
+        limits:
+          cpu: "4"
+          memory: 4Gi
+        requests:
+          cpu: "1"
+          memory: 1Gi
       securityContext:
         capabilities:
           add:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -654,7 +654,7 @@ spec:
   - args:
     - $(params.IMAGE)
     computeResources: {}
-    image: quay.io/rbean/testing:icm-injection-scripts
+    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
     name: icm
     securityContext:
       capabilities:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -552,15 +552,51 @@ spec:
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 
       container=$(buildah from --pull-never "$IMAGE")
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+
+        # Inject a content sets file for backwards compatibility
+        # This is only possible for images built hermetically with prefetch
+        base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
+        base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
+        cat >content-sets.json <<EOF
+        {
+            "metadata": {
+                "icm_version": 1,
+                "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
+                "image_layer_index": 0
+            },
+            "from_dnf_hint": true,
+            "content_sets": []
+        }
+
+      EOF
+
+        while IFS='' read -r content_set; do
+          jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json >content-sets.json.tmp
+          mv content-sets.json.tmp content-sets.json
+        done <<<"$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
+
+        echo "Writing to /root/buildinfo/content_manifests/content-sets.json"
+        buildah copy "$container" content-sets.json /root/buildinfo/content_manifests/
+        buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$container"
+
+        BUILDAH_ARGS=()
+        if [ "${SQUASH}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash")
+        fi
+
+        buildah commit "${BUILDAH_ARGS[@]}" "$container" "$IMAGE"
+        # End content sets backwards compatibility
+      fi
+
       buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container >/shared/container_name
-
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
-      if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-      fi
 
       touch /shared/base_images_digests
       for image in $BASE_IMAGES; do

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -306,8 +306,7 @@ spec:
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
       elif [ -e "$DOCKERFILE" ]; then
-        # Custom Dockerfile location is mainly used for instrumented builds for SAST scanning and analyzing.
-        # Instrumented builds use this step as their base and also need to provide modified Dockerfile.
+        # Instrumented builds (SAST) use this custom dockerffile step as their base
         dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
@@ -363,7 +362,7 @@ spec:
           shift
           # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
           # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
-          # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE - they take precedence.
+          # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
           while [[ $# -gt 0 && $1 != --* ]]; do
             build_args+=("$1")
             shift
@@ -513,8 +512,7 @@ spec:
 
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
         # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
-        # This is primarily used in instrumented builds for SAST scanning and analyzing.
-        # Instrumented builds use this step as their base and add some other tools.
+        # Instrumented builds (SAST) use this step as their base and add some other tools.
         while read -r volume_mount; do
           VOLUME_MOUNTS+=("--volume=$volume_mount")
         done <<<"$ADDITIONAL_VOLUME_MOUNTS"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -557,40 +557,6 @@ spec:
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-
-        # Inject a content sets file for backwards compatibility
-        # This is only possible for images built hermetically with prefetch
-        base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
-        base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
-        cat >content-sets.json <<EOF
-        {
-            "metadata": {
-                "icm_version": 1,
-                "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
-                "image_layer_index": 0
-            },
-            "from_dnf_hint": true,
-            "content_sets": []
-        }
-
-      EOF
-
-        while IFS='' read -r content_set; do
-          jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json >content-sets.json.tmp
-          mv content-sets.json.tmp content-sets.json
-        done <<<"$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
-
-        echo "Writing to /root/buildinfo/content_manifests/content-sets.json"
-        buildah copy "$container" content-sets.json /root/buildinfo/content_manifests/
-        buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$container"
-
-        BUILDAH_ARGS=()
-        if [ "${SQUASH}" == "true" ]; then
-          BUILDAH_ARGS+=("--squash")
-        fi
-
-        buildah commit "${BUILDAH_ARGS[@]}" "$container" "$IMAGE"
-        # End content sets backwards compatibility
       fi
 
       buildah mount $container | tee /shared/container_path
@@ -679,6 +645,25 @@ spec:
     - mountPath: /ssh
       name: ssh
       readOnly: true
+    workingDir: /var/workdir
+  - args:
+    - $(params.IMAGE)
+    computeResources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    image: quay.io/rbean/testing:icm-injection-scripts
+    name: icm
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
     workingDir: /var/workdir
   - computeResources:
       limits:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -154,7 +154,13 @@ spec:
     name: SBOM_JAVA_COMPONENTS_COUNT
     type: string
   stepTemplate:
-    computeResources: {}
+    computeResources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
     env:
     - name: ACTIVATION_KEY
       value: $(params.ACTIVATION_KEY)
@@ -472,9 +478,8 @@ spec:
       # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
       # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
       # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
-      #    to buildah but don't pre-register for backwards compatibility. In this case mount an empty directory on
-      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced
-      #    container.
+      #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
 
       if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
@@ -648,13 +653,7 @@ spec:
     workingDir: /var/workdir
   - args:
     - $(params.IMAGE)
-    computeResources:
-      limits:
-        cpu: "4"
-        memory: 4Gi
-      requests:
-        cpu: "1"
-        memory: 1Gi
+    computeResources: {}
     image: quay.io/rbean/testing:icm-injection-scripts
     name: icm
     securityContext:
@@ -665,13 +664,7 @@ spec:
     - mountPath: /var/lib/containers
       name: varlibcontainers
     workingDir: /var/workdir
-  - computeResources:
-      limits:
-        cpu: "4"
-        memory: 4Gi
-      requests:
-        cpu: "1"
-        memory: 1Gi
+  - computeResources: {}
     image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: push
     script: |
@@ -730,13 +723,7 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: /var/workdir
-  - computeResources:
-      limits:
-        cpu: "2"
-        memory: 4Gi
-      requests:
-        cpu: 500m
-        memory: 1Gi
+  - computeResources: {}
     image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     name: sbom-syft-generate
     script: |

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -288,8 +288,7 @@ spec:
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
       elif [ -e "$DOCKERFILE" ]; then
-        # Custom Dockerfile location is mainly used for instrumented builds for SAST scanning and analyzing.
-        # Instrumented builds use this step as their base and also need to provide modified Dockerfile.
+        # Instrumented builds (SAST) use this custom dockerffile step as their base
         dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
@@ -345,7 +344,7 @@ spec:
                   shift
                   # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
                   # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
-                  # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE - they take precedence.
+                  # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
                   while [[ $# -gt 0 && $1 != --* ]]; do build_args+=("$1"); shift; done
                   ;;
               --labels)
@@ -489,8 +488,7 @@ spec:
 
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
         # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
-        # This is primarily used in instrumented builds for SAST scanning and analyzing.
-        # Instrumented builds use this step as their base and add some other tools.
+        # Instrumented builds (SAST) use this step as their base and add some other tools.
         while read -r volume_mount; do
           VOLUME_MOUNTS+=("--volume=$volume_mount")
         done <<< "$ADDITIONAL_VOLUME_MOUNTS"

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -630,7 +630,7 @@ spec:
   - args:
     - $(params.IMAGE)
     computeResources: {}
-    image: quay.io/rbean/testing:icm-injection-scripts
+    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
     name: icm
     securityContext:
       capabilities:

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -145,7 +145,13 @@ spec:
       central.
     name: JAVA_COMMUNITY_DEPENDENCIES
   stepTemplate:
-    computeResources: {}
+    computeResources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
     env:
     - name: BUILDAH_FORMAT
       value: oci
@@ -358,7 +364,6 @@ spec:
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
-
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
           jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json
@@ -449,9 +454,8 @@ spec:
       # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
       # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
       # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
-      #    to buildah but don't pre-register for backwards compatibility. In this case mount an empty directory on
-      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced
-      #    container.
+      #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
 
       if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
@@ -625,13 +629,7 @@ spec:
     workingDir: $(workspaces.source.path)
   - args:
     - $(params.IMAGE)
-    computeResources:
-      limits:
-        cpu: "4"
-        memory: 4Gi
-      requests:
-        cpu: "1"
-        memory: 1Gi
+    computeResources: {}
     image: quay.io/rbean/testing:icm-injection-scripts
     name: icm
     securityContext:
@@ -642,13 +640,7 @@ spec:
     - mountPath: /var/lib/containers
       name: varlibcontainers
     workingDir: $(workspaces.source.path)
-  - computeResources:
-      limits:
-        cpu: "4"
-        memory: 4Gi
-      requests:
-        cpu: "1"
-        memory: 1Gi
+  - computeResources: {}
     image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     name: push
     script: |
@@ -709,13 +701,7 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - computeResources:
-      limits:
-        cpu: "2"
-        memory: 4Gi
-      requests:
-        cpu: 500m
-        memory: 1Gi
+  - computeResources: {}
     image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.4.1@sha256:34d7065427085a31dc4949bd283c001b91794d427e1e4cdf1b21ea4faf9fee3f
     name: sbom-syft-generate
     script: |

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -534,41 +534,6 @@ spec:
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-
-        # Inject a content sets file for backwards compatibility
-        # This is only possible for images built hermetically with prefetch
-        base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
-        base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
-        cat >content-sets.json <<EOF
-        {
-            "metadata": {
-                "icm_version": 1,
-                "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
-                "image_layer_index": 0
-            },
-            "from_dnf_hint": true,
-            "content_sets": []
-        }
-
-      EOF
-
-        while IFS='' read -r content_set;
-        do
-          jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json > content-sets.json.tmp
-          mv content-sets.json.tmp content-sets.json
-        done <<< "$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
-
-        echo "Writing to /root/buildinfo/content_manifests/content-sets.json"
-        buildah copy "$container" content-sets.json /root/buildinfo/content_manifests/
-        buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$container"
-
-        BUILDAH_ARGS=()
-        if [ "${SQUASH}" == "true" ]; then
-          BUILDAH_ARGS+=("--squash")
-        fi
-
-        buildah commit "${BUILDAH_ARGS[@]}" "$container" "$IMAGE"
-        # End content sets backwards compatibility
       fi
 
       buildah mount $container | tee /shared/container_path
@@ -657,6 +622,25 @@ spec:
     - mountPath: /ssh
       name: ssh
       readOnly: true
+    workingDir: $(workspaces.source.path)
+  - args:
+    - $(params.IMAGE)
+    computeResources:
+      limits:
+        cpu: "4"
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    image: quay.io/rbean/testing:icm-injection-scripts
+    name: icm
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
     workingDir: $(workspaces.source.path)
   - computeResources:
       limits:

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -529,15 +529,52 @@ spec:
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 
       container=$(buildah from --pull-never "$IMAGE")
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+
+        # Inject a content sets file for backwards compatibility
+        # This is only possible for images built hermetically with prefetch
+        base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
+        base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
+        cat >content-sets.json <<EOF
+        {
+            "metadata": {
+                "icm_version": 1,
+                "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
+                "image_layer_index": 0
+            },
+            "from_dnf_hint": true,
+            "content_sets": []
+        }
+
+      EOF
+
+        while IFS='' read -r content_set;
+        do
+          jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json > content-sets.json.tmp
+          mv content-sets.json.tmp content-sets.json
+        done <<< "$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
+
+        echo "Writing to /root/buildinfo/content_manifests/content-sets.json"
+        buildah copy "$container" content-sets.json /root/buildinfo/content_manifests/
+        buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$container"
+
+        BUILDAH_ARGS=()
+        if [ "${SQUASH}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash")
+        fi
+
+        buildah commit "${BUILDAH_ARGS[@]}" "$container" "$IMAGE"
+        # End content sets backwards compatibility
+      fi
+
       buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
-
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
-      if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-      fi
 
       touch /shared/base_images_digests
       for image in $BASE_IMAGES; do

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -455,41 +455,6 @@ spec:
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-
-        # Inject a content sets file for backwards compatibility
-        # This is only possible for images built hermetically with prefetch
-        base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
-        base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
-        cat >content-sets.json <<EOF
-        {
-            "metadata": {
-                "icm_version": 1,
-                "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
-                "image_layer_index": 0
-            },
-            "from_dnf_hint": true,
-            "content_sets": []
-        }
-
-      EOF
-
-        while IFS='' read -r content_set;
-        do
-          jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json > content-sets.json.tmp
-          mv content-sets.json.tmp content-sets.json
-        done <<< "$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
-
-        echo "Writing to /root/buildinfo/content_manifests/content-sets.json"
-        buildah copy "$container" content-sets.json /root/buildinfo/content_manifests/
-        buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$container"
-
-        BUILDAH_ARGS=()
-        if [ "${SQUASH}" == "true" ]; then
-          BUILDAH_ARGS+=("--squash")
-        fi
-
-        buildah commit "${BUILDAH_ARGS[@]}" "$container" "$IMAGE"
-        # End content sets backwards compatibility
       fi
 
       buildah mount $container | tee /shared/container_path
@@ -524,7 +489,24 @@ spec:
       mountPath: /mnt/trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-
+  - name: icm
+    image: quay.io/rbean/testing:icm-injection-scripts
+    computeResources:
+      limits:
+        memory: 4Gi
+        cpu: '4'
+      requests:
+        memory: 1Gi
+        cpu: '1'
+    securityContext:
+      capabilities:
+        add:
+          - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+    args: [$(params.IMAGE)]
   - name: push
     image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     computeResources:

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -210,8 +210,7 @@ spec:
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
       elif [ -e "$DOCKERFILE" ]; then
-        # Custom Dockerfile location is mainly used for instrumented builds for SAST scanning and analyzing.
-        # Instrumented builds use this step as their base and also need to provide modified Dockerfile.
+        # Instrumented builds (SAST) use this custom dockerffile step as their base
         dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
@@ -267,7 +266,7 @@ spec:
                   shift
                   # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
                   # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
-                  # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE - they take precedence.
+                  # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
                   while [[ $# -gt 0 && $1 != --* ]]; do build_args+=("$1"); shift; done
                   ;;
               --labels)
@@ -411,8 +410,7 @@ spec:
 
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
         # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
-        # This is primarily used in instrumented builds for SAST scanning and analyzing.
-        # Instrumented builds use this step as their base and add some other tools.
+        # Instrumented builds (SAST) use this step as their base and add some other tools.
         while read -r volume_mount; do
           VOLUME_MOUNTS+=("--volume=$volume_mount")
         done <<< "$ADDITIONAL_VOLUME_MOUNTS"

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -495,7 +495,7 @@ spec:
       readOnly: true
     workingDir: $(workspaces.source.path)
   - name: icm
-    image: quay.io/rbean/testing:icm-injection-scripts
+    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
     securityContext:
       capabilities:
         add:

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -124,6 +124,13 @@ spec:
   - name: JAVA_COMMUNITY_DEPENDENCIES
     description: The Java dependencies that came from community sources such as Maven central.
   stepTemplate:
+    computeResources:
+      limits:
+        memory: 4Gi
+        cpu: '4'
+      requests:
+        memory: 1Gi
+        cpu: '1'
     volumeMounts:
       - mountPath: /shared
         name: shared
@@ -279,7 +286,6 @@ spec:
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
-
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
           jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json
@@ -370,9 +376,8 @@ spec:
       # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
       # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
       # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
-      #    to buildah but don't pre-register for backwards compatibility. In this case mount an empty directory on
-      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included in the produced
-      #    container.
+      #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
 
       if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
         cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
@@ -491,13 +496,6 @@ spec:
     workingDir: $(workspaces.source.path)
   - name: icm
     image: quay.io/rbean/testing:icm-injection-scripts
-    computeResources:
-      limits:
-        memory: 4Gi
-        cpu: '4'
-      requests:
-        memory: 1Gi
-        cpu: '1'
     securityContext:
       capabilities:
         add:
@@ -509,13 +507,6 @@ spec:
     args: [$(params.IMAGE)]
   - name: push
     image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
-    computeResources:
-      limits:
-        memory: 4Gi
-        cpu: '4'
-      requests:
-        memory: 1Gi
-        cpu: '1'
     script: |
       #!/bin/bash
       set -e
@@ -577,13 +568,6 @@ spec:
     # Respect Syft configuration if the user has it in the root of their repository
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source
-    computeResources:
-      limits:
-        memory: 4Gi
-        cpu: '2'
-      requests:
-        memory: 1Gi
-        cpu: 500m
     script: |
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json="$(workspaces.source.path)/sbom-source.json"

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -450,15 +450,52 @@ spec:
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 
       container=$(buildah from --pull-never "$IMAGE")
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+
+        # Inject a content sets file for backwards compatibility
+        # This is only possible for images built hermetically with prefetch
+        base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' "$IMAGE" | cut -f1 -d'@')
+        base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' "$IMAGE")
+        cat >content-sets.json <<EOF
+        {
+            "metadata": {
+                "icm_version": 1,
+                "icm_spec": "https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json",
+                "image_layer_index": 0
+            },
+            "from_dnf_hint": true,
+            "content_sets": []
+        }
+
+      EOF
+
+        while IFS='' read -r content_set;
+        do
+          jq --arg content_set "$content_set" '.content_sets += [$content_set]' content-sets.json > content-sets.json.tmp
+          mv content-sets.json.tmp content-sets.json
+        done <<< "$(jq -r '.components[].purl' sbom-cachi2.json | grep -o -P '(?<=repository_id=).*(?=(&|$))' | sort -u)"
+
+        echo "Writing to /root/buildinfo/content_manifests/content-sets.json"
+        buildah copy "$container" content-sets.json /root/buildinfo/content_manifests/
+        buildah config -a "org.opencontainers.image.base.name=${base_image_name}" -a "org.opencontainers.image.base.digest=${base_image_digest}" "$container"
+
+        BUILDAH_ARGS=()
+        if [ "${SQUASH}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash")
+        fi
+
+        buildah commit "${BUILDAH_ARGS[@]}" "$container" "$IMAGE"
+        # End content sets backwards compatibility
+      fi
+
       buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
-
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
-      if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
-      fi
 
       touch /shared/base_images_digests
       for image in $BASE_IMAGES; do


### PR DESCRIPTION
For backwards compatibility with image scanners that still expect https://raw.githubusercontent.com/containerbuildsystem/atomic-reactor/master/atomic_reactor/schemas/content_manifest.json

Looking forward, clair and other scanners are going to adapt to start reading the content sets from the dnf database and later from our sboms - but they're not ready for that yet. Add this file to support them while they migrate.

See also https://github.com/containerbuildsystem/atomic-reactor/pull/2140

https://issues.redhat.com/browse/KONFLUX-6200