### PR TITLE
prefetch-dependencies: support SPDX

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -155,6 +155,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
 ### push-dockerfile-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -152,6 +152,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
 ### push-dockerfile-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -146,6 +146,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
 ### push-dockerfile:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -126,6 +126,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -74,6 +74,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
 ### sast-coverity-check-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -69,6 +69,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
 ### sast-coverity-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -73,6 +73,7 @@
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
 ### push-dockerfile:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/task/prefetch-dependencies-oci-ta/0.1/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.1/README.md
@@ -36,6 +36,7 @@ params:
 |log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
 |ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
 |ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
+|sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
 
 ## Results
 |name|description|

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -73,6 +73,10 @@ spec:
     - name: ociStorage
       description: The OCI repository where the Trusted Artifacts are stored.
       type: string
+    - name: sbom-type
+      description: 'Select the SBOM format to generate. Valid values: spdx,
+        cyclonedx.'
+      default: cyclonedx
   results:
     - name: CACHI2_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
@@ -314,6 +318,8 @@ spec:
           value: $(params.dev-package-managers)
         - name: LOG_LEVEL
           value: $(params.log-level)
+        - name: SBOM_TYPE
+          value: $(params.sbom-type)
         - name: WORKSPACE_GIT_AUTH_BOUND
           value: $(workspaces.git-basic-auth.bound)
         - name: WORKSPACE_GIT_AUTH_PATH
@@ -385,6 +391,7 @@ spec:
           $dev_pacman_flag \
           --source=/var/workdir/source \
           --output=/var/workdir/cachi2/output \
+          --sbom-output-type="$SBOM_TYPE" \
           "${INPUT}"
 
         cachi2 --log-level="$LOG_LEVEL" generate-env /var/workdir/cachi2/output \

--- a/task/prefetch-dependencies/0.1/README.md
+++ b/task/prefetch-dependencies/0.1/README.md
@@ -28,6 +28,7 @@ params:
 |dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
 |log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
 |config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -45,6 +45,9 @@ spec:
       Note this needs to be passed as a YAML-formatted config dump, not as a file path!
     name: config-file-content
     default: ""
+  - name: sbom-type
+    default: cyclonedx
+    description: "Select the SBOM format to generate. Valid values: spdx, cyclonedx."
   - name: caTrustConfigMapName
     type: string
     description: The name of the ConfigMap to read CA bundle data from.
@@ -241,6 +244,8 @@ spec:
       value: $(params.dev-package-managers)
     - name: LOG_LEVEL
       value: $(params.log-level)
+    - name: SBOM_TYPE
+      value: $(params.sbom-type)
     - name: WORKSPACE_GIT_AUTH_BOUND
       value: $(workspaces.git-basic-auth.bound)
     - name: WORKSPACE_GIT_AUTH_PATH
@@ -325,6 +330,7 @@ spec:
       $dev_pacman_flag \
       --source=$(workspaces.source.path)/source \
       --output=$(workspaces.source.path)/cachi2/output \
+      --sbom-output-type="$SBOM_TYPE" \
       "${INPUT}"
 
       cachi2 --log-level="$LOG_LEVEL" generate-env $(workspaces.source.path)/cachi2/output \


### PR DESCRIPTION
Add sbom-type param to allow choosing the SBOM format cachi2 should generate. Defaults to cyclonedx for now.