### PR TITLE
chore(KFLUXVNGD-155): Add custom certificate support for git clone and buildah task

### DIFF
--- a/task-generator/trusted-artifacts/README.md
+++ b/task-generator/trusted-artifacts/README.md
@@ -55,10 +55,12 @@ The following is the list of supported options:
 | `addResult`          | sequence of Tekton [TaskResult]s                 | Additional Tekton Task results to add to the Task |
 | `addVolume`          | sequence of [Volume]s                            | Additional Volumes to add to the Task |
 | `addVolumeMount`     | sequence of [VolumeMount]s                       | Additional VolumeMount to add to the Task |
+| `addTAVolumeMount`   | sequence of [VolumeMount]s                       | Additional VolumeMount to add to the `use-trusted-artifact` and `create-trusted-artifact` steps in the Trusted Artifact Task |
 | `base`               | string                                           | Relative path from `recipe.yaml` to the Task definition of the non-Trusted Artifacts Task |
 | `description`        | string                                           | Description of the Trusted Artifacts Task |
 | `displaySuffix`      | string                                           | Additional text to place to the value of `tekton.dev/displayName` annotation from the non-Trusted Artifacts Task to the Trusted Artifacts Task (default: `" oci trusted artifacts"`) |
 | `preferStepTemplate` | boolean                                          | When `true` preference is set to configure common configuration on the `Task.spec.stepTemplate` rather than on each Task Step |
+| `useTAVolumeMount`   | boolean                                          | When `true` VolumeMounts are added to the `use-trusted-artifact` and `create-trusted-artifact` steps. If `addTAVolumeMount` is provided then those VolumeMounts are added. Otherwise, default VolumeMounts are added |
 | `regexReplacements`  | map of strings keys and string values            | Perform regular expression-based replacement with keys being the regular expression and the values being the replacement, see [Replacements](#replacements) |
 | `removeParams`       | sequence of strings                              | Names of Task parameters to remove |
 | `removeVolumes`      | sequence of strings                              | Names of Task Volumes to remove |

--- a/task-generator/trusted-artifacts/recipe.go
+++ b/task-generator/trusted-artifacts/recipe.go
@@ -24,10 +24,12 @@ type Recipe struct {
 	AddResult          []pipeline.TaskResult `json:"addResult"`
 	AddVolume          []core.Volume         `json:"addVolume"`
 	AddVolumeMount     []core.VolumeMount    `json:"addVolumeMount"`
+	AddTAVolumeMount   []core.VolumeMount    `json:"addTAVolumeMount"`
 	Base               string                `json:"base"`
 	Description        string                `json:"description"`
 	DisplaySuffix      string                `json:"displaySuffix"`
 	PreferStepTemplate bool                  `json:"preferStepTemplate"`
+	UseTAVolumeMount   bool                  `json:"useTAVolumeMount"`
 	RegexReplacements  map[string]string     `json:"regexReplacements"`
 	RemoveParams       []string              `json:"removeParams"`
 	RemoveVolumes      []string              `json:"removeVolumes"`

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -246,6 +246,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
     - name: build
       image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
       args:

--- a/task/buildah-oci-ta/0.2/recipe.yaml
+++ b/task/buildah-oci-ta/0.2/recipe.yaml
@@ -7,6 +7,7 @@ add:
   - use-cachi2
 removeWorkspaces:
   - source
+useTAVolumeMount: true
 replacements:
   workspaces.source.path: /var/workdir
 regexReplacements:

--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -247,6 +247,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
     - name: build
       image: quay.io/konflux-ci/buildah-task:latest@sha256:b2d6c32d1e05e91920cd4475b2761d58bb7ee11ad5dff3ecb59831c7572b4d0c
       args:

--- a/task/buildah-oci-ta/0.3/recipe.yaml
+++ b/task/buildah-oci-ta/0.3/recipe.yaml
@@ -7,6 +7,7 @@ add:
   - use-cachi2
 removeWorkspaces:
   - source
+useTAVolumeMount: true
 replacements:
   workspaces.source.path: /var/workdir
 regexReplacements:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -232,6 +232,11 @@ spec:
     computeResources: {}
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     name: use-trusted-artifact
+    volumeMounts:
+    - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
   - args:
     - --build-args
     - $(params.BUILD_ARGS[*])

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -233,6 +233,11 @@ spec:
     computeResources: {}
     image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
     name: use-trusted-artifact
+    volumeMounts:
+    - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
   - args:
     - --build-args
     - $(params.BUILD_ARGS[*])

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -307,6 +307,10 @@ spec:
       volumeMounts:
         - mountPath: /var/workdir
           name: workdir
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
       env:
         - name: IMAGE_EXPIRES_AFTER
           value: $(params.ociArtifactExpiresAfter)

--- a/task/git-clone-oci-ta/0.1/recipe.yaml
+++ b/task/git-clone-oci-ta/0.1/recipe.yaml
@@ -9,6 +9,7 @@ addEnvironment:
     value: /var/workdir/source
 add:
   - create-source
+useTAVolumeMount: true
 removeWorkspaces:
   - output
 description: The git-clone-oci-ta Task will clone a repo from the provided url and store it as a trusted


### PR DESCRIPTION
Add param to support the custom certificate support for git-clone-oci-ta and
buildah-oci-ta tasks to connect to internal registry. For this we have updated
the use-trusted-artifact/create-trusted-artifact steps, which download/upload
the artifact from/to a registry.


Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-155
