### PR TITLE
change sbom-utility-scripts refs to new location

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -163,7 +163,7 @@ spec:
         add:
           - SETFCAP
 
-  - image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+  - image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
     name: create-sbom
     computeResources:
       limits:

--- a/task/build-paketo-builder-oci-ta/0.1/build-paketo-builder-oci-ta.yaml
+++ b/task/build-paketo-builder-oci-ta/0.1/build-paketo-builder-oci-ta.yaml
@@ -325,7 +325,7 @@ spec:
         requests:
           cpu: 100m
           memory: 256Mi
-      image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
       name: prepare-sboms
       script: |
         #!/bin/bash

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -683,7 +683,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: prepare-sboms
-      image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
       workingDir: /var/workdir
       script: |
         if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then

--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -648,7 +648,7 @@ spec:
         echo "Running syft on the image filesystem"
         syft dir:"$(cat /shared/container_path)" --output cyclonedx-json="/var/workdir/sbom-image.json"
     - name: prepare-sboms
-      image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
       workingDir: /var/workdir
       script: |
         if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -820,7 +820,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -779,7 +779,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -798,7 +798,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -757,7 +757,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -627,7 +627,7 @@ spec:
       runAsUser: 0
 
   - name: prepare-sboms
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
     computeResources:
       limits:
         memory: 512Mi

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -593,7 +593,7 @@ spec:
       name: shared
 
   - name: prepare-sboms
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:9f1fd11d9c3c517ecc112d192ad361d16ecf6ce00b83b109c93cf3d1c644a357
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
     computeResources:
       limits:
         memory: 512Mi

--- a/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
+++ b/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
@@ -241,7 +241,7 @@ spec:
         requests:
           memory: 6Gi
     - name: merge-cachi2-sbom
-      image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:f1c07f273536a00fa6539e2aa41b3fddab3bb282a157c9676572858bfd19d7e4
+      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
       workingDir: /var/workdir
       script: |
         cachi2_sbom=./cachi2/output/bom.json

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -222,7 +222,7 @@ spec:
       - mountPath: /var/lib/containers
         name: varlibcontainers
   - name: merge-cachi2-sbom
-    image: quay.io/redhat-appstudio/sbom-utility-scripts-image@sha256:f1c07f273536a00fa6539e2aa41b3fddab3bb282a157c9676572858bfd19d7e4
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:8f6e3348367e5dd418f49e4394afec92c9d7ff7cf3d333ba96ccba3f07eede0b
     script: |
       cachi2_sbom=./cachi2/output/bom.json
       if [ -f "$cachi2_sbom" ]; then


### PR DESCRIPTION
- `quay.io/redhat-appstudio/sbom-utility-scripts-image` got renamed and moved, so it's now `konflux-ci/sbom-utility-scripts`
- This is a part of the effort to decomission redhat-appstudio Quay org
- Change the image references to the new location
