### PR TITLE
fix(buildah-remote): logs when build on remote host started/finished

### DIFF
--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -273,6 +273,8 @@ if ! [[ $IS_LOCALHOST ]]; then
 else
   bash ` + containerScript + ` "$@"
 fi
+echo "Build on remote host $SSH_HOST finished"
+
 buildah images
 container=$(buildah from --pull-never "$IMAGE")
 buildah mount "$container" | tee /shared/container_path

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -496,6 +496,8 @@ spec:
       else
         bash scripts/script-build.sh "$@"
       fi
+      echo "Build on remote host $SSH_HOST finished"
+
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -656,6 +656,8 @@ spec:
       else
         bash scripts/script-build.sh "$@"
       fi
+      echo "Build on remote host $SSH_HOST finished"
+
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -653,6 +653,8 @@ spec:
       else
         bash scripts/script-build.sh "$@"
       fi
+      echo "Build on remote host $SSH_HOST finished"
+
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -489,6 +489,8 @@ spec:
       else
         bash scripts/script-build.sh "$@"
       fi
+      echo "Build on remote host $SSH_HOST finished"
+
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -632,6 +632,8 @@ spec:
       else
         bash scripts/script-build.sh "$@"
       fi
+      echo "Build on remote host $SSH_HOST finished"
+
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -629,6 +629,8 @@ spec:
       else
         bash scripts/script-build.sh "$@"
       fi
+      echo "Build on remote host $SSH_HOST finished"
+
       buildah images
       container=$(buildah from --pull-never "$IMAGE")
       buildah mount "$container" | tee /shared/container_path


### PR DESCRIPTION
It's hard to determine if the issue happened on remote host or in container.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
