### PR TITLE
task/rpm-ostree: Add gursewak1997

### DIFF
--- a/task/rpm-ostree/OWNERS
+++ b/task/rpm-ostree/OWNERS
@@ -2,5 +2,7 @@
 #See the OWNERS docs: https://go.k8s.io/owners
 approvers:
   - cgwalters
+  - gursewak1997
 reviewers:
   - cgwalters
+  - gursewak1997


### PR DESCRIPTION
We are planning to deprecate and remove the rpm-ostree task in favor of buildah (ref https://issues.redhat.com/browse/BIFROST-408 ) but in the short term add gursewak who is part of the team now.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
