### PR TITLE
sast-coverity-check: Fix error while creating filtered file

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.1/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.1/sast-coverity-check-oci-ta.yaml
@@ -264,8 +264,8 @@ spec:
         csgrep --mode=sarif --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
           --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
           --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
-          --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}"
-        filtered_sast_coverity_buildless_check_all_findings.json \
+          --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}" \
+          filtered_sast_coverity_buildless_check_all_findings.json \
           >"/var/workdir"/coverity-results.sarif
 
         if [[ -z "$(csgrep --mode=evtstat filtered_sast_coverity_buildless_check_all_findings.json)" ]]; then

--- a/task/sast-coverity-check/0.1/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.1/sast-coverity-check.yaml
@@ -247,7 +247,7 @@ spec:
         csgrep --mode=sarif --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
         --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
         --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
-        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}"
+        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}" \
         filtered_sast_coverity_buildless_check_all_findings.json \
         > "$(workspaces.workspace.path)"/coverity-results.sarif
 


### PR DESCRIPTION
Related: https://issues.redhat.com/browse/OSH-801

The missing character prevented the filtered files to be correctly generated and uploaded

Tested pipeline: https://konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/application-pipeline/workspaces/jperezde/applications/test-coverity/pipelineruns/automation-hub-web-container-on-pull-request-cpsfd
