### PR TITLE
sast-synk-check: enable KFP by default

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -222,7 +222,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |IGNORE_FILE_PATHS| Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
-|KFP_GIT_URL| URL from repository to download known false positives files| | |
+|KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value for the Konflux instance in use. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
 |RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
 |SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -219,7 +219,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |IGNORE_FILE_PATHS| Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
-|KFP_GIT_URL| URL from repository to download known false positives files| | |
+|KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value for the Konflux instance in use. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
 |RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
 |SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -194,7 +194,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ARGS| Append arguments.| | |
 |IGNORE_FILE_PATHS| Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
-|KFP_GIT_URL| URL from repository to download known false positives files| | |
+|KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value for the Konflux instance in use. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
 |RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
 |SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -123,7 +123,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |IGNORE_FILE_PATHS| Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
-|KFP_GIT_URL| URL from repository to download known false positives files| | |
+|KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value for the Konflux instance in use. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
 |RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
 |SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -100,7 +100,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ARGS| Append arguments.| | |
 |IGNORE_FILE_PATHS| Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
-|KFP_GIT_URL| URL from repository to download known false positives files| | |
+|KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value for the Konflux instance in use. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
 |RECORD_EXCLUDED| Write excluded records in file. Useful for auditing (defaults to false).| false| |
 |SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |

--- a/task/sast-snyk-check-oci-ta/0.3/README.md
+++ b/task/sast-snyk-check-oci-ta/0.3/README.md
@@ -15,7 +15,7 @@ See https://snyk.io/product/snyk-code/ and https://snyk.io/ for more information
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
 |IGNORE_FILE_PATHS|Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.|""|false|
 |IMP_FINDINGS_ONLY|Report only important findings. Default is true. To report all findings, specify "false"|true|false|
-|KFP_GIT_URL|URL from repository to download known false positives files|""|false|
+|KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value for the Konflux instance in use. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 |PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
 |RECORD_EXCLUDED|Write excluded records in file. Useful for auditing (defaults to false).|false|false|
 |SNYK_SECRET|Name of secret which contains Snyk token.|snyk-secret|false|

--- a/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml
@@ -38,9 +38,12 @@ spec:
       type: string
       default: "true"
     - name: KFP_GIT_URL
-      description: URL from repository to download known false positives files
+      description: Known False Positives (KFP) git URL (optionally taking
+        a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+        the default value for the Konflux instance in use. If set to an empty
+        string, the KFP filtering is disabled.
       type: string
-      default: ""
+      default: SITE_DEFAULT
     - name: PROJECT_NAME
       description: Name of the scanned project, used to find path exclusions.
         By default, the Konflux component name will be used.
@@ -128,6 +131,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['appstudio.openshift.io/component']
+        - name: BUILD_PLR_LOG_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
       script: |
         #!/usr/bin/env bash
 
@@ -195,6 +202,17 @@ spec:
 
           echo "Results:"
           (set -x && csgrep --mode=evtstat sast_snyk_check_out_all_findings.json)
+
+          if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+            case "${BUILD_PLR_LOG_URL}" in
+            *console.redhat.com* | *console.dev.redhat.com*)
+              KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+              ;;
+            *)
+              KFP_GIT_URL=
+              ;;
+            esac
+          fi
 
           # We check if the KFP_GIT_URL variable is set to apply the filters or not
           if [[ -z "${KFP_GIT_URL}" ]]; then

--- a/task/sast-snyk-check/0.3/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.3/sast-snyk-check.yaml
@@ -46,9 +46,10 @@ spec:
       default: "true"
     - name: KFP_GIT_URL
       type: string
-      description: URL from repository to download known false positives files
-      # FIXME: Red Hat internal projects will default to https://gitlab.cee.redhat.com/osh/known-false-positives.git when KONFLUX-4530 is resolved
-      default: ""
+      description: Known False Positives (KFP) git URL (optionally taking a revision delimited by \#).
+        Defaults to "SITE_DEFAULT", which means the default value for the Konflux instance in use.
+        If set to an empty string, the KFP filtering is disabled.
+      default: "SITE_DEFAULT"
     - name: PROJECT_NAME
       type: string
       description: Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.
@@ -105,6 +106,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.labels['appstudio.openshift.io/component']
+        - name: BUILD_PLR_LOG_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
       script: |
         #!/usr/bin/env bash
 
@@ -172,6 +177,17 @@ spec:
 
           echo "Results:"
           (set -x && csgrep --mode=evtstat sast_snyk_check_out_all_findings.json)
+
+          if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+            case "${BUILD_PLR_LOG_URL}" in
+              *console.redhat.com*|*console.dev.redhat.com*)
+                KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+                ;;
+              *)
+                KFP_GIT_URL=
+                ;;
+            esac
+          fi
 
           # We check if the KFP_GIT_URL variable is set to apply the filters or not
           if [[ -z "${KFP_GIT_URL}" ]]; then


### PR DESCRIPTION
... for the internal Konflux clusters

Based-on: https://github.com/konflux-ci/build-definitions/pull/1848
Related: https://issues.redhat.com/browse/OSH-763