### PR TITLE
fix(KONFLUX-6229) fix ICM injection for multiarch images

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -555,7 +555,7 @@ spec:
           add:
             - SETFCAP
     - name: icm
-      image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
+      image: quay.io/redhat-user-workloads/rhtap-build-tenant/icm-injection-scripts:on-pr-af6b37488731417f72f0e5f95d7ab3e7cbd03f98
       args:
         - $(params.IMAGE)
       workingDir: /var/workdir

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -652,7 +652,7 @@ spec:
   - args:
     - $(params.IMAGE)
     computeResources: {}
-    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
+    image: quay.io/redhat-user-workloads/rhtap-build-tenant/icm-injection-scripts:on-pr-af6b37488731417f72f0e5f95d7ab3e7cbd03f98
     name: icm
     securityContext:
       capabilities:

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -628,7 +628,7 @@ spec:
   - args:
     - $(params.IMAGE)
     computeResources: {}
-    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
+    image: quay.io/redhat-user-workloads/rhtap-build-tenant/icm-injection-scripts:on-pr-af6b37488731417f72f0e5f95d7ab3e7cbd03f98
     name: icm
     securityContext:
       capabilities:

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -493,7 +493,7 @@ spec:
       readOnly: true
     workingDir: $(workspaces.source.path)
   - name: icm
-    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
+    image: quay.io/redhat-user-workloads/rhtap-build-tenant/icm-injection-scripts:on-pr-af6b37488731417f72f0e5f95d7ab3e7cbd03f98
     securityContext:
       capabilities:
         add:


### PR DESCRIPTION
This ICM injection step accepts the IMAGE param as the image to operate on, which needs to account for whether or not the IMAGE_APPEND_PLATFORM param is also set to true.

Incorporates: https://github.com/konflux-ci/build-tasks-dockerfiles/pull/214
Fixes: https://issues.redhat.com/browse/KONFLUX-6229
