### PR TITLE
buildah*/0.3: port icm fix from buildah/0.2

### DIFF
--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -556,12 +556,14 @@ spec:
             - SETFCAP
     - name: icm
       image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
-      args:
-        - $(params.IMAGE)
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers
           name: varlibcontainers
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        /scripts/inject-icm.sh "$IMAGE"
       securityContext:
         capabilities:
           add:

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -661,11 +661,17 @@ spec:
       name: ssh
       readOnly: true
     workingDir: /var/workdir
-  - args:
-    - $(params.IMAGE)
-    computeResources: {}
+  - computeResources: {}
     image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
     name: icm
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      /scripts/inject-icm.sh "$IMAGE"
     securityContext:
       capabilities:
         add:

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -637,11 +637,17 @@ spec:
       name: ssh
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - args:
-    - $(params.IMAGE)
-    computeResources: {}
+  - computeResources: {}
     image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:462980e94ba689b5f56c3d5dfb3358cd8c685300daf65a71532f11898935e7f1
     name: icm
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      /scripts/inject-icm.sh "$IMAGE"
     securityContext:
       capabilities:
         add:

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -503,7 +503,10 @@ spec:
     - mountPath: /var/lib/containers
       name: varlibcontainers
     workingDir: $(workspaces.source.path)
-    args: [$(params.IMAGE)]
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
   - name: push
     image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
     script: |


### PR DESCRIPTION
See 2ac6602697a28ed44f63b0d58c9275c3b5a1a2d6.
The fix got lost while creating the 0.3 version of buildah.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
