### PR TITLE
feat: validate kustomize build of tasks and pipelines

### DIFF
--- a/.github/workflows/check-kustomize-build.yaml
+++ b/.github/workflows/check-kustomize-build.yaml
@@ -1,0 +1,20 @@
+name: Validate PR - kustomize manifests
+'on':
+  pull_request:
+    branches: [main]
+jobs:
+  kustomize-build:
+    name: Check Kustomize Build of Task and Pipelines
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Install oc
+        run: |
+          set -euo pipefail
+          url=https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.17/openshift-client-linux.tar.gz
+          if ! which oc; then
+            curl --fail --no-progress-meter -L "$url" | gzip -cd | sudo -- tar -x -C /usr/bin oc
+          fi
+      - name: Validate Manifests
+        run: hack/verify-manifests.sh

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ Buildah also has a remote version, which can be generated with:
 ./hack/generate-buildah-remote.sh
 ```
 
+## Making changes to tasks and pipelines
+
+If your tasks or pipelines contains `kustomization.yaml`, after making changes to the tasks or pipelines, run `hack/build-manifests.sh` and
+commit the generated manifests as well to the same directory (in addition to your changes).
+It will help us to make sure the kustomize build of your changes is successful and nothing broken while review the changes.
+
+In CI, `hack/verify-manifests.sh` script will verify that you have submitted the built manifests as well while sending the PR. 
+
 ## Testing
 
 ### Prerequisites

--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -1,0 +1,84 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+# You can ignore building manifests for some tasks by providing the SKIP_TASKS variable
+# with the task name separated by a space, for example:
+# SKIP_TASKS="git-clone init"
+
+SKIP_TASKS="generate-odcs-compose provision-env-with-ephemeral-namespace verify-signed-rpms"
+
+# You can ignore building manifests for some pipelines by providing the SKIP_PIPELINES variable
+# with the task name separated by a space, for example:
+# SKIP_PIPELINES="rhtap gitops-pull-request-rhtap"
+
+SKIP_PIPELINES="gitops-pull-request-rhtap"
+
+main() {
+    local dirs
+
+    cd "$SCRIPT_DIR/.."
+    local ret=0
+    find task/*/*/*.yaml -maxdepth 0 | awk -F '/' '{ print $0, $2, $3, $4 }' | \
+    while read -r task_path task_name task_version file_name
+    do
+        if [[ "$file_name" == "kustomization.yaml" ]]; then
+          echo "Building task manifest for: $task_name/$task_version"
+        else
+          continue
+        fi
+        
+        # Skip the tasks mentioned in SKIP_TASKS
+        skipit=
+        for tname in ${SKIP_TASKS};do
+            [[ ${tname} == "${task_name}" ]] && skipit=True
+        done
+        [[ -n ${skipit} ]] && continue
+
+        # Check if there is only one resource in the kustomization file and it is <task_name>.yaml
+        resources=$(yq -r '.resources[]' "$task_path")
+        if [[ "$resources" == "$task_name.yaml" ]]; then
+          echo "Skip generating manifest for the task: $task_name/$task_version"
+          continue
+        fi
+        if ! oc kustomize -o "task/$task_name/$task_version/$task_name.yaml" "task/$task_name/$task_version/"; then
+            echo "failed to build task: $task_name" >&2
+            ret=1
+        fi
+    done
+
+    find pipelines/*/*.yaml -maxdepth 0 | awk -F '/' '{ print $0, $2, $3 }' | \
+    while read -r pipeline_path pipeline_name file_name
+    do
+        if [[ "$file_name" == "kustomization.yaml" ]]; then
+          echo "Building pipeline manifest for: $pipeline_name"
+        else
+          continue
+        fi
+        
+        # Skip the pipelines mentioned in SKIP_PIPELINES
+        skipit=
+        for pname in ${SKIP_PIPELINES};do
+            [[ ${pname} == "${pipeline_name}" ]] && skipit=True
+        done
+        [[ -n ${skipit} ]] && continue
+        
+        # Check if there is only one resource in the kustomization file and it is <pipeline_name>.yaml
+        resources=$(yq -r '.resources[]' "$pipeline_path")
+        if [[ "$resources" == "$pipeline_name.yaml" ]]; then
+          echo "Skip generating manifest for the pipeline: $pipeline_name"
+          continue
+        fi
+        if ! oc kustomize -o "pipelines/$pipeline_name/$pipeline_name.yaml" "pipelines/$pipeline_name"; then
+            echo "failed to build pipeline: $pipeline_name" >&2
+            ret=1
+        fi
+    done
+
+    exit "$ret"
+
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/hack/missing-ta-tasks.sh
+++ b/hack/missing-ta-tasks.sh
@@ -14,22 +14,31 @@ trap 'rm "${tmp_files[@]}" > /dev/null 2>&1' EXIT
 # Tasks that are currently missing Trusted Artifact variant
 todo=(
   task/buildah-10gb/0.2/kustomization.yaml
+  task/buildah-10gb/0.2/buildah-10gb.yaml
   task/buildah-20gb/0.2/kustomization.yaml
+  task/buildah-20gb/0.2/buildah-20gb.yaml
   task/buildah-24gb/0.2/kustomization.yaml
+  task/buildah-24gb/0.2/buildah-24gb.yaml
   task/buildah-6gb/0.2/kustomization.yaml
+  task/buildah-6gb/0.2/buildah-6gb.yaml
   task/buildah-8gb/0.2/kustomization.yaml
+  task/buildah-8gb/0.2/buildah-8gb.yaml
   task/buildah-min/0.2/kustomization.yaml
+  task/buildah-min/0.2/buildah-min.yaml
   task/buildah-rhtap/0.1/buildah-rhtap.yaml
   task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
   task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
   task/fbc-related-image-check/0.2/kustomization.yaml
+  task/fbc-related-image-check/0.2/fbc-related-image-check.yaml
   task/fbc-validation/0.1/fbc-validation.yaml
   task/fbc-validation/0.2/kustomization.yaml
+  task/fbc-validation/0.2/fbc-validation.yaml
   task/gather-deploy-images/0.1/gather-deploy-images.yaml
   task/generate-odcs-compose/0.2/generate-odcs-compose.yaml
   task/generate-odcs-compose/0.2/kustomization.yaml
   task/inspect-image/0.1/inspect-image.yaml
   task/inspect-image/0.2/kustomization.yaml
+  task/inspect-image/0.2/inspect-image.yaml
   task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
   task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
   task/opm-render-bundles/0.1/opm-render-bundles.yaml

--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -1,0 +1,20 @@
+#!/bin/bash -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+
+main() {
+
+    "${SCRIPT_DIR}"/build-manifests.sh
+    if [[ $(git status --porcelain) ]]; then
+        git diff --exit-code >&2 || {
+            echo "Did you forget to build the manifests locally?" >&2;
+            echo "Please run ./hack/build-manifests.sh and update your PR" >&2;
+            exit 1;
+        }
+    fi
+    echo "changes are up to date" >&2
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+    main "$@"
+fi

--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -1,0 +1,527 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  annotations:
+    appstudio.openshift.io/core-services-ci: "1"
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  name: docker-build
+spec:
+  description: |
+    This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+
+    _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom
+      version: "0.1"
+  - name: show-summary
+    params:
+    - name: pipelinerun-name
+      value: $(context.pipelineRun.name)
+    - name: git-url
+      value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+    - name: image-url
+      value: $(params.output-image)
+    - name: build-task-status
+      value: $(tasks.build-image-index.status)
+    taskRef:
+      name: summary
+      version: "0.2"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: infra-deployments-mr
+    params:
+    - name: ORIGIN_REPO
+      value: $(params.git-url)
+    - name: REVISION
+      value: $(params.revision)
+    - name: SCRIPT
+      value: $(params.infra-deployment-update-script)
+    taskRef:
+      name: update-infra-deployments
+      version: "0.1"
+    when:
+    - input: $(params.infra-deployment-update-script)
+      operator: notin
+      values:
+      - ""
+    - input: $(tasks.status)
+      operator: notin
+      values:
+      - Failed
+  - name: update-repo
+    params:
+    - name: ORIGIN_REPO
+      value: $(params.git-url)
+    - name: REVISION
+      value: $(params.revision)
+    - name: SCRIPT
+      value: $(params.update-repo-script)
+    - name: TARGET_GH_REPO
+      value: $(params.update-repo-name)
+    taskRef:
+      name: update-infra-deployments
+      version: "0.1"
+    when:
+    - input: $(params.update-repo-script)
+      operator: notin
+      values:
+      - ""
+    - input: $(params.update-repo-name)
+      operator: notin
+      values:
+      - ""
+    - input: $(tasks.status)
+      operator: notin
+      values:
+      - Failed
+  - name: slack-webhook-notification
+    params:
+    - name: message
+      value: Tekton pipelineRun $(context.pipelineRun.name) failed
+    - name: key-name
+      value: $(params.slack-webhook-notification-team)
+    taskRef:
+      name: slack-webhook-notification
+      version: "0.1"
+    when:
+    - input: $(params.slack-webhook-notification-team)
+      operator: notin
+      values:
+      - ""
+    - input: $(tasks.status)
+      operator: in
+      values:
+      - Failed
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "false"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "false"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  - default: ""
+    name: infra-deployment-update-script
+  - default: ""
+    name: update-repo-script
+  - default: ""
+    name: update-repo-name
+  - default: ""
+    name: slack-webhook-notification-team
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies
+      version: "0.1"
+    when:
+    - input: $(params.prefetch-input)
+      operator: notin
+      values:
+      - ""
+    workspaces:
+    - name: source
+      workspace: workspace
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-container
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      name: buildah
+      version: "0.3"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      name: build-image-index
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: build-source-image
+    params:
+    - name: BINARY_IMAGE
+      value: $(params.output-image)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: source-build
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    - input: $(params.build-source-image)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: deprecated-image-check
+      version: "0.4"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: clair-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clair-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: ecosystem-cert-preflight-checks
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-snyk-check
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: clamav-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clamav-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-coverity-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      name: sast-coverity-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: coverity-availability-check
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: coverity-availability-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-shell-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-unicode-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.1"
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: push-dockerfile
+      version: "0.1"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: rpms-signature-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -1,0 +1,462 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  name: docker-build-multi-platform-oci-ta
+spec:
+  description: |
+    This pipeline is ideal for building multi-arch container images from a Containerfile while maintaining trust after pipeline customization.
+
+    _Uses `buildah` to create a multi-platform container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. This pipeline requires that the [multi platform controller](https://github.com/konflux-ci/multi-platform-controller) is deployed and configured on your Konflux instance. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-multi-platform-oci-ta?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom
+      version: "0.1"
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "false"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "true"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  - default:
+    - linux/x86_64
+    description: List of platforms to build the container images on. The available
+      set of values is determined by the configuration of the multi-platform-controller.
+    name: build-platforms
+    type: array
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: ociStorage
+      value: $(params.output-image).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone-oci-ta
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).prefetch
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies-oci-ta
+      version: "0.1"
+    workspaces:
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - matrix:
+      params:
+      - name: PLATFORM
+        value:
+        - $(params.build-platforms)
+    name: build-images
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: IMAGE_APPEND_PLATFORM
+      value: "true"
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      name: buildah-remote-oci-ta
+      version: "0.3"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces: []
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-images.results.IMAGE_REF[*])
+    runAfter:
+    - build-images
+    taskRef:
+      name: build-image-index
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: build-source-image
+    params:
+    - name: BINARY_IMAGE
+      value: $(params.output-image)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: source-build-oci-ta
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    - input: $(params.build-source-image)
+      operator: in
+      values:
+      - "true"
+    workspaces: []
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: deprecated-image-check
+      version: "0.4"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: clair-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clair-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: ecosystem-cert-preflight-checks
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-snyk-check-oci-ta
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: clamav-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clamav-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-coverity-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      name: sast-coverity-check-oci-ta
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces: []
+  - name: coverity-availability-check
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: coverity-availability-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-shell-check-oci-ta
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-unicode-check-oci-ta
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.1"
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: push-dockerfile-oci-ta
+      version: "0.1"
+    workspaces: []
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: rpms-signature-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -1,0 +1,449 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  name: docker-build-oci-ta
+spec:
+  description: |
+    This pipeline is ideal for building container images from a Containerfile while maintaining trust after pipeline customization.
+
+    _Uses `buildah` to create a container image leveraging [trusted artifacts](https://konflux-ci.dev/architecture/ADR/0036-trusted-artifacts.html). It also optionally creates a source image and runs some build-time tests. Information is shared between tasks using OCI artifacts instead of PVCs. EC will pass the [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) policy as long as all data used to build the artifact is generated from trusted tasks.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build-oci-ta?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom
+      version: "0.1"
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "false"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "false"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: ociStorage
+      value: $(params.output-image).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone-oci-ta
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).prefetch
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies-oci-ta
+      version: "0.1"
+    workspaces:
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-container
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      name: buildah-oci-ta
+      version: "0.3"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces: []
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      name: build-image-index
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: build-source-image
+    params:
+    - name: BINARY_IMAGE
+      value: $(params.output-image)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: source-build-oci-ta
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    - input: $(params.build-source-image)
+      operator: in
+      values:
+      - "true"
+    workspaces: []
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: deprecated-image-check
+      version: "0.4"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: clair-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clair-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: ecosystem-cert-preflight-checks
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-snyk-check-oci-ta
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: clamav-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clamav-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-coverity-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      name: sast-coverity-check-oci-ta
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces: []
+  - name: coverity-availability-check
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: coverity-availability-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-shell-check-oci-ta
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-unicode-check-oci-ta
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.1"
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: push-dockerfile-oci-ta
+      version: "0.1"
+    workspaces: []
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: rpms-signature-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/pipelines/docker-build-rhtap/docker-build-rhtap.yaml
+++ b/pipelines/docker-build-rhtap/docker-build-rhtap.yaml
@@ -1,0 +1,285 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  name: docker-build-rhtap
+spec:
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-container.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom-rhdh
+      version: "0.1"
+  - name: show-summary
+    params:
+    - name: pipelinerun-name
+      value: $(context.pipelineRun.name)
+    - name: git-url
+      value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+    - name: image-url
+      value: $(params.output-image)
+    - name: build-task-status
+      value: $(tasks.build-container.status)
+    taskRef:
+      name: summary
+      version: "0.2"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: rox-api-token
+    name: stackrox-secret
+    type: string
+  - default: gitops-auth-secret
+    description: 'Secret name to enable this pipeline to update the gitops repo with
+      the new image. '
+    name: gitops-auth-secret-name
+    type: string
+  - default: push
+    description: Event that triggered the pipeline run, e.g. push, pull_request
+    name: event-type
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-container.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-container.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  - name: ACS_SCAN_OUTPUT
+    value: $(tasks.acs-image-scan.results.SCAN_OUTPUT)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: build-container
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: buildah-rhtap
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-unicode-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.1"
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: push-dockerfile
+      version: "0.1"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: rpms-signature-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: acs-image-check
+    params:
+    - name: rox-secret-name
+      value: $(params.stackrox-secret)
+    - name: image
+      value: $(params.output-image)
+    - name: insecure-skip-tls-verify
+      value: "true"
+    - name: image-digest
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      name: acs-image-check
+  - name: acs-image-scan
+    params:
+    - name: rox-secret-name
+      value: $(params.stackrox-secret)
+    - name: image
+      value: $(params.output-image)
+    - name: insecure-skip-tls-verify
+      value: "true"
+    - name: image-digest
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      kind: Task
+      name: acs-image-scan
+  - name: acs-deploy-check
+    params:
+    - name: rox-secret-name
+      value: $(params.stackrox-secret)
+    - name: gitops-repo-url
+      value: $(params.git-url)-gitops
+    - name: insecure-skip-tls-verify
+      value: "true"
+    runAfter:
+    - update-deployment
+    taskRef:
+      kind: Task
+      name: acs-deploy-check
+    when:
+    - input: $(params.event-type)
+      operator: in
+      values:
+      - push
+      - Push
+  - name: update-deployment
+    params:
+    - name: gitops-repo-url
+      value: $(params.git-url)-gitops
+    - name: image
+      value: $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    - name: gitops-auth-secret-name
+      value: $(params.gitops-auth-secret-name)
+    runAfter:
+    - build-container
+    taskRef:
+      kind: Task
+      name: update-deployment
+    when:
+    - input: $(params.event-type)
+      operator: notin
+      values:
+      - pull_request
+      - Merge Request
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -1,0 +1,453 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  name: docker-build
+spec:
+  description: |
+    This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+
+    _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://enterprisecontract.dev/docs/ec-policies/release_policy.html#trusted_task__trusted) if any tasks are added to the pipeline.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom
+      version: "0.1"
+  - name: show-summary
+    params:
+    - name: pipelinerun-name
+      value: $(context.pipelineRun.name)
+    - name: git-url
+      value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+    - name: image-url
+      value: $(params.output-image)
+    - name: build-task-status
+      value: $(tasks.build-image-index.status)
+    taskRef:
+      name: summary
+      version: "0.2"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "false"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "false"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies
+      version: "0.1"
+    when:
+    - input: $(params.prefetch-input)
+      operator: notin
+      values:
+      - ""
+    workspaces:
+    - name: source
+      workspace: workspace
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-container
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      name: buildah
+      version: "0.3"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      name: build-image-index
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: build-source-image
+    params:
+    - name: BINARY_IMAGE
+      value: $(params.output-image)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: source-build
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    - input: $(params.build-source-image)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: deprecated-image-check
+      version: "0.4"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: clair-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clair-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: ecosystem-cert-preflight-checks
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-snyk-check
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: clamav-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clamav-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-coverity-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      name: sast-coverity-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: coverity-availability-check
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: coverity-availability-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-shell-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-unicode-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.1"
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: push-dockerfile
+      version: "0.1"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: rpms-signature-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -1,0 +1,261 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: fbc
+    pipelines.openshift.io/strategy: fbc
+    pipelines.openshift.io/used-by: build-cloud
+  name: fbc-builder
+spec:
+  description: |
+    This pipeline is ideal for building and verifying [file-based catalogs](https://konflux-ci.dev/docs/advanced-how-tos/building-olm.adoc#building-the-file-based-catalog).
+
+    _Uses `buildah` to create a container image. Its build-time tests are limited to verifying the included catalog and do not scan the image.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-fbc-builder?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom
+      version: "0.1"
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "true"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "true"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  - default:
+    - linux/x86_64
+    description: List of platforms to build the container images on. The available
+      set of values is determined by the configuration of the multi-platform-controller.
+    name: build-platforms
+    type: array
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: ociStorage
+      value: $(params.output-image).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone-oci-ta
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).prefetch
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies-oci-ta
+      version: "0.1"
+    workspaces:
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - matrix:
+      params:
+      - name: PLATFORM
+        value:
+        - $(params.build-platforms)
+    name: build-images
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: HERMETIC
+      value: $(params.hermetic)
+    - name: PREFETCH_INPUT
+      value: $(params.prefetch-input)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    - name: IMAGE_APPEND_PLATFORM
+      value: "true"
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: buildah-remote-oci-ta
+      version: "0.3"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces: []
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-images.results.IMAGE_REF[*])
+    runAfter:
+    - build-images
+    taskRef:
+      name: build-image-index
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: deprecated-image-check
+      version: "0.4"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.1"
+  - name: validate-fbc
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: validate-fbc
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -1,0 +1,233 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: maven-zip
+    pipelines.openshift.io/used-by: build-cloud
+  name: maven-zip-build-oci-ta
+spec:
+  description: |
+    This pipeline will build the maven zip to oci-artifact while maintaining trust after pipeline customization.
+
+    _Uses `prefetch-dependencies` to fetch all artifacts which will be the content of the maven zip, and then uses `build-maven-zip-oci-ta` to create zip and push it to quay.io as oci-artifact. Information is shared between tasks using OCI artifacts instead of PVCs.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-maven-zip-build-oci-ta?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom
+      version: "0.1"
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: generic
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: ociStorage
+      value: $(params.output-image).git
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone-oci-ta
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).prefetch
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies-oci-ta
+      version: "0.1"
+    workspaces:
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-oci-artifact
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      name: build-maven-zip-oci-ta
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces: []
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-oci-artifact
+    taskRef:
+      name: sast-snyk-check-oci-ta
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: sast-coverity-check
+    params:
+    - name: image-url
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      name: sast-coverity-check-oci-ta
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces: []
+  - name: coverity-availability-check
+    runAfter:
+    - build-oci-artifact
+    taskRef:
+      name: coverity-availability-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-oci-artifact
+    taskRef:
+      name: sast-shell-check-oci-ta
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    - name: CACHI2_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+    runAfter:
+    - build-oci-artifact
+    taskRef:
+      name: sast-shell-check-oci-ta
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces: []
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -1,0 +1,240 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: maven-zip
+    pipelines.openshift.io/used-by: build-cloud
+  name: maven-zip-build
+spec:
+  description: |
+    This pipeline will build the maven zip to oci-artifact.
+
+    _Uses `prefetch-dependencies` to fetch all artifacts which will be the content of the maven zip, and then uses `build-maven-zip` to create zip and push it to quay.io as oci-artifact.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-maven-zip-build?tab=tags)_
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom
+      version: "0.1"
+  - name: show-summary
+    params:
+    - name: pipelinerun-name
+      value: $(context.pipelineRun.name)
+    - name: git-url
+      value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+    - name: image-url
+      value: $(params.output-image)
+    - name: build-task-status
+      value: $(tasks.build-oci-artifact.status)
+    taskRef:
+      name: summary
+      version: "0.2"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: generic
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies
+      version: "0.1"
+    when:
+    - input: $(params.prefetch-input)
+      operator: notin
+      values:
+      - ""
+    workspaces:
+    - name: source
+      workspace: workspace
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-oci-artifact
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      name: build-maven-zip
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    runAfter:
+    - build-oci-artifact
+    taskRef:
+      name: sast-snyk-check
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: sast-coverity-check
+    params:
+    - name: image-url
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      name: sast-coverity-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: coverity-availability-check
+    runAfter:
+    - build-oci-artifact
+    taskRef:
+      name: coverity-availability-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    runAfter:
+    - build-oci-artifact
+    taskRef:
+      name: sast-shell-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-oci-artifact.results.IMAGE_URL)
+    runAfter:
+    - build-oci-artifact
+    taskRef:
+      name: sast-unicode-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/pipelines/rhtap/rhtap.yaml
+++ b/pipelines/rhtap/rhtap.yaml
@@ -1,0 +1,448 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: generic
+    pipelines.openshift.io/strategy: docker
+    pipelines.openshift.io/used-by: build-cloud
+  name: docker-build-rhtap
+spec:
+  finally:
+  - name: show-sbom
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-container.results.IMAGE_URL)
+    taskRef:
+      name: show-sbom-rhdh
+      version: "0.1"
+  - name: show-summary
+    params:
+    - name: pipelinerun-name
+      value: $(context.pipelineRun.name)
+    - name: git-url
+      value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+    - name: image-url
+      value: $(params.output-image)
+    - name: build-task-status
+      value: $(tasks.build-container.status)
+    taskRef:
+      name: summary
+      version: "0.2"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: rox-api-token
+    name: stackrox-secret
+    type: string
+  - default: gitops-auth-secret
+    description: 'Secret name to enable this pipeline to update the gitops repo with
+      the new image. '
+    name: gitops-auth-secret-name
+    type: string
+  - default: push
+    description: Event that triggered the pipeline run, e.g. push, pull_request
+    name: event-type
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings) for buildah
+    name: build-args
+    type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-container.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-container.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  - name: ACS_SCAN_OUTPUT
+    value: $(tasks.acs-image-scan.results.SCAN_OUTPUT)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: build-container
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    - name: BUILD_ARGS_FILE
+      value: $(params.build-args-file)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: buildah-rhtap
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-unicode-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.1"
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: push-dockerfile
+      version: "0.1"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: rpms-signature-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: acs-image-check
+    params:
+    - name: rox-secret-name
+      value: $(params.stackrox-secret)
+    - name: image
+      value: $(params.output-image)
+    - name: insecure-skip-tls-verify
+      value: "true"
+    - name: image-digest
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      name: acs-image-check
+  - name: acs-image-scan
+    params:
+    - name: rox-secret-name
+      value: $(params.stackrox-secret)
+    - name: image
+      value: $(params.output-image)
+    - name: insecure-skip-tls-verify
+      value: "true"
+    - name: image-digest
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      kind: Task
+      name: acs-image-scan
+  - name: acs-deploy-check
+    params:
+    - name: rox-secret-name
+      value: $(params.stackrox-secret)
+    - name: gitops-repo-url
+      value: $(params.git-url)-gitops
+    - name: insecure-skip-tls-verify
+      value: "true"
+    runAfter:
+    - update-deployment
+    taskRef:
+      kind: Task
+      name: acs-deploy-check
+    when:
+    - input: $(params.event-type)
+      operator: in
+      values:
+      - push
+      - Push
+  - name: update-deployment
+    params:
+    - name: gitops-repo-url
+      value: $(params.git-url)-gitops
+    - name: image
+      value: $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    - name: gitops-auth-secret-name
+      value: $(params.gitops-auth-secret-name)
+    runAfter:
+    - build-container
+    taskRef:
+      kind: Task
+      name: update-deployment
+    when:
+    - input: $(params.event-type)
+      operator: notin
+      values:
+      - pull_request
+      - Merge Request
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: gitops-pull-request
+spec:
+  params:
+  - description: Gitops repo url
+    name: git-url
+    type: string
+  - default: ""
+    description: Gitops repo revision
+    name: revision
+    type: string
+  - default: main
+    description: The target branch for the pull request
+    name: target-branch
+    type: string
+  - default: github.com/enterprise-contract/config//default
+    description: Enterprise Contract policy to validate against
+    name: ec-policy-configuration
+    type: string
+  - default: "true"
+    description: Should EC violations cause the pipeline to fail?
+    name: ec-strict
+    type: string
+  - default: k8s://$(context.pipelineRun.namespace)/cosign-pub
+    description: The public key that EC should use to verify signatures
+    name: ec-public-key
+    type: string
+  - default: http://rekor-server.rhtap-tas.svc
+    description: The Rekor host that EC should use to look up transparency logs
+    name: ec-rekor-host
+    type: string
+  - default: http://tuf.rhtap-tas.svc
+    description: The TUF mirror that EC should use
+    name: ec-tuf-mirror
+    type: string
+  - default: tpa-secret
+    description: The name of the Secret that contains Trustification (TPA) configuration
+    name: trustification-secret-name
+    type: string
+  - default: "true"
+    description: Should the pipeline fail when there are SBOMs to upload but Trustification
+      is not properly configured (i.e. the secret is missing or doesn't have all the
+      required keys)?
+    name: fail-if-trustification-not-configured
+    type: string
+  tasks:
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    - name: fetchTags
+      value: "true"
+    taskRef:
+      name: git-clone
+      version: "0.1"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: get-images-to-verify
+    params:
+    - name: TARGET_BRANCH
+      value: $(params.target-branch)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: gather-deploy-images
+      version: "0.1"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: verify-enterprise-contract
+    params:
+    - name: IMAGES
+      value: $(tasks.get-images-to-verify.results.IMAGES_TO_VERIFY)
+    - name: STRICT
+      value: $(params.ec-strict)
+    - name: POLICY_CONFIGURATION
+      value: $(params.ec-policy-configuration)
+    - name: PUBLIC_KEY
+      value: $(params.ec-public-key)
+    - name: REKOR_HOST
+      value: $(params.ec-rekor-host)
+    - name: TUF_MIRROR
+      value: $(params.ec-tuf-mirror)
+    runAfter:
+    - get-images-to-verify
+    taskRef:
+      name: verify-enterprise-contract
+      version: "0.1"
+    when:
+    - input: $(tasks.get-images-to-verify.results.IMAGES_TO_VERIFY)
+      operator: notin
+      values:
+      - ""
+  - name: get-images-to-upload-sbom
+    params:
+    - name: TARGET_BRANCH
+      value: $(params.target-branch)
+    - name: FROM_ENVIRONMENTS
+      value:
+      - stage
+      - prod
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: gather-deploy-images
+      version: "0.1"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: download-sboms
+    params:
+    - name: IMAGES
+      value: $(tasks.get-images-to-upload-sbom.results.IMAGES_TO_VERIFY)
+    - name: SBOMS_DIR
+      value: sboms
+    - name: PUBLIC_KEY
+      value: $(params.ec-public-key)
+    - name: REKOR_HOST
+      value: $(params.ec-rekor-host)
+    - name: TUF_MIRROR
+      value: $(params.ec-tuf-mirror)
+    runAfter:
+    - get-images-to-upload-sbom
+    taskRef:
+      name: download-sbom-from-url-in-attestation
+      version: "0.1"
+    when:
+    - input: $(tasks.get-images-to-upload-sbom.results.IMAGES_TO_VERIFY)
+      operator: notin
+      values:
+      - ""
+    workspaces:
+    - name: sboms
+      workspace: workspace
+  - name: upload-sboms-to-trustification
+    params:
+    - name: SBOMS_DIR
+      value: sboms
+    - name: TRUSTIFICATION_SECRET_NAME
+      value: $(params.trustification-secret-name)
+    - name: FAIL_IF_TRUSTIFICATION_NOT_CONFIGURED
+      value: $(params.fail-if-trustification-not-configured)
+    runAfter:
+    - download-sboms
+    taskRef:
+      name: upload-sbom-to-trustification
+      version: "0.1"
+    when:
+    - input: $(tasks.get-images-to-upload-sbom.results.IMAGES_TO_VERIFY)
+      operator: notin
+      values:
+      - ""
+    workspaces:
+    - name: sboms
+      workspace: workspace

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -1,0 +1,267 @@
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: ""
+    pipelines.openshift.io/strategy: ""
+    pipelines.openshift.io/used-by: ""
+  name: tekton-bundle-builder
+spec:
+  finally:
+  - name: show-summary
+    params:
+    - name: pipelinerun-name
+      value: $(context.pipelineRun.name)
+    - name: git-url
+      value: $(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)
+    - name: image-url
+      value: $(params.output-image)
+    - name: build-task-status
+      value: $(tasks.build-image-index.status)
+    taskRef:
+      name: summary
+      version: "0.2"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: Dockerfile
+    description: Path to the Dockerfile inside the context specified by parameter
+      path-context
+    name: dockerfile
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "false"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched by Cachi2
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "false"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies
+      version: "0.1"
+    when:
+    - input: $(params.prefetch-input)
+      operator: notin
+      values:
+      - ""
+    workspaces:
+    - name: source
+      workspace: workspace
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-container
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: CONTEXT
+      value: $(params.path-context)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      name: tkn-bundle
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    runAfter:
+    - build-container
+    taskRef:
+      name: build-image-index
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: sast-coverity-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      name: sast-coverity-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: sast-unicode-check
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-unicode-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: apply-tags
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.1"
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: push-dockerfile
+      version: "0.1"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: rpms-signature-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -1,0 +1,220 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+  name: build-image-manifest
+spec:
+  description: This takes existing Image Manifests and combines them in an Image Index.
+  params:
+  - description: The target image and tag where the image will be pushed to.
+    name: IMAGE
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: The commit the image is built from.
+    name: COMMIT_SHA
+    type: string
+  - description: List of Image Manifests to be referenced by the Image Index
+    name: IMAGES
+    type: array
+  - default: ""
+    description: Delete image tag after specified time resulting in garbage collection
+      of the digest. Empty means to keep the image tag. Time values could be something
+      like 1h, 2d, 3w for hours, days, and weeks, respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: "true"
+    description: Build an image index even if IMAGES is of length 1. Default true.
+      If the image index generation is skipped, the task will forward values for params.IMAGES[0]
+      to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest
+      format for the IMAGES parameter.
+    name: ALWAYS_BUILD_INDEX
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: List of all referenced image manifests
+    name: IMAGES
+  - description: Image reference of the built image containing both the repository
+      and the digest
+    name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  stepTemplate:
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.ALWAYS_BUILD_INDEX)
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    volumeMounts:
+    - mountPath: /index-build-data
+      name: shared-dir
+  steps:
+  - args:
+    - $(params.IMAGES[*])
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: 250m
+        memory: 512Mi
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |
+      #!/bin/bash
+      # Fixing group permission on /var/lib/containers
+      set -eu
+      set -o pipefail
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      if [[ $# -ne 1 && "$ALWAYS_BUILD_INDEX" != "true" ]]; then
+        echo "Skipping image index generation while supplying multiple image inputs is unsupported."
+        exit 2
+      fi
+
+      buildah manifest create "$IMAGE"
+      for i in $@
+      do
+        TOADD="$i"
+        TOADD_URL="$(echo "$i" | cut -d@ -f1)"
+        TOADD_DIGEST="$(echo "$i" | cut -d@ -f2)"
+        if [[ $(echo "$i" | tr -cd ":" | wc -c) == 2 ]]; then
+          #format is repository:tag@sha256:digest
+          #we need to remove the tag, and just reference the digest
+          #as tag + digest is not supported
+          TOADD_REPOSITORY="$(echo "$i" | cut -d: -f1)"
+          TOADD="${TOADD_REPOSITORY}@${TOADD_DIGEST}"
+        fi
+        if [[ "$ALWAYS_BUILD_INDEX" != "true" ]]; then
+          echo "Skipping image index generation. Returning results for $TOADD."
+          echo -n "${TOADD_URL}" > "$(results.IMAGE_URL.path)"
+          echo -n "${TOADD_DIGEST}" > "$(results.IMAGE_DIGEST.path)"
+          echo -n "${TOADD}" > "$(results.IMAGES.path)"
+          exit 0
+        fi
+        echo "Adding $TOADD"
+        buildah manifest add $IMAGE "docker://$TOADD" --all
+      done
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing image to registry"
+        buildah manifest push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      INDEX_REPOSITORY="$(echo "$IMAGE" | cut -d@ -f1 | cut -d: -f1)"
+      MANIFEST_DIGESTS=$(buildah manifest inspect "$IMAGE" | jq -er ".manifests[].digest")
+      image_manifests=""
+      for i in $MANIFEST_DIGESTS
+      do
+        image_manifests="${image_manifests} ${INDEX_REPOSITORY}@${i},"
+      done
+
+      cat image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+      {
+        echo -n "${IMAGE}@"
+        cat "image-digest"
+      } > "$(results.IMAGE_REF.path)"
+      echo -n "${image_manifests:1:-1}" > "$(results.IMAGES.path)"
+
+      IMAGE_DIGEST=$(cat image-digest)
+
+      INDEX_IMAGE_PULLSPEC="${IMAGE}@${IMAGE_DIGEST}"
+      buildah manifest inspect "$INDEX_IMAGE_PULLSPEC" > /index-build-data/manifest_data.json
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+  - computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: create-sbom
+    script: |
+      #!/bin/bash
+      set -e
+
+      MANIFEST_DATA_FILE="/index-build-data/manifest_data.json"
+      if [ ! -f "$MANIFEST_DATA_FILE" ]; then
+        echo "The manifest_data.json file does not exist. Skipping the SBOM creation..."
+        exit 0
+      fi
+
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+      echo "Creating SBOM result file..."
+      python3 index_image_sbom_script.py \
+        --image-index-url "$IMAGE_URL" \
+        --image-index-digest "$IMAGE_DIGEST" \
+        --inspect-input-file "$MANIFEST_DATA_FILE" \
+        --output-path /index-build-data/sbom-results.json
+  - computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      set -e
+
+      SBOM_RESULT_FILE="/index-build-data/sbom-results.json"
+      if [ ! -f "$SBOM_RESULT_FILE" ]; then
+        echo "The sbom_results.json file does not exists. Skipping the SBOM upload..."
+        exit 0
+      fi
+
+      cosign attach sbom --sbom "$SBOM_RESULT_FILE" --type spdx "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum "$SBOM_RESULT_FILE" | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+  volumes:
+  - emptyDir: {}
+    name: shared-dir

--- a/task/build-maven-zip-oci-ta/0.1/kustomization.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- build-maven-zip-oci-ta.yaml

--- a/task/buildah-10gb/0.1/buildah-10gb.yaml
+++ b/task/buildah-10gb/0.1/buildah-10gb.yaml
@@ -1,0 +1,585 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+  name: buildah-10gb
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
+    name: BUILDER_IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: unused, should be removed in next task version
+    name: DOCKER_AUTH
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
+  stepTemplate:
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: PARAM_BUILDER_IMAGE
+      value: $(params.BUILDER_IMAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+  steps:
+  - args:
+    - $(params.BUILD_ARGS[*])
+    computeResources:
+      limits:
+        memory: 10Gi
+      requests:
+        cpu: 250m
+        memory: 8Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ $http_code != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ $http_code = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_path"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_path"
+        touch /var/lib/containers/java
+      fi
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      BUILDAH_ARGS=()
+
+      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS="--net"
+        for image in $BASE_IMAGES; do
+          if [ "${image}" != "scratch" ]; then
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          fi
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
+      fi
+
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}"
+      fi
+
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      if [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+
+      elif find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
+        echo "Adding the entitlement to the build"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
+        $VOLUME_MOUNTS \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
+        --tls-verify=$TLSVERIFY --no-cache \
+        --ulimit nofile=4096:4096 \
+        -f "$dockerfile_path" -t $IMAGE .
+
+      container=$(buildah from --pull-never $IMAGE)
+      buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
+      for image in $BASE_IMAGES; do
+        if [ "${image}" != "scratch" ]; then
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)
+        fi
+      done
+
+      # Needed to generate base images SBOM
+      echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      echo "Running syft on the source directory"
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      echo "Running syft on the image filesystem"
+      syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
+      else
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: merge-syft-sboms
+    script: |
+      #!/bin/python3
+      import json
+
+      # load SBOMs
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+      # fetch unique components from available SBOMs
+      def get_identifier(component):
+        return component["name"] + '@' + component.get("version", "")
+
+      image_sbom_components = image_sbom.setdefault("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
+
+      source_sbom_components = source_sbom.get("components", [])
+      for component in source_sbom_components:
+        if get_identifier(component) not in existing_components:
+          image_sbom_components.append(component)
+          existing_components.append(get_identifier(component))
+
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
+
+      # write the CycloneDX unified SBOM
+      with open("./sbom-cyclonedx.json", "w") as f:
+        json.dump(image_sbom, f, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/cachi2:0.19.0@sha256:f67e7f9771c3d425bdd917313553c882d0ed942076dc31d9ce35524bdda1fb6e
+    name: merge-cachi2-sbom
+    script: |
+      if [ -f "sbom-cachi2.json" ]; then
+        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
+        merge_syft_sbom sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: create-purl-sbom
+    script: |
+      #!/bin/python3
+      import json
+
+      with open("./sbom-cyclonedx.json") as f:
+        cyclonedx_sbom = json.load(f)
+
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
+      purl_content = {"image_contents": {"dependencies": purls}}
+
+      with open("sbom-purl.json", "w") as output_file:
+        json.dump(purl_content, output_file, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - env:
+    - name: BASE_IMAGES_DIGESTS_PATH
+      value: $(results.BASE_IMAGES_DIGESTS.path)
+    image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
+    name: create-base-images-sbom
+    script: |
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: inject-sbom-and-push
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
+      container=$(buildah from --pull-never $IMAGE)
+      buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing sbom image to registry"
+        buildah push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push sbom image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - args:
+    - attach
+    - sbom
+    - --sbom
+    - sbom-cyclonedx.json
+    - --type
+    - cyclonedx
+    - $(params.IMAGE)
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    name: upload-sbom
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/buildah-10gb/0.2/buildah-10gb.yaml
+++ b/task/buildah-10gb/0.2/buildah-10gb.yaml
@@ -2,16 +2,22 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: docker
-  name: sast-coverity-check
+  name: buildah-10gb
 spec:
-  description: Scans source code for security vulnerabilities, including common issues
-    such as SQL injection, cross-site scripting (XSS), and code injection attacks
-    using Coverity.
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
   - description: Reference of the image buildah will produce.
     name: IMAGE
@@ -125,43 +131,27 @@ spec:
       to fail if enabled
     name: SKIP_SBOM_GENERATION
     type: string
-  - default: cyclonedx
-    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
-      Note: the SBOM from the prefetch task - if there is one - must be in the same
-      format.'
-    name: SBOM_TYPE
-    type: string
-  - name: image-url
-    type: string
-  - default: cov-license
-    description: Name of secret which contains the Coverity license
-    name: COV_LICENSE
-    type: string
-  - default: ""
-    name: PROJECT_NAME
-    type: string
-  - default: "false"
-    name: RECORD_EXCLUDED
-    type: string
-  - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
-    description: Arguments to be appended to the cov-analyze command
-    name: COV_ANALYZE_ARGS
-    type: string
-  - default: "true"
-    description: Report only important findings. Default is true. To report all findings,
-      specify "false"
-    name: IMP_FINDINGS_ONLY
-    type: string
-  - default: ""
-    description: URL from repository to download known false positives files
-    name: KFP_GIT_URL
-    type: string
   results:
-  - description: Tekton task test output.
-    name: TEST_OUTPUT
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
   stepTemplate:
     computeResources:
       limits:
+        cpu: "4"
         memory: 4Gi
       requests:
         cpu: "1"
@@ -209,119 +199,10 @@ spec:
       value: $(params.PRIVILEGED_NESTED)
     - name: SKIP_SBOM_GENERATION
       value: $(params.SKIP_SBOM_GENERATION)
-    - name: SBOM_TYPE
-      value: $(params.SBOM_TYPE)
     volumeMounts:
     - mountPath: /shared
       name: shared
   steps:
-  - env:
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: prepare
-    script: |
-      #!/bin/bash
-
-      # FIXME: Dockerfile discovery logic is copied from buildah task
-      SOURCE_CODE_DIR=source
-      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
-      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
-      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
-        echo "Fetch Dockerfile from $DOCKERFILE"
-        dockerfile_path=$(mktemp --suffix=-Dockerfile)
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
-          echo "No Dockerfile is fetched. Server responds $http_code"
-          exit 1
-        fi
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
-          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
-        fi
-      else
-        echo "Cannot find Dockerfile $DOCKERFILE"
-        exit 1
-      fi
-
-      # install Coverity license file
-      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
-
-      # pre-create directory for SAST scanning results
-      install -vm1777 -d /shared/sast-results
-
-      # create a wrapper script to instrument RUN lines
-      tee /shared/cmd-wrap.sh >&2 << EOF
-      #!/bin/bash -x
-      id >&2
-
-      # use current directory as project directory by default
-      proj_dir=\$(pwd)
-
-      # if current directory is "/", fallback to an empty temp directory
-      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
-
-      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
-      if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
-        install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
-      fi
-
-      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
-      trap 'rm -fr /tmp/idir' EXIT
-
-      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
-      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
-        - "\$@"
-
-      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
-      $(declare -p COV_ANALYZE_ARGS)
-
-      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
-      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
-
-      if [ \$? -eq 0 ]; then
-        # assign a unique file name for scan results
-        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
-
-        # obtain capture stats to process them later on
-        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
-
-        # export scan results and embed source code context into the scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
-          > "\${json_file}"
-      fi
-
-      # propagate the original exit code of the wrapped command
-      exit "\$(</tmp/idir/build-cmd-ec.txt)"
-      EOF
-      echo >&2
-
-      # make the wrapper script executable
-      chmod -v 0755 /shared/cmd-wrap.sh
-
-      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
-      EC=$?
-
-      # if we have no RUN lines to instrument, it is not a reason to make the task fail
-      if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
-        echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
-      else
-        cat /tmp/cstrans-df-run.log >&2
-        exit $EC
-      fi
-    volumeMounts:
-    - mountPath: /etc/secrets/cov
-      name: cov-license
-      readOnly: true
-    workingDir: $(workspaces.source.path)
   - args:
     - --build-args
     - $(params.BUILD_ARGS[*])
@@ -329,23 +210,17 @@ spec:
     - $(params.LABELS[*])
     computeResources:
       limits:
-        cpu: 16
-        memory: 16Gi
+        cpu: "4"
+        memory: 10Gi
       requests:
-        cpu: 4
-        memory: 4Gi
+        cpu: "1"
+        memory: 8Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
-      value: /shared/Containerfile
-    - name: ADDITIONAL_VOLUME_MOUNTS
-      value: |-
-        /opt:/opt
-        /shared:/shared
-        /shared/license.dat:/opt/coverity/bin/license.dat
-        /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      value: $(params.DOCKERFILE)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: build
     script: |
       #!/bin/bash
@@ -368,14 +243,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
+        if [ $http_code != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
+        if [ $http_code = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -384,6 +259,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
+        touch /var/lib/containers/java
+      fi
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -434,7 +314,7 @@ spec:
 
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json
       )
 
       BUILDAH_ARGS=()
@@ -445,7 +325,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -498,14 +378,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p "${YUM_REPOS_D_FETCHED}"
-        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
-        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -613,7 +493,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount "$container" | tee /shared/container_path
+      buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
@@ -645,43 +525,26 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        cpu: 2
-        memory: 2Gi
-    env:
-    - name: IMAGE_URL
-      value: $(params.image-url)
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: KFP_GIT_URL
-      value: $(params.KFP_GIT_URL)
-    - name: IMP_FINDINGS_ONLY
-      value: $(params.IMP_FINDINGS_ONLY)
-    - name: PROJECT_NAME
-      value: $(params.PROJECT_NAME)
-    - name: RECORD_EXCLUDED
-      value: $(params.RECORD_EXCLUDED)
-    - name: COMPONENT_LABEL
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.labels['appstudio.openshift.io/component']
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: postprocess
+  - image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    name: icm
     script: |
-      #!/bin/bash -e
-      # shellcheck source=/dev/null
-      set -o pipefail
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: push
+    script: |
+      #!/bin/bash
+      set -e
 
-      . /usr/local/share/konflux-test/utils.sh
-      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
-      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
-
-      # Installation of Red Hat certificates for cloning Red Hat internal repositories
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -689,115 +552,166 @@ spec:
         update-ca-trust
       fi
 
-      if [ -z "$(ls /shared/sast-results/)" ]; then (
-        set +e
-        set -x
-
-        # fallback to buildless scan if we have no scan results from buildful
-        # shellcheck disable=SC2086
-        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
-
-        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
-
-        # install Coverity license file
-        install -vm0644 /{shared,opt/coverity/bin}/license.dat
-
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
-
-        # export scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | csgrep --mode=json --embed-context=3 \
-          > /shared/sast-results/coverity-buildless.json
-      ) fi
-
-      # collect capture stats (FIXME: this doe not take findings deduplication into account)
-      set +e
-      for file in /shared/sast-results/*-summary.txt; do
-        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
-      done
-
-      # calculate the total number of files
-      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
-
-      # calculate the ratio of successful files to total files
-      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
-      set -e
-
-      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
-      IMP_LEVEL=1
-      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
-        IMP_LEVEL=0
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
       fi
 
-      # collect scan results
-      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
-        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
-        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
-        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
-        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
-        | tee coverity-results-raw.json \
-        | csgrep --mode=evtstat
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
 
-      # We check if the KFP_GIT_URL variable is set to apply the filters or not
-      if [[ -z "${KFP_GIT_URL}" ]]; then
-        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
-        mv coverity-results{-raw,}.json
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+      echo "Running syft on the source directory"
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       else
-        echo "Filtering false positives in results files using csfilter-kfp..."
-        CMD=(
-          csfilter-kfp
-          --verbose
-          --kfp-git-url="${KFP_GIT_URL}"
-          --project-nvr="${PROJECT_NAME}"
-        )
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: prepare-sboms
+    script: |
+      #!/bin/bash
+      set -euo pipefail
 
-        if [ "${RECORD_EXCLUDED}" == "true" ]; then
-          CMD+=(--record-excluded="excluded-findings.json")
-        fi
-
-        "${CMD[@]}" coverity-results-raw.json \
-          | tee coverity-results.json \
-          | csgrep --mode=evtstat
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
 
-      # convert the scan results into SARIF
-      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
 
-      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
-        note="Task $(context.task.name) success: No finding was detected"
-        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-      else
-        TEST_OUTPUT=
-        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
-        note="Task $(context.task.name) failed: For details, check Tekton task log."
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
       fi
 
-      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom-cyclonedx.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom-cyclonedx.json
 
-      # upload scan results
-      echo "Selecting auth for upload of scan results"
-      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+      echo "Adding base images data to sbom-cyclonedx.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom-cyclonedx.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
 
-      upload_file() (
-        set -x
-        UPLOAD_FILE="$1"
-        MEDIA_TYPE="$2"
-        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
-      )
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
 
-      echo "Attaching scan results to ${IMAGE_URL}"
-      upload_file "coverity-results.sarif" "application/sarif+json"
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom-cyclonedx.json \
+        --output-file /tmp/sbom-cyclonedx.tmp.json
 
-      # upload excluded-findings.json if enabled
-      if [ -f "excluded-findings.json" ]; then
-        upload_file "excluded-findings.json" "application/json"
+      mv /tmp/sbom-cyclonedx.tmp.json sbom-cyclonedx.json
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     volumeMounts:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
@@ -827,10 +741,6 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
-  - name: cov-license
-    secret:
-      optional: false
-      secretName: $(params.COV_LICENSE)
   workspaces:
   - description: Workspace containing the source code to build.
     name: source

--- a/task/buildah-20gb/0.1/buildah-20gb.yaml
+++ b/task/buildah-20gb/0.1/buildah-20gb.yaml
@@ -1,0 +1,585 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+  name: buildah-20gb
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
+    name: BUILDER_IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: unused, should be removed in next task version
+    name: DOCKER_AUTH
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
+  stepTemplate:
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: PARAM_BUILDER_IMAGE
+      value: $(params.BUILDER_IMAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+  steps:
+  - args:
+    - $(params.BUILD_ARGS[*])
+    computeResources:
+      limits:
+        memory: 20Gi
+      requests:
+        cpu: 250m
+        memory: 16Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ $http_code != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ $http_code = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_path"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_path"
+        touch /var/lib/containers/java
+      fi
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      BUILDAH_ARGS=()
+
+      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS="--net"
+        for image in $BASE_IMAGES; do
+          if [ "${image}" != "scratch" ]; then
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          fi
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
+      fi
+
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}"
+      fi
+
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      if [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+
+      elif find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
+        echo "Adding the entitlement to the build"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
+        $VOLUME_MOUNTS \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
+        --tls-verify=$TLSVERIFY --no-cache \
+        --ulimit nofile=4096:4096 \
+        -f "$dockerfile_path" -t $IMAGE .
+
+      container=$(buildah from --pull-never $IMAGE)
+      buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
+      for image in $BASE_IMAGES; do
+        if [ "${image}" != "scratch" ]; then
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)
+        fi
+      done
+
+      # Needed to generate base images SBOM
+      echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      echo "Running syft on the source directory"
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      echo "Running syft on the image filesystem"
+      syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
+      else
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: merge-syft-sboms
+    script: |
+      #!/bin/python3
+      import json
+
+      # load SBOMs
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+      # fetch unique components from available SBOMs
+      def get_identifier(component):
+        return component["name"] + '@' + component.get("version", "")
+
+      image_sbom_components = image_sbom.setdefault("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
+
+      source_sbom_components = source_sbom.get("components", [])
+      for component in source_sbom_components:
+        if get_identifier(component) not in existing_components:
+          image_sbom_components.append(component)
+          existing_components.append(get_identifier(component))
+
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
+
+      # write the CycloneDX unified SBOM
+      with open("./sbom-cyclonedx.json", "w") as f:
+        json.dump(image_sbom, f, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/cachi2:0.19.0@sha256:f67e7f9771c3d425bdd917313553c882d0ed942076dc31d9ce35524bdda1fb6e
+    name: merge-cachi2-sbom
+    script: |
+      if [ -f "sbom-cachi2.json" ]; then
+        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
+        merge_syft_sbom sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: create-purl-sbom
+    script: |
+      #!/bin/python3
+      import json
+
+      with open("./sbom-cyclonedx.json") as f:
+        cyclonedx_sbom = json.load(f)
+
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
+      purl_content = {"image_contents": {"dependencies": purls}}
+
+      with open("sbom-purl.json", "w") as output_file:
+        json.dump(purl_content, output_file, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - env:
+    - name: BASE_IMAGES_DIGESTS_PATH
+      value: $(results.BASE_IMAGES_DIGESTS.path)
+    image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
+    name: create-base-images-sbom
+    script: |
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: inject-sbom-and-push
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
+      container=$(buildah from --pull-never $IMAGE)
+      buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing sbom image to registry"
+        buildah push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push sbom image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - args:
+    - attach
+    - sbom
+    - --sbom
+    - sbom-cyclonedx.json
+    - --type
+    - cyclonedx
+    - $(params.IMAGE)
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    name: upload-sbom
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/buildah-20gb/0.2/buildah-20gb.yaml
+++ b/task/buildah-20gb/0.2/buildah-20gb.yaml
@@ -2,16 +2,22 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: docker
-  name: sast-coverity-check
+  name: buildah-20gb
 spec:
-  description: Scans source code for security vulnerabilities, including common issues
-    such as SQL injection, cross-site scripting (XSS), and code injection attacks
-    using Coverity.
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
   - description: Reference of the image buildah will produce.
     name: IMAGE
@@ -125,43 +131,27 @@ spec:
       to fail if enabled
     name: SKIP_SBOM_GENERATION
     type: string
-  - default: cyclonedx
-    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
-      Note: the SBOM from the prefetch task - if there is one - must be in the same
-      format.'
-    name: SBOM_TYPE
-    type: string
-  - name: image-url
-    type: string
-  - default: cov-license
-    description: Name of secret which contains the Coverity license
-    name: COV_LICENSE
-    type: string
-  - default: ""
-    name: PROJECT_NAME
-    type: string
-  - default: "false"
-    name: RECORD_EXCLUDED
-    type: string
-  - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
-    description: Arguments to be appended to the cov-analyze command
-    name: COV_ANALYZE_ARGS
-    type: string
-  - default: "true"
-    description: Report only important findings. Default is true. To report all findings,
-      specify "false"
-    name: IMP_FINDINGS_ONLY
-    type: string
-  - default: ""
-    description: URL from repository to download known false positives files
-    name: KFP_GIT_URL
-    type: string
   results:
-  - description: Tekton task test output.
-    name: TEST_OUTPUT
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
   stepTemplate:
     computeResources:
       limits:
+        cpu: "4"
         memory: 4Gi
       requests:
         cpu: "1"
@@ -209,119 +199,10 @@ spec:
       value: $(params.PRIVILEGED_NESTED)
     - name: SKIP_SBOM_GENERATION
       value: $(params.SKIP_SBOM_GENERATION)
-    - name: SBOM_TYPE
-      value: $(params.SBOM_TYPE)
     volumeMounts:
     - mountPath: /shared
       name: shared
   steps:
-  - env:
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: prepare
-    script: |
-      #!/bin/bash
-
-      # FIXME: Dockerfile discovery logic is copied from buildah task
-      SOURCE_CODE_DIR=source
-      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
-      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
-      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
-        echo "Fetch Dockerfile from $DOCKERFILE"
-        dockerfile_path=$(mktemp --suffix=-Dockerfile)
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
-          echo "No Dockerfile is fetched. Server responds $http_code"
-          exit 1
-        fi
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
-          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
-        fi
-      else
-        echo "Cannot find Dockerfile $DOCKERFILE"
-        exit 1
-      fi
-
-      # install Coverity license file
-      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
-
-      # pre-create directory for SAST scanning results
-      install -vm1777 -d /shared/sast-results
-
-      # create a wrapper script to instrument RUN lines
-      tee /shared/cmd-wrap.sh >&2 << EOF
-      #!/bin/bash -x
-      id >&2
-
-      # use current directory as project directory by default
-      proj_dir=\$(pwd)
-
-      # if current directory is "/", fallback to an empty temp directory
-      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
-
-      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
-      if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
-        install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
-      fi
-
-      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
-      trap 'rm -fr /tmp/idir' EXIT
-
-      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
-      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
-        - "\$@"
-
-      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
-      $(declare -p COV_ANALYZE_ARGS)
-
-      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
-      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
-
-      if [ \$? -eq 0 ]; then
-        # assign a unique file name for scan results
-        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
-
-        # obtain capture stats to process them later on
-        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
-
-        # export scan results and embed source code context into the scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
-          > "\${json_file}"
-      fi
-
-      # propagate the original exit code of the wrapped command
-      exit "\$(</tmp/idir/build-cmd-ec.txt)"
-      EOF
-      echo >&2
-
-      # make the wrapper script executable
-      chmod -v 0755 /shared/cmd-wrap.sh
-
-      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
-      EC=$?
-
-      # if we have no RUN lines to instrument, it is not a reason to make the task fail
-      if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
-        echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
-      else
-        cat /tmp/cstrans-df-run.log >&2
-        exit $EC
-      fi
-    volumeMounts:
-    - mountPath: /etc/secrets/cov
-      name: cov-license
-      readOnly: true
-    workingDir: $(workspaces.source.path)
   - args:
     - --build-args
     - $(params.BUILD_ARGS[*])
@@ -329,23 +210,17 @@ spec:
     - $(params.LABELS[*])
     computeResources:
       limits:
-        cpu: 16
-        memory: 16Gi
+        cpu: "4"
+        memory: 20Gi
       requests:
-        cpu: 4
-        memory: 4Gi
+        cpu: "1"
+        memory: 16Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
-      value: /shared/Containerfile
-    - name: ADDITIONAL_VOLUME_MOUNTS
-      value: |-
-        /opt:/opt
-        /shared:/shared
-        /shared/license.dat:/opt/coverity/bin/license.dat
-        /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      value: $(params.DOCKERFILE)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: build
     script: |
       #!/bin/bash
@@ -368,14 +243,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
+        if [ $http_code != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
+        if [ $http_code = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -384,6 +259,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
+        touch /var/lib/containers/java
+      fi
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -434,7 +314,7 @@ spec:
 
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json
       )
 
       BUILDAH_ARGS=()
@@ -445,7 +325,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -498,14 +378,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p "${YUM_REPOS_D_FETCHED}"
-        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
-        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -613,7 +493,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount "$container" | tee /shared/container_path
+      buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
@@ -645,43 +525,26 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        cpu: 2
-        memory: 2Gi
-    env:
-    - name: IMAGE_URL
-      value: $(params.image-url)
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: KFP_GIT_URL
-      value: $(params.KFP_GIT_URL)
-    - name: IMP_FINDINGS_ONLY
-      value: $(params.IMP_FINDINGS_ONLY)
-    - name: PROJECT_NAME
-      value: $(params.PROJECT_NAME)
-    - name: RECORD_EXCLUDED
-      value: $(params.RECORD_EXCLUDED)
-    - name: COMPONENT_LABEL
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.labels['appstudio.openshift.io/component']
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: postprocess
+  - image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    name: icm
     script: |
-      #!/bin/bash -e
-      # shellcheck source=/dev/null
-      set -o pipefail
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: push
+    script: |
+      #!/bin/bash
+      set -e
 
-      . /usr/local/share/konflux-test/utils.sh
-      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
-      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
-
-      # Installation of Red Hat certificates for cloning Red Hat internal repositories
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -689,115 +552,166 @@ spec:
         update-ca-trust
       fi
 
-      if [ -z "$(ls /shared/sast-results/)" ]; then (
-        set +e
-        set -x
-
-        # fallback to buildless scan if we have no scan results from buildful
-        # shellcheck disable=SC2086
-        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
-
-        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
-
-        # install Coverity license file
-        install -vm0644 /{shared,opt/coverity/bin}/license.dat
-
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
-
-        # export scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | csgrep --mode=json --embed-context=3 \
-          > /shared/sast-results/coverity-buildless.json
-      ) fi
-
-      # collect capture stats (FIXME: this doe not take findings deduplication into account)
-      set +e
-      for file in /shared/sast-results/*-summary.txt; do
-        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
-      done
-
-      # calculate the total number of files
-      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
-
-      # calculate the ratio of successful files to total files
-      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
-      set -e
-
-      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
-      IMP_LEVEL=1
-      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
-        IMP_LEVEL=0
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
       fi
 
-      # collect scan results
-      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
-        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
-        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
-        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
-        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
-        | tee coverity-results-raw.json \
-        | csgrep --mode=evtstat
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
 
-      # We check if the KFP_GIT_URL variable is set to apply the filters or not
-      if [[ -z "${KFP_GIT_URL}" ]]; then
-        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
-        mv coverity-results{-raw,}.json
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+      echo "Running syft on the source directory"
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       else
-        echo "Filtering false positives in results files using csfilter-kfp..."
-        CMD=(
-          csfilter-kfp
-          --verbose
-          --kfp-git-url="${KFP_GIT_URL}"
-          --project-nvr="${PROJECT_NAME}"
-        )
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: prepare-sboms
+    script: |
+      #!/bin/bash
+      set -euo pipefail
 
-        if [ "${RECORD_EXCLUDED}" == "true" ]; then
-          CMD+=(--record-excluded="excluded-findings.json")
-        fi
-
-        "${CMD[@]}" coverity-results-raw.json \
-          | tee coverity-results.json \
-          | csgrep --mode=evtstat
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
 
-      # convert the scan results into SARIF
-      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
 
-      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
-        note="Task $(context.task.name) success: No finding was detected"
-        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-      else
-        TEST_OUTPUT=
-        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
-        note="Task $(context.task.name) failed: For details, check Tekton task log."
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
       fi
 
-      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom-cyclonedx.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom-cyclonedx.json
 
-      # upload scan results
-      echo "Selecting auth for upload of scan results"
-      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+      echo "Adding base images data to sbom-cyclonedx.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom-cyclonedx.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
 
-      upload_file() (
-        set -x
-        UPLOAD_FILE="$1"
-        MEDIA_TYPE="$2"
-        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
-      )
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
 
-      echo "Attaching scan results to ${IMAGE_URL}"
-      upload_file "coverity-results.sarif" "application/sarif+json"
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom-cyclonedx.json \
+        --output-file /tmp/sbom-cyclonedx.tmp.json
 
-      # upload excluded-findings.json if enabled
-      if [ -f "excluded-findings.json" ]; then
-        upload_file "excluded-findings.json" "application/json"
+      mv /tmp/sbom-cyclonedx.tmp.json sbom-cyclonedx.json
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     volumeMounts:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
@@ -827,10 +741,6 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
-  - name: cov-license
-    secret:
-      optional: false
-      secretName: $(params.COV_LICENSE)
   workspaces:
   - description: Workspace containing the source code to build.
     name: source

--- a/task/buildah-24gb/0.1/buildah-24gb.yaml
+++ b/task/buildah-24gb/0.1/buildah-24gb.yaml
@@ -1,0 +1,586 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+  name: buildah-24gb
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
+    name: BUILDER_IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: unused, should be removed in next task version
+    name: DOCKER_AUTH
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
+  stepTemplate:
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: PARAM_BUILDER_IMAGE
+      value: $(params.BUILDER_IMAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+  steps:
+  - args:
+    - $(params.BUILD_ARGS[*])
+    computeResources:
+      limits:
+        cpu: "20"
+        memory: 24Gi
+      requests:
+        cpu: "10"
+        memory: 20Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ $http_code != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ $http_code = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_path"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_path"
+        touch /var/lib/containers/java
+      fi
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      BUILDAH_ARGS=()
+
+      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS="--net"
+        for image in $BASE_IMAGES; do
+          if [ "${image}" != "scratch" ]; then
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          fi
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
+      fi
+
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}"
+      fi
+
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      if [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+
+      elif find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
+        echo "Adding the entitlement to the build"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
+        $VOLUME_MOUNTS \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
+        --tls-verify=$TLSVERIFY --no-cache \
+        --ulimit nofile=4096:4096 \
+        -f "$dockerfile_path" -t $IMAGE .
+
+      container=$(buildah from --pull-never $IMAGE)
+      buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
+      for image in $BASE_IMAGES; do
+        if [ "${image}" != "scratch" ]; then
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)
+        fi
+      done
+
+      # Needed to generate base images SBOM
+      echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      echo "Running syft on the source directory"
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      echo "Running syft on the image filesystem"
+      syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
+      else
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: merge-syft-sboms
+    script: |
+      #!/bin/python3
+      import json
+
+      # load SBOMs
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+      # fetch unique components from available SBOMs
+      def get_identifier(component):
+        return component["name"] + '@' + component.get("version", "")
+
+      image_sbom_components = image_sbom.setdefault("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
+
+      source_sbom_components = source_sbom.get("components", [])
+      for component in source_sbom_components:
+        if get_identifier(component) not in existing_components:
+          image_sbom_components.append(component)
+          existing_components.append(get_identifier(component))
+
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
+
+      # write the CycloneDX unified SBOM
+      with open("./sbom-cyclonedx.json", "w") as f:
+        json.dump(image_sbom, f, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/cachi2:0.19.0@sha256:f67e7f9771c3d425bdd917313553c882d0ed942076dc31d9ce35524bdda1fb6e
+    name: merge-cachi2-sbom
+    script: |
+      if [ -f "sbom-cachi2.json" ]; then
+        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
+        merge_syft_sbom sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: create-purl-sbom
+    script: |
+      #!/bin/python3
+      import json
+
+      with open("./sbom-cyclonedx.json") as f:
+        cyclonedx_sbom = json.load(f)
+
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
+      purl_content = {"image_contents": {"dependencies": purls}}
+
+      with open("sbom-purl.json", "w") as output_file:
+        json.dump(purl_content, output_file, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - env:
+    - name: BASE_IMAGES_DIGESTS_PATH
+      value: $(results.BASE_IMAGES_DIGESTS.path)
+    image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
+    name: create-base-images-sbom
+    script: |
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: inject-sbom-and-push
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
+      container=$(buildah from --pull-never $IMAGE)
+      buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing sbom image to registry"
+        buildah push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push sbom image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - args:
+    - attach
+    - sbom
+    - --sbom
+    - sbom-cyclonedx.json
+    - --type
+    - cyclonedx
+    - $(params.IMAGE)
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    name: upload-sbom
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/buildah-24gb/0.2/buildah-24gb.yaml
+++ b/task/buildah-24gb/0.2/buildah-24gb.yaml
@@ -2,16 +2,22 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: docker
-  name: sast-coverity-check
+  name: buildah-24gb
 spec:
-  description: Scans source code for security vulnerabilities, including common issues
-    such as SQL injection, cross-site scripting (XSS), and code injection attacks
-    using Coverity.
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
   - description: Reference of the image buildah will produce.
     name: IMAGE
@@ -125,43 +131,27 @@ spec:
       to fail if enabled
     name: SKIP_SBOM_GENERATION
     type: string
-  - default: cyclonedx
-    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
-      Note: the SBOM from the prefetch task - if there is one - must be in the same
-      format.'
-    name: SBOM_TYPE
-    type: string
-  - name: image-url
-    type: string
-  - default: cov-license
-    description: Name of secret which contains the Coverity license
-    name: COV_LICENSE
-    type: string
-  - default: ""
-    name: PROJECT_NAME
-    type: string
-  - default: "false"
-    name: RECORD_EXCLUDED
-    type: string
-  - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
-    description: Arguments to be appended to the cov-analyze command
-    name: COV_ANALYZE_ARGS
-    type: string
-  - default: "true"
-    description: Report only important findings. Default is true. To report all findings,
-      specify "false"
-    name: IMP_FINDINGS_ONLY
-    type: string
-  - default: ""
-    description: URL from repository to download known false positives files
-    name: KFP_GIT_URL
-    type: string
   results:
-  - description: Tekton task test output.
-    name: TEST_OUTPUT
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
   stepTemplate:
     computeResources:
       limits:
+        cpu: "4"
         memory: 4Gi
       requests:
         cpu: "1"
@@ -209,119 +199,10 @@ spec:
       value: $(params.PRIVILEGED_NESTED)
     - name: SKIP_SBOM_GENERATION
       value: $(params.SKIP_SBOM_GENERATION)
-    - name: SBOM_TYPE
-      value: $(params.SBOM_TYPE)
     volumeMounts:
     - mountPath: /shared
       name: shared
   steps:
-  - env:
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: prepare
-    script: |
-      #!/bin/bash
-
-      # FIXME: Dockerfile discovery logic is copied from buildah task
-      SOURCE_CODE_DIR=source
-      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
-      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
-      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
-        echo "Fetch Dockerfile from $DOCKERFILE"
-        dockerfile_path=$(mktemp --suffix=-Dockerfile)
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
-          echo "No Dockerfile is fetched. Server responds $http_code"
-          exit 1
-        fi
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
-          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
-        fi
-      else
-        echo "Cannot find Dockerfile $DOCKERFILE"
-        exit 1
-      fi
-
-      # install Coverity license file
-      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
-
-      # pre-create directory for SAST scanning results
-      install -vm1777 -d /shared/sast-results
-
-      # create a wrapper script to instrument RUN lines
-      tee /shared/cmd-wrap.sh >&2 << EOF
-      #!/bin/bash -x
-      id >&2
-
-      # use current directory as project directory by default
-      proj_dir=\$(pwd)
-
-      # if current directory is "/", fallback to an empty temp directory
-      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
-
-      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
-      if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
-        install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
-      fi
-
-      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
-      trap 'rm -fr /tmp/idir' EXIT
-
-      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
-      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
-        - "\$@"
-
-      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
-      $(declare -p COV_ANALYZE_ARGS)
-
-      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
-      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
-
-      if [ \$? -eq 0 ]; then
-        # assign a unique file name for scan results
-        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
-
-        # obtain capture stats to process them later on
-        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
-
-        # export scan results and embed source code context into the scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
-          > "\${json_file}"
-      fi
-
-      # propagate the original exit code of the wrapped command
-      exit "\$(</tmp/idir/build-cmd-ec.txt)"
-      EOF
-      echo >&2
-
-      # make the wrapper script executable
-      chmod -v 0755 /shared/cmd-wrap.sh
-
-      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
-      EC=$?
-
-      # if we have no RUN lines to instrument, it is not a reason to make the task fail
-      if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
-        echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
-      else
-        cat /tmp/cstrans-df-run.log >&2
-        exit $EC
-      fi
-    volumeMounts:
-    - mountPath: /etc/secrets/cov
-      name: cov-license
-      readOnly: true
-    workingDir: $(workspaces.source.path)
   - args:
     - --build-args
     - $(params.BUILD_ARGS[*])
@@ -329,23 +210,17 @@ spec:
     - $(params.LABELS[*])
     computeResources:
       limits:
-        cpu: 16
-        memory: 16Gi
+        cpu: "4"
+        memory: 24Gi
       requests:
-        cpu: 4
-        memory: 4Gi
+        cpu: "10"
+        memory: 20Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
-      value: /shared/Containerfile
-    - name: ADDITIONAL_VOLUME_MOUNTS
-      value: |-
-        /opt:/opt
-        /shared:/shared
-        /shared/license.dat:/opt/coverity/bin/license.dat
-        /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      value: $(params.DOCKERFILE)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: build
     script: |
       #!/bin/bash
@@ -368,14 +243,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
+        if [ $http_code != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
+        if [ $http_code = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -384,6 +259,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
+        touch /var/lib/containers/java
+      fi
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -434,7 +314,7 @@ spec:
 
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json
       )
 
       BUILDAH_ARGS=()
@@ -445,7 +325,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -498,14 +378,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p "${YUM_REPOS_D_FETCHED}"
-        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
-        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -613,7 +493,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount "$container" | tee /shared/container_path
+      buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
@@ -645,43 +525,26 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        cpu: 2
-        memory: 2Gi
-    env:
-    - name: IMAGE_URL
-      value: $(params.image-url)
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: KFP_GIT_URL
-      value: $(params.KFP_GIT_URL)
-    - name: IMP_FINDINGS_ONLY
-      value: $(params.IMP_FINDINGS_ONLY)
-    - name: PROJECT_NAME
-      value: $(params.PROJECT_NAME)
-    - name: RECORD_EXCLUDED
-      value: $(params.RECORD_EXCLUDED)
-    - name: COMPONENT_LABEL
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.labels['appstudio.openshift.io/component']
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: postprocess
+  - image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    name: icm
     script: |
-      #!/bin/bash -e
-      # shellcheck source=/dev/null
-      set -o pipefail
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: push
+    script: |
+      #!/bin/bash
+      set -e
 
-      . /usr/local/share/konflux-test/utils.sh
-      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
-      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
-
-      # Installation of Red Hat certificates for cloning Red Hat internal repositories
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -689,115 +552,166 @@ spec:
         update-ca-trust
       fi
 
-      if [ -z "$(ls /shared/sast-results/)" ]; then (
-        set +e
-        set -x
-
-        # fallback to buildless scan if we have no scan results from buildful
-        # shellcheck disable=SC2086
-        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
-
-        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
-
-        # install Coverity license file
-        install -vm0644 /{shared,opt/coverity/bin}/license.dat
-
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
-
-        # export scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | csgrep --mode=json --embed-context=3 \
-          > /shared/sast-results/coverity-buildless.json
-      ) fi
-
-      # collect capture stats (FIXME: this doe not take findings deduplication into account)
-      set +e
-      for file in /shared/sast-results/*-summary.txt; do
-        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
-      done
-
-      # calculate the total number of files
-      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
-
-      # calculate the ratio of successful files to total files
-      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
-      set -e
-
-      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
-      IMP_LEVEL=1
-      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
-        IMP_LEVEL=0
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
       fi
 
-      # collect scan results
-      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
-        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
-        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
-        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
-        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
-        | tee coverity-results-raw.json \
-        | csgrep --mode=evtstat
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
 
-      # We check if the KFP_GIT_URL variable is set to apply the filters or not
-      if [[ -z "${KFP_GIT_URL}" ]]; then
-        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
-        mv coverity-results{-raw,}.json
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+      echo "Running syft on the source directory"
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       else
-        echo "Filtering false positives in results files using csfilter-kfp..."
-        CMD=(
-          csfilter-kfp
-          --verbose
-          --kfp-git-url="${KFP_GIT_URL}"
-          --project-nvr="${PROJECT_NAME}"
-        )
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: prepare-sboms
+    script: |
+      #!/bin/bash
+      set -euo pipefail
 
-        if [ "${RECORD_EXCLUDED}" == "true" ]; then
-          CMD+=(--record-excluded="excluded-findings.json")
-        fi
-
-        "${CMD[@]}" coverity-results-raw.json \
-          | tee coverity-results.json \
-          | csgrep --mode=evtstat
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
 
-      # convert the scan results into SARIF
-      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
 
-      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
-        note="Task $(context.task.name) success: No finding was detected"
-        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-      else
-        TEST_OUTPUT=
-        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
-        note="Task $(context.task.name) failed: For details, check Tekton task log."
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
       fi
 
-      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom-cyclonedx.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom-cyclonedx.json
 
-      # upload scan results
-      echo "Selecting auth for upload of scan results"
-      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+      echo "Adding base images data to sbom-cyclonedx.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom-cyclonedx.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
 
-      upload_file() (
-        set -x
-        UPLOAD_FILE="$1"
-        MEDIA_TYPE="$2"
-        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
-      )
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
 
-      echo "Attaching scan results to ${IMAGE_URL}"
-      upload_file "coverity-results.sarif" "application/sarif+json"
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom-cyclonedx.json \
+        --output-file /tmp/sbom-cyclonedx.tmp.json
 
-      # upload excluded-findings.json if enabled
-      if [ -f "excluded-findings.json" ]; then
-        upload_file "excluded-findings.json" "application/json"
+      mv /tmp/sbom-cyclonedx.tmp.json sbom-cyclonedx.json
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     volumeMounts:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
@@ -827,10 +741,6 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
-  - name: cov-license
-    secret:
-      optional: false
-      secretName: $(params.COV_LICENSE)
   workspaces:
   - description: Workspace containing the source code to build.
     name: source

--- a/task/buildah-6gb/0.1/buildah-6gb.yaml
+++ b/task/buildah-6gb/0.1/buildah-6gb.yaml
@@ -1,0 +1,585 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+  name: buildah-6gb
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
+    name: BUILDER_IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: unused, should be removed in next task version
+    name: DOCKER_AUTH
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
+  stepTemplate:
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: PARAM_BUILDER_IMAGE
+      value: $(params.BUILDER_IMAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+  steps:
+  - args:
+    - $(params.BUILD_ARGS[*])
+    computeResources:
+      limits:
+        memory: 6Gi
+      requests:
+        cpu: 250m
+        memory: 4Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ $http_code != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ $http_code = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_path"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_path"
+        touch /var/lib/containers/java
+      fi
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      BUILDAH_ARGS=()
+
+      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS="--net"
+        for image in $BASE_IMAGES; do
+          if [ "${image}" != "scratch" ]; then
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          fi
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
+      fi
+
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}"
+      fi
+
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      if [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+
+      elif find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
+        echo "Adding the entitlement to the build"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
+        $VOLUME_MOUNTS \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
+        --tls-verify=$TLSVERIFY --no-cache \
+        --ulimit nofile=4096:4096 \
+        -f "$dockerfile_path" -t $IMAGE .
+
+      container=$(buildah from --pull-never $IMAGE)
+      buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
+      for image in $BASE_IMAGES; do
+        if [ "${image}" != "scratch" ]; then
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)
+        fi
+      done
+
+      # Needed to generate base images SBOM
+      echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      echo "Running syft on the source directory"
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      echo "Running syft on the image filesystem"
+      syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
+      else
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: merge-syft-sboms
+    script: |
+      #!/bin/python3
+      import json
+
+      # load SBOMs
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+      # fetch unique components from available SBOMs
+      def get_identifier(component):
+        return component["name"] + '@' + component.get("version", "")
+
+      image_sbom_components = image_sbom.setdefault("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
+
+      source_sbom_components = source_sbom.get("components", [])
+      for component in source_sbom_components:
+        if get_identifier(component) not in existing_components:
+          image_sbom_components.append(component)
+          existing_components.append(get_identifier(component))
+
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
+
+      # write the CycloneDX unified SBOM
+      with open("./sbom-cyclonedx.json", "w") as f:
+        json.dump(image_sbom, f, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/cachi2:0.19.0@sha256:f67e7f9771c3d425bdd917313553c882d0ed942076dc31d9ce35524bdda1fb6e
+    name: merge-cachi2-sbom
+    script: |
+      if [ -f "sbom-cachi2.json" ]; then
+        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
+        merge_syft_sbom sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: create-purl-sbom
+    script: |
+      #!/bin/python3
+      import json
+
+      with open("./sbom-cyclonedx.json") as f:
+        cyclonedx_sbom = json.load(f)
+
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
+      purl_content = {"image_contents": {"dependencies": purls}}
+
+      with open("sbom-purl.json", "w") as output_file:
+        json.dump(purl_content, output_file, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - env:
+    - name: BASE_IMAGES_DIGESTS_PATH
+      value: $(results.BASE_IMAGES_DIGESTS.path)
+    image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
+    name: create-base-images-sbom
+    script: |
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: inject-sbom-and-push
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
+      container=$(buildah from --pull-never $IMAGE)
+      buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing sbom image to registry"
+        buildah push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push sbom image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - args:
+    - attach
+    - sbom
+    - --sbom
+    - sbom-cyclonedx.json
+    - --type
+    - cyclonedx
+    - $(params.IMAGE)
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    name: upload-sbom
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/buildah-6gb/0.2/buildah-6gb.yaml
+++ b/task/buildah-6gb/0.2/buildah-6gb.yaml
@@ -2,16 +2,22 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: docker
-  name: sast-coverity-check
+  name: buildah-6gb
 spec:
-  description: Scans source code for security vulnerabilities, including common issues
-    such as SQL injection, cross-site scripting (XSS), and code injection attacks
-    using Coverity.
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
   - description: Reference of the image buildah will produce.
     name: IMAGE
@@ -125,43 +131,27 @@ spec:
       to fail if enabled
     name: SKIP_SBOM_GENERATION
     type: string
-  - default: cyclonedx
-    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
-      Note: the SBOM from the prefetch task - if there is one - must be in the same
-      format.'
-    name: SBOM_TYPE
-    type: string
-  - name: image-url
-    type: string
-  - default: cov-license
-    description: Name of secret which contains the Coverity license
-    name: COV_LICENSE
-    type: string
-  - default: ""
-    name: PROJECT_NAME
-    type: string
-  - default: "false"
-    name: RECORD_EXCLUDED
-    type: string
-  - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
-    description: Arguments to be appended to the cov-analyze command
-    name: COV_ANALYZE_ARGS
-    type: string
-  - default: "true"
-    description: Report only important findings. Default is true. To report all findings,
-      specify "false"
-    name: IMP_FINDINGS_ONLY
-    type: string
-  - default: ""
-    description: URL from repository to download known false positives files
-    name: KFP_GIT_URL
-    type: string
   results:
-  - description: Tekton task test output.
-    name: TEST_OUTPUT
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
   stepTemplate:
     computeResources:
       limits:
+        cpu: "4"
         memory: 4Gi
       requests:
         cpu: "1"
@@ -209,119 +199,10 @@ spec:
       value: $(params.PRIVILEGED_NESTED)
     - name: SKIP_SBOM_GENERATION
       value: $(params.SKIP_SBOM_GENERATION)
-    - name: SBOM_TYPE
-      value: $(params.SBOM_TYPE)
     volumeMounts:
     - mountPath: /shared
       name: shared
   steps:
-  - env:
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: prepare
-    script: |
-      #!/bin/bash
-
-      # FIXME: Dockerfile discovery logic is copied from buildah task
-      SOURCE_CODE_DIR=source
-      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
-      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
-      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
-        echo "Fetch Dockerfile from $DOCKERFILE"
-        dockerfile_path=$(mktemp --suffix=-Dockerfile)
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
-          echo "No Dockerfile is fetched. Server responds $http_code"
-          exit 1
-        fi
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
-          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
-        fi
-      else
-        echo "Cannot find Dockerfile $DOCKERFILE"
-        exit 1
-      fi
-
-      # install Coverity license file
-      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
-
-      # pre-create directory for SAST scanning results
-      install -vm1777 -d /shared/sast-results
-
-      # create a wrapper script to instrument RUN lines
-      tee /shared/cmd-wrap.sh >&2 << EOF
-      #!/bin/bash -x
-      id >&2
-
-      # use current directory as project directory by default
-      proj_dir=\$(pwd)
-
-      # if current directory is "/", fallback to an empty temp directory
-      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
-
-      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
-      if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
-        install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
-      fi
-
-      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
-      trap 'rm -fr /tmp/idir' EXIT
-
-      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
-      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
-        - "\$@"
-
-      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
-      $(declare -p COV_ANALYZE_ARGS)
-
-      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
-      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
-
-      if [ \$? -eq 0 ]; then
-        # assign a unique file name for scan results
-        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
-
-        # obtain capture stats to process them later on
-        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
-
-        # export scan results and embed source code context into the scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
-          > "\${json_file}"
-      fi
-
-      # propagate the original exit code of the wrapped command
-      exit "\$(</tmp/idir/build-cmd-ec.txt)"
-      EOF
-      echo >&2
-
-      # make the wrapper script executable
-      chmod -v 0755 /shared/cmd-wrap.sh
-
-      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
-      EC=$?
-
-      # if we have no RUN lines to instrument, it is not a reason to make the task fail
-      if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
-        echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
-      else
-        cat /tmp/cstrans-df-run.log >&2
-        exit $EC
-      fi
-    volumeMounts:
-    - mountPath: /etc/secrets/cov
-      name: cov-license
-      readOnly: true
-    workingDir: $(workspaces.source.path)
   - args:
     - --build-args
     - $(params.BUILD_ARGS[*])
@@ -329,23 +210,17 @@ spec:
     - $(params.LABELS[*])
     computeResources:
       limits:
-        cpu: 16
-        memory: 16Gi
+        cpu: "4"
+        memory: 6Gi
       requests:
-        cpu: 4
+        cpu: "1"
         memory: 4Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
-      value: /shared/Containerfile
-    - name: ADDITIONAL_VOLUME_MOUNTS
-      value: |-
-        /opt:/opt
-        /shared:/shared
-        /shared/license.dat:/opt/coverity/bin/license.dat
-        /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      value: $(params.DOCKERFILE)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: build
     script: |
       #!/bin/bash
@@ -368,14 +243,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
+        if [ $http_code != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
+        if [ $http_code = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -384,6 +259,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
+        touch /var/lib/containers/java
+      fi
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -434,7 +314,7 @@ spec:
 
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json
       )
 
       BUILDAH_ARGS=()
@@ -445,7 +325,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -498,14 +378,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p "${YUM_REPOS_D_FETCHED}"
-        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
-        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -613,7 +493,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount "$container" | tee /shared/container_path
+      buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
@@ -645,43 +525,26 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        cpu: 2
-        memory: 2Gi
-    env:
-    - name: IMAGE_URL
-      value: $(params.image-url)
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: KFP_GIT_URL
-      value: $(params.KFP_GIT_URL)
-    - name: IMP_FINDINGS_ONLY
-      value: $(params.IMP_FINDINGS_ONLY)
-    - name: PROJECT_NAME
-      value: $(params.PROJECT_NAME)
-    - name: RECORD_EXCLUDED
-      value: $(params.RECORD_EXCLUDED)
-    - name: COMPONENT_LABEL
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.labels['appstudio.openshift.io/component']
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: postprocess
+  - image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    name: icm
     script: |
-      #!/bin/bash -e
-      # shellcheck source=/dev/null
-      set -o pipefail
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: push
+    script: |
+      #!/bin/bash
+      set -e
 
-      . /usr/local/share/konflux-test/utils.sh
-      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
-      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
-
-      # Installation of Red Hat certificates for cloning Red Hat internal repositories
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -689,115 +552,166 @@ spec:
         update-ca-trust
       fi
 
-      if [ -z "$(ls /shared/sast-results/)" ]; then (
-        set +e
-        set -x
-
-        # fallback to buildless scan if we have no scan results from buildful
-        # shellcheck disable=SC2086
-        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
-
-        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
-
-        # install Coverity license file
-        install -vm0644 /{shared,opt/coverity/bin}/license.dat
-
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
-
-        # export scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | csgrep --mode=json --embed-context=3 \
-          > /shared/sast-results/coverity-buildless.json
-      ) fi
-
-      # collect capture stats (FIXME: this doe not take findings deduplication into account)
-      set +e
-      for file in /shared/sast-results/*-summary.txt; do
-        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
-      done
-
-      # calculate the total number of files
-      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
-
-      # calculate the ratio of successful files to total files
-      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
-      set -e
-
-      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
-      IMP_LEVEL=1
-      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
-        IMP_LEVEL=0
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
       fi
 
-      # collect scan results
-      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
-        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
-        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
-        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
-        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
-        | tee coverity-results-raw.json \
-        | csgrep --mode=evtstat
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
 
-      # We check if the KFP_GIT_URL variable is set to apply the filters or not
-      if [[ -z "${KFP_GIT_URL}" ]]; then
-        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
-        mv coverity-results{-raw,}.json
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+      echo "Running syft on the source directory"
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       else
-        echo "Filtering false positives in results files using csfilter-kfp..."
-        CMD=(
-          csfilter-kfp
-          --verbose
-          --kfp-git-url="${KFP_GIT_URL}"
-          --project-nvr="${PROJECT_NAME}"
-        )
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: prepare-sboms
+    script: |
+      #!/bin/bash
+      set -euo pipefail
 
-        if [ "${RECORD_EXCLUDED}" == "true" ]; then
-          CMD+=(--record-excluded="excluded-findings.json")
-        fi
-
-        "${CMD[@]}" coverity-results-raw.json \
-          | tee coverity-results.json \
-          | csgrep --mode=evtstat
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
 
-      # convert the scan results into SARIF
-      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
 
-      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
-        note="Task $(context.task.name) success: No finding was detected"
-        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-      else
-        TEST_OUTPUT=
-        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
-        note="Task $(context.task.name) failed: For details, check Tekton task log."
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
       fi
 
-      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom-cyclonedx.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom-cyclonedx.json
 
-      # upload scan results
-      echo "Selecting auth for upload of scan results"
-      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+      echo "Adding base images data to sbom-cyclonedx.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom-cyclonedx.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
 
-      upload_file() (
-        set -x
-        UPLOAD_FILE="$1"
-        MEDIA_TYPE="$2"
-        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
-      )
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
 
-      echo "Attaching scan results to ${IMAGE_URL}"
-      upload_file "coverity-results.sarif" "application/sarif+json"
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom-cyclonedx.json \
+        --output-file /tmp/sbom-cyclonedx.tmp.json
 
-      # upload excluded-findings.json if enabled
-      if [ -f "excluded-findings.json" ]; then
-        upload_file "excluded-findings.json" "application/json"
+      mv /tmp/sbom-cyclonedx.tmp.json sbom-cyclonedx.json
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     volumeMounts:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
@@ -827,10 +741,6 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
-  - name: cov-license
-    secret:
-      optional: false
-      secretName: $(params.COV_LICENSE)
   workspaces:
   - description: Workspace containing the source code to build.
     name: source

--- a/task/buildah-8gb/0.1/buildah-8gb.yaml
+++ b/task/buildah-8gb/0.1/buildah-8gb.yaml
@@ -1,0 +1,585 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+  name: buildah-8gb
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
+    name: BUILDER_IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: unused, should be removed in next task version
+    name: DOCKER_AUTH
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
+  stepTemplate:
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: PARAM_BUILDER_IMAGE
+      value: $(params.BUILDER_IMAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+  steps:
+  - args:
+    - $(params.BUILD_ARGS[*])
+    computeResources:
+      limits:
+        memory: 8Gi
+      requests:
+        cpu: 250m
+        memory: 6Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ $http_code != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ $http_code = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_path"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_path"
+        touch /var/lib/containers/java
+      fi
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      BUILDAH_ARGS=()
+
+      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS="--net"
+        for image in $BASE_IMAGES; do
+          if [ "${image}" != "scratch" ]; then
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          fi
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
+      fi
+
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}"
+      fi
+
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      if [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+
+      elif find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
+        echo "Adding the entitlement to the build"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
+        $VOLUME_MOUNTS \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
+        --tls-verify=$TLSVERIFY --no-cache \
+        --ulimit nofile=4096:4096 \
+        -f "$dockerfile_path" -t $IMAGE .
+
+      container=$(buildah from --pull-never $IMAGE)
+      buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
+      for image in $BASE_IMAGES; do
+        if [ "${image}" != "scratch" ]; then
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)
+        fi
+      done
+
+      # Needed to generate base images SBOM
+      echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      echo "Running syft on the source directory"
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      echo "Running syft on the image filesystem"
+      syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
+      else
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: merge-syft-sboms
+    script: |
+      #!/bin/python3
+      import json
+
+      # load SBOMs
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+      # fetch unique components from available SBOMs
+      def get_identifier(component):
+        return component["name"] + '@' + component.get("version", "")
+
+      image_sbom_components = image_sbom.setdefault("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
+
+      source_sbom_components = source_sbom.get("components", [])
+      for component in source_sbom_components:
+        if get_identifier(component) not in existing_components:
+          image_sbom_components.append(component)
+          existing_components.append(get_identifier(component))
+
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
+
+      # write the CycloneDX unified SBOM
+      with open("./sbom-cyclonedx.json", "w") as f:
+        json.dump(image_sbom, f, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/cachi2:0.19.0@sha256:f67e7f9771c3d425bdd917313553c882d0ed942076dc31d9ce35524bdda1fb6e
+    name: merge-cachi2-sbom
+    script: |
+      if [ -f "sbom-cachi2.json" ]; then
+        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
+        merge_syft_sbom sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: create-purl-sbom
+    script: |
+      #!/bin/python3
+      import json
+
+      with open("./sbom-cyclonedx.json") as f:
+        cyclonedx_sbom = json.load(f)
+
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
+      purl_content = {"image_contents": {"dependencies": purls}}
+
+      with open("sbom-purl.json", "w") as output_file:
+        json.dump(purl_content, output_file, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - env:
+    - name: BASE_IMAGES_DIGESTS_PATH
+      value: $(results.BASE_IMAGES_DIGESTS.path)
+    image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
+    name: create-base-images-sbom
+    script: |
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: inject-sbom-and-push
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
+      container=$(buildah from --pull-never $IMAGE)
+      buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing sbom image to registry"
+        buildah push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push sbom image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - args:
+    - attach
+    - sbom
+    - --sbom
+    - sbom-cyclonedx.json
+    - --type
+    - cyclonedx
+    - $(params.IMAGE)
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    name: upload-sbom
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/buildah-8gb/0.2/buildah-8gb.yaml
+++ b/task/buildah-8gb/0.2/buildah-8gb.yaml
@@ -2,16 +2,22 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-21T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to buildah task (you can find latest bundle reference here: https://quay.io/repository/konflux-ci/tekton-catalog/task-buildah)
+      and configure build step resources as described in the doc: https://konflux-ci.dev/docs/how-tos/configuring/overriding-compute-resources/'
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: docker
-  name: sast-coverity-check
+  name: buildah-8gb
 spec:
-  description: Scans source code for security vulnerabilities, including common issues
-    such as SQL injection, cross-site scripting (XSS), and code injection attacks
-    using Coverity.
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
   - description: Reference of the image buildah will produce.
     name: IMAGE
@@ -125,43 +131,27 @@ spec:
       to fail if enabled
     name: SKIP_SBOM_GENERATION
     type: string
-  - default: cyclonedx
-    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
-      Note: the SBOM from the prefetch task - if there is one - must be in the same
-      format.'
-    name: SBOM_TYPE
-    type: string
-  - name: image-url
-    type: string
-  - default: cov-license
-    description: Name of secret which contains the Coverity license
-    name: COV_LICENSE
-    type: string
-  - default: ""
-    name: PROJECT_NAME
-    type: string
-  - default: "false"
-    name: RECORD_EXCLUDED
-    type: string
-  - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
-    description: Arguments to be appended to the cov-analyze command
-    name: COV_ANALYZE_ARGS
-    type: string
-  - default: "true"
-    description: Report only important findings. Default is true. To report all findings,
-      specify "false"
-    name: IMP_FINDINGS_ONLY
-    type: string
-  - default: ""
-    description: URL from repository to download known false positives files
-    name: KFP_GIT_URL
-    type: string
   results:
-  - description: Tekton task test output.
-    name: TEST_OUTPUT
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
   stepTemplate:
     computeResources:
       limits:
+        cpu: "4"
         memory: 4Gi
       requests:
         cpu: "1"
@@ -209,119 +199,10 @@ spec:
       value: $(params.PRIVILEGED_NESTED)
     - name: SKIP_SBOM_GENERATION
       value: $(params.SKIP_SBOM_GENERATION)
-    - name: SBOM_TYPE
-      value: $(params.SBOM_TYPE)
     volumeMounts:
     - mountPath: /shared
       name: shared
   steps:
-  - env:
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: prepare
-    script: |
-      #!/bin/bash
-
-      # FIXME: Dockerfile discovery logic is copied from buildah task
-      SOURCE_CODE_DIR=source
-      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
-      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
-      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
-        echo "Fetch Dockerfile from $DOCKERFILE"
-        dockerfile_path=$(mktemp --suffix=-Dockerfile)
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
-          echo "No Dockerfile is fetched. Server responds $http_code"
-          exit 1
-        fi
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
-          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
-        fi
-      else
-        echo "Cannot find Dockerfile $DOCKERFILE"
-        exit 1
-      fi
-
-      # install Coverity license file
-      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
-
-      # pre-create directory for SAST scanning results
-      install -vm1777 -d /shared/sast-results
-
-      # create a wrapper script to instrument RUN lines
-      tee /shared/cmd-wrap.sh >&2 << EOF
-      #!/bin/bash -x
-      id >&2
-
-      # use current directory as project directory by default
-      proj_dir=\$(pwd)
-
-      # if current directory is "/", fallback to an empty temp directory
-      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
-
-      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
-      if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
-        install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
-      fi
-
-      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
-      trap 'rm -fr /tmp/idir' EXIT
-
-      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
-      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
-        - "\$@"
-
-      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
-      $(declare -p COV_ANALYZE_ARGS)
-
-      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
-      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
-
-      if [ \$? -eq 0 ]; then
-        # assign a unique file name for scan results
-        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
-
-        # obtain capture stats to process them later on
-        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
-
-        # export scan results and embed source code context into the scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
-          > "\${json_file}"
-      fi
-
-      # propagate the original exit code of the wrapped command
-      exit "\$(</tmp/idir/build-cmd-ec.txt)"
-      EOF
-      echo >&2
-
-      # make the wrapper script executable
-      chmod -v 0755 /shared/cmd-wrap.sh
-
-      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
-      EC=$?
-
-      # if we have no RUN lines to instrument, it is not a reason to make the task fail
-      if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
-        echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
-      else
-        cat /tmp/cstrans-df-run.log >&2
-        exit $EC
-      fi
-    volumeMounts:
-    - mountPath: /etc/secrets/cov
-      name: cov-license
-      readOnly: true
-    workingDir: $(workspaces.source.path)
   - args:
     - --build-args
     - $(params.BUILD_ARGS[*])
@@ -329,23 +210,17 @@ spec:
     - $(params.LABELS[*])
     computeResources:
       limits:
-        cpu: 16
-        memory: 16Gi
+        cpu: "4"
+        memory: 8Gi
       requests:
-        cpu: 4
-        memory: 4Gi
+        cpu: "1"
+        memory: 6Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
-      value: /shared/Containerfile
-    - name: ADDITIONAL_VOLUME_MOUNTS
-      value: |-
-        /opt:/opt
-        /shared:/shared
-        /shared/license.dat:/opt/coverity/bin/license.dat
-        /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      value: $(params.DOCKERFILE)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: build
     script: |
       #!/bin/bash
@@ -368,14 +243,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
+        if [ $http_code != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
+        if [ $http_code = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -384,6 +259,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
+        touch /var/lib/containers/java
+      fi
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -434,7 +314,7 @@ spec:
 
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json
       )
 
       BUILDAH_ARGS=()
@@ -445,7 +325,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -498,14 +378,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p "${YUM_REPOS_D_FETCHED}"
-        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
-        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -613,7 +493,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount "$container" | tee /shared/container_path
+      buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
@@ -645,43 +525,26 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        cpu: 2
-        memory: 2Gi
-    env:
-    - name: IMAGE_URL
-      value: $(params.image-url)
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: KFP_GIT_URL
-      value: $(params.KFP_GIT_URL)
-    - name: IMP_FINDINGS_ONLY
-      value: $(params.IMP_FINDINGS_ONLY)
-    - name: PROJECT_NAME
-      value: $(params.PROJECT_NAME)
-    - name: RECORD_EXCLUDED
-      value: $(params.RECORD_EXCLUDED)
-    - name: COMPONENT_LABEL
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.labels['appstudio.openshift.io/component']
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: postprocess
+  - image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    name: icm
     script: |
-      #!/bin/bash -e
-      # shellcheck source=/dev/null
-      set -o pipefail
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: push
+    script: |
+      #!/bin/bash
+      set -e
 
-      . /usr/local/share/konflux-test/utils.sh
-      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
-      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
-
-      # Installation of Red Hat certificates for cloning Red Hat internal repositories
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -689,115 +552,166 @@ spec:
         update-ca-trust
       fi
 
-      if [ -z "$(ls /shared/sast-results/)" ]; then (
-        set +e
-        set -x
-
-        # fallback to buildless scan if we have no scan results from buildful
-        # shellcheck disable=SC2086
-        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
-
-        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
-
-        # install Coverity license file
-        install -vm0644 /{shared,opt/coverity/bin}/license.dat
-
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
-
-        # export scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | csgrep --mode=json --embed-context=3 \
-          > /shared/sast-results/coverity-buildless.json
-      ) fi
-
-      # collect capture stats (FIXME: this doe not take findings deduplication into account)
-      set +e
-      for file in /shared/sast-results/*-summary.txt; do
-        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
-      done
-
-      # calculate the total number of files
-      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
-
-      # calculate the ratio of successful files to total files
-      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
-      set -e
-
-      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
-      IMP_LEVEL=1
-      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
-        IMP_LEVEL=0
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
       fi
 
-      # collect scan results
-      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
-        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
-        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
-        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
-        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
-        | tee coverity-results-raw.json \
-        | csgrep --mode=evtstat
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
 
-      # We check if the KFP_GIT_URL variable is set to apply the filters or not
-      if [[ -z "${KFP_GIT_URL}" ]]; then
-        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
-        mv coverity-results{-raw,}.json
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+      echo "Running syft on the source directory"
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       else
-        echo "Filtering false positives in results files using csfilter-kfp..."
-        CMD=(
-          csfilter-kfp
-          --verbose
-          --kfp-git-url="${KFP_GIT_URL}"
-          --project-nvr="${PROJECT_NAME}"
-        )
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: prepare-sboms
+    script: |
+      #!/bin/bash
+      set -euo pipefail
 
-        if [ "${RECORD_EXCLUDED}" == "true" ]; then
-          CMD+=(--record-excluded="excluded-findings.json")
-        fi
-
-        "${CMD[@]}" coverity-results-raw.json \
-          | tee coverity-results.json \
-          | csgrep --mode=evtstat
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
 
-      # convert the scan results into SARIF
-      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
 
-      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
-        note="Task $(context.task.name) success: No finding was detected"
-        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-      else
-        TEST_OUTPUT=
-        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
-        note="Task $(context.task.name) failed: For details, check Tekton task log."
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
       fi
 
-      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom-cyclonedx.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom-cyclonedx.json
 
-      # upload scan results
-      echo "Selecting auth for upload of scan results"
-      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+      echo "Adding base images data to sbom-cyclonedx.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom-cyclonedx.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
 
-      upload_file() (
-        set -x
-        UPLOAD_FILE="$1"
-        MEDIA_TYPE="$2"
-        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
-      )
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
 
-      echo "Attaching scan results to ${IMAGE_URL}"
-      upload_file "coverity-results.sarif" "application/sarif+json"
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom-cyclonedx.json \
+        --output-file /tmp/sbom-cyclonedx.tmp.json
 
-      # upload excluded-findings.json if enabled
-      if [ -f "excluded-findings.json" ]; then
-        upload_file "excluded-findings.json" "application/json"
+      mv /tmp/sbom-cyclonedx.tmp.json sbom-cyclonedx.json
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     volumeMounts:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
@@ -827,10 +741,6 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
-  - name: cov-license
-    secret:
-      optional: false
-      secretName: $(params.COV_LICENSE)
   workspaces:
   - description: Workspace containing the source code to build.
     name: source

--- a/task/buildah-min/0.1/buildah-min.yaml
+++ b/task/buildah-min/0.1/buildah-min.yaml
@@ -1,0 +1,582 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2024-11-13T00:00:00Z"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: docker
+  name: buildah-min
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
+    name: BUILDER_IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: ""
+    description: unused, should be removed in next task version
+    name: DOCKER_AUTH
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Digests of the base images used for build
+    name: BASE_IMAGES_DIGESTS
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
+  stepTemplate:
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: PARAM_BUILDER_IMAGE
+      value: $(params.BUILDER_IMAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+  steps:
+  - args:
+    - $(params.BUILD_ARGS[*])
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ $http_code != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ $http_code = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+      if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_path"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_path"
+        touch /var/lib/containers/java
+      fi
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      BUILDAH_ARGS=()
+
+      BASE_IMAGES=$(grep -i '^\s*FROM' "$dockerfile_path" | sed 's/--platform=\S*//' | awk '{print $2}' | (grep -v ^oci-archive: || true))
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS="--net"
+        for image in $BASE_IMAGES; do
+          if [ "${image}" != "scratch" ]; then
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
+          fi
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        BUILDAH_ARGS+=("--build-arg-file=$(pwd)/$SOURCE_CODE_DIR/${BUILD_ARGS_FILE}")
+      fi
+
+      for build_arg in "$@"; do
+        BUILDAH_ARGS+=("--build-arg=$build_arg")
+      done
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS="--volume /tmp/cachi2:/cachi2"
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_path"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume ${mount_point}:${YUM_REPOS_D_TARGET}"
+      fi
+
+      LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      if [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir /shared/rhsm-tmp
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/activation-key:/activation-key -v /shared/rhsm-tmp:/etc/pki/entitlement:Z"
+        echo "Adding activation key to the build"
+
+      elif find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS="${VOLUME_MOUNTS} --volume /tmp/entitlement:/etc/pki/entitlement"
+        echo "Adding the entitlement to the build"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      unshare -Uf $UNSHARE_ARGS --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w ${SOURCE_CODE_DIR}/$CONTEXT -- buildah build \
+        $VOLUME_MOUNTS \
+        "${BUILDAH_ARGS[@]}" \
+        "${LABELS[@]}" \
+        --tls-verify=$TLSVERIFY --no-cache \
+        --ulimit nofile=4096:4096 \
+        -f "$dockerfile_path" -t $IMAGE .
+
+      container=$(buildah from --pull-never $IMAGE)
+      buildah mount $container | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      # Expose base image digests
+      touch $(results.BASE_IMAGES_DIGESTS.path)
+      for image in $BASE_IMAGES; do
+        if [ "${image}" != "scratch" ]; then
+          buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image" >> $(results.BASE_IMAGES_DIGESTS.path)
+        fi
+      done
+
+      # Needed to generate base images SBOM
+      echo "$BASE_IMAGES" > $(workspaces.source.path)/base_images_from_dockerfile
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      echo "Running syft on the source directory"
+      syft dir:$(workspaces.source.path)/source --output cyclonedx-json=$(workspaces.source.path)/sbom-source.json
+      echo "Running syft on the image filesystem"
+      syft dir:$(cat /shared/container_path) --output cyclonedx-json=$(workspaces.source.path)/sbom-image.json
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
+      else
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: merge-syft-sboms
+    script: |
+      #!/bin/python3
+      import json
+
+      # load SBOMs
+      with open("./sbom-image.json") as f:
+        image_sbom = json.load(f)
+
+      with open("./sbom-source.json") as f:
+        source_sbom = json.load(f)
+
+      # fetch unique components from available SBOMs
+      def get_identifier(component):
+        return component["name"] + '@' + component.get("version", "")
+
+      image_sbom_components = image_sbom.setdefault("components", [])
+      existing_components = [get_identifier(component) for component in image_sbom_components]
+
+      source_sbom_components = source_sbom.get("components", [])
+      for component in source_sbom_components:
+        if get_identifier(component) not in existing_components:
+          image_sbom_components.append(component)
+          existing_components.append(get_identifier(component))
+
+      image_sbom_components.sort(key=lambda c: get_identifier(c))
+
+      # write the CycloneDX unified SBOM
+      with open("./sbom-cyclonedx.json", "w") as f:
+        json.dump(image_sbom, f, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/cachi2:0.19.0@sha256:f67e7f9771c3d425bdd917313553c882d0ed942076dc31d9ce35524bdda1fb6e
+    name: merge-cachi2-sbom
+    script: |
+      if [ -f "sbom-cachi2.json" ]; then
+        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
+        merge_syft_sbom sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        mv sbom-temp.json sbom-cyclonedx.json
+      else
+        echo "Skipping step since no Cachi2 SBOM was produced"
+      fi
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
+    name: create-purl-sbom
+    script: |
+      #!/bin/python3
+      import json
+
+      with open("./sbom-cyclonedx.json") as f:
+        cyclonedx_sbom = json.load(f)
+
+      purls = [{"purl": component["purl"]} for component in cyclonedx_sbom.get("components", []) if "purl" in component]
+      purl_content = {"image_contents": {"dependencies": purls}}
+
+      with open("sbom-purl.json", "w") as output_file:
+        json.dump(purl_content, output_file, indent=4)
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - env:
+    - name: BASE_IMAGES_DIGESTS_PATH
+      value: $(results.BASE_IMAGES_DIGESTS.path)
+    image: quay.io/redhat-appstudio/base-images-sbom-script@sha256:667669e3def018f9dbb8eaf8868887a40bc07842221e9a98f6787edcff021840
+    name: create-base-images-sbom
+    script: |
+      python3 /app/base_images_sbom_script.py --sbom=sbom-cyclonedx.json --base-images-from-dockerfile=base_images_from_dockerfile --base-images-digests=$BASE_IMAGES_DIGESTS_PATH
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: inject-sbom-and-push
+    script: |
+      if [ -n "${PARAM_BUILDER_IMAGE}" ]; then
+        echo "WARNING: provided deprecated BUILDER_IMAGE parameter has no effect."
+      fi
+
+      base_image_name=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.name"}}' $IMAGE | cut -f1 -d'@')
+      base_image_digest=$(buildah inspect --format '{{ index .ImageAnnotations "org.opencontainers.image.base.digest"}}' $IMAGE)
+      container=$(buildah from --pull-never $IMAGE)
+      buildah copy $container sbom-cyclonedx.json sbom-purl.json /root/buildinfo/content_manifests/
+      buildah config -a org.opencontainers.image.base.name=${base_image_name} -a org.opencontainers.image.base.digest=${base_image_digest} $container
+
+      BUILDAH_ARGS=()
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      buildah commit "${BUILDAH_ARGS[@]}" $container $IMAGE
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec
+        echo "Pushing sbom image to registry"
+        buildah push \
+          --tls-verify=$TLSVERIFY \
+          --digestfile $(workspaces.source.path)/image-digest $IMAGE \
+          docker://$IMAGE && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to push sbom image to registry after ${max_run} tries"
+          exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - args:
+    - attach
+    - sbom
+    - --sbom
+    - sbom-cyclonedx.json
+    - --type
+    - cyclonedx
+    - $(params.IMAGE)
+    image: quay.io/redhat-appstudio/cosign:v2.1.1@sha256:c883d6f8d39148f2cea71bff4622d196d89df3e510f36c140c097b932f0dd5d5
+    name: upload-sbom
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/buildah-min/0.2/buildah-min.yaml
+++ b/task/buildah-min/0.2/buildah-min.yaml
@@ -7,11 +7,13 @@ metadata:
   labels:
     app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: docker
-  name: sast-coverity-check
+  name: buildah-min
 spec:
-  description: Scans source code for security vulnerabilities, including common issues
-    such as SQL injection, cross-site scripting (XSS), and code injection attacks
-    using Coverity.
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When [Java dependency rebuild](https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/cli/proc_enabled_java_dependencies.html) is enabled it triggers rebuilds of Java artifacts.
+    When prefetch-dependencies task was activated it is using its artifacts to run build in hermetic environment.
   params:
   - description: Reference of the image buildah will produce.
     name: IMAGE
@@ -125,47 +127,31 @@ spec:
       to fail if enabled
     name: SKIP_SBOM_GENERATION
     type: string
-  - default: cyclonedx
-    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
-      Note: the SBOM from the prefetch task - if there is one - must be in the same
-      format.'
-    name: SBOM_TYPE
-    type: string
-  - name: image-url
-    type: string
-  - default: cov-license
-    description: Name of secret which contains the Coverity license
-    name: COV_LICENSE
-    type: string
-  - default: ""
-    name: PROJECT_NAME
-    type: string
-  - default: "false"
-    name: RECORD_EXCLUDED
-    type: string
-  - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
-    description: Arguments to be appended to the cov-analyze command
-    name: COV_ANALYZE_ARGS
-    type: string
-  - default: "true"
-    description: Report only important findings. Default is true. To report all findings,
-      specify "false"
-    name: IMP_FINDINGS_ONLY
-    type: string
-  - default: ""
-    description: URL from repository to download known false positives files
-    name: KFP_GIT_URL
-    type: string
   results:
-  - description: Tekton task test output.
-    name: TEST_OUTPUT
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  - description: The counting of Java components by publisher in JSON format
+    name: SBOM_JAVA_COMPONENTS_COUNT
+    type: string
+  - description: The Java dependencies that came from community sources such as Maven
+      central.
+    name: JAVA_COMMUNITY_DEPENDENCIES
   stepTemplate:
     computeResources:
       limits:
-        memory: 4Gi
+        cpu: "4"
+        memory: 2Gi
       requests:
-        cpu: "1"
-        memory: 1Gi
+        cpu: 100m
+        memory: 512Mi
     env:
     - name: BUILDAH_FORMAT
       value: oci
@@ -209,119 +195,10 @@ spec:
       value: $(params.PRIVILEGED_NESTED)
     - name: SKIP_SBOM_GENERATION
       value: $(params.SKIP_SBOM_GENERATION)
-    - name: SBOM_TYPE
-      value: $(params.SBOM_TYPE)
     volumeMounts:
     - mountPath: /shared
       name: shared
   steps:
-  - env:
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: DOCKERFILE
-      value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: prepare
-    script: |
-      #!/bin/bash
-
-      # FIXME: Dockerfile discovery logic is copied from buildah task
-      SOURCE_CODE_DIR=source
-      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
-      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
-        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
-      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
-        echo "Fetch Dockerfile from $DOCKERFILE"
-        dockerfile_path=$(mktemp --suffix=-Dockerfile)
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
-          echo "No Dockerfile is fetched. Server responds $http_code"
-          exit 1
-        fi
-        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
-          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
-        fi
-      else
-        echo "Cannot find Dockerfile $DOCKERFILE"
-        exit 1
-      fi
-
-      # install Coverity license file
-      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
-
-      # pre-create directory for SAST scanning results
-      install -vm1777 -d /shared/sast-results
-
-      # create a wrapper script to instrument RUN lines
-      tee /shared/cmd-wrap.sh >&2 << EOF
-      #!/bin/bash -x
-      id >&2
-
-      # use current directory as project directory by default
-      proj_dir=\$(pwd)
-
-      # if current directory is "/", fallback to an empty temp directory
-      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
-
-      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
-      if ! [ -x /usr/bin/file ] && [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
-        install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
-      fi
-
-      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
-      trap 'rm -fr /tmp/idir' EXIT
-
-      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
-      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
-        - "\$@"
-
-      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
-      $(declare -p COV_ANALYZE_ARGS)
-
-      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
-      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
-
-      if [ \$? -eq 0 ]; then
-        # assign a unique file name for scan results
-        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
-
-        # obtain capture stats to process them later on
-        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
-
-        # export scan results and embed source code context into the scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
-          > "\${json_file}"
-      fi
-
-      # propagate the original exit code of the wrapped command
-      exit "\$(</tmp/idir/build-cmd-ec.txt)"
-      EOF
-      echo >&2
-
-      # make the wrapper script executable
-      chmod -v 0755 /shared/cmd-wrap.sh
-
-      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
-      EC=$?
-
-      # if we have no RUN lines to instrument, it is not a reason to make the task fail
-      if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
-        echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
-      else
-        cat /tmp/cstrans-df-run.log >&2
-        exit $EC
-      fi
-    volumeMounts:
-    - mountPath: /etc/secrets/cov
-      name: cov-license
-      readOnly: true
-    workingDir: $(workspaces.source.path)
   - args:
     - --build-args
     - $(params.BUILD_ARGS[*])
@@ -329,23 +206,17 @@ spec:
     - $(params.LABELS[*])
     computeResources:
       limits:
-        cpu: 16
-        memory: 16Gi
-      requests:
-        cpu: 4
+        cpu: "4"
         memory: 4Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
-      value: /shared/Containerfile
-    - name: ADDITIONAL_VOLUME_MOUNTS
-      value: |-
-        /opt:/opt
-        /shared:/shared
-        /shared/license.dat:/opt/coverity/bin/license.dat
-        /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      value: $(params.DOCKERFILE)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: build
     script: |
       #!/bin/bash
@@ -368,14 +239,14 @@ spec:
         echo "Fetch Dockerfile from $DOCKERFILE"
         dockerfile_path=$(mktemp --suffix=-Dockerfile)
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
-        if [ "$http_code" != 200 ]; then
+        if [ $http_code != 200 ]; then
           echo "No Dockerfile is fetched. Server responds $http_code"
           exit 1
         fi
         http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
-        if [ "$http_code" = 200 ]; then
+        if [ $http_code = 200 ]; then
           echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
-          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" $SOURCE_CODE_DIR/$CONTEXT/.dockerignore
         fi
       else
         echo "Cannot find Dockerfile $DOCKERFILE"
@@ -384,6 +255,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      if [ -n "${JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR-}" ] && grep -q '^\s*RUN \(./\)\?mvn' "$dockerfile_copy"; then
+        sed -i -e "s|^\s*RUN \(\(./\)\?mvn\)\(.*\)|RUN echo \"<settings><mirrors><mirror><id>mirror.default</id><url>http://$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR/v1/cache/default/0/</url><mirrorOf>*</mirrorOf></mirror></mirrors></settings>\" > /tmp/settings.yaml; \1 -s /tmp/settings.yaml \3|g" "$dockerfile_copy"
+        touch /var/lib/containers/java
+      fi
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -434,7 +310,7 @@ spec:
 
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
-          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json
       )
 
       BUILDAH_ARGS=()
@@ -445,7 +321,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull $image
         done
         echo "Build will be executed with network isolation"
       fi
@@ -498,14 +374,14 @@ spec:
 
       # if yum repofiles stored in git, copy them to mount point outside the source dir
       if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
-        mkdir -p "${YUM_REPOS_D_FETCHED}"
-        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        mkdir -p ${YUM_REPOS_D_FETCHED}
+        cp -r ${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}/* ${YUM_REPOS_D_FETCHED}
       fi
 
       # if anything in the repofiles mount point (either fetched or from git), mount it
       if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
-        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
-        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        chmod -R go+rwX ${YUM_REPOS_D_FETCHED}
+        mount_point=$(realpath ${YUM_REPOS_D_FETCHED})
         VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
       fi
 
@@ -613,7 +489,7 @@ spec:
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
-      buildah mount "$container" | tee /shared/container_path
+      buildah mount $container | tee /shared/container_path
       # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
       find $(cat /shared/container_path) -xtype l -delete
       echo $container > /shared/container_name
@@ -645,43 +521,26 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        cpu: 2
-        memory: 2Gi
-    env:
-    - name: IMAGE_URL
-      value: $(params.image-url)
-    - name: COV_ANALYZE_ARGS
-      value: $(params.COV_ANALYZE_ARGS)
-    - name: KFP_GIT_URL
-      value: $(params.KFP_GIT_URL)
-    - name: IMP_FINDINGS_ONLY
-      value: $(params.IMP_FINDINGS_ONLY)
-    - name: PROJECT_NAME
-      value: $(params.PROJECT_NAME)
-    - name: RECORD_EXCLUDED
-      value: $(params.RECORD_EXCLUDED)
-    - name: COMPONENT_LABEL
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.labels['appstudio.openshift.io/component']
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
-    name: postprocess
+  - image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    name: icm
     script: |
-      #!/bin/bash -e
-      # shellcheck source=/dev/null
-      set -o pipefail
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: push
+    script: |
+      #!/bin/bash
+      set -e
 
-      . /usr/local/share/konflux-test/utils.sh
-      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
-
-      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
-      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
-
-      # Installation of Red Hat certificates for cloning Red Hat internal repositories
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
@@ -689,115 +548,166 @@ spec:
         update-ca-trust
       fi
 
-      if [ -z "$(ls /shared/sast-results/)" ]; then (
-        set +e
-        set -x
-
-        # fallback to buildless scan if we have no scan results from buildful
-        # shellcheck disable=SC2086
-        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
-
-        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
-
-        # install Coverity license file
-        install -vm0644 /{shared,opt/coverity/bin}/license.dat
-
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
-
-        # export scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | csgrep --mode=json --embed-context=3 \
-          > /shared/sast-results/coverity-buildless.json
-      ) fi
-
-      # collect capture stats (FIXME: this doe not take findings deduplication into account)
-      set +e
-      for file in /shared/sast-results/*-summary.txt; do
-        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
-        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
-      done
-
-      # calculate the total number of files
-      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
-
-      # calculate the ratio of successful files to total files
-      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
-      set -e
-
-      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
-      IMP_LEVEL=1
-      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
-        IMP_LEVEL=0
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
       fi
 
-      # collect scan results
-      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
-        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
-        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
-        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
-        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
-        | tee coverity-results-raw.json \
-        | csgrep --mode=evtstat
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
 
-      # We check if the KFP_GIT_URL variable is set to apply the filters or not
-      if [[ -z "${KFP_GIT_URL}" ]]; then
-        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
-        mv coverity-results{-raw,}.json
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+      echo "Running syft on the source directory"
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output cyclonedx-json@1.5="$(workspaces.source.path)/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+    image: quay.io/redhat-appstudio/hacbs-jvm-build-request-processor:127ee0c223a2b56a9bd20a6f2eaeed3bd6015f77
+    name: analyse-dependencies-java-sbom
+    script: |
+      if [ -f /var/lib/containers/java ]; then
+        /opt/jboss/container/java/run/run-java.sh analyse-dependencies path $(cat /shared/container_path) -s $(workspaces.source.path)/sbom-image.json --task-run-name $(context.taskRun.name) --publishers $(results.SBOM_JAVA_COMPONENTS_COUNT.path)
+        sed -i 's/^/ /' $(results.SBOM_JAVA_COMPONENTS_COUNT.path) # Workaround for SRVKP-2875
       else
-        echo "Filtering false positives in results files using csfilter-kfp..."
-        CMD=(
-          csfilter-kfp
-          --verbose
-          --kfp-git-url="${KFP_GIT_URL}"
-          --project-nvr="${PROJECT_NAME}"
-        )
+        touch $(results.JAVA_COMMUNITY_DEPENDENCIES.path)
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: prepare-sboms
+    script: |
+      #!/bin/bash
+      set -euo pipefail
 
-        if [ "${RECORD_EXCLUDED}" == "true" ]; then
-          CMD+=(--record-excluded="excluded-findings.json")
-        fi
-
-        "${CMD[@]}" coverity-results-raw.json \
-          | tee coverity-results.json \
-          | csgrep --mode=evtstat
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
 
-      # convert the scan results into SARIF
-      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
 
-      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
-        note="Task $(context.task.name) success: No finding was detected"
-        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-      else
-        TEST_OUTPUT=
-        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
-        note="Task $(context.task.name) failed: For details, check Tekton task log."
-        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
       fi
 
-      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom-cyclonedx.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom-cyclonedx.json
 
-      # upload scan results
-      echo "Selecting auth for upload of scan results"
-      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+      echo "Adding base images data to sbom-cyclonedx.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom-cyclonedx.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
 
-      upload_file() (
-        set -x
-        UPLOAD_FILE="$1"
-        MEDIA_TYPE="$2"
-        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
-      )
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
 
-      echo "Attaching scan results to ${IMAGE_URL}"
-      upload_file "coverity-results.sarif" "application/sarif+json"
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom-cyclonedx.json \
+        --output-file /tmp/sbom-cyclonedx.tmp.json
 
-      # upload excluded-findings.json if enabled
-      if [ -f "excluded-findings.json" ]; then
-        upload_file "excluded-findings.json" "application/json"
+      mv /tmp/sbom-cyclonedx.tmp.json sbom-cyclonedx.json
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        cpu: 200m
+        memory: 2Gi
+      requests:
+        cpu: 100m
+        memory: 512Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
       fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom-cyclonedx.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     volumeMounts:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
@@ -827,10 +737,6 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
-  - name: cov-license
-    secret:
-      optional: false
-      secretName: $(params.COV_LICENSE)
   workspaces:
   - description: Workspace containing the source code to build.
     name: source

--- a/task/buildah-oci-ta/0.1/kustomization.yaml
+++ b/task/buildah-oci-ta/0.1/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-
-resources:
-- buildah-oci-ta.yaml

--- a/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.1/fbc-related-image-check.yaml
@@ -31,10 +31,12 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+        # shellcheck source=/dev/null
         source /utils.sh
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
         FAILEDIMAGES=""
+        # shellcheck disable=SC2046
         catalog="$(opm render $(workspaces.workspace.path)/hacbs/fbc-validation/confdir/)"
 
         # OPM generates catalog file in a way that yaml file could contain stream of JSON objects
@@ -42,6 +44,7 @@ spec:
         # however there is also posibility that catalog.yaml has yaml data in it
 
         status=0
+        # shellcheck disable=SC2086
         relImgs="$(jq -r '.relatedImages[]?.image' <<< ${catalog})" || status=$?
         if [ $status -ne 0 ]; then
           echo "Could not get related images. Make sure catalog.yaml exists in FBC fragment image and it is valid .yaml or .json format."

--- a/task/fbc-related-image-check/0.2/fbc-related-image-check.yaml
+++ b/task/fbc-related-image-check/0.2/fbc-related-image-check.yaml
@@ -1,0 +1,75 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-31T00:00:00Z"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.2"
+  name: fbc-related-image-check
+spec:
+  description: Checks the validity of all the images referenced in the file-based
+    catalog (FBC) to inspect manifest content using Skopeo.
+  results:
+  - description: Tekton task test output.
+    name: TEST_OUTPUT
+  steps:
+  - computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: 10m
+        memory: 512Mi
+    image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
+    name: check-related-images
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      # shellcheck source=/dev/null
+      source /utils.sh
+      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+      FAILEDIMAGES=""
+      # shellcheck disable=SC2046
+      catalog="$(opm render $(workspaces.workspace.path)/hacbs/fbc-validation/confdir/)"
+
+      # OPM generates catalog file in a way that yaml file could contain stream of JSON objects
+      # thats why we need jq in for this situation, because yq can't parse this file
+      # however there is also posibility that catalog.yaml has yaml data in it
+
+      status=0
+      # shellcheck disable=SC2086
+      relImgs="$(jq -r '.relatedImages[]?.image' <<< ${catalog})" || status=$?
+      if [ $status -ne 0 ]; then
+        echo "Could not get related images. Make sure catalog.yaml exists in FBC fragment image and it is valid .yaml or .json format."
+        note="Task $(context.task.name) failed: Could not fetch related images. Make sure you have catalog.yaml or catalog.json formatted correctly in your file-based catalog (FBC) fragment image."
+        TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      fi
+
+      echo -e "These are related images:\n$relImgs."
+      # cycle through those related images and show outputs
+      for i in ${relImgs// /}
+      do
+        if ! skopeo inspect --no-tags "docker://${i}"; then
+          echo "Skopeo inspect failed on related image: $i."
+          FAILEDIMAGES+="$i, "
+        fi
+      done
+      if [ -z "$FAILEDIMAGES" ]; then
+        note="Task $(context.task.name) succeeded: For details, check Tekton task logs."
+        TEST_OUTPUT=$(make_result_json -r SUCCESS -s 1 -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      else
+        echo "These images failed inspection: $FAILEDIMAGES."
+        note="Task $(context.task.name) failed: Command skopeo inspect could not inspect images. For details, check Tekton task log."
+        TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      fi
+    workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+  workspaces:
+  - name: workspace

--- a/task/fbc-validation/0.1/fbc-validation.yaml
+++ b/task/fbc-validation/0.1/fbc-validation.yaml
@@ -50,6 +50,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+        # shellcheck source=/dev/null
         source /utils.sh
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
@@ -80,7 +81,7 @@ spec:
         done
 
         if [[ "${allowed}" == false ]]; then
-          echo "Base image ${BASE_IMAGE} is not allowed for the file based catalog image. Allowed images: ${ALLOWED_BASE_IMAGES}"
+          echo "Base image ${BASE_IMAGE} is not allowed for the file based catalog image. Allowed images: ${ALLOWED_BASE_IMAGES[*]}"
           note="Task $(context.task.name) failed: Base image ${BASE_IMAGE} is not allowed for the file based catalog image. For details, check Tekton task logs"
           TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
           echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
@@ -145,6 +146,7 @@ spec:
           exit 0
         fi
 
+        # shellcheck disable=SC2086
         if [ -z "$(ls -A .$conffolder)" ]; then
           echo "$conffolder is missing catalog file."
           TEST_OUTPUT="$(make_result_json -r ERROR)"
@@ -153,11 +155,12 @@ spec:
           exit 0
         fi
         # copy content of conffolder to confdir - will be used in next task - related image check
-        cp -r .$conffolder/* $(workspaces.workspace.path)/hacbs/$(context.task.name)/confdir
+        # shellcheck disable=SC2086
+        cp -r .$conffolder/* "$(workspaces.workspace.path)/hacbs/$(context.task.name)/confdir"
 
         EXTRACT_DIR="/extracted_base_img"
         mkdir "${EXTRACT_DIR}"
-        if ! oc image extract ${BASE_IMAGE} --path /:"${EXTRACT_DIR}"; then
+        if ! oc image extract "${BASE_IMAGE}" --path /:"${EXTRACT_DIR}"; then
           echo "Unable to extract opm binary"
           note="Task $(context.task.name) failed: Failed to extract base image with oc extract command, so it cannot validate extracted binaries.  For details, check Tekton task log."
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")

--- a/task/fbc-validation/0.2/fbc-validation.yaml
+++ b/task/fbc-validation/0.2/fbc-validation.yaml
@@ -1,0 +1,281 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-31T00:00:00Z"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.2"
+  name: fbc-validation
+spec:
+  description: Ensures file-based catalog (FBC) components are uniquely linted for
+    proper construction as part of build pipeline.
+  params:
+  - description: Fully qualified image name.
+    name: IMAGE_URL
+  - description: Image digest.
+    name: IMAGE_DIGEST
+  - description: Fully qualified base image name.
+    name: BASE_IMAGE
+  results:
+  - description: Tekton task test output.
+    name: TEST_OUTPUT
+  steps:
+  - computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: 10m
+        memory: 512Mi
+    env:
+    - name: IMAGE_URL
+      value: $(params.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(params.IMAGE_DIGEST)
+    - name: BASE_IMAGE
+      value: $(params.BASE_IMAGE)
+    image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
+    name: extract-and-check-binaries
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      # shellcheck source=/dev/null
+      source /utils.sh
+      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+      declare -a ALLOWED_BASE_IMAGES=(
+        "registry.redhat.io/openshift4/ose-operator-registry"
+        "registry.redhat.io/openshift4/ose-operator-registry-rhel9"
+        "brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9"
+      )
+
+      ### FBC base image check
+      if [ -z "${BASE_IMAGE}" ]; then
+        echo "Base image is unknown. The file-based catalog must have base image defined. Check inspect-image task log."
+        note="Task $(context.task.name) failed: The file-based catalog must have base image defined. For details, check Tekton task result TEST_OUTPUT in task inspect-image."
+        TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      fi
+
+      IMAGE_WITHOUT_TAG=$(echo "${BASE_IMAGE}" | sed "s/:.*$//" | sed "s/@.*$//")
+
+      allowed=false
+      for value in "${ALLOWED_BASE_IMAGES[@]}"
+      do
+        if [[ "${IMAGE_WITHOUT_TAG}" == "${value}" ]]; then
+          allowed=true
+          break
+        fi
+      done
+
+      if [[ "${allowed}" == false ]]; then
+        echo "Base image ${BASE_IMAGE} is not allowed for the file based catalog image. Allowed images: ${ALLOWED_BASE_IMAGES[*]}"
+        note="Task $(context.task.name) failed: Base image ${BASE_IMAGE} is not allowed for the file based catalog image. For details, check Tekton task logs"
+        TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      fi
+
+      ### Try to extract binaries with configs > check binaries functionality > check opm validate ###
+      if [ ! -s ../inspect-image/image_inspect.json ]; then
+        echo "File $(workspaces.workspace.path)/hacbs/inspect-image/image_inspect.json did not generate correctly. Check inspect-image task log."
+        note="Task $(context.task.name) failed: $(workspaces.workspace.path)/hacbs/inspect-image/image_inspect.json did not generate correctly. For details, check Tekton task result TEST_OUTPUT in task inspect-image."
+        TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      fi
+
+      if [ ! -s ../inspect-image/raw_image_inspect.json ]; then
+        echo "File $(workspaces.workspace.path)/hacbs/inspect-image/raw_image_inspect.json did not generate correctly. Check inspect-image task log."
+        note="Task $(context.task.name) failed: $(workspaces.workspace.path)/hacbs/inspect-image/raw_image_inspect.json did not generate correctly. For details, check Tekton task result TEST_OUTPUT in task inspect-image."
+        TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      fi
+
+      echo "Getting base image for source image ${IMAGE_URL}."
+      base_image_name="$(jq -r ".annotations.\"org.opencontainers.image.base.name\"" ../inspect-image/raw_image_inspect.json)" || status=$?
+      if [ "$base_image_name" == 'null' ]; then
+        echo "Could not get annotations from inspect-image/raw_image_inspect.json. Make sure file exists and it contains this annotation: org.opencontainers.image.base.name"
+        echo "Try to get base image from label..."
+        base_image_name="$(jq -r ".Labels.\"org.opencontainers.image.base.name\"" ../inspect-image/image_inspect.json)" || status=$?
+        if [ "$base_image_name" == 'null' ]; then
+          echo "Cannot get base image info from Labels. For details, check source image ../inspect-image/image_inspect.json."
+          TEST_OUTPUT="$(make_result_json -r ERROR)"
+          echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+      fi
+      if [ -z "$base_image_name" ]; then
+        echo "Source image ${IMAGE_URL} is built from scratch, so there is no base image."
+        TEST_OUTPUT="$(make_result_json -r ERROR)"
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      fi
+
+      status=0
+      conffolder=$(jq -r '.Labels ."operators.operatorframework.io.index.configs.v1"' ../inspect-image/image_inspect.json) || status=$?
+      if [ $status -ne 0 ]; then
+        echo "Could not get labels from inspect-image/image_inspect.json. Make sure file exists and it contains this label: operators.operatorframework.io.index.configs.v1."
+        TEST_OUTPUT="$(make_result_json -r ERROR)"
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        exit 0
+      fi
+      mkdir -p /tmp/image-content confdir
+      pushd /tmp/image-content
+      image_with_digest="${IMAGE_URL}@${IMAGE_DIGEST}"
+
+      if ! oc image extract --registry-config ~/.docker/config.json "${image_with_digest}" ; then
+        echo "Unable to extract or validate extracted binaries."
+        note="Task $(context.task.name) failed: Failed to extract image with oc extract command, so it cannot validate extracted binaries. For details, check Tekton task log."
+        ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        popd
+        exit 0
+      fi
+
+      # shellcheck disable=SC2086
+      if [ -z "$(ls -A .$conffolder)" ]; then
+        echo "$conffolder is missing catalog file."
+        TEST_OUTPUT="$(make_result_json -r ERROR)"
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        popd
+        exit 0
+      fi
+      # copy content of conffolder to confdir - will be used in next task - related image check
+      # shellcheck disable=SC2086
+      cp -r .$conffolder/* "$(workspaces.workspace.path)/hacbs/$(context.task.name)/confdir"
+
+      EXTRACT_DIR="/extracted_base_img"
+      mkdir "${EXTRACT_DIR}"
+      if ! oc image extract "${BASE_IMAGE}" --path /:"${EXTRACT_DIR}"; then
+        echo "Unable to extract opm binary"
+        note="Task $(context.task.name) failed: Failed to extract base image with oc extract command, so it cannot validate extracted binaries.  For details, check Tekton task log."
+        ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        exit 0
+      fi
+
+      OPM_BINARIES="$(find "${EXTRACT_DIR}" -type f -name opm)"
+      BINARIES_COUNT=$(wc -l <<< "${OPM_BINARIES}")
+      if [[ $BINARIES_COUNT -ne "1" ]]; then
+          note="Task $(context.task.name) failed: Expected exactly one opm binary in base image.  For details, check Tekton task log"
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          echo "found $BINARIES_COUNT opm binaries:"
+          echo "${OPM_BINARIES}"
+          exit 0
+      fi
+      OPM_BINARY=$(echo "${OPM_BINARIES}" | head -n 1)
+      echo "OPM_BINARY: '${OPM_BINARY}'"
+      chmod 775 "$OPM_BINARY"
+
+      # We have 6 total checks
+      check_num=6
+      failure_num=0
+      TESTPASSED=true
+
+      if [[ ! $(find . -name "grpc_health_probe") ]]; then
+        echo "!FAILURE! - grpc_health_probe binary presence check failed."
+        failure_num=$((failure_num + 1))
+        TESTPASSED=false
+      fi
+
+      if ! ${OPM_BINARY} validate ."${conffolder}"; then
+        echo "!FAILURE! - opm validate check failed."
+        failure_num=$((failure_num + 1))
+        TESTPASSED=false
+      fi
+
+      OPM_RENDERED_CATALOG=/tmp/catalog.json
+      ${OPM_BINARY} render ."${conffolder}" > ${OPM_RENDERED_CATALOG}
+      if [ ! -f ${OPM_RENDERED_CATALOG} ]; then
+        echo "!FAILURE! - unable to render the fragment FBC."
+        failure_num=$((failure_num + 1))
+        TESTPASSED=false
+      fi
+
+      if jq -en 'reduce (inputs | select(.schema == "olm.package")) as $obj (0; .+1) < 1' ${OPM_RENDERED_CATALOG}; then
+        echo "!FAILURE! - There are no olm package entries defined in this FBC fragment."
+        failure_num=$((failure_num + 1))
+        TESTPASSED=false
+      fi
+
+      # examines the base_image_name tag to derive the target OCP version
+      # assumes this is in the form
+      # image-path:[v]major-digits.minor-digits[@sha...]
+      OCP_VER_FROM_BASE=$(echo "${base_image_name}" | sed -e "s/@.*$//" -e "s/^.*://")   # strips hash first due to greedy match
+      # extracts major digits and filters out any leading alphabetic characters, for e.g. 'v4' --> '4'
+      OCP_VER_MAJOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 1 | sed "s/^[a-zA-Z]*//")
+      OCP_VER_MINOR=$(echo "${OCP_VER_FROM_BASE}" | cut -d '.' -f 2)
+
+      RUN_OCP_VERSION_VALIDATION="false"
+      digits_regex='^[0-9]*$'
+      if [[ ${OCP_VER_MAJOR} =~ $digits_regex ]] && [[ ${OCP_VER_MINOR} =~ $digits_regex ]] ; then
+        RUN_OCP_VERSION_VALIDATION="true"
+      fi
+
+      if [ "${RUN_OCP_VERSION_VALIDATION}" == "false" ] ; then
+        echo "!WARNING! - unable to assess bundle metadata alignment with OCP version because we cannot extract version info from base_image_name: ${base_image_name}"
+      else
+        OCP_BUNDLE_METADATA_THRESHOLD_MAJOR=4
+        OCP_BUNDLE_METADATA_THRESHOLD_MINOR=17
+        OCP_BUNDLE_METADATA_FORMAT="olm.bundle.object"
+
+        if [[ "${OCP_VER_MAJOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MAJOR}" ]] && [[ "${OCP_VER_MINOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MINOR}" ]]; then
+           OCP_BUNDLE_METADATA_FORMAT="olm.csv.metadata"
+        fi
+
+        # enforce the presence of either olm.csv.metadata or olm.bundle.object based on OCP version
+        if [[ "${OCP_BUNDLE_METADATA_FORMAT}" = "olm.csv.metadata" ]]; then
+          if ! jq -en 'reduce( inputs | select(.schema == "olm.bundle" and .properties[].type == "olm.bundle.object")) as $_ (0;.+1) == 0' ${OPM_RENDERED_CATALOG}; then
+            echo "!FAILURE! - olm.bundle.object bundle properties are not permitted in a FBC fragment for OCP version ${OCP_VER_MAJOR}.${OCP_VER_MINOR}. Fragments must move to olm.csv.metadata bundle metadata."
+          failure_num=$((failure_num + 1))
+            TESTPASSED=false
+          fi
+        else
+          if ! jq -en 'reduce( inputs | select(.schema == "olm.bundle" and .properties[].type == "olm.csv.metadata")) as $_ (0;.+1) == 0' ${OPM_RENDERED_CATALOG}; then
+            echo "!FAILURE! - olm.csv.metadata bundle properties are not permitted in a FBC fragment for OCP version ${OCP_VER_MAJOR}.${OCP_VER_MINOR}. Fragments must only use olm.bundle.object bundle metadata."
+          failure_num=$((failure_num + 1))
+            TESTPASSED=false
+          fi
+        fi
+
+        # enforce that each bundle has the OCP-version-appropriate bundle metadata.
+        BUNDLE_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema=="olm.bundle"))' ${OPM_RENDERED_CATALOG})
+        BUNDLE_BO_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema == "olm.bundle" and .properties[].type == "olm.bundle.object"))' ${OPM_RENDERED_CATALOG})
+        BUNDLE_CM_COUNT=$(jq -en 'def count(stream): reduce stream as $i (0; .+1); count(inputs|select(.schema == "olm.bundle" and .properties[].type == "olm.csv.metadata"))' ${OPM_RENDERED_CATALOG})
+
+        if [[ "${OCP_BUNDLE_METADATA_FORMAT}" = "olm.csv.metadata" ]]; then
+          if [[ "${BUNDLE_COUNT}" -ne "${BUNDLE_CM_COUNT}" ]]; then
+            echo "!FAILURE! - every olm.bundle object in the fragment must have a corresponding olm.csv.metadata bundle property"
+          failure_num=$((failure_num + 1))
+            TESTPASSED=false
+          fi
+        else
+          if [[ "${BUNDLE_BO_COUNT}" -lt "${BUNDLE_COUNT}" ]]; then
+            echo "!FAILURE! - every olm.bundle object in the fragment must have at least one olm.bundle.object bundle property"
+          failure_num=$((failure_num + 1))
+            TESTPASSED=false
+          fi
+        fi
+      fi
+
+      note="Task $(context.task.name) completed: Check result for task result."
+      if [ $TESTPASSED == false ]; then
+        ERROR_OUTPUT=$(make_result_json -r FAILURE -f $failure_num -s $((check_num - failure_num)) -t "$note")
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      else
+        TEST_OUTPUT=$(make_result_json -r SUCCESS -s $check_num -t "$note")
+        echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      fi
+      popd
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+  workspaces:
+  - name: workspace

--- a/task/inspect-image/0.2/inspect-image.yaml
+++ b/task/inspect-image/0.2/inspect-image.yaml
@@ -1,0 +1,168 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-01-31T00:00:00Z"
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.2"
+  name: inspect-image
+spec:
+  description: Inspects and analyzes manifest data of the container's source image,
+    and its base image (if available) using Skopeo. An image's manifest data contains
+    information about the layers that make up the image, the platforms for which the
+    image is intended, and other metadata about the image.
+  params:
+  - description: Fully qualified image name.
+    name: IMAGE_URL
+  - description: Image digest.
+    name: IMAGE_DIGEST
+    type: string
+  - default: ""
+    description: unused, should be removed in next task version
+    name: DOCKER_AUTH
+    type: string
+  results:
+  - description: Base image source image is built from.
+    name: BASE_IMAGE
+  - description: Base image repository URL.
+    name: BASE_IMAGE_REPOSITORY
+  - description: Tekton task test output.
+    name: TEST_OUTPUT
+  steps:
+  - env:
+    - name: IMAGE_URL
+      value: $(params.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(params.IMAGE_DIGEST)
+    image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
+    name: inspect-image
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+      source /utils.sh
+      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+      IMAGE_INSPECT=image_inspect.json
+      BASE_IMAGE_INSPECT=base_image_inspect.json
+      RAW_IMAGE_INSPECT=raw_image_inspect.json
+
+      IMAGE_URL="${IMAGE_URL}@${IMAGE_DIGEST}"
+      # Given a tag and a the digest in the IMAGE_URL we opt to use the digest alone
+      # this is because containers/image currently doesn't support image references
+      # that contain both. See https://github.com/containers/image/issues/1736
+      if [[ "${IMAGE_URL}" == *":"*"@"* ]]; then
+        IMAGE_URL="${IMAGE_URL/:*@/@}"
+      fi
+
+      status=-1
+      max_run=5
+      sleep_sec=10
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec  # skip last sleep
+        echo "Inspecting manifest for source image ${IMAGE_URL} (try $run/$max_run)."
+        skopeo inspect --no-tags docker://"${IMAGE_URL}" > $IMAGE_INSPECT && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to inspect image ${IMAGE_URL}"
+          note="Task $(context.task.name) failed: Encountered errors while inspecting image. For details, check Tekton task log."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+          exit 0
+      fi
+      echo "Image ${IMAGE_URL} metadata:"
+      cat "$IMAGE_INSPECT"
+
+      run=1
+      while [ "$run" -le "$max_run" ]; do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec  # skip last sleep
+        echo "Inspecting raw image manifest ${IMAGE_URL} (try $run/$max_run)."
+        skopeo inspect --no-tags --raw docker://"${IMAGE_URL}" > $RAW_IMAGE_INSPECT || status=$?
+
+        if [ "$status" -eq 0 ] && [ "$(jq 'has("manifests")' ${RAW_IMAGE_INSPECT})" = "true" ]; then
+            echo "Found an image index, lookup for amd64 manifest"
+            INDEX_IMAGE_MANIFESTS=$(jq ' .manifests | map ( {(.platform.architecture|tostring|ascii_downcase):  .digest} ) | add'  "${RAW_IMAGE_INSPECT}" || true)
+
+            AMD64_MANIFEST_DIGEST=$(jq -r '.amd64' <<< "${INDEX_IMAGE_MANIFESTS}" || true )
+            if [ -z "$AMD64_MANIFEST_DIGEST" ]; then
+              # we didn't find amd64 platform, fail horribly as it's the required platform currently for all checks
+              echo "[ERROR] Could not find amd64 image manifest for image $IMAGE_URL"
+              note="Task $(context.task.name) failed: Couldn't find amd64 image manifest"
+              TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+              echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+              exit 0
+            fi
+
+            # Replace image URL with new digest
+            IMAGE_URL="${IMAGE_URL/[@:]*/@$AMD64_MANIFEST_DIGEST}"
+            echo "Setting AMD64 specific image: $IMAGE_URL"
+            run=1  # reset runs, we are looking another image; new image, new life
+        else
+            break
+        fi
+      done
+
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to get raw metadata of image ${IMAGE_URL}"
+          note="Task $(context.task.name) failed: Encountered errors while inspecting image. For details, check Tekton task log."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+          exit 0
+      fi
+
+      echo "Image ${IMAGE_URL} raw metadata:"
+      cat "$RAW_IMAGE_INSPECT" | jq  # jq for readable formatting
+
+      echo "Getting base image manifest for source image ${IMAGE_URL}."
+      BASE_IMAGE_NAME="$(jq -r ".annotations.\"org.opencontainers.image.base.name\"" $RAW_IMAGE_INSPECT)"
+      BASE_IMAGE_DIGEST="$(jq -r ".annotations.\"org.opencontainers.image.base.digest\"" $RAW_IMAGE_INSPECT)"
+      if [ $BASE_IMAGE_NAME == 'null' ]; then
+        echo "Cannot get base image info from annotations."
+        BASE_IMAGE_NAME="$(jq -r ".Labels.\"org.opencontainers.image.base.name\"" $IMAGE_INSPECT)"
+        BASE_IMAGE_DIGEST="$(jq -r ".annotations.\"org.opencontainers.image.base.digest\"" $IMAGE_INSPECT)"
+        if [ "$BASE_IMAGE_NAME" == 'null' ]; then
+          echo "Cannot get base image info from Labels. For details, check source image ${IMAGE_URL}."
+          exit 0
+        fi
+      fi
+      if [ -z "$BASE_IMAGE_NAME" ]; then
+        echo "Source image ${IMAGE_URL} is built from scratch, so there is no base image."
+        exit 0
+      fi
+
+      BASE_IMAGE="${BASE_IMAGE_NAME%:*}@$BASE_IMAGE_DIGEST"
+      echo "Detected base image: $BASE_IMAGE"
+      echo -n "$BASE_IMAGE" > $(results.BASE_IMAGE.path)
+
+      for run in $(seq 1 $max_run); do
+        status=0
+        [ "$run" -gt 1 ] && sleep $sleep_sec  # skip last sleep
+        echo "Inspecting base image ${BASE_IMAGE} (try $run/$max_run)."
+        skopeo inspect --no-tags "docker://$BASE_IMAGE"  > $BASE_IMAGE_INSPECT && break || status=$?
+      done
+      if [ "$status" -ne 0 ]; then
+          echo "Failed to inspect base image ${BASE_IMAGE}"
+          note="Task $(context.task.name) failed: Encountered errors while inspecting image. For details, check Tekton task log."
+          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+          exit 0
+      fi
+
+      BASE_IMAGE_REPOSITORY="$(jq -r '.Name | sub("[^/]+/"; "") | sub("[:@].*"; "")' "$BASE_IMAGE_INSPECT")"
+      echo "Detected base image repository: $BASE_IMAGE_REPOSITORY"
+      echo -n "$BASE_IMAGE_REPOSITORY" > $(results.BASE_IMAGE_REPOSITORY.path)
+
+      note="Task $(context.task.name) completed: Check inspected JSON files under $(workspaces.source.path)/hacbs/$(context.task.name)."
+      TEST_OUTPUT=$(make_result_json -r SUCCESS -s 1 -t "$note")
+      echo "${TEST_OUTPUT}" | tee $(results.TEST_OUTPUT.path)
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)
+  workspaces:
+  - name: source

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -856,7 +856,6 @@ spec:
         fi
       computeResources:
         limits:
-          cpu: "4"
           memory: 4Gi
         requests:
           cpu: "2"

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -280,7 +280,6 @@
     computeResources:
       limits:
         memory: 4Gi
-        cpu: 4
       requests:
         memory: 2Gi
         cpu: 2


### PR DESCRIPTION
This PR adds a CI check to validate kustomize build is successful and also checks that PR authors are committing built manifests files of task/pipeline change with the help of `hack/build-manifests.sh` script  with their task/pipeline changes.
Part of story: https://issues.redhat.com/browse/STONEBLD-3042
