### PR TITLE
fix: add 4h task timeout in the ec pipeline

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -119,3 +119,4 @@ spec:
             value: verify-enterprise-contract
           - name: kind
             value: task
+      timeout: 4h


### PR DESCRIPTION
Since the default timeout for tasks is hardcoded to 1h/2h, this change sets the timeout to a higher value to
support users who run bigger sets of images through the verify task.

It is still possible to limit the duration of the check on the pipeline or pipelineRun level, depending on usage.

Signed-off-by: dirgim <kpavic@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
