### PR TITLE
Fix buildah remote

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -556,12 +556,14 @@ spec:
             - SETFCAP
     - name: icm
       image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
-      args:
-        - $(params.IMAGE)
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        /scripts/inject-icm.sh "$IMAGE"
       securityContext:
         capabilities:
           add:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -827,6 +827,10 @@ spec:
     script: |
       #!/bin/bash
 
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -649,11 +649,17 @@ spec:
       name: ssh
       readOnly: true
     workingDir: /var/workdir
-  - args:
-    - $(params.IMAGE)
-    computeResources: {}
+  - computeResources: {}
     image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
     name: icm
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      /scripts/inject-icm.sh "$IMAGE"
     securityContext:
       capabilities:
         add:

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -625,11 +625,17 @@ spec:
       name: ssh
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - args:
-    - $(params.IMAGE)
-    computeResources: {}
+  - computeResources: {}
     image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
     name: icm
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      /scripts/inject-icm.sh "$IMAGE"
     securityContext:
       capabilities:
         add:

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -805,6 +805,10 @@ spec:
     script: |
       #!/bin/bash
 
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -502,7 +502,10 @@ spec:
     - mountPath: /var/lib/containers
       name: varlibcontainers
     workingDir: $(workspaces.source.path)
-    args: [$(params.IMAGE)]
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
   - name: push
     image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     script: |


### PR DESCRIPTION
The new 'icm' step was broken because it didn't take into account the
IMAGE modifications done in every other step. To fix it, switch the step
from "command-style" to "script-style" to make the task-generator tool
notice that it has to do its thing.

Also fix the task-generator because it wasn't handling things very well