### PR TITLE
git-clone task: Support fetching tags of submodules

### DIFF
--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -9,6 +9,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
 |enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
+|fetchSubmoduleTags|Fetch all tags from all submodules.|false|false|
 |fetchTags|Fetch all tags for the repo.|false|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -34,6 +34,10 @@ spec:
         Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
       type: string
       default: "true"
+    - name: fetchSubmoduleTags
+      description: Fetch all tags from all submodules.
+      type: string
+      default: "false"
     - name: fetchTags
       description: Fetch all tags for the repo.
       type: string
@@ -184,6 +188,8 @@ spec:
           value: $(params.userHome)
         - name: PARAM_FETCH_TAGS
           value: $(params.fetchTags)
+        - name: PARAM_FETCH_SUBMODULE_TAGS
+          value: $(params.fetchSubmoduleTags)
         - name: WORKSPACE_SSH_DIRECTORY_BOUND
           value: $(workspaces.ssh-directory.bound)
         - name: WORKSPACE_SSH_DIRECTORY_PATH
@@ -262,6 +268,10 @@ spec:
         if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
           echo "Fetching tags"
           git fetch --tags
+        fi
+        if [ "${PARAM_FETCH_SUBMODULE_TAGS}" = "true" ]; then
+          echo "Fetching tags of submodules"
+          git submodule foreach --recursive "git fetch --tags"
         fi
       securityContext:
         runAsUser: 0

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -23,6 +23,7 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
 |enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
 |fetchTags|Fetch all tags for the repo.|false|false|
+|fetchSubmoduleTags|Fetch all tags from all submodules.|false|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -87,6 +87,10 @@ spec:
     description: Fetch all tags for the repo.
     name: fetchTags
     type: string
+  - name: fetchSubmoduleTags
+    description: Fetch all tags from all submodules.
+    type: string
+    default: "false"
   - name: caTrustConfigMapName
     type: string
     description: The name of the ConfigMap to read CA bundle data from.
@@ -145,6 +149,8 @@ spec:
       value: $(params.userHome)
     - name: PARAM_FETCH_TAGS
       value: $(params.fetchTags)
+    - name: PARAM_FETCH_SUBMODULE_TAGS
+      value: $(params.fetchSubmoduleTags)
     - name: PARAM_GIT_INIT_IMAGE
       value: $(params.gitInitImage)
     - name: WORKSPACE_OUTPUT_PATH
@@ -258,6 +264,10 @@ spec:
       if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
         echo "Fetching tags"
         git fetch --tags
+      fi
+      if [ "${PARAM_FETCH_SUBMODULE_TAGS}" = "true" ]; then
+        echo "Fetching tags of submodules"
+        git submodule foreach --recursive "git fetch --tags"
       fi
 
   - name: symlink-check


### PR DESCRIPTION
Add a new `fetchSubmoduleTags` param to the git-clone task to fetch tags from all submodules.

The change should be straightforward, but I didn't test it so far. Is there a _simple_ way to build a container for this task, push it to a public registry and flip this line: https://github.com/os-observability/konflux-tempo/blob/8090ec116d33d2a2bb1bcdc3967159f18a258b3f/.tekton/multi-arch-build-pipeline.yaml#L42 to test this change?