### PR TITLE
feat: capturing e2e-tests logs of CI in an oci artifact 

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -228,6 +228,12 @@ spec:
             value: "$(tasks.build-bundles.results.custom-docker-build-multi-platform-oci-ta-bundle)"
           - name: fbc-builder-bundle
             value: "$(tasks.build-bundles.results.custom-fbc-builder-bundle)"
+          - name: artifact_dir
+            value: /workspace/artifact-dir
+          - name: pipelinerun_name
+            value: $(context.pipelineRun.name)
+          - name: revision
+            value: "{{revision}}"
         runAfter:
           - build-bundles
         taskRef:
@@ -298,6 +304,45 @@ spec:
                 # Perform cleanup of resources created by gitops service
                 oc delete --ignore-not-found deployment --all -n $(params.e2e_test_namespace)
                 oc delete --ignore-not-found eventlisteners --all -n $(params.e2e_test_namespace)
+      - name: pull-request-status-message
+        when:
+          - input: "tasks_pipelines"
+            operator: "in"
+            values: ["$(tasks.task-switchboard.results.bindings[*])"]
+        taskRef:
+          resolver: git
+          params:
+            - name: url
+              value: https://github.com/konflux-ci/tekton-integration-catalog.git
+            - name: revision
+              value: main
+            - name: pathInRepo
+              value: common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+        params:
+          - name: test-name
+            value: "$(context.pipelineRun.name)"
+          - name: oci-container
+            value: "quay.io/konflux-test-storage/konflux-team/build-definitions:{{ revision }}"
+          - name: pipeline-aggregate-status
+            value: "$(tasks.status)"
+          - name: pull-request-author
+            value: "{{sender}}"
+          - name: pull-request-number
+            value: "{{pull_request_number}}"
+          - name: git-repo
+            value: "{{repo_name}}"
+          - name: git-org
+            value: "{{repo_owner}}"
+          - name: git-revision
+            value: "{{revision}}"
+          - name: junit-report-name
+            value: e2e-report.xml
+          - name: e2e-log-name
+            value: e2e-tests.log
+          - name: cluster-provision-log-name
+            value: cluster-provision.log
+          - name: enable-test-results-analysis
+            value: "true"
   # Added a timeout due to https://issues.redhat.com/browse/STONEBLD-2265
   # If this timeout increases, the age of stale resources should be increased too.
   # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/tekton-ci/production/cleanup-cronjob.yaml

--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -28,6 +28,16 @@ spec:
       type: string
     - name: fbc-builder-bundle
       type: string
+    - name: artifact_dir
+      type: string
+    - name: pipelinerun_name
+      type: string
+    - name: revision
+      type: string
+  volumes:
+    - name: konflux-test-infra-volume
+      secret:
+        secretName: konflux-test-infra
   steps:
     - name: e2e-test
       image: quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests:698910d2098c6bc8b5b92553eacc319859c812c1
@@ -36,6 +46,7 @@ spec:
       # against build-definitions to update this tag
       args: [
         "--ginkgo.label-filter=build-templates-e2e",
+        "--ginkgo.junit-report=$(params.artifact_dir)/e2e-report.xml",
         "--ginkgo.no-color",
         "--ginkgo.v",
         "--ginkgo.timeout=2h"
@@ -44,6 +55,7 @@ spec:
         capabilities:
           add:
           - SETFCAP
+      onError: continue
       env:
       - name: APP_SUFFIX
         value: "$(params.app_suffix)"
@@ -77,3 +89,38 @@ spec:
         value: "$(params.docker-build-multi-platform-oci-ta-bundle)"
       - name: CUSTOM_FBC_BUILDER_PIPELINE_BUNDLE
         value: "$(params.fbc-builder-bundle)"
+    - name: capture-log
+      image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-$(params.revision)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        echo "Storing e2e-tests pod log..."
+        artifact_dir=$(params.artifact_dir)
+        oc logs "$(params.pipelinerun_name)-e2e-tests-pod" --all-containers > "${artifact_dir}"/e2e-tests.log
+    - name: secure-push-oci
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/secure-push-oci/0.1/secure-push-oci.yaml
+      params:
+        - name: workdir-path
+          value: /workspace/artifact-dir
+        - name: oci-ref
+          value: quay.io/konflux-test-storage/konflux-team/build-definitions:$(params.revision)
+        - name: credentials-volume-name
+          value: konflux-test-infra-volume
+    - name: fail-if-any-step-failed
+      ref:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: stepactions/fail-if-any-step-failed/0.1/fail-if-any-step-failed.yaml


### PR DESCRIPTION
This PR will enable archiving e2e-tests logs to an oci image and add the link to the image in the PR comments (when there is test failures).
Part of the story: https://issues.redhat.com/browse/STONEBLD-3025
