### PR TITLE
improve buildah 0.3 migration files

### DIFF
--- a/task/buildah-oci-ta/0.3/MIGRATION.md
+++ b/task/buildah-oci-ta/0.3/MIGRATION.md
@@ -8,8 +8,14 @@ Removes references to `jvm-build-service`
 
 ## Action from users
 
-The removed items are not in use, so their removal will not impact users.
+Before migrating, please check if your PipelineRun definitions contain the following results:
+- `JAVA_COMMUNITY_DEPENDENCIES`
+- `SBOM_JAVA_COMPONENTS_COUNT`
 
-A Renovate bot PR will be created with a warning icon for this task.
-
-This is expected, and no action from users is needed.
+They should look similar to this following code block:
+```
+    - description: ""
+      name: JAVA_COMMUNITY_DEPENDENCIES
+      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
+```
+If your PipelineRun definition contains the results, please delete them.

--- a/task/buildah-remote-oci-ta/0.3/MIGRATION.md
+++ b/task/buildah-remote-oci-ta/0.3/MIGRATION.md
@@ -8,8 +8,14 @@ Removes references to `jvm-build-service`
 
 ## Action from users
 
-The removed items are not in use, so their removal will not impact users.
+Before migrating, please check if your PipelineRun definitions contain the following results:
+- `JAVA_COMMUNITY_DEPENDENCIES`
+- `SBOM_JAVA_COMPONENTS_COUNT`
 
-A Renovate bot PR will be created with a warning icon for this task.
-
-This is expected, and no action from users is needed.
+They should look similar to this following code block:
+```
+    - description: ""
+      name: JAVA_COMMUNITY_DEPENDENCIES
+      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
+```
+If your PipelineRun definition contains the results, please delete them.

--- a/task/buildah-remote/0.3/MIGRATION.md
+++ b/task/buildah-remote/0.3/MIGRATION.md
@@ -8,8 +8,14 @@ Removes references to `jvm-build-service`
 
 ## Action from users
 
-The removed items are not in use, so their removal will not impact users.
+Before migrating, please check if your PipelineRun definitions contain the following results:
+- `JAVA_COMMUNITY_DEPENDENCIES`
+- `SBOM_JAVA_COMPONENTS_COUNT`
 
-A Renovate bot PR will be created with a warning icon for this task.
-
-This is expected, and no action from users is needed.
+They should look similar to this following code block:
+```
+    - description: ""
+      name: JAVA_COMMUNITY_DEPENDENCIES
+      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
+```
+If your PipelineRun definition contains the results, please delete them.

--- a/task/buildah/0.3/MIGRATION.md
+++ b/task/buildah/0.3/MIGRATION.md
@@ -8,8 +8,14 @@ Removes references to `jvm-build-service`
 
 ## Action from users
 
-The removed items are not in use, so their removal will not impact users.
+Before migrating, please check if your PipelineRun definitions contain the following results:
+- `JAVA_COMMUNITY_DEPENDENCIES`
+- `SBOM_JAVA_COMPONENTS_COUNT`
 
-A Renovate bot PR will be created with a warning icon for this task.
-
-This is expected, and no action from users is needed.
+They should look similar to this following code block:
+```
+    - description: ""
+      name: JAVA_COMMUNITY_DEPENDENCIES
+      value: $(tasks.build-container.results.JAVA_COMMUNITY_DEPENDENCIES)
+```
+If your PipelineRun definition contains the results, please delete them.


### PR DESCRIPTION
- Some users have encountered problems when migrating buildah tasks from 0.2 to 0.3 when using older PipelineRun definitions which still include the results that are being removed in buildah 0.3
- Mention in the Migration files that users should check if their PipelineRun contains the removed results and that they should be removed