### PR TITLE
Add new tasks specific for testing

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -36,6 +36,8 @@
 /task/update-deployment                     @konflux-ci/build-maintainers
 /task/update-infra-deployments              @konflux-ci/build-maintainers
 /task/upload-sbom-to-trustification         @konflux-ci/build-maintainers
+/task/test-task-1                           @konflux-ci/build-maintainers
+/task/test-task-2                           @konflux-ci/build-maintainers
 
 # renovate groupName=build
 /task/prefetch-dependencies         @konflux-ci/build-maintainers @brunoapimentel @eskultety @taylormadore

--- a/renovate.json
+++ b/renovate.json
@@ -62,6 +62,8 @@
         "task/source-build-oci-ta/**",
         "task/source-build/**",
         "task/summary/**",
+        "task/test-task-1/**",
+        "task/test-task-2/**",
         "task/update-deployment/**",
         "task/update-infra-deployments/**",
         "task/upload-sbom-to-trustification/**"

--- a/task/test-task-1/0.1/README.md
+++ b/task/test-task-1/0.1/README.md
@@ -1,0 +1,4 @@
+# test-task-1 task
+
+Task for build team internal testing.
+

--- a/task/test-task-1/0.1/test-task-1.yaml
+++ b/task/test-task-1/0.1/test-task-1.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: test-task-1
+spec:
+  description: Task for build team internal testing.
+  steps:
+  - name: step-1
+    image: registry.access.redhat.com/ubi9/ubi-minimal:9.5-1734497536@sha256:94b434a29a894129301f6ff52dbddb19422fc800a109170c634b056da8cd704f
+    script: |
+      echo test task

--- a/task/test-task-2/0.1/README.md
+++ b/task/test-task-2/0.1/README.md
@@ -1,0 +1,4 @@
+# test-task-2 task
+
+Task for build team internal testing.
+

--- a/task/test-task-2/0.1/test-task-2.yaml
+++ b/task/test-task-2/0.1/test-task-2.yaml
@@ -1,0 +1,16 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: test-task-2
+spec:
+  description: Task for build team internal testing.
+  steps:
+  - name: step-1
+    image: registry.access.redhat.com/ubi9/ubi-minimal:9.5-1734497536@sha256:94b434a29a894129301f6ff52dbddb19422fc800a109170c634b056da8cd704f
+    script: |
+      echo test task


### PR DESCRIPTION
[STONEBLD-2712](https://issues.redhat.com//browse/STONEBLD-2712)

These two tasks are used to test the pipeline-migration-tool, which is deployed in the Mintmaker image.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
