### PR TITLE
source-build, deprecated-image-check: support reading base images from SPDX SBOMs

### DIFF
--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -91,7 +91,18 @@ spec:
               continue
             fi
 
-            cat ${SBOM_FILE_PATH} | jq -r '.formulation? // empty | .[] | .components? // empty | .[] | select(any((.properties // empty)[]; .name | test("^konflux:container:is_(base|builder)_image"))) | .name' >> ${IMAGES_TO_BE_PROCESSED_PATH}
+            < "${SBOM_FILE_PATH}" jq -r '
+                if .bomFormat == "CycloneDX" then
+                    .formulation[]?
+                    | .components[]?
+                    | select(any(.properties[]?; .name | test("^konflux:container:is_(base|builder)_image")))
+                    | .name
+                else
+                    .packages[]
+                    | select(any(.annotations[]?.comment; (fromjson?).name? | test("^konflux:container:is_(base|builder)_image")?))
+                    | .name
+                end
+            ' >> "${IMAGES_TO_BE_PROCESSED_PATH}"
             echo "Detected base images from $arch SBOM:"
             cat "${IMAGES_TO_BE_PROCESSED_PATH}"
             echo ""

--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -103,16 +103,28 @@ spec:
         fi
 
         echo -n "Looking for base image in SBOM"
-        echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+
         # Note: the SBOM should contain at most one image with the is_base_image property - the
         # base image for the last FROM instruction. That is the only base image we care about.
-        jq -r '
-            .formulation[]?
-            | .components[]?
-            | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
-            | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
-            | .name + "@" + $matched.digest
-        ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
+        if jq -e '.bomFormat == "CycloneDX"' <<<"$sbom" >/dev/null; then
+          echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+          jq -r '
+                .formulation[]?
+                | .components[]?
+                | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
+                | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+                | .name + "@" + $matched.digest
+            ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
+        else
+          echo ' (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)'
+          jq -r '
+                .packages[]
+                | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
+                | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                | ($purls | first | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+                | .name + "@" + $matched.digest
+            ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
+        fi
     - name: build
       image: quay.io/konflux-ci/source-container-build:latest@sha256:4002c18472e33b5f3d2b92e7897b0b31e4181dd5f8b8a3c4097937035e899ba3
       workingDir: /var/workdir

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -90,16 +90,28 @@ spec:
         fi
 
         echo -n "Looking for base image in SBOM"
-        echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+
         # Note: the SBOM should contain at most one image with the is_base_image property - the
         # base image for the last FROM instruction. That is the only base image we care about.
-        jq -r '
-            .formulation[]?
-            | .components[]?
-            | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
-            | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
-            | .name + "@" + $matched.digest
-        ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
+        if jq -e '.bomFormat == "CycloneDX"' <<< "$sbom" >/dev/null; then
+            echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+            jq -r '
+                .formulation[]?
+                | .components[]?
+                | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
+                | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+                | .name + "@" + $matched.digest
+            ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
+        else
+            echo ' (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)'
+            jq -r '
+                .packages[]
+                | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
+                | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                | ($purls | first | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+                | .name + "@" + $matched.digest
+            ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
+        fi
 
     - name: build
       image: quay.io/konflux-ci/source-container-build:latest@sha256:4002c18472e33b5f3d2b92e7897b0b31e4181dd5f8b8a3c4097937035e899ba3


### PR DESCRIPTION
Support extracting the base/builder images from both CycloneDX SBOMs
and SPDX SBOMs.

Tested in https://github.com/redhat-appstudio/rh-syft/pull/105

source-build:
```
Found SBOM of media type: text/spdx+json
Looking for base image in SBOM (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)
registry.access.redhat.com/ubi9/ubi-micro@sha256:7f376b75faf8ea546f28f8529c37d24adcde33dca4103f4897ae19a43d58192b
```

deprecated-image-check:
```
Found SBOM of media type: text/spdx+json
Detected base images from amd64 SBOM:
brew.registry.redhat.io/rh-osbs/openshift-golang-builder
registry.access.redhat.com/ubi9/ubi-micro

Images to be checked:
brew.registry.redhat.io/rh-osbs/openshift-golang-builder
registry.access.redhat.com/ubi9/ubi-micro
```