### PR TITLE
Log activity when recording base image digests

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -547,12 +547,13 @@ spec:
         echo $container >/shared/container_name
 
         touch /shared/base_images_digests
+        echo "Recording base image digests used"
         for image in $BASE_IMAGES; do
           base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
           # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
           # if buildah did not use that particular image during build because it was skipped
           if [ -n "$base_image_digest" ]; then
-            echo "$image $base_image_digest" >>/shared/base_images_digests
+            echo "$image $base_image_digest" | tee -a /shared/base_images_digests
           fi
         done
       computeResources:

--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -535,12 +535,13 @@ spec:
         echo $container >/shared/container_name
 
         touch /shared/base_images_digests
+        echo "Recording base image digests used"
         for image in $BASE_IMAGES; do
           base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
           # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
           # if buildah did not use that particular image during build because it was skipped
           if [ -n "$base_image_digest" ]; then
-            echo "$image $base_image_digest" >>/shared/base_images_digests
+            echo "$image $base_image_digest" | tee -a /shared/base_images_digests
           fi
         done
       computeResources:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -581,12 +581,13 @@ spec:
       echo $container >/shared/container_name
 
       touch /shared/base_images_digests
+      echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
-          echo "$image $base_image_digest" >>/shared/base_images_digests
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
 

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -569,12 +569,13 @@ spec:
       echo $container >/shared/container_name
 
       touch /shared/base_images_digests
+      echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
-          echo "$image $base_image_digest" >>/shared/base_images_digests
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
 

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -557,12 +557,13 @@ spec:
       echo $container > /shared/container_name
 
       touch /shared/base_images_digests
+      echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
-          echo "$image $base_image_digest" >> /shared/base_images_digests
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
 

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -545,12 +545,13 @@ spec:
       echo $container > /shared/container_name
 
       touch /shared/base_images_digests
+      echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
-          echo "$image $base_image_digest" >> /shared/base_images_digests
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
 

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -478,12 +478,13 @@ spec:
       echo $container > /shared/container_name
 
       touch /shared/base_images_digests
+      echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
-          echo "$image $base_image_digest" >> /shared/base_images_digests
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
 

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -467,12 +467,13 @@ spec:
       echo $container > /shared/container_name
 
       touch /shared/base_images_digests
+      echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
-          echo "$image $base_image_digest" >> /shared/base_images_digests
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
 


### PR DESCRIPTION
The purpose is just to help users debug failures in the future. I have one such failure now where a later step complains that these base image digest lines are malformed. I'm just trying to get visibility on that.