### PR TITLE
`--json` not supported in version of curl in use

### DIFF
--- a/.tekton/scripts/create-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/create-task-pipeline-bundle-repos.sh
@@ -47,7 +47,7 @@ locate_in_all_namespaces() {
                 --arg description "" \
                 '$ARGS.named'
             )
-            if ! err_msg=$(curl --oauth2-bearer "${QUAY_TOKEN}" "https://quay.io/api/v1/repository" --json "$payload" | jq '.error_message // empty');
+            if ! err_msg=$(curl --oauth2-bearer "${QUAY_TOKEN}" "https://quay.io/api/v1/repository" --data-binary "$payload" -H "Content-Type: application/json" -H "Accept: application/json" | jq '.error_message // empty');
             then
               echo "curl returned an error when creating the repository. See the error above."
               exit 1


### PR DESCRIPTION
The version of `curl` (7.76.1) we currently use in quay.io/konflux-ci/appstudio-utils does not support the `--json` parameter, so this reverts to using lengthier `--data-binary` and setting the Content-Type and Accept headers.