### PR TITLE
Switch the default SBOM type to SPDX

### DIFF
--- a/hack/generate-buildah-remote.sh
+++ b/hack/generate-buildah-remote.sh
@@ -6,7 +6,7 @@ SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "${SCRIPTDIR}/../task-generator/remote"
 go build -o /tmp/remote-generator main.go
 
-for version in 0.1 0.2 0.3; do
+for version in 0.1 0.2 0.3 0.4; do
     /tmp/remote-generator --buildah-task="${SCRIPTDIR}/../task/buildah/${version}/buildah.yaml" \
         --remote-task="${SCRIPTDIR}/../task/buildah-remote/${version}/buildah-remote.yaml" --task-version="$version"
     /tmp/remote-generator --buildah-task="${SCRIPTDIR}/../task/buildah-oci-ta/${version}/buildah-oci-ta.yaml" \

--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -217,7 +217,7 @@ spec:
     - clone-repository
     taskRef:
       name: prefetch-dependencies
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.prefetch-input)
       operator: notin
@@ -255,7 +255,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -295,7 +295,7 @@ spec:
     - build-image-index
     taskRef:
       name: source-build
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -318,7 +318,7 @@ spec:
     - build-image-index
     taskRef:
       name: deprecated-image-check
-      version: "0.4"
+      version: "0.5"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -7,18 +7,18 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.3:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.3:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.4:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.3:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.4:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-images:0.3:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-images:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-images:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.3:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-images:0.3:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-images:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-images:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.4:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-images:0.4:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -41,7 +41,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
-### buildah-remote-oci-ta:0.3 task parameters
+### buildah-remote-oci-ta:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -62,7 +62,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
@@ -96,7 +96,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
-### deprecated-image-check:0.4 task parameters
+### deprecated-image-check:0.5 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of base build images.| | |
@@ -140,7 +140,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
-### prefetch-dependencies-oci-ta:0.1 task parameters
+### prefetch-dependencies-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -153,7 +153,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
-|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### push-dockerfile-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -259,7 +259,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_URL| Fully qualified image name to show SBOM for.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |PLATFORM| Specific architecture to display the SBOM for. An example arch would be "linux/amd64". If IMAGE_URL refers to a multi-arch image and this parameter is empty, the task will default to use "linux/amd64".| linux/amd64| |
-### source-build-oci-ta:0.1 task parameters
+### source-build-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BASE_IMAGES| By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.| | |
@@ -279,11 +279,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### buildah-remote-oci-ta:0.3 task results
+### buildah-remote-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_DIGEST| Digest of the image just built| |
@@ -307,7 +307,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |STATUS| Tekton task simple status to be later checked| |
 |TEST_OUTPUT| Tekton task result output.| |
-### deprecated-image-check:0.4 task results
+### deprecated-image-check:0.5 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
@@ -321,8 +321,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
-|commit| The precise commit SHA that was fetched by this Task.| build-images:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
+|commit| The precise commit SHA that was fetched by this Task.| build-images:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
@@ -330,11 +330,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### prefetch-dependencies-oci-ta:0.1 task results
+### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.4:CACHI2_ARTIFACT ; build-source-image:0.2:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.4:SOURCE_ARTIFACT ; build-source-image:0.2:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -361,7 +361,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### source-build-oci-ta:0.1 task results
+### source-build-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BUILD_RESULT| Build result.| |
@@ -372,15 +372,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
-|netrc| |True| prefetch-dependencies:0.1:netrc|
+|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
+|netrc| |True| prefetch-dependencies:0.2:netrc|
 ## Available workspaces from tasks
 ### git-clone-oci-ta:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### prefetch-dependencies-oci-ta:0.1 task workspaces
+### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -141,7 +141,7 @@ spec:
     - clone-repository
     taskRef:
       name: prefetch-dependencies-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: git-basic-auth
       workspace: git-auth
@@ -183,7 +183,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah-remote-oci-ta
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -225,7 +225,7 @@ spec:
     - build-image-index
     taskRef:
       name: source-build-oci-ta
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -246,7 +246,7 @@ spec:
     - build-image-index
     taskRef:
       name: deprecated-image-check
-      version: "0.4"
+      version: "0.5"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -7,17 +7,17 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.3:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.3:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.4:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.3:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-container:0.3:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-container:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-container:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.3:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.3:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-container:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.4:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -40,7 +40,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
-### buildah-oci-ta:0.3 task parameters
+### buildah-oci-ta:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -59,7 +59,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
@@ -93,7 +93,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
-### deprecated-image-check:0.4 task parameters
+### deprecated-image-check:0.5 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of base build images.| | |
@@ -137,7 +137,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
-### prefetch-dependencies-oci-ta:0.1 task parameters
+### prefetch-dependencies-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -150,7 +150,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
-|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### push-dockerfile-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -256,7 +256,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_URL| Fully qualified image name to show SBOM for.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |PLATFORM| Specific architecture to display the SBOM for. An example arch would be "linux/amd64". If IMAGE_URL refers to a multi-arch image and this parameter is empty, the task will default to use "linux/amd64".| linux/amd64| |
-### source-build-oci-ta:0.1 task parameters
+### source-build-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BASE_IMAGES| By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.| | |
@@ -276,11 +276,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### buildah-oci-ta:0.3 task results
+### buildah-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_DIGEST| Digest of the image just built| |
@@ -304,7 +304,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |STATUS| Tekton task simple status to be later checked| |
 |TEST_OUTPUT| Tekton task result output.| |
-### deprecated-image-check:0.4 task results
+### deprecated-image-check:0.5 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
@@ -318,8 +318,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
-|commit| The precise commit SHA that was fetched by this Task.| build-container:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
+|commit| The precise commit SHA that was fetched by this Task.| build-container:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
@@ -327,11 +327,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### prefetch-dependencies-oci-ta:0.1 task results
+### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.3:CACHI2_ARTIFACT ; build-source-image:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.3:SOURCE_ARTIFACT ; build-source-image:0.1:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.4:CACHI2_ARTIFACT ; build-source-image:0.2:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.4:SOURCE_ARTIFACT ; build-source-image:0.2:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -358,7 +358,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### source-build-oci-ta:0.1 task results
+### source-build-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BUILD_RESULT| Build result.| |
@@ -369,15 +369,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
-|netrc| |True| prefetch-dependencies:0.1:netrc|
+|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
+|netrc| |True| prefetch-dependencies:0.2:netrc|
 ## Available workspaces from tasks
 ### git-clone-oci-ta:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### prefetch-dependencies-oci-ta:0.1 task workspaces
+### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -135,7 +135,7 @@ spec:
     - clone-repository
     taskRef:
       name: prefetch-dependencies-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: git-basic-auth
       workspace: git-auth
@@ -170,7 +170,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah-oci-ta
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -212,7 +212,7 @@ spec:
     - build-image-index
     taskRef:
       name: source-build-oci-ta
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -233,7 +233,7 @@ spec:
     - build-image-index
     taskRef:
       name: deprecated-image-check
-      version: "0.4"
+      version: "0.5"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -7,17 +7,17 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.3:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.3:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.4:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.3:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-container:0.3:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.3:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.1:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.3:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-container:0.3:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.4:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -40,7 +40,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
-### buildah:0.3 task parameters
+### buildah:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -58,7 +58,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
@@ -91,7 +91,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |AUTH_TOKEN_COVERITY_IMAGE| Name of secret which contains the authentication token for pulling the Coverity image.| auth-token-coverity-image| |
 |COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
-### deprecated-image-check:0.4 task parameters
+### deprecated-image-check:0.5 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of base build images.| | |
@@ -136,7 +136,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
-### prefetch-dependencies:0.1 task parameters
+### prefetch-dependencies:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -146,7 +146,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
-|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### push-dockerfile:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -243,7 +243,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |IMAGE_URL| Fully qualified image name to show SBOM for.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |PLATFORM| Specific architecture to display the SBOM for. An example arch would be "linux/amd64". If IMAGE_URL refers to a multi-arch image and this parameter is empty, the task will default to use "linux/amd64".| linux/amd64| |
-### source-build:0.1 task parameters
+### source-build:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BASE_IMAGES| By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.| | |
@@ -268,11 +268,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### buildah:0.3 task results
+### buildah:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_DIGEST| Digest of the image just built| |
@@ -296,7 +296,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |STATUS| Tekton task simple status to be later checked| |
 |TEST_OUTPUT| Tekton task result output.| |
-### deprecated-image-check:0.4 task results
+### deprecated-image-check:0.5 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
@@ -310,7 +310,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
-|commit| The precise commit SHA that was fetched by this Task.| build-container:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
+|commit| The precise commit SHA that was fetched by this Task.| build-container:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
@@ -344,7 +344,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### source-build:0.1 task results
+### source-build:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BUILD_RESULT| Build result.| |
@@ -355,11 +355,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
-|netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.3:source ; build-source-image:0.1:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
+|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
+|netrc| |True| prefetch-dependencies:0.2:netrc|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.4:source ; build-source-image:0.2:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
-### buildah:0.3 task workspaces
+### buildah:0.4 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |source| Workspace containing the source code to build.| False| workspace|
@@ -369,7 +369,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |output| The git repo will be cloned onto the volume backing this Workspace.| False| workspace|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### prefetch-dependencies:0.1 task workspaces
+### prefetch-dependencies:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
@@ -395,7 +395,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|
-### source-build:0.1 task workspaces
+### source-build:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| The workspace where source code is included.| False| workspace|

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -143,7 +143,7 @@ spec:
     - clone-repository
     taskRef:
       name: prefetch-dependencies
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.prefetch-input)
       operator: notin
@@ -181,7 +181,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -221,7 +221,7 @@ spec:
     - build-image-index
     taskRef:
       name: source-build
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -244,7 +244,7 @@ spec:
     - build-image-index
     taskRef:
       name: deprecated-image-check
-      version: "0.4"
+      version: "0.5"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -43,7 +43,7 @@
   path: /spec/tasks/3/taskRef
   value:
     name: buildah
-    version: "0.3"
+    version: "0.4"
 - op: add
   path: /spec/params/-
   value:

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -7,18 +7,18 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.3:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.3:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.4:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.4:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.3:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.4:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| true| build-images:0.3:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-images:0.3:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-images:0.3:IMAGE ; build-image-index:0.1:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.3:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input ; build-images:0.3:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| true| build-images:0.4:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-images:0.4:IMAGE ; build-image-index:0.1:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.4:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-images:0.4:PREFETCH_INPUT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -41,7 +41,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
-### buildah-remote-oci-ta:0.3 task parameters
+### buildah-remote-oci-ta:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -62,7 +62,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
@@ -75,7 +75,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-### deprecated-image-check:0.4 task parameters
+### deprecated-image-check:0.5 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |BASE_IMAGES_DIGESTS| Digests of base build images.| | |
@@ -120,7 +120,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
-### prefetch-dependencies-oci-ta:0.1 task parameters
+### prefetch-dependencies-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -133,7 +133,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
-|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -159,18 +159,18 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.4:IMAGE_DIGEST ; validate-fbc:0.1:IMAGE_DIGEST ; fbc-target-index-pruning-check:0.1:IMAGE_DIGEST|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; validate-fbc:0.1:IMAGE_DIGEST ; fbc-target-index-pruning-check:0.1:IMAGE_DIGEST|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.4:IMAGE_URL ; apply-tags:0.1:IMAGE ; validate-fbc:0.1:IMAGE_URL ; fbc-target-index-pruning-check:0.1:IMAGE_URL|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; apply-tags:0.1:IMAGE ; validate-fbc:0.1:IMAGE_URL ; fbc-target-index-pruning-check:0.1:IMAGE_URL|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### buildah-remote-oci-ta:0.3 task results
+### buildah-remote-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_DIGEST| Digest of the image just built| |
 |IMAGE_REF| Image reference of the built image| build-image-index:0.1:IMAGES|
 |IMAGE_URL| Image repository and tag where the built image was pushed| |
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### deprecated-image-check:0.4 task results
+### deprecated-image-check:0.5 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
@@ -185,8 +185,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
-|commit| The precise commit SHA that was fetched by this Task.| build-images:0.3:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
+|commit| The precise commit SHA that was fetched by this Task.| build-images:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
@@ -194,11 +194,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### prefetch-dependencies-oci-ta:0.1 task results
+### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.3:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.3:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.4:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.4:SOURCE_ARTIFACT|
 ### validate-fbc:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -212,15 +212,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
-|netrc| |True| prefetch-dependencies:0.1:netrc|
+|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
+|netrc| |True| prefetch-dependencies:0.2:netrc|
 ## Available workspaces from tasks
 ### git-clone-oci-ta:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### prefetch-dependencies-oci-ta:0.1 task workspaces
+### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -141,7 +141,7 @@ spec:
     - clone-repository
     taskRef:
       name: prefetch-dependencies-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: git-basic-auth
       workspace: git-auth
@@ -183,7 +183,7 @@ spec:
     - clone-repository
     taskRef:
       name: buildah-remote-oci-ta
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(tasks.init.results.build)
       operator: in
@@ -223,7 +223,7 @@ spec:
     - build-image-index
     taskRef:
       name: deprecated-image-check
-      version: "0.4"
+      version: "0.5"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -8,9 +8,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.1:ociArtifactExpiresAfter ; build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.1:ociStorage ; build-oci-artifact:0.1:IMAGE|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| generic| prefetch-dependencies:0.1:input|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-oci-artifact:0.1:IMAGE|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| generic| prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -59,7 +59,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
-### prefetch-dependencies-oci-ta:0.1 task parameters
+### prefetch-dependencies-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -72,7 +72,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
-|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### sast-coverity-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -186,7 +186,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.1:SOURCE_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| |
 |commit-timestamp| The commit timestamp of the checkout| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
@@ -195,7 +195,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### prefetch-dependencies-oci-ta:0.1 task results
+### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-oci-artifact:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
@@ -220,8 +220,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
-|netrc| |True| prefetch-dependencies:0.1:netrc|
+|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
+|netrc| |True| prefetch-dependencies:0.2:netrc|
 |workspace| |False| |
 ## Available workspaces from tasks
 ### git-clone-oci-ta:0.1 task workspaces
@@ -229,7 +229,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### prefetch-dependencies-oci-ta:0.1 task workspaces
+### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -105,7 +105,7 @@ spec:
     - clone-repository
     taskRef:
       name: prefetch-dependencies-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: git-basic-auth
       workspace: git-auth

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -10,7 +10,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-oci-artifact:0.1:IMAGE|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| generic| prefetch-dependencies:0.1:input|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| generic| prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -59,7 +59,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
-### prefetch-dependencies:0.1 task parameters
+### prefetch-dependencies:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -69,7 +69,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
-|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### sast-coverity-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -210,9 +210,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
-|netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
+|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
+|netrc| |True| prefetch-dependencies:0.2:netrc|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
 ## Available workspaces from tasks
 ### build-maven-zip:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -224,7 +224,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |output| The git repo will be cloned onto the volume backing this Workspace.| False| workspace|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### prefetch-dependencies:0.1 task workspaces
+### prefetch-dependencies:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -113,7 +113,7 @@ spec:
     - clone-repository
     taskRef:
       name: prefetch-dependencies
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.prefetch-input)
       operator: notin

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -11,7 +11,7 @@
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-image-index:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; build-image-index:0.1:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.1:input|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -63,7 +63,7 @@
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
-### prefetch-dependencies:0.1 task parameters
+### prefetch-dependencies:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -73,7 +73,7 @@
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
-|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| cyclonedx| |
+|sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### push-dockerfile:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -211,9 +211,9 @@
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.1:git-basic-auth|
-|netrc| |True| prefetch-dependencies:0.1:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.1:source ; build-container:0.1:source ; sast-coverity-check:0.2:source ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
+|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
+|netrc| |True| prefetch-dependencies:0.2:netrc|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.1:source ; sast-coverity-check:0.2:source ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -221,7 +221,7 @@
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |output| The git repo will be cloned onto the volume backing this Workspace.| False| workspace|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### prefetch-dependencies:0.1 task workspaces
+### prefetch-dependencies:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -123,7 +123,7 @@ spec:
     - clone-repository
     taskRef:
       name: prefetch-dependencies
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.prefetch-input)
       operator: notin

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -101,7 +101,7 @@ spec:
         - clone-repository
       taskRef:
         name: prefetch-dependencies
-        version: "0.1"
+        version: "0.2"
       workspaces:
         - name: source
           workspace: workspace
@@ -155,7 +155,7 @@ spec:
         - build-image-index
       taskRef:
         name: source-build
-        version: "0.1"
+        version: "0.2"
       params:
         - name: BINARY_IMAGE
           value: "$(params.output-image)"
@@ -169,7 +169,7 @@ spec:
         values: ["false"]
       taskRef:
         name: deprecated-image-check
-        version: "0.4"
+        version: "0.5"
       params:
       - name: IMAGE_URL
         value: $(tasks.build-image-index.results.IMAGE_URL)

--- a/task/buildah-oci-ta/0.4/MIGRATION.md
+++ b/task/buildah-oci-ta/0.4/MIGRATION.md
@@ -1,0 +1,21 @@
+# Migration from 0.3 to 0.4
+
+Version 0.4:
+
+* Changes the default SBOM format from CycloneDX to SPDX.
+
+## Action from users
+
+In order for a typical Konflux pipeline to work well with SPDX, all the tasks
+that handle SBOMs must be SPDX-ready. Relevant tasks and required versions:
+
+* `prefetch-dependencies >= 0.2`
+* `source-build >= 0.2`
+* `deprecated-image-check >= 0.5`
+
+> Note: the same version constraints apply even if you use the `*-oci-ta` variants
+> of these tasks.
+
+If your pipeline uses these tasks, please make sure their versions are high enough.
+There's a good chance that the Pull Request which led you to this migration document
+has updated every relevant task in your pipelines at once.

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -23,7 +23,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
-|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -1,0 +1,47 @@
+# buildah-oci-ta task
+
+Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
+|ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+|IMAGE|Reference of the image buildah will produce.||true|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_REF|Image reference of the built image|
+|IMAGE_URL|Image repository and tag where the built image was pushed|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -1,0 +1,754 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: buildah-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: 0.2.1
+    build.appstudio.redhat.com/build_type: docker
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+  params:
+    - name: ACTIVATION_KEY
+      description: Name of secret which contains subscription activation key
+      type: string
+      default: activation-key
+    - name: ADDITIONAL_SECRET
+      description: Name of a secret which will be made available to the build
+        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
+      type: string
+      default: does-not-exist
+    - name: ADD_CAPABILITIES
+      description: Comma separated list of extra capabilities to add when
+        running 'buildah build'
+      type: string
+      default: ""
+    - name: BUILD_ARGS
+      description: Array of --build-arg values ("arg=value" strings)
+      type: array
+      default: []
+    - name: BUILD_ARGS_FILE
+      description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      type: string
+      default: ""
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: COMMIT_SHA
+      description: The image is built from this commit.
+      type: string
+      default: ""
+    - name: CONTEXT
+      description: Path to the directory to use as context.
+      type: string
+      default: .
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      type: string
+      default: ./Dockerfile
+    - name: ENTITLEMENT_SECRET
+      description: Name of secret which contains the entitlement certificates
+      type: string
+      default: etc-pki-entitlement
+    - name: HERMETIC
+      description: Determines if build will be executed without network access.
+      type: string
+      default: "false"
+    - name: IMAGE
+      description: Reference of the image buildah will produce.
+      type: string
+    - name: IMAGE_EXPIRES_AFTER
+      description: Delete image tag after specified time. Empty means to keep
+        the image tag. Time values could be something like 1h, 2d, 3w for
+        hours, days, and weeks, respectively.
+      type: string
+      default: ""
+    - name: LABELS
+      description: Additional key=value labels that should be applied to the
+        image
+      type: array
+      default: []
+    - name: PREFETCH_INPUT
+      description: In case it is not empty, the prefetched content should
+        be made available to the build.
+      type: string
+      default: ""
+    - name: PRIVILEGED_NESTED
+      description: Whether to enable privileged mode
+      type: string
+      default: "false"
+    - name: SBOM_TYPE
+      description: 'Select the SBOM format to generate. Valid values: spdx,
+        cyclonedx. Note: the SBOM from the prefetch task - if there is one
+        - must be in the same format.'
+      type: string
+      default: cyclonedx
+    - name: SKIP_SBOM_GENERATION
+      description: Skip SBOM-related operations. This will likely cause EC
+        policies to fail if enabled
+      type: string
+      default: "false"
+    - name: SKIP_UNUSED_STAGES
+      description: Whether to skip stages in Containerfile that seem unused
+        by subsequent stages
+      type: string
+      default: "true"
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: SQUASH
+      description: Squash all new and previous layers added as a part of this
+        build, as per --squash
+      type: string
+      default: "false"
+    - name: STORAGE_DRIVER
+      description: Storage driver to configure for buildah
+      type: string
+      default: vfs
+    - name: TARGET_STAGE
+      description: Target stage in Dockerfile to build. If not specified,
+        the Dockerfile is processed entirely to (and including) its last stage.
+      type: string
+      default: ""
+    - name: TLSVERIFY
+      description: Verify the TLS on the registry endpoint (for push/pull
+        to a non-TLS registry)
+      type: string
+      default: "true"
+    - name: YUM_REPOS_D_FETCHED
+      description: Path in source workspace where dynamically-fetched repos
+        are present
+      default: fetched.repos.d
+    - name: YUM_REPOS_D_SRC
+      description: Path in the git repository in which yum repository files
+        are stored
+      default: repos.d
+    - name: YUM_REPOS_D_TARGET
+      description: Target path on the container in which yum repository files
+        should be made available
+      default: /etc/yum.repos.d
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the image just built
+    - name: IMAGE_REF
+      description: Image reference of the built image
+    - name: IMAGE_URL
+      description: Image repository and tag where the built image was pushed
+    - name: SBOM_BLOB_URL
+      description: Reference of SBOM blob digest to enable digest-based verification
+        from provenance
+      type: string
+  volumes:
+    - name: activation-key
+      secret:
+        optional: true
+        secretName: $(params.ACTIVATION_KEY)
+    - name: additional-secret
+      secret:
+        optional: true
+        secretName: $(params.ADDITIONAL_SECRET)
+    - name: etc-pki-entitlement
+      secret:
+        optional: true
+        secretName: $(params.ENTITLEMENT_SECRET)
+    - name: shared
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: varlibcontainers
+      emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    env:
+      - name: ACTIVATION_KEY
+        value: $(params.ACTIVATION_KEY)
+      - name: ADDITIONAL_SECRET
+        value: $(params.ADDITIONAL_SECRET)
+      - name: ADD_CAPABILITIES
+        value: $(params.ADD_CAPABILITIES)
+      - name: BUILDAH_FORMAT
+        value: oci
+      - name: BUILD_ARGS_FILE
+        value: $(params.BUILD_ARGS_FILE)
+      - name: CONTEXT
+        value: $(params.CONTEXT)
+      - name: ENTITLEMENT_SECRET
+        value: $(params.ENTITLEMENT_SECRET)
+      - name: HERMETIC
+        value: $(params.HERMETIC)
+      - name: IMAGE
+        value: $(params.IMAGE)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.IMAGE_EXPIRES_AFTER)
+      - name: PRIVILEGED_NESTED
+        value: $(params.PRIVILEGED_NESTED)
+      - name: SBOM_TYPE
+        value: $(params.SBOM_TYPE)
+      - name: SKIP_SBOM_GENERATION
+        value: $(params.SKIP_SBOM_GENERATION)
+      - name: SKIP_UNUSED_STAGES
+        value: $(params.SKIP_UNUSED_STAGES)
+      - name: SOURCE_CODE_DIR
+        value: source
+      - name: SQUASH
+        value: $(params.SQUASH)
+      - name: STORAGE_DRIVER
+        value: $(params.STORAGE_DRIVER)
+      - name: TARGET_STAGE
+        value: $(params.TARGET_STAGE)
+      - name: TLSVERIFY
+        value: $(params.TLSVERIFY)
+      - name: YUM_REPOS_D_FETCHED
+        value: $(params.YUM_REPOS_D_FETCHED)
+      - name: YUM_REPOS_D_SRC
+        value: $(params.YUM_REPOS_D_SRC)
+      - name: YUM_REPOS_D_TARGET
+        value: $(params.YUM_REPOS_D_TARGET)
+    volumeMounts:
+      - mountPath: /shared
+        name: shared
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+    - name: build
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+      args:
+        - --build-args
+        - $(params.BUILD_ARGS[*])
+        - --labels
+        - $(params.LABELS[*])
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+        - mountPath: /entitlement
+          name: etc-pki-entitlement
+        - mountPath: /activation-key
+          name: activation-key
+        - mountPath: /additional-secret
+          name: additional-secret
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: COMMIT_SHA
+          value: $(params.COMMIT_SHA)
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+        elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+        elif [ -e "$DOCKERFILE" ]; then
+          # Instrumented builds (SAST) use this custom dockerffile step as their base
+          dockerfile_path="$DOCKERFILE"
+        elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+          echo "Fetch Dockerfile from $DOCKERFILE"
+          dockerfile_path=$(mktemp --suffix=-Dockerfile)
+          http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+          if [ "$http_code" != 200 ]; then
+            echo "No Dockerfile is fetched. Server responds $http_code"
+            exit 1
+          fi
+          http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+          if [ "$http_code" = 200 ]; then
+            echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+            mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          fi
+        else
+          echo "Cannot find Dockerfile $DOCKERFILE"
+          exit 1
+        fi
+
+        dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
+        cp "$dockerfile_path" "$dockerfile_copy"
+
+        # Fixing group permission on /var/lib/containers
+        chown root:root /var/lib/containers
+
+        sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+        # Setting new namespace to run buildah - 2^32-2
+        echo 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid
+
+        build_args=()
+        if [ -n "${BUILD_ARGS_FILE}" ]; then
+          # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+          echo "Parsing ARGs from $BUILD_ARGS_FILE"
+          mapfile -t build_args < <(
+            # https://www.mankier.com/1/buildah-build#--build-arg-file
+            # delete lines that start with #
+            # delete blank lines
+            sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+          )
+        fi
+
+        LABELS=()
+        # Split `args` into two sets of arguments.
+        while [[ $# -gt 0 ]]; do
+          case $1 in
+          --build-args)
+            shift
+            # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+            # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+            # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              build_args+=("$1")
+              shift
+            done
+            ;;
+          --labels)
+            shift
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              LABELS+=("--label" "$1")
+              shift
+            done
+            ;;
+          *)
+            echo "unexpected argument: $1" >&2
+            exit 2
+            ;;
+          esac
+        done
+
+        BUILD_ARG_FLAGS=()
+        for build_arg in "${build_args[@]}"; do
+          BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+        done
+
+        dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
+        BASE_IMAGES=$(
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+        )
+
+        BUILDAH_ARGS=()
+        UNSHARE_ARGS=()
+
+        if [ "${HERMETIC}" == "true" ]; then
+          BUILDAH_ARGS+=("--pull=never")
+          UNSHARE_ARGS+=("--net")
+
+          for image in $BASE_IMAGES; do
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          done
+          echo "Build will be executed with network isolation"
+        fi
+
+        if [ -n "${TARGET_STAGE}" ]; then
+          BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+        fi
+
+        BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+        if [ "${PRIVILEGED_NESTED}" == "true" ]; then
+          BUILDAH_ARGS+=("--security-opt=label=disable")
+          BUILDAH_ARGS+=("--cap-add=all")
+          BUILDAH_ARGS+=("--device=/dev/fuse")
+        fi
+
+        if [ -n "${ADD_CAPABILITIES}" ]; then
+          BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+        fi
+
+        if [ "${SQUASH}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash")
+        fi
+
+        if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
+          BUILDAH_ARGS+=("--skip-unused-stages=false")
+        fi
+
+        VOLUME_MOUNTS=()
+
+        if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
+          cp -r "/var/workdir/cachi2" /tmp/
+          chmod -R go+rwX /tmp/cachi2
+          VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)
+          # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+          # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+          sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_copy"
+          echo "Prefetched content will be made available"
+
+          prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+          if [ -f "$prefetched_repo_for_my_arch" ]; then
+            echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+            mkdir -p "$YUM_REPOS_D_FETCHED"
+            cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          fi
+        fi
+
+        # if yum repofiles stored in git, copy them to mount point outside the source dir
+        if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+          mkdir -p "${YUM_REPOS_D_FETCHED}"
+          cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        fi
+
+        # if anything in the repofiles mount point (either fetched or from git), mount it
+        if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+          chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+          mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+          VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
+        fi
+
+        DEFAULT_LABELS=(
+          "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+          "--label" "architecture=$(uname -m)"
+          "--label" "vcs-type=git"
+        )
+        [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+        [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+        # Concatenate defaults and explicit labels. If a label appears twice, the last one wins.
+        LABELS=("${DEFAULT_LABELS[@]}" "${LABELS[@]}")
+
+        ACTIVATION_KEY_PATH="/activation-key"
+        ENTITLEMENT_PATH="/entitlement"
+
+        # 0. if hermetic=true, skip all subscription related stuff
+        # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+        # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+        # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+        # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+        #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+        #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
+
+        if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          mkdir -p /shared/rhsm/etc/pki/entitlement
+          mkdir -p /shared/rhsm/etc/pki/consumer
+
+          VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key
+            -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z
+            -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)
+          echo "Adding activation key to the build"
+
+          if ! grep -E "^[^#]*subscription-manager.[^#]*register" "$dockerfile_path"; then
+            # user is not running registration in the Containerfile: pre-register.
+            echo "Pre-registering with subscription manager."
+            subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+            trap 'subscription-manager unregister || true' EXIT
+
+            # copy generated certificates to /shared volume
+            cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement
+            cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer
+
+            # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+            VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)
+          fi
+
+        elif [ "${HERMETIC}" != "true" ] && find /entitlement -name "*.pem" >>null; then
+          cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+          VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
+          echo "Adding the entitlement to the build"
+        fi
+
+        if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
+          # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+          # Instrumented builds (SAST) use this step as their base and add some other tools.
+          while read -r volume_mount; do
+            VOLUME_MOUNTS+=("--volume=$volume_mount")
+          done <<<"$ADDITIONAL_VOLUME_MOUNTS"
+        fi
+
+        ADDITIONAL_SECRET_PATH="/additional-secret"
+        ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+        if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+          cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+          while read -r filename; do
+            echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+            BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+          done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+        fi
+
+        # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
+        declare IMAGE
+
+        buildah_cmd_array=(
+          buildah build
+          "${VOLUME_MOUNTS[@]}"
+          "${BUILDAH_ARGS[@]}"
+          "${LABELS[@]}"
+          --tls-verify="$TLSVERIFY" --no-cache
+          --ulimit nofile=4096:4096
+          -f "$dockerfile_copy" -t "$IMAGE" .
+        )
+        buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
+
+        if [ "${HERMETIC}" == "true" ]; then
+          # enabling loopback adapter enables Bazel builds to work in hermetic mode.
+          command="ip link set lo up && $buildah_cmd"
+        else
+          command="$buildah_cmd"
+        fi
+
+        # disable host subcription manager integration
+        find /usr/share/rhel/secrets -type l -exec unlink {} \;
+
+        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+
+        container=$(buildah from --pull-never "$IMAGE")
+
+        # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+        if [ -f "/tmp/cachi2/output/bom.json" ]; then
+          echo "Making copy of sbom-cachi2.json"
+          cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        fi
+
+        buildah mount "$container" | tee /shared/container_path
+        # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+        find $(cat /shared/container_path) -xtype l -delete
+        echo $container >/shared/container_name
+
+        touch /shared/base_images_digests
+        echo "Recording base image digests used"
+        for image in $BASE_IMAGES; do
+          base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+          # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
+          # if buildah did not use that particular image during build because it was skipped
+          if [ -n "$base_image_digest" ]; then
+            echo "$image $base_image_digest" | tee -a /shared/base_images_digests
+          fi
+        done
+      computeResources:
+        limits:
+          memory: 8Gi
+        requests:
+          cpu: "1"
+          memory: 2Gi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+    - name: icm
+      image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+        /scripts/inject-icm.sh "$IMAGE"
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+    - name: push
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      script: |
+        #!/bin/bash
+        set -e
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        retries=5
+        # Push to a unique tag based on the TaskRun name to avoid race conditions
+        echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+        if ! buildah push \
+          --retry "$retries" \
+          --tls-verify="$TLSVERIFY" \
+          "$IMAGE" \
+          "docker://${IMAGE%:*}:$(context.taskRun.name)"; then
+          echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+          exit 1
+        fi
+
+        # Push to a tag based on the git revision
+        echo "Pushing to ${IMAGE}"
+        if ! buildah push \
+          --retry "$retries" \
+          --tls-verify="$TLSVERIFY" \
+          --digestfile "/var/workdir/image-digest" "$IMAGE" \
+          "docker://$IMAGE"; then
+          echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+          exit 1
+        fi
+
+        cat "/var/workdir"/image-digest | tee $(results.IMAGE_DIGEST.path)
+        echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+        {
+          echo -n "${IMAGE}@"
+          cat "/var/workdir/image-digest"
+        } >"$(results.IMAGE_REF.path)"
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+        runAsUser: 0
+    - name: sbom-syft-generate
+      image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+      workingDir: /var/workdir/source
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+        - mountPath: /shared
+          name: shared
+      script: |
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
+
+        case $SBOM_TYPE in
+        cyclonedx)
+          syft_sbom_type=cyclonedx-json@1.5
+          ;;
+        spdx)
+          syft_sbom_type=spdx-json@2.3
+          ;;
+        *)
+          echo "Invalid SBOM type: $SBOM_TYPE. Valid: cyclonedx, spdx" >&2
+          exit 1
+          ;;
+        esac
+
+        echo "Running syft on the source directory"
+        syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="/var/workdir/sbom-source.json"
+        echo "Running syft on the image filesystem"
+        syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
+    - name: prepare-sboms
+      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+      workingDir: /var/workdir
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
+
+        sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
+
+        if [ -f "sbom-cachi2.json" ]; then
+          sboms_to_merge+=(cachi2:sbom-cachi2.json)
+        fi
+
+        echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
+        python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" >sbom.json
+
+        echo "Adding image reference to sbom"
+        IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+        IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+        python3 /scripts/add_image_reference.py \
+          --image-url "$IMAGE_URL" \
+          --image-digest "$IMAGE_DIGEST" \
+          --input-file sbom.json \
+          --output-file /tmp/sbom.tmp.json
+
+        mv /tmp/sbom.tmp.json sbom.json
+
+        echo "Adding base images data to sbom.json"
+        python3 /scripts/base_images_sbom_script.py \
+          --sbom=sbom.json \
+          --parsed-dockerfile=/shared/parsed_dockerfile.json \
+          --base-images-digests=/shared/base_images_digests
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
+      securityContext:
+        runAsUser: 0
+    - name: upload-sbom
+      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      script: |
+        #!/bin/bash
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+
+        # Remove tag from IMAGE while allowing registry to contain a port number.
+        sbom_repo="${IMAGE%:*}"
+        sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+        # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+        echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: "0.4"
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -90,7 +90,7 @@ spec:
         cyclonedx. Note: the SBOM from the prefetch task - if there is one
         - must be in the same format.'
       type: string
-      default: cyclonedx
+      default: spdx
     - name: SKIP_SBOM_GENERATION
       description: Skip SBOM-related operations. This will likely cause EC
         policies to fail if enabled

--- a/task/buildah-oci-ta/0.4/recipe.yaml
+++ b/task/buildah-oci-ta/0.4/recipe.yaml
@@ -1,0 +1,14 @@
+---
+base: ../../buildah/0.4/buildah.yaml
+removeParams:
+  - BUILDER_IMAGE
+add:
+  - use-source
+  - use-cachi2
+removeWorkspaces:
+  - source
+useTAVolumeMount: true
+replacements:
+  workspaces.source.path: /var/workdir
+regexReplacements:
+  "/workspace(/.*)": /var/workdir$1

--- a/task/buildah-remote-oci-ta/0.4/MIGRATION.md
+++ b/task/buildah-remote-oci-ta/0.4/MIGRATION.md
@@ -1,0 +1,21 @@
+# Migration from 0.3 to 0.4
+
+Version 0.4:
+
+* Changes the default SBOM format from CycloneDX to SPDX.
+
+## Action from users
+
+In order for a typical Konflux pipeline to work well with SPDX, all the tasks
+that handle SBOMs must be SPDX-ready. Relevant tasks and required versions:
+
+* `prefetch-dependencies >= 0.2`
+* `source-build >= 0.2`
+* `deprecated-image-check >= 0.5`
+
+> Note: the same version constraints apply even if you use the `*-oci-ta` variants
+> of these tasks.
+
+If your pipeline uses these tasks, please make sure their versions are high enough.
+There's a good chance that the Pull Request which led you to this migration document
+has updated every relevant task in your pipelines at once.

--- a/task/buildah-remote-oci-ta/0.4/README.md
+++ b/task/buildah-remote-oci-ta/0.4/README.md
@@ -1,0 +1,49 @@
+# buildah-remote-oci-ta task
+
+Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
+|ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+|IMAGE|Reference of the image buildah will produce.||true|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|PLATFORM|The platform to build on||true|
+|IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_REF|Image reference of the built image|
+|IMAGE_URL|Image repository and tag where the built image was pushed|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: "0.4"
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -84,7 +84,7 @@ spec:
     description: Whether to enable privileged mode
     name: PRIVILEGED_NESTED
     type: string
-  - default: cyclonedx
+  - default: spdx
     description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
       Note: the SBOM from the prefetch task - if there is one - must be in the same
       format.'

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -1,0 +1,920 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/version: 0.2.1
+    build.appstudio.redhat.com/build_type: docker
+  name: buildah-remote-oci-ta
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: ""
+    description: The Trusted Artifact URI pointing to the artifact with the prefetched
+      dependencies.
+    name: CACHI2_ARTIFACT
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: []
+    description: Additional key=value labels that should be applied to the image
+    name: LABELS
+    type: array
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: "false"
+    description: Whether to enable privileged mode
+    name: PRIVILEGED_NESTED
+    type: string
+  - default: cyclonedx
+    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
+      Note: the SBOM from the prefetch task - if there is one - must be in the same
+      format.'
+    name: SBOM_TYPE
+    type: string
+  - default: "false"
+    description: Skip SBOM-related operations. This will likely cause EC policies
+      to fail if enabled
+    name: SKIP_SBOM_GENERATION
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  - description: The Trusted Artifact URI pointing to the artifact with the application
+      source code.
+    name: SOURCE_ARTIFACT
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - description: The platform to build on
+    name: PLATFORM
+    type: string
+  - default: "false"
+    description: Whether to append a sanitized platform architecture on the IMAGE
+      tag
+    name: IMAGE_APPEND_PLATFORM
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  stepTemplate:
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    env:
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: PRIVILEGED_NESTED
+      value: $(params.PRIVILEGED_NESTED)
+    - name: SBOM_TYPE
+      value: $(params.SBOM_TYPE)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    - name: SOURCE_CODE_DIR
+      value: source
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: BUILDER_IMAGE
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    - name: PLATFORM
+      value: $(params.PLATFORM)
+    - name: IMAGE_APPEND_PLATFORM
+      value: $(params.IMAGE_APPEND_PLATFORM)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+    - mountPath: /var/workdir
+      name: workdir
+  steps:
+  - args:
+    - use
+    - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    computeResources: {}
+    image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+    name: use-trusted-artifact
+    volumeMounts:
+    - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
+  - args:
+    - --build-args
+    - $(params.BUILD_ARGS[*])
+    - --labels
+    - $(params.LABELS[*])
+    computeResources:
+      limits:
+        memory: 8Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |-
+      #!/bin/bash
+      set -e
+      set -o verbose
+      mkdir -p ~/.ssh
+      if [ -e "/ssh/error" ]; then
+        #no server could be provisioned
+        cat /ssh/error
+        exit 1
+      fi
+      export SSH_HOST=$(cat /ssh/host)
+
+      if [ "$SSH_HOST" == "localhost" ] ; then
+        IS_LOCALHOST=true
+        echo "Localhost detected; running build in cluster"
+      elif [ -e "/ssh/otp" ]; then
+        curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+        echo "" >> ~/.ssh/id_rsa
+      else
+        cp /ssh/id_rsa ~/.ssh
+      fi
+
+      mkdir -p scripts
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        chmod 0400 ~/.ssh/id_rsa
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+        echo "$BUILD_DIR"
+        # shellcheck disable=SC2086
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+
+        PORT_FORWARD=""
+        PODMAN_PORT_FORWARD=""
+        if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
+          PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
+          PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+        fi
+
+        rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
+        rsync -ra /var/workdir/ "$SSH_HOST:$BUILD_DIR/volumes/workdir/"
+        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+        rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
+        rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
+        rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
+        rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+        rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/results/"
+      fi
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+
+      cat >scripts/script-build.sh <<'REMOTESSHEOF'
+      #!/bin/bash
+      set -euo pipefail
+      cd /var/workdir
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        dockerfile_path="$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
+      cp "$dockerfile_path" "$dockerfile_copy"
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid
+
+      build_args=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+        echo "Parsing ARGs from $BUILD_ARGS_FILE"
+        mapfile -t build_args < <(
+          # https://www.mankier.com/1/buildah-build#--build-arg-file
+          # delete lines that start with #
+          # delete blank lines
+          sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+        )
+      fi
+
+      LABELS=()
+      # Split `args` into two sets of arguments.
+      while [[ $# -gt 0 ]]; do
+        case $1 in
+        --build-args)
+          shift
+          # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+          # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+          # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
+          while [[ $# -gt 0 && $1 != --* ]]; do
+            build_args+=("$1")
+            shift
+          done
+          ;;
+        --labels)
+          shift
+          while [[ $# -gt 0 && $1 != --* ]]; do
+            LABELS+=("--label" "$1")
+            shift
+          done
+          ;;
+        *)
+          echo "unexpected argument: $1" >&2
+          exit 2
+          ;;
+        esac
+      done
+
+      BUILD_ARG_FLAGS=()
+      for build_arg in "${build_args[@]}"; do
+        BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+      done
+
+      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
+      BASE_IMAGES=$(
+        jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+      )
+
+      BUILDAH_ARGS=()
+      UNSHARE_ARGS=()
+
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS+=("--net")
+
+        for image in $BASE_IMAGES; do
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      if [ "${PRIVILEGED_NESTED}" == "true" ]; then
+        BUILDAH_ARGS+=("--security-opt=label=disable")
+        BUILDAH_ARGS+=("--cap-add=all")
+        BUILDAH_ARGS+=("--device=/dev/fuse")
+      fi
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      VOLUME_MOUNTS=()
+
+      if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
+        cp -r "/var/workdir/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+          -e 'H;1h;$!d;x' \
+          -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+          "$dockerfile_copy"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p "${YUM_REPOS_D_FETCHED}"
+        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
+      fi
+
+      DEFAULT_LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      # Concatenate defaults and explicit labels. If a label appears twice, the last one wins.
+      LABELS=("${DEFAULT_LABELS[@]}" "${LABELS[@]}")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      # 0. if hermetic=true, skip all subscription related stuff
+      # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+      # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+      # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+      #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
+
+      if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir -p /shared/rhsm/etc/pki/entitlement
+        mkdir -p /shared/rhsm/etc/pki/consumer
+
+        VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key
+          -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z
+          -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)
+        echo "Adding activation key to the build"
+
+        if ! grep -E "^[^#]*subscription-manager.[^#]*register" "$dockerfile_path"; then
+          # user is not running registration in the Containerfile: pre-register.
+          echo "Pre-registering with subscription manager."
+          subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+          trap 'subscription-manager unregister || true' EXIT
+
+          # copy generated certificates to /shared volume
+          cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement
+          cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer
+
+          # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+          VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)
+        fi
+
+      elif [ "${HERMETIC}" != "true" ] && find /entitlement -name "*.pem" >>null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
+        echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
+        # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+        # Instrumented builds (SAST) use this step as their base and add some other tools.
+        while read -r volume_mount; do
+          VOLUME_MOUNTS+=("--volume=$volume_mount")
+        done <<<"$ADDITIONAL_VOLUME_MOUNTS"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
+      declare IMAGE
+
+      buildah_cmd_array=(
+        buildah build
+        "${VOLUME_MOUNTS[@]}"
+        "${BUILDAH_ARGS[@]}"
+        "${LABELS[@]}"
+        --tls-verify="$TLSVERIFY" --no-cache
+        --ulimit nofile=4096:4096
+        -f "$dockerfile_copy" -t "$IMAGE" .
+      )
+      buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
+
+      if [ "${HERMETIC}" == "true" ]; then
+        # enabling loopback adapter enables Bazel builds to work in hermetic mode.
+        command="ip link set lo up && $buildah_cmd"
+      else
+        command="$buildah_cmd"
+      fi
+
+      # disable host subcription manager integration
+      find /usr/share/rhel/secrets -type l -exec unlink {} \;
+
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+
+      container=$(buildah from --pull-never "$IMAGE")
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container >/shared/container_name
+
+      touch /shared/base_images_digests
+      echo "Recording base image digests used"
+      for image in $BASE_IMAGES; do
+        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
+        # if buildah did not use that particular image during build because it was skipped
+        if [ -n "$base_image_digest" ]; then
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
+        fi
+      done
+
+      buildah push "$IMAGE" "oci:konflux-final-image:$IMAGE"
+      REMOTESSHEOF
+      chmod +x scripts/script-build.sh
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        PRIVILEGED_NESTED_FLAGS=()
+        if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
+          # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
+          # https://github.com/coreos/rpm-ostree/discussions/4648
+          # shellcheck disable=SC2086
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
+        fi
+        rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
+        # shellcheck disable=SC2086
+        ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+          --tmpfs /run/secrets \
+          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
+          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
+          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
+          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
+          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
+          -e CONTEXT="$CONTEXT" \
+          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+          -e HERMETIC="$HERMETIC" \
+          -e IMAGE="$IMAGE" \
+          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+          -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
+          -e SBOM_TYPE="$SBOM_TYPE" \
+          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
+          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
+          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
+          -e SQUASH="$SQUASH" \
+          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
+          -e TARGET_STAGE="$TARGET_STAGE" \
+          -e TLSVERIFY="$TLSVERIFY" \
+          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
+          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
+          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
+          -e COMMIT_SHA="$COMMIT_SHA" \
+          -e DOCKERFILE="$DOCKERFILE" \
+          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
+          -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
+          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
+          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
+          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
+          -v "$BUILD_DIR/results/:/tekton/results:Z" \
+          -v "$BUILD_DIR/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]}" \
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
+        buildah pull "oci:konflux-final-image:$IMAGE"
+      else
+        bash scripts/script-build.sh "$@"
+      fi
+      echo "Build on remote host $SSH_HOST finished"
+
+      buildah images
+      container=$(buildah from --pull-never "$IMAGE")
+      buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    - mountPath: /ssh
+      name: ssh
+      readOnly: true
+    workingDir: /var/workdir
+  - computeResources: {}
+    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    name: icm
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      /scripts/inject-icm.sh "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: /var/workdir
+  - computeResources: {}
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: push
+    script: |
+      #!/bin/bash
+      set -e
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)"; then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
+      fi
+
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "/var/workdir/image-digest" "$IMAGE" \
+        "docker://$IMAGE"; then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
+
+      cat "/var/workdir"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "/var/workdir/image-digest"
+      } >"$(results.IMAGE_REF.path)"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: /var/workdir
+  - computeResources: {}
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      #!/bin/bash
+      set -e
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      case $SBOM_TYPE in
+      cyclonedx)
+        syft_sbom_type=cyclonedx-json@1.5
+        ;;
+      spdx)
+        syft_sbom_type=spdx-json@2.3
+        ;;
+      *)
+        echo "Invalid SBOM type: $SBOM_TYPE. Valid: cyclonedx, spdx" >&2
+        exit 1
+        ;;
+      esac
+
+      echo "Running syft on the source directory"
+      syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="/var/workdir/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: /var/workdir/source
+  - computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: prepare-sboms
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
+
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
+      fi
+
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" >sbom.json
+
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom.json \
+        --output-file /tmp/sbom.tmp.json
+
+      mv /tmp/sbom.tmp.json sbom.json
+
+      echo "Adding base images data to sbom.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
+    securityContext:
+      runAsUser: 0
+    workingDir: /var/workdir
+  - computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+    volumeMounts:
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: /var/workdir
+  volumes:
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - emptyDir: {}
+    name: shared
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: workdir
+  - name: ssh
+    secret:
+      optional: false
+      secretName: multi-platform-ssh-$(context.taskRun.name)

--- a/task/buildah-remote/0.4/MIGRATION.md
+++ b/task/buildah-remote/0.4/MIGRATION.md
@@ -1,0 +1,21 @@
+# Migration from 0.3 to 0.4
+
+Version 0.4:
+
+* Changes the default SBOM format from CycloneDX to SPDX.
+
+## Action from users
+
+In order for a typical Konflux pipeline to work well with SPDX, all the tasks
+that handle SBOMs must be SPDX-ready. Relevant tasks and required versions:
+
+* `prefetch-dependencies >= 0.2`
+* `source-build >= 0.2`
+* `deprecated-image-check >= 0.5`
+
+> Note: the same version constraints apply even if you use the `*-oci-ta` variants
+> of these tasks.
+
+If your pipeline uses these tasks, please make sure their versions are high enough.
+There's a good chance that the Pull Request which led you to this migration document
+has updated every relevant task in your pipelines at once.

--- a/task/buildah-remote/0.4/README.md
+++ b/task/buildah-remote/0.4/README.md
@@ -1,0 +1,51 @@
+# buildah-remote task
+
+Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image buildah will produce.||true|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+|PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|PLATFORM|The platform to build on||true|
+|IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_URL|Image repository and tag where the built image was pushed|
+|IMAGE_REF|Image reference of the built image|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace containing the source code to build.|false|

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -1,0 +1,892 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/version: 0.2.1
+    build.appstudio.redhat.com/build_type: docker
+  name: buildah-remote
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  - default: []
+    description: Additional key=value labels that should be applied to the image
+    name: LABELS
+    type: array
+  - default: "false"
+    description: Whether to enable privileged mode
+    name: PRIVILEGED_NESTED
+    type: string
+  - default: "false"
+    description: Skip SBOM-related operations. This will likely cause EC policies
+      to fail if enabled
+    name: SKIP_SBOM_GENERATION
+    type: string
+  - default: cyclonedx
+    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
+      Note: the SBOM from the prefetch task - if there is one - must be in the same
+      format.'
+    name: SBOM_TYPE
+    type: string
+  - description: The platform to build on
+    name: PLATFORM
+    type: string
+  - default: "false"
+    description: Whether to append a sanitized platform architecture on the IMAGE
+      tag
+    name: IMAGE_APPEND_PLATFORM
+    type: string
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - description: Reference of SBOM blob digest to enable digest-based verification
+      from provenance
+    name: SBOM_BLOB_URL
+    type: string
+  stepTemplate:
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: SOURCE_CODE_DIR
+      value: source
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    - name: PRIVILEGED_NESTED
+      value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
+    - name: SBOM_TYPE
+      value: $(params.SBOM_TYPE)
+    - name: BUILDER_IMAGE
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    - name: PLATFORM
+      value: $(params.PLATFORM)
+    - name: IMAGE_APPEND_PLATFORM
+      value: $(params.IMAGE_APPEND_PLATFORM)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+  steps:
+  - args:
+    - --build-args
+    - $(params.BUILD_ARGS[*])
+    - --labels
+    - $(params.LABELS[*])
+    computeResources:
+      limits:
+        memory: 8Gi
+      requests:
+        cpu: "1"
+        memory: 2Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    script: |-
+      #!/bin/bash
+      set -e
+      set -o verbose
+      mkdir -p ~/.ssh
+      if [ -e "/ssh/error" ]; then
+        #no server could be provisioned
+        cat /ssh/error
+        exit 1
+      fi
+      export SSH_HOST=$(cat /ssh/host)
+
+      if [ "$SSH_HOST" == "localhost" ] ; then
+        IS_LOCALHOST=true
+        echo "Localhost detected; running build in cluster"
+      elif [ -e "/ssh/otp" ]; then
+        curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+        echo "" >> ~/.ssh/id_rsa
+      else
+        cp /ssh/id_rsa ~/.ssh
+      fi
+
+      mkdir -p scripts
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        chmod 0400 ~/.ssh/id_rsa
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
+        echo "$BUILD_DIR"
+        # shellcheck disable=SC2086
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+
+        PORT_FORWARD=""
+        PODMAN_PORT_FORWARD=""
+        if [ -n "$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR" ] ; then
+          PORT_FORWARD=" -L 80:$JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR:80"
+          PODMAN_PORT_FORWARD=" -e JVM_BUILD_WORKSPACE_ARTIFACT_CACHE_PORT_80_TCP_ADDR=localhost"
+        fi
+
+        rsync -ra $(workspaces.source.path)/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
+        rsync -ra /shared/ "$SSH_HOST:$BUILD_DIR/volumes/shared/"
+        rsync -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/volumes/etc-pki-entitlement/"
+        rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
+        rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
+        rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
+        rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+        rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/results/"
+      fi
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+
+      cat >scripts/script-build.sh <<'REMOTESSHEOF'
+      #!/bin/bash
+      set -euo pipefail
+      cd $(workspaces.source.path)
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        dockerfile_path="$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
+      cp "$dockerfile_path" "$dockerfile_copy"
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      build_args=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+        echo "Parsing ARGs from $BUILD_ARGS_FILE"
+        mapfile -t build_args < <(
+          # https://www.mankier.com/1/buildah-build#--build-arg-file
+          # delete lines that start with #
+          # delete blank lines
+          sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+        )
+      fi
+
+      LABELS=()
+      # Split `args` into two sets of arguments.
+      while [[ $# -gt 0 ]]; do
+          case $1 in
+              --build-args)
+                  shift
+                  # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+                  # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+                  # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
+                  while [[ $# -gt 0 && $1 != --* ]]; do build_args+=("$1"); shift; done
+                  ;;
+              --labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do LABELS+=("--label" "$1"); shift; done
+                  ;;
+              *)
+                  echo "unexpected argument: $1" >&2
+                  exit 2
+                  ;;
+          esac
+      done
+
+      BUILD_ARG_FLAGS=()
+      for build_arg in "${build_args[@]}"; do
+        BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+      done
+
+      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
+      BASE_IMAGES=$(
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+      )
+
+      BUILDAH_ARGS=()
+      UNSHARE_ARGS=()
+
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS+=("--net")
+
+        for image in $BASE_IMAGES; do
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      if [ "${PRIVILEGED_NESTED}" == "true" ]; then
+        BUILDAH_ARGS+=("--security-opt=label=disable")
+        BUILDAH_ARGS+=("--cap-add=all")
+        BUILDAH_ARGS+=("--device=/dev/fuse")
+      fi
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      VOLUME_MOUNTS=()
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_copy"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p "${YUM_REPOS_D_FETCHED}"
+        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
+      fi
+
+      DEFAULT_LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      # Concatenate defaults and explicit labels. If a label appears twice, the last one wins.
+      LABELS=("${DEFAULT_LABELS[@]}" "${LABELS[@]}")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      # 0. if hermetic=true, skip all subscription related stuff
+      # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+      # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+      # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+      #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
+
+      if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir -p /shared/rhsm/etc/pki/entitlement
+        mkdir -p /shared/rhsm/etc/pki/consumer
+
+        VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key \
+                        -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z \
+                        -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)
+        echo "Adding activation key to the build"
+
+        if ! grep -E "^[^#]*subscription-manager.[^#]*register" "$dockerfile_path"; then
+          # user is not running registration in the Containerfile: pre-register.
+          echo "Pre-registering with subscription manager."
+          subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+          trap 'subscription-manager unregister || true' EXIT
+
+          # copy generated certificates to /shared volume
+          cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement
+          cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer
+
+          # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+          VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)
+        fi
+
+      elif [ "${HERMETIC}" != "true" ] && find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
+        echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
+        # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+        # Instrumented builds (SAST) use this step as their base and add some other tools.
+        while read -r volume_mount; do
+          VOLUME_MOUNTS+=("--volume=$volume_mount")
+        done <<< "$ADDITIONAL_VOLUME_MOUNTS"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
+      declare IMAGE
+
+      buildah_cmd_array=(
+          buildah build
+          "${VOLUME_MOUNTS[@]}"
+          "${BUILDAH_ARGS[@]}"
+          "${LABELS[@]}"
+          --tls-verify="$TLSVERIFY" --no-cache
+          --ulimit nofile=4096:4096
+          -f "$dockerfile_copy" -t "$IMAGE" .
+      )
+      buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
+
+      if [ "${HERMETIC}" == "true" ]; then
+        # enabling loopback adapter enables Bazel builds to work in hermetic mode.
+        command="ip link set lo up && $buildah_cmd"
+      else
+        command="$buildah_cmd"
+      fi
+
+      # disable host subcription manager integration
+      find /usr/share/rhel/secrets -type l -exec unlink {} \;
+
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+
+      container=$(buildah from --pull-never "$IMAGE")
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      touch /shared/base_images_digests
+      echo "Recording base image digests used"
+      for image in $BASE_IMAGES; do
+        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
+        # if buildah did not use that particular image during build because it was skipped
+        if [ -n "$base_image_digest" ]; then
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
+        fi
+      done
+
+      buildah push "$IMAGE" "oci:konflux-final-image:$IMAGE"
+      REMOTESSHEOF
+      chmod +x scripts/script-build.sh
+
+      if ! [[ $IS_LOCALHOST ]]; then
+        PRIVILEGED_NESTED_FLAGS=()
+        if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
+          # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
+          # https://github.com/coreos/rpm-ostree/discussions/4648
+          # shellcheck disable=SC2086
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
+        fi
+        rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
+        # shellcheck disable=SC2086
+        ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
+          --tmpfs /run/secrets \
+          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
+          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
+          -e HERMETIC="$HERMETIC" \
+          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
+          -e CONTEXT="$CONTEXT" \
+          -e IMAGE="$IMAGE" \
+          -e TLSVERIFY="$TLSVERIFY" \
+          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
+          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
+          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
+          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
+          -e TARGET_STAGE="$TARGET_STAGE" \
+          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
+          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
+          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
+          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
+          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
+          -e SQUASH="$SQUASH" \
+          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
+          -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
+          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
+          -e SBOM_TYPE="$SBOM_TYPE" \
+          -e COMMIT_SHA="$COMMIT_SHA" \
+          -e DOCKERFILE="$DOCKERFILE" \
+          -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
+          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
+          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
+          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
+          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
+          -v "$BUILD_DIR/results/:/tekton/results:Z" \
+          -v "$BUILD_DIR/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]}" \
+          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+        rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
+        rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
+        rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"
+        buildah pull "oci:konflux-final-image:$IMAGE"
+      else
+        bash scripts/script-build.sh "$@"
+      fi
+      echo "Build on remote host $SSH_HOST finished"
+
+      buildah images
+      container=$(buildah from --pull-never "$IMAGE")
+      buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    - mountPath: /ssh
+      name: ssh
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    name: icm
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      /scripts/inject-icm.sh "$IMAGE"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: push
+    script: |
+      #!/bin/bash
+      set -e
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
+      fi
+
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - computeResources: {}
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    name: sbom-syft-generate
+    script: |
+      #!/bin/bash
+      set -e
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      case $SBOM_TYPE in
+        cyclonedx)
+          syft_sbom_type=cyclonedx-json@1.5 ;;
+        spdx)
+          syft_sbom_type=spdx-json@2.3 ;;
+        *)
+          echo "Invalid SBOM type: $SBOM_TYPE. Valid: cyclonedx, spdx" >&2
+          exit 1
+          ;;
+      esac
+
+      echo "Running syft on the source directory"
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+    workingDir: $(workspaces.source.path)/source
+  - computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    name: prepare-sboms
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
+
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
+      fi
+
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom.json
+
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom.json \
+        --output-file /tmp/sbom.tmp.json
+
+      mv /tmp/sbom.tmp.json sbom.json
+
+      echo "Adding base images data to sbom.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    name: upload-sbom
+    script: |
+      #!/bin/bash
+      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        export IMAGE
+      fi
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+    volumeMounts:
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  - name: ssh
+    secret:
+      optional: false
+      secretName: multi-platform-ssh-$(context.taskRun.name)
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: "0.4"
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -127,7 +127,7 @@ spec:
       to fail if enabled
     name: SKIP_SBOM_GENERATION
     type: string
-  - default: cyclonedx
+  - default: spdx
     description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
       Note: the SBOM from the prefetch task - if there is one - must be in the same
       format.'

--- a/task/buildah/0.4/MIGRATION.md
+++ b/task/buildah/0.4/MIGRATION.md
@@ -1,0 +1,21 @@
+# Migration from 0.3 to 0.4
+
+Version 0.4:
+
+* Changes the default SBOM format from CycloneDX to SPDX.
+
+## Action from users
+
+In order for a typical Konflux pipeline to work well with SPDX, all the tasks
+that handle SBOMs must be SPDX-ready. Relevant tasks and required versions:
+
+* `prefetch-dependencies >= 0.2`
+* `source-build >= 0.2`
+* `deprecated-image-check >= 0.5`
+
+> Note: the same version constraints apply even if you use the `*-oci-ta` variants
+> of these tasks.
+
+If your pipeline uses these tasks, please make sure their versions are high enough.
+There's a good chance that the Pull Request which led you to this migration document
+has updated every relevant task in your pipelines at once.

--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -1,0 +1,49 @@
+# buildah task
+
+Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image buildah will produce.||true|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+|PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_URL|Image repository and tag where the built image was pushed|
+|IMAGE_REF|Image reference of the built image|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace containing the source code to build.|false|

--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -33,7 +33,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
-|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -1,0 +1,722 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.2.1"
+    build.appstudio.redhat.com/build_type: "docker"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, konflux"
+  name: buildah
+spec:
+  description: |-
+    Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
+    In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
+    When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)
+    name: TLSVERIFY
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - name: COMMIT_SHA
+    description: The image is built from this commit.
+    type: string
+    default: ""
+  - name: YUM_REPOS_D_SRC
+    description: Path in the git repository in which yum repository files are stored
+    default: repos.d
+  - name: YUM_REPOS_D_FETCHED
+    description: Path in source workspace where dynamically-fetched repos are present
+    default: fetched.repos.d
+  - name: YUM_REPOS_D_TARGET
+    description: Target path on the container in which yum repository files should be made available
+    default: /etc/yum.repos.d
+  - name: TARGET_STAGE
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.
+    type: string
+    default: ""
+  - name: ENTITLEMENT_SECRET
+    description: Name of secret which contains the entitlement certificates
+    type: string
+    default: "etc-pki-entitlement"
+  - name: ACTIVATION_KEY
+    default: activation-key
+    description: Name of secret which contains subscription activation key
+    type: string
+  - name: ADDITIONAL_SECRET
+    description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    type: string
+    default: "does-not-exist"
+  - name: BUILD_ARGS
+    description: Array of --build-arg values ("arg=value" strings)
+    type: array
+    default: []
+  - name: BUILD_ARGS_FILE
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    type: string
+    default: ""
+  - name: caTrustConfigMapName
+    type: string
+    description: The name of the ConfigMap to read CA bundle data from.
+    default: trusted-ca
+  - name: caTrustConfigMapKey
+    type: string
+    description: The name of the key in the ConfigMap that contains the CA bundle data.
+    default: ca-bundle.crt
+  - name: ADD_CAPABILITIES
+    description: Comma separated list of extra capabilities to add when running 'buildah build'
+    type: string
+    default: ""
+  - name: SQUASH
+    description: Squash all new and previous layers added as a part of this build, as per --squash
+    type: string
+    default: "false"
+  - name: STORAGE_DRIVER
+    description: Storage driver to configure for buildah
+    type: string
+    default: vfs
+  - name: SKIP_UNUSED_STAGES
+    description: Whether to skip stages in Containerfile that seem unused by subsequent stages
+    type: string
+    default: "true"
+  - name: LABELS
+    description: Additional key=value labels that should be applied to the image
+    type: array
+    default: []
+  - name: PRIVILEGED_NESTED
+    description: Whether to enable privileged mode
+    type: string
+    default: "false"
+  - name: SKIP_SBOM_GENERATION
+    description: Skip SBOM-related operations. This will likely cause EC policies to fail if enabled
+    type: string
+    default: "false"
+  - name: SBOM_TYPE
+    description: >-
+      Select the SBOM format to generate. Valid values: spdx, cyclonedx.
+      Note: the SBOM from the prefetch task - if there is one - must be in the same format.
+    type: string
+    default: cyclonedx
+
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  - name: SBOM_BLOB_URL
+    description: Reference of SBOM blob digest to enable digest-based verification from provenance
+    type: string
+  stepTemplate:
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 1Gi
+        cpu: '1'
+    volumeMounts:
+      - mountPath: /shared
+        name: shared
+    env:
+    - name: BUILDAH_FORMAT
+      value: oci
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: SOURCE_CODE_DIR
+      value: source
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    - name: PRIVILEGED_NESTED
+      value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
+    - name: SBOM_TYPE
+      value: $(params.SBOM_TYPE)
+
+  steps:
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    name: build
+    computeResources:
+      limits:
+        memory: 8Gi
+      requests:
+        memory: 2Gi
+        cpu: '1'
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    args:
+      - --build-args
+      - $(params.BUILD_ARGS[*])
+      - --labels
+      - $(params.LABELS[*])
+
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        dockerfile_path="$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
+      cp "$dockerfile_path" "$dockerfile_copy"
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      build_args=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+        echo "Parsing ARGs from $BUILD_ARGS_FILE"
+        mapfile -t build_args < <(
+          # https://www.mankier.com/1/buildah-build#--build-arg-file
+          # delete lines that start with #
+          # delete blank lines
+          sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+        )
+      fi
+
+      LABELS=()
+      # Split `args` into two sets of arguments.
+      while [[ $# -gt 0 ]]; do
+          case $1 in
+              --build-args)
+                  shift
+                  # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+                  # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+                  # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
+                  while [[ $# -gt 0 && $1 != --* ]]; do build_args+=("$1"); shift; done
+                  ;;
+              --labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do LABELS+=("--label" "$1"); shift; done
+                  ;;
+              *)
+                  echo "unexpected argument: $1" >&2
+                  exit 2
+                  ;;
+          esac
+      done
+
+      BUILD_ARG_FLAGS=()
+      for build_arg in "${build_args[@]}"; do
+        BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+      done
+
+      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
+      BASE_IMAGES=$(
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not) | sub("\"?(?<image>[^\"]*)\"?" ; .image)' /shared/parsed_dockerfile.json
+      )
+
+      BUILDAH_ARGS=()
+      UNSHARE_ARGS=()
+
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS+=("--net")
+
+        for image in $BASE_IMAGES; do
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      if [ "${PRIVILEGED_NESTED}" == "true" ]; then
+        BUILDAH_ARGS+=("--security-opt=label=disable")
+        BUILDAH_ARGS+=("--cap-add=all")
+        BUILDAH_ARGS+=("--device=/dev/fuse")
+      fi
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      VOLUME_MOUNTS=()
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_copy"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p "${YUM_REPOS_D_FETCHED}"
+        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
+      fi
+
+      DEFAULT_LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      # Concatenate defaults and explicit labels. If a label appears twice, the last one wins.
+      LABELS=("${DEFAULT_LABELS[@]}" "${LABELS[@]}")
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      # 0. if hermetic=true, skip all subscription related stuff
+      # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+      # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+      # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+      #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
+
+      if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir -p /shared/rhsm/etc/pki/entitlement
+        mkdir -p /shared/rhsm/etc/pki/consumer
+
+        VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key \
+                        -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z \
+                        -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)
+        echo "Adding activation key to the build"
+
+        if ! grep -E "^[^#]*subscription-manager.[^#]*register" "$dockerfile_path"; then
+          # user is not running registration in the Containerfile: pre-register.
+          echo "Pre-registering with subscription manager."
+          subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+          trap 'subscription-manager unregister || true' EXIT
+
+          # copy generated certificates to /shared volume
+          cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement
+          cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer
+
+          # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+          VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)
+        fi
+
+      elif [ "${HERMETIC}" != "true" ] && find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
+        echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
+        # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+        # Instrumented builds (SAST) use this step as their base and add some other tools.
+        while read -r volume_mount; do
+          VOLUME_MOUNTS+=("--volume=$volume_mount")
+        done <<< "$ADDITIONAL_VOLUME_MOUNTS"
+      fi
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
+      declare IMAGE
+
+      buildah_cmd_array=(
+          buildah build
+          "${VOLUME_MOUNTS[@]}"
+          "${BUILDAH_ARGS[@]}"
+          "${LABELS[@]}"
+          --tls-verify="$TLSVERIFY" --no-cache
+          --ulimit nofile=4096:4096
+          -f "$dockerfile_copy" -t "$IMAGE" .
+      )
+      buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
+
+      if [ "${HERMETIC}" == "true" ]; then
+        # enabling loopback adapter enables Bazel builds to work in hermetic mode.
+        command="ip link set lo up && $buildah_cmd"
+      else
+        command="$buildah_cmd"
+      fi
+
+      # disable host subcription manager integration
+      find /usr/share/rhel/secrets -type l -exec unlink {} \;
+
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+
+      container=$(buildah from --pull-never "$IMAGE")
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      touch /shared/base_images_digests
+      echo "Recording base image digests used"
+      for image in $BASE_IMAGES; do
+        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
+        # if buildah did not use that particular image during build because it was skipped
+        if [ -n "$base_image_digest" ]; then
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
+        fi
+      done
+
+    securityContext:
+      capabilities:
+        add:
+          - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: "/entitlement"
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: "/additional-secret"
+      name: additional-secret
+    - name: trusted-ca
+      mountPath: /mnt/trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - name: icm
+    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:523689a26c74790be67d6036820abfb9aa10bec6efff98cc1c9b74bd2f99eeb1
+    securityContext:
+      capabilities:
+        add:
+          - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    workingDir: $(workspaces.source.path)
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      /scripts/inject-icm.sh "$IMAGE"
+  - name: push
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    script: |
+      #!/bin/bash
+      set -e
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      retries=5
+      # Push to a unique tag based on the TaskRun name to avoid race conditions
+      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        "$IMAGE" \
+        "docker://${IMAGE%:*}:$(context.taskRun.name)";
+      then
+        echo "Failed to push sbom image to ${IMAGE%:*}:$(context.taskRun.name) after ${retries} tries"
+        exit 1
+      fi
+
+      # Push to a tag based on the git revision
+      echo "Pushing to ${IMAGE}"
+      if ! buildah push \
+        --retry "$retries" \
+        --tls-verify="$TLSVERIFY" \
+        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+        "docker://$IMAGE";
+      then
+        echo "Failed to push sbom image to $IMAGE after ${retries} tries"
+        exit 1
+      fi
+
+      cat "$(workspaces.source.path)"/image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+      {
+        echo -n "${IMAGE}@"
+        cat "$(workspaces.source.path)/image-digest"
+      } > "$(results.IMAGE_REF.path)"
+
+    securityContext:
+      runAsUser: 0
+      capabilities:
+        add:
+          - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - name: trusted-ca
+      mountPath: /mnt/trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+
+  - name: sbom-syft-generate
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.18.1@sha256:398f0ef395de137f05563d8de43e508bcb2e6810aa9d9adc638154b52c1a469c
+    # Respect Syft configuration if the user has it in the root of their repository
+    # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
+    workingDir: $(workspaces.source.path)/source
+    script: |
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      case $SBOM_TYPE in
+        cyclonedx)
+          syft_sbom_type=cyclonedx-json@1.5 ;;
+        spdx)
+          syft_sbom_type=spdx-json@2.3 ;;
+        *)
+          echo "Invalid SBOM type: $SBOM_TYPE. Valid: cyclonedx, spdx" >&2
+          exit 1
+          ;;
+      esac
+
+      echo "Running syft on the source directory"
+      syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-source.json"
+      echo "Running syft on the image filesystem"
+      syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /shared
+      name: shared
+
+  - name: prepare-sboms
+    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+    computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        memory: 256Mi
+        cpu: 100m
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
+
+      if [ -f "sbom-cachi2.json" ]; then
+        sboms_to_merge+=(cachi2:sbom-cachi2.json)
+      fi
+
+      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
+      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom.json
+
+      echo "Adding image reference to sbom"
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+      python3 /scripts/add_image_reference.py \
+        --image-url "$IMAGE_URL" \
+        --image-digest "$IMAGE_DIGEST" \
+        --input-file sbom.json \
+        --output-file /tmp/sbom.tmp.json
+
+      mv /tmp/sbom.tmp.json sbom.json
+
+      echo "Adding base images data to sbom.json"
+      python3 /scripts/base_images_sbom_script.py \
+        --sbom=sbom.json \
+        --parsed-dockerfile=/shared/parsed_dockerfile.json \
+        --base-images-digests=/shared/base_images_digests
+    workingDir: $(workspaces.source.path)
+    securityContext:
+      runAsUser: 0
+
+  - name: upload-sbom
+    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    script: |
+      #!/bin/bash
+      if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+        echo "Skipping SBOM generation"
+        exit 0
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo="${IMAGE%:*}"
+      sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+    computeResources:
+      limits:
+        memory: 512Mi
+      requests:
+        memory: 256Mi
+        cpu: 100m
+    volumeMounts:
+    - name: trusted-ca
+      mountPath: /mnt/trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+
+  volumes:
+  - name: varlibcontainers
+    emptyDir: {}
+  - name: shared
+    emptyDir: {}
+  - name: etc-pki-entitlement
+    secret:
+      secretName: $(params.ENTITLEMENT_SECRET)
+      optional: true
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      secretName: $(params.ADDITIONAL_SECRET)
+      optional: true
+  - name: trusted-ca
+    configMap:
+      name: $(params.caTrustConfigMapName)
+      items:
+        - key: $(params.caTrustConfigMapKey)
+          path: ca-bundle.crt
+      optional: true
+  workspaces:
+  - name: source
+    description: Workspace containing the source code to build.

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.4"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -119,7 +119,7 @@ spec:
       Select the SBOM format to generate. Valid values: spdx, cyclonedx.
       Note: the SBOM from the prefetch task - if there is one - must be in the same format.
     type: string
-    default: cyclonedx
+    default: spdx
 
   results:
   - description: Digest of the image just built

--- a/task/buildah/0.4/kustomization.yaml
+++ b/task/buildah/0.4/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- buildah.yaml

--- a/task/deprecated-image-check/0.5/MIGRATION.md
+++ b/task/deprecated-image-check/0.5/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.4 to 0.5
+
+Version 0.5:
+
+* Adds support for SPDX SBOMs.
+
+## Action from users
+
+No action needed. The version bump simply marks the addition of SPDX support.

--- a/task/deprecated-image-check/0.5/README.md
+++ b/task/deprecated-image-check/0.5/README.md
@@ -1,0 +1,38 @@
+# deprecated-image-check task
+
+## Description
+
+The deprecated-image-check checks for deprecated images that are no longer maintained and prone to security issues.
+Image SBOM and BASE_IMAGES_DIGESTS param is used to determine which base images were used during build of the image.
+It accomplishes this by verifying the data using Pyxis to query container image data and running Conftest using the
+supplied conftest policy. Conftest is an open-source tool that provides a way to enforce policies written
+in a high-level declarative language called Rego.
+
+## Params
+
+| name                    | description                                     | default |
+|-------------------------|-------------------------------------------------|-|
+| POLICY_DIR              | Path to directory containing Conftest policies. | /project/repository/ |
+| POLICY_NAMESPACE        | Namespace for Conftest policy.                  | required_checks |
+| BASE_IMAGES_DIGESTS     | (Optional) Digests of base build images.        | |
+| IMAGE_DIGEST            | Image digest.                                   | None |
+| IMAGE_URL               | Fully qualified image name.                     | None |
+| CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read CA bundle data from.| trusted-ca |
+| CA_TRUST_CONFIG_MAP_KEY |The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt |
+
+## Results
+
+| name              | description                               |
+|-------------------|-------------------------------------------|
+| TEST_OUTPUT       | Tekton task test output.                  |
+
+## Source repository for image
+
+https://github.com/konflux-ci/konflux-test
+
+## Additional links
+
+https://catalog.redhat.com/api/containers/docs/
+https://www.redhat.com/en/blog/gathering-security-data-container-images-using-pyxis-api
+https://github.com/open-policy-agent/conftest
+https://redhat-appstudio.github.io/docs.stonesoup.io/Documentation/main/concepts/testing_applications/sanity_tests.html#_deprecated_image_checks

--- a/task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -1,0 +1,215 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: deprecated-image-check
+spec:
+  description: >-
+    Identifies the unmaintained and potentially insecure deprecated base images.
+    Pyxis API collects metadata from image repository, and Conftest applies supplied policy to identify the deprecated images using that metadata.
+  params:
+    - name: POLICY_DIR
+      description: Path to directory containing Conftest policies.
+      default: "/project/repository/"
+    - name: POLICY_NAMESPACE
+      description: Namespace for Conftest policy.
+      default: "required_checks"
+    - name: BASE_IMAGES_DIGESTS
+      description: Digests of base build images.
+      default: ""
+    - name: IMAGE_URL
+      description: Fully qualified image name.
+    - name: IMAGE_DIGEST
+      description: Image digest.
+    - name: CA_TRUST_CONFIG_MAP_NAME
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: CA_TRUST_CONFIG_MAP_KEY
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+  results:
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+    - description: Images processed in the task.
+      name: IMAGES_PROCESSED
+
+  steps:
+    - name: check-images
+      image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      env:
+        - name: POLICY_DIR
+          value: $(params.POLICY_DIR)
+        - name: POLICY_NAMESPACE
+          value: $(params.POLICY_NAMESPACE)
+        - name: BASE_IMAGES_DIGESTS
+          value: $(params.BASE_IMAGES_DIGESTS)
+        - name: IMAGE_URL
+          value: $(params.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(params.IMAGE_DIGEST)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        source /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        IMAGES_TO_BE_PROCESSED_PATH="/tmp/images_to_be_processed.txt"
+        touch /tmp/images_to_be_processed.txt
+
+        success_counter=0
+        failure_counter=0
+        error_counter=0
+        warnings_counter=0
+
+        images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
+        digests_processed=()
+
+        imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
+        # strip new-line escape symbol from parameter and save it to variable
+        imageanddigest=$(echo -n $imagewithouttag@$IMAGE_DIGEST)
+
+        # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
+        image_manifests=$(get_image_manifests -i ${imageanddigest})
+        if [ -n "$image_manifests" ]; then
+          while read -r arch arch_sha; do
+            SBOM_FILE_PATH=$(echo "/tmp/sbom-$arch.json")
+            arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)
+
+            # Get base images from SBOM
+            cosign download sbom $arch_imageanddigest > ${SBOM_FILE_PATH}
+            if [ $? -ne 0 ]; then
+              echo "Unable to download sbom for arch $arch."
+              continue
+            fi
+
+            < "${SBOM_FILE_PATH}" jq -r '
+                if .bomFormat == "CycloneDX" then
+                    .formulation[]?
+                    | .components[]?
+                    | select(any(.properties[]?; .name | test("^konflux:container:is_(base|builder)_image")))
+                    | .name
+                else
+                    .packages[]
+                    | select(any(.annotations[]?.comment; (fromjson?).name? | test("^konflux:container:is_(base|builder)_image")?))
+                    | .name
+                end
+            ' >> "${IMAGES_TO_BE_PROCESSED_PATH}"
+            echo "Detected base images from $arch SBOM:"
+            cat "${IMAGES_TO_BE_PROCESSED_PATH}"
+            echo ""
+
+            digests_processed+=("\"$arch_sha\"")
+          done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+        fi
+
+        # If the image is an Image Index, also add the Image Index digest to the list.
+        if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
+          digests_processed+=("\"$IMAGE_DIGEST\"")
+        fi
+
+        digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
+
+        if [ -n "${BASE_IMAGES_DIGESTS}" ];
+        then
+          echo "Base images passed by param BASE_IMAGES_DIGESTS: $BASE_IMAGES_DIGESTS"
+          # Get images from the parameter
+          for IMAGE_WITH_TAG in $(echo -n "$BASE_IMAGES_DIGESTS" | sed 's/\\n/\'$'\n''/g' );
+          do
+            echo $IMAGE_WITH_TAG | cut -d ":" -f1 >> ${IMAGES_TO_BE_PROCESSED_PATH}
+          done
+        fi
+
+        # we want to remove duplicated entries
+        BASE_IMAGES=$(sort -u "${IMAGES_TO_BE_PROCESSED_PATH}")
+
+        echo "Images to be checked:"
+        echo "$BASE_IMAGES"
+        echo ""
+
+        for BASE_IMAGE in ${BASE_IMAGES};
+        do
+          IFS=:'/' read -r IMAGE_REGISTRY IMAGE_REPOSITORY<<< $BASE_IMAGE
+
+          # Red Hat Catalog hack: registry.redhat.io must be queried as registry.access.redhat.com in Red Hat catalog
+          IMAGE_REGISTRY_CATALOG=$(echo "${IMAGE_REGISTRY}" | sed 's/^registry.redhat.io$/registry.access.redhat.com/')
+
+          export IMAGE_REPO_PATH=/tmp/${IMAGE_REPOSITORY}
+          mkdir -p ${IMAGE_REPO_PATH}
+          echo "Querying Red Hat Catalog for $BASE_IMAGE."
+          http_code=$(curl -s -o ${IMAGE_REPO_PATH}/repository_data.json -w '%{http_code}' "https://catalog.redhat.com/api/containers/v1/repositories/registry/${IMAGE_REGISTRY_CATALOG}/repository/${IMAGE_REPOSITORY}")
+
+          if [ "$http_code" == "200" ];
+          then
+            echo "Running conftest using $POLICY_DIR policy, $POLICY_NAMESPACE namespace."
+            /usr/bin/conftest test --no-fail ${IMAGE_REPO_PATH}/repository_data.json \
+            --policy $POLICY_DIR --namespace $POLICY_NAMESPACE \
+            --output=json | tee ${IMAGE_REPO_PATH}/deprecated_image_check_output.json
+
+            failures_num=$(jq -r '.[].failures|length' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)
+            if [[ "${failures_num}" -gt 0 ]]; then
+              echo "[FAILURE] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} has been deprecated"
+            fi
+            failure_counter=$((failure_counter+failures_num))
+
+            successes_num=$(jq -r '.[].successes' ${IMAGE_REPO_PATH}/deprecated_image_check_output.json)
+            if [[ "${successes_num}" -gt 0 ]]; then
+              echo "[SUCCESS] Image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} is valid"
+            fi
+            success_counter=$((success_counter+successes_num))
+
+          elif [ "$http_code" == "404" ];
+          then
+            echo "[WARNING] Registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY} not found in Red Hat Catalog. Task cannot provide results if image is deprecated."
+            warnings_counter=$((warnings_counter+1))
+          else
+            echo "[ERROR] Unexpected error (HTTP code: ${http_code}) occurred for registry/image ${IMAGE_REGISTRY}/${IMAGE_REPOSITORY}."
+            error_counter=$((error_counter+1))
+          fi
+        done
+
+        note="Task $(context.task.name) failed: Command conftest failed. For details, check Tekton task log."
+        ERROR_OUTPUT=$(make_result_json -r ERROR -n "$POLICY_NAMESPACE" -t "$note")
+
+        note="Task $(context.task.name) completed: Check result for task result."
+        if [[ "$error_counter" == 0 ]];
+        then
+          if [[ "${failure_counter}" -gt 0 ]]; then
+            RES="FAILURE"
+          elif [[ "${warnings_counter}" -gt 0 ]]; then
+            RES="WARNING"
+          elif [[ "${success_counter}" -eq 0 ]]; then
+            # when all counters are 0, there are no base images to check
+            note="Task $(context.task.name) success: No base images to check."
+            RES="SUCCESS"
+          else
+            RES="SUCCESS"
+          fi
+          TEST_OUTPUT=$(make_result_json \
+            -r "${RES}" -n "$POLICY_NAMESPACE" \
+            -s "${success_counter}" -f "${failure_counter}" -w "${warnings_counter}" -t "$note")
+        fi
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
+
+        echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee $(results.IMAGES_PROCESSED.path)
+      volumeMounts:
+      - name: trusted-ca
+        mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        subPath: ca-bundle.crt
+        readOnly: true
+  volumes:
+  - name: trusted-ca
+    configMap:
+      name: $(params.CA_TRUST_CONFIG_MAP_NAME)
+      items:
+        - key: $(params.CA_TRUST_CONFIG_MAP_KEY)
+          path: ca-bundle.crt
+      optional: true

--- a/task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.5"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/oci-copy-oci-ta/0.2/MIGRATION.md
+++ b/task/oci-copy-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,22 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+* Changes the default SBOM format from CycloneDX to SPDX.
+
+## Action from users
+
+A typical pipeline based around the `oci-copy` task doesn't include any other
+SBOM-handling tasks. No action needed.
+
+For completeness, the tasks that *could* be relevant and their SPDX-ready versions:
+
+* `source-build >= 0.2`
+* `deprecated-image-check >= 0.5`
+
+> Note: the same version constraints apply even if you use the `*-oci-ta` variants
+> of these tasks.
+
+If your pipeline uses these tasks, please make sure their versions are high enough.
+There's a good chance that the Pull Request which led you to this migration document
+has updated every relevant task in your pipelines at once.

--- a/task/oci-copy-oci-ta/0.2/README.md
+++ b/task/oci-copy-oci-ta/0.2/README.md
@@ -1,0 +1,22 @@
+# oci-copy-oci-ta task
+
+Given a file in the user's source directory, copy content from arbitrary urls into the OCI registry.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`. In the future, this will be reimplemented to use v4 auth: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.|does-not-exist|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
+|IMAGE|Reference of the image we will push||true|
+|OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the artifact just pushed|
+|IMAGE_REF|Image reference of the built image|
+|IMAGE_URL|Repository where the artifact was pushed|
+|SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
+

--- a/task/oci-copy-oci-ta/0.2/README.md
+++ b/task/oci-copy-oci-ta/0.2/README.md
@@ -9,7 +9,7 @@ Given a file in the user's source directory, copy content from arbitrary urls in
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
 |IMAGE|Reference of the image we will push||true|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
-|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|spdx|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 
 ## Results

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: oci-artifact
 spec:
   description: Given a file in the user's source directory, copy content from
@@ -41,7 +41,7 @@ spec:
       description: 'Select the SBOM format to generate. Valid values: spdx,
         cyclonedx.'
       type: string
-      default: cyclonedx
+      default: spdx
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -1,0 +1,339 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: oci-copy-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: oci-artifact
+spec:
+  description: Given a file in the user's source directory, copy content from
+    arbitrary urls into the OCI registry.
+  params:
+    - name: AWS_SECRET_NAME
+      description: 'Name of a secret which will be made available to the build
+        to construct Authorization headers for requests to Amazon S3 using
+        v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html.
+        If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME.
+        The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.
+        In the future, this will be reimplemented to use v4 auth: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.'
+      type: string
+      default: does-not-exist
+    - name: BEARER_TOKEN_SECRET_NAME
+      description: Name of a secret which will be made available to the build
+        as an Authorization header. Note, the token will be sent to all servers
+        found in the oci-copy.yaml file. If you do not wish to send the token
+        to all servers, different taskruns and therefore different oci artifacts
+        must be used.
+      type: string
+      default: does-not-exist
+    - name: IMAGE
+      description: Reference of the image we will push
+      type: string
+    - name: OCI_COPY_FILE
+      description: Path to the oci copy file.
+      type: string
+      default: ./oci-copy.yaml
+    - name: SBOM_TYPE
+      description: 'Select the SBOM format to generate. Valid values: spdx,
+        cyclonedx.'
+      type: string
+      default: cyclonedx
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the artifact just pushed
+    - name: IMAGE_REF
+      description: Image reference of the built image
+    - name: IMAGE_URL
+      description: Repository where the artifact was pushed
+    - name: SBOM_BLOB_URL
+      description: Link to the SBOM blob pushed to the registry.
+  volumes:
+    - name: varlibcontainers
+      emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    env:
+      - name: IMAGE
+        value: $(params.IMAGE)
+      - name: OCI_COPY_FILE
+        value: $(params.OCI_COPY_FILE)
+      - name: SBOM_TYPE
+        value: $(params.SBOM_TYPE)
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: prepare
+      image: quay.io/konflux-ci/yq:latest@sha256:93bb15cff64b708263055a5814b24a0b450d8724b86a7e5206396f25d81fcc21
+      workingDir: /var/workdir
+      script: |
+        #!/bin/bash
+        set -eu
+        set -o pipefail
+
+        oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
+
+        mkdir -p "/var/workdir/vars/"
+
+        for entry in $(cat $oci_copy_file_path | yq '.artifacts[] | @json | @base64'); do
+          entry=$(echo $entry | base64 -d)
+          source=$(echo $entry | yq .source)
+          filename=$(echo $entry | yq .filename)
+          artifact_type=$(echo $entry | yq .type)
+          artifact_digest=$(echo $entry | yq .sha256sum)
+
+          {
+            echo "declare OCI_SOURCE=${source}"
+            echo "declare OCI_FILENAME=${filename}"
+            echo "declare OCI_ARTIFACT_TYPE=${artifact_type}"
+            echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}"
+          } >"/var/workdir/vars/$filename"
+
+          echo "Wrote /var/workdir/vars/$filename with contents:"
+          cat "/var/workdir/vars/$filename"
+        done
+    - name: oci-copy
+      image: quay.io/konflux-ci/oras:latest@sha256:c68c23fe7bb1ba9fc335192761ea94fc2c9beb701f3c205890581ff62fd38d80
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      env:
+        - name: BEARER_TOKEN
+          valueFrom:
+            secretKeyRef:
+              key: token
+              name: $(params.BEARER_TOKEN_SECRET_NAME)
+              optional: true
+        - name: AWS_ACCESS_KEY_ID
+          valueFrom:
+            secretKeyRef:
+              key: aws_access_key_id
+              name: $(params.AWS_SECRET_NAME)
+              optional: true
+        - name: AWS_SECRET_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              key: aws_secret_access_key
+              name: $(params.AWS_SECRET_NAME)
+              optional: true
+      script: |
+        #!/bin/bash
+        set -e
+        set -o pipefail
+
+        download() {
+          url="$1"
+          file="$2"
+          method="GET"
+
+          curl_args=(--fail --silent --show-error)
+          if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
+            # This implements v4 auth https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
+            path=$(echo "$url" | cut -d/ -f4-)
+            echo "Bucket path is $path"
+            date="$(date -u '+%Y%m%dT%H%M%SZ')"
+            host=$(echo -n "$url" | awk -F '/' '{print $3}')
+            if [[ "$host" == *.amazonaws.com ]]; then
+              # AWS Style
+              region=$(echo -n "$host" | awk -F '.' '{print $3}')
+            else
+              # IBM Cloud style
+              region=$(echo -n "$host" | awk -F '.' '{print $2}')
+            fi
+
+            # This e3b0c44 digest is digest of the empty string. No request body.
+            payload_digest=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+            # Step 1: construct canonical request
+            IFS= read -r -d '' canonical_request <<EOF || true
+        $method
+        /$path
+
+        host:$host
+        x-amz-content-sha256:$payload_digest
+        x-amz-date:$date
+
+        host;x-amz-content-sha256;x-amz-date
+        $payload_digest
+        EOF
+            canonical_request=$(echo -n "$canonical_request" | head -c -1) # Strip trailing newline
+            canonical_digest=$(echo -n "$canonical_request" | sha256sum | cut -d " " -f 1)
+
+            # Step 2: construct string to sign
+            IFS= read -r -d '' string_to_sign <<EOF || true
+        AWS4-HMAC-SHA256
+        $date
+        ${date%T*}/$region/s3/aws4_request
+        $canonical_digest
+        EOF
+            string_to_sign=$(echo -n "$string_to_sign" | head -c -1) # Strip trailing newline
+
+            # Step 3: derive a signing key
+            startkey="AWS4${AWS_SECRET_ACCESS_KEY}"
+            datekey=$(echo -n "${date%T*}" | openssl dgst -sha256 -hex -hmac "${startkey}" | awk '{ print $2 }' | tr -d '\n')
+            dateregionkey=$(echo -n "${region}" | openssl dgst -sha256 -hex -mac HMAC -macopt "hexkey:${datekey}" | awk '{ print $2 }' | tr -d '\n')
+            dateregionservicekey=$(echo -n "s3" | openssl dgst -sha256 -hex -mac HMAC -macopt "hexkey:${dateregionkey}" | awk '{ print $2 }' | tr -d '\n')
+            signingkey=$(echo -n "aws4_request" | openssl dgst -sha256 -hex -mac HMAC -macopt "hexkey:${dateregionservicekey}" | awk '{ print $2 }' | tr -d '\n')
+
+            # Step 4: use the signing key
+            signature=$(echo -n "$string_to_sign" | openssl dgst -sha256 -hex -mac HMAC -macopt "hexkey:${signingkey}" | awk '{ print $2 }' | tr -d '\n')
+            authorization="AWS4-HMAC-SHA256 Credential=${AWS_ACCESS_KEY_ID}/${date%T*}/${region}/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=${signature}"
+
+            curl "${curl_args[@]}" \
+              -H "X-Amz-Date: ${date}" \
+              -H "X-Amz-Content-SHA256: $payload_digest" \
+              -H "Authorization: ${authorization}" \
+              --location "$url" \
+              -o "$file"
+          elif [ -n "${BEARER_TOKEN:-}" ]; then
+            echo "Found bearer token. Using it for authentication."
+            curl "${curl_args[@]}" -H "Authorization: Bearer ${BEARER_TOKEN}" --location "$url" -o "$file"
+          else
+            echo "Proceeding with anonymous requests"
+            curl "${curl_args[@]}" --location "$url" -o "$file"
+          fi
+        }
+
+        set -u
+
+        echo "Selecting auth for $IMAGE"
+        select-oci-auth $IMAGE >auth.json
+
+        echo "Extracting artifact_type"
+        ARTIFACT_TYPE=$(cat "$(pwd)/source/$OCI_COPY_FILE" | yq '.artifact_type')
+
+        REPO=${IMAGE%:*}
+        echo "Found that ${REPO} is the repository for ${IMAGE}"
+
+        cat >artifact-manifest.json <<EOL
+        {
+          "schemaVersion": 2,
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "artifactType": "${ARTIFACT_TYPE}",
+          "config": {
+            "mediaType": "application/vnd.oci.empty.v1+json",
+            "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+            "size": 2,
+            "data": "e30="
+          },
+          "layers": [],
+          "annotations": {
+            "org.opencontainers.image.created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+        }
+        EOL
+
+        echo "Ensuring that the empty blob exists, for the image manifest config."
+        echo -n "{}" | oras blob push \
+          --registry-config auth.json \
+          ${REPO}@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a \
+          --media-type application/vnd.oci.empty.v1+json --size 2 -
+
+        for varfile in "/var/workdir"/vars/*; do
+          echo "Reading $varfile"
+          # shellcheck source=/dev/null
+          source $varfile
+
+          echo "Checking to see if blob $OCI_ARTIFACT_DIGEST exists"
+          if [[ $(oras blob fetch --registry-config auth.json --descriptor "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}") ]]; then
+            echo "Blob for ${OCI_FILENAME} already exists in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}. Skipping download."
+          else
+            echo "Blob for ${OCI_FILENAME} does not yet exist in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}."
+            echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
+            download "$OCI_SOURCE" "$OCI_FILENAME"
+
+            echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
+            echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
+
+            echo "Pushing blob of $OCI_FILENAME of type $OCI_ARTIFACT_TYPE"
+            oras blob push --registry-config auth.json ${REPO} --media-type ${OCI_ARTIFACT_TYPE} ${OCI_FILENAME}
+
+            echo "Removing local copy of $OCI_FILENAME to save space."
+            rm ${OCI_FILENAME}
+          fi
+
+          echo "Grabbing descriptor of blob from the registry"
+          oras blob fetch --registry-config auth.json --descriptor "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}" >descriptor.json
+
+          echo "Setting mediaType to ${OCI_ARTIFACT_TYPE}"
+          yq -oj -i '.mediaType = "'${OCI_ARTIFACT_TYPE}'"' descriptor.json
+
+          echo "Inserting org.opencontainers.image.title = ${OCI_FILENAME} annotation"
+          yq -oj -i '.annotations."org.opencontainers.image.title" = "'${OCI_FILENAME}'"' descriptor.json
+
+          echo "Appending blob descriptor for ${OCI_FILENAME} to the overall artifact manifest for ${IMAGE}"
+          yq -oj -i ".layers += $(cat descriptor.json)" artifact-manifest.json
+
+          echo "Done with ${OCI_FILENAME}."
+        done
+
+        echo "Pushing complete artifact manifest to ${IMAGE}"
+        oras manifest push --no-tty --registry-config auth.json "${IMAGE}" artifact-manifest.json
+
+        RESULTING_DIGEST=$(oras resolve --registry-config auth.json "${IMAGE}")
+        echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${IMAGE}@${RESULTING_DIGEST}" >"$(results.IMAGE_REF.path)"
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 512Mi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+    - name: sbom-generate
+      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+      workingDir: /var/workdir
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        IMAGE_URL=$(cat "$(results.IMAGE_URL.path)")
+        IMAGE_DIGEST=$(cat "$(results.IMAGE_DIGEST.path)")
+        oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
+
+        python3 /scripts/sbom_for_oci_copy_task.py "$oci_copy_file_path" \
+          --sbom-type "$SBOM_TYPE" \
+          -o sbom.json
+
+        python3 /scripts/add_image_reference.py \
+          --image-url "$IMAGE_URL" \
+          --image-digest "$IMAGE_DIGEST" \
+          --input-file sbom.json \
+          --output-file /tmp/sbom.tmp.json
+
+        mv /tmp/sbom.tmp.json sbom.json
+    - name: upload-sbom
+      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      workingDir: /var/workdir
+      script: |
+        cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+    - name: report-sbom-url
+      image: quay.io/konflux-ci/yq:latest@sha256:93bb15cff64b708263055a5814b24a0b450d8724b86a7e5206396f25d81fcc21
+      workingDir: /var/workdir
+      script: |
+        #!/bin/bash
+        REPO=${IMAGE%:*}
+        echo "Found that ${REPO} is the repository for ${IMAGE}"
+        SBOM_DIGEST=$(sha256sum sbom.json | awk '{ print $1 }')
+        echo "Found that ${SBOM_DIGEST} is the SBOM digest"
+        echo -n "${REPO}@sha256:${SBOM_DIGEST}" | tee $(results.SBOM_BLOB_URL.path)

--- a/task/oci-copy-oci-ta/0.2/recipe.yaml
+++ b/task/oci-copy-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,10 @@
+---
+base: ../../oci-copy/0.2/oci-copy.yaml
+add:
+  - use-source
+removeWorkspaces:
+  - source
+replacements:
+  workspaces.source.path: /var/workdir
+regexReplacements:
+  "/workspace(/.*)": /var/workdir$1

--- a/task/oci-copy/0.2/MIGRATION.md
+++ b/task/oci-copy/0.2/MIGRATION.md
@@ -1,0 +1,22 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+* Changes the default SBOM format from CycloneDX to SPDX.
+
+## Action from users
+
+A typical pipeline based around the `oci-copy` task doesn't include any other
+SBOM-handling tasks. No action needed.
+
+For completeness, the tasks that *could* be relevant and their SPDX-ready versions:
+
+* `source-build >= 0.2`
+* `deprecated-image-check >= 0.5`
+
+> Note: the same version constraints apply even if you use the `*-oci-ta` variants
+> of these tasks.
+
+If your pipeline uses these tasks, please make sure their versions are high enough.
+There's a good chance that the Pull Request which led you to this migration document
+has updated every relevant task in your pipelines at once.

--- a/task/oci-copy/0.2/README.md
+++ b/task/oci-copy/0.2/README.md
@@ -1,0 +1,72 @@
+# oci-copy task
+
+Given an `oci-copy.yaml` file in the user's source directory, the `oci-copy` task will copy content from arbitrary urls into the OCI registry.
+
+It generates a limited SBOM and pushes that into the OCI registry alongside the image.
+
+It is not to be considered safe for general use as it cannot provide a high degree of provenance for artficats and reports them only as "general" type artifacts in the purl spec it reports in the SBOM. Use only in limited situations.
+
+Note: the bearer token secret, if specified, will be sent to **all servers listed in the oci-copy.yaml file**.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image we will push||true|
+|OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
+|BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
+|AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`. In the future, this will be reimplemented to use v4 auth: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.|does-not-exist|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the artifact just pushed|
+|IMAGE_URL|Repository where the artifact was pushed|
+|SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
+|IMAGE_REF|Image reference of the built image|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace containing the source code to copy.|false|
+
+## oci-copy.yaml schema
+JSON schema for the `oci-copy.yaml` file.
+
+```json
+{
+    "type": "object",
+    "required": ["artifacts", "artifact_type"],
+    "properties": {
+        "artifact_type": {
+            "description": "Artifact type to be applied to the top-level OCI artifact, i.e. `application/x-mlmodel`",
+            "type": "string"
+        },
+        "artifacts": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["source", "filename", "type", "sha256sum"],
+                "properties": {
+                    "source": {
+                        "description": "URL of the artifact to copy",
+                        "type": "string"
+                    },
+                    "filename": {
+                        "description": "Filename that should be applied to the artifact in the OCI registry",
+                        "type": "string"
+                    },
+                    "type": {
+                        "description": "Media type that should be applied to the artifact in the OCI registry",
+                        "type": "string"
+                    },
+                    "sha256sum": {
+                        "description": "Digest of the artifact to be checked before copy",
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}
+```

--- a/task/oci-copy/0.2/README.md
+++ b/task/oci-copy/0.2/README.md
@@ -15,7 +15,7 @@ Note: the bearer token secret, if specified, will be sent to **all servers liste
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
 |AWS_SECRET_NAME|Name of a secret which will be made available to the build to construct Authorization headers for requests to Amazon S3 using v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`. In the future, this will be reimplemented to use v4 auth: https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.|does-not-exist|false|
-|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|spdx|false|
 
 ## Results
 |name|description|

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: oci-artifact
   name: oci-copy
 spec:
@@ -37,7 +37,7 @@ spec:
     - name: SBOM_TYPE
       description: "Select the SBOM format to generate. Valid values: spdx, cyclonedx."
       type: string
-      default: cyclonedx
+      default: spdx
 
   results:
     - description: Digest of the artifact just pushed

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -1,0 +1,325 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: oci-artifact
+  name: oci-copy
+spec:
+  description: Given a file in the user's source directory, copy content from arbitrary urls into the OCI registry.
+  params:
+    - description: Reference of the image we will push
+      name: IMAGE
+      type: string
+    - default: ./oci-copy.yaml
+      description: Path to the oci copy file.
+      name: OCI_COPY_FILE
+      type: string
+    - name: BEARER_TOKEN_SECRET_NAME
+      description: >-
+        Name of a secret which will be made available to the build as an Authorization header. Note, the token will
+        be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers,
+        different taskruns and therefore different oci artifacts must be used.
+      type: string
+      default: "does-not-exist"
+    - name: AWS_SECRET_NAME
+      description: >-
+        Name of a secret which will be made available to the build to construct Authorization headers for requests to
+        Amazon S3 using v2 auth https://docs.aws.amazon.com/AmazonS3/latest/userguide/RESTAuthentication.html.
+        If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys:
+        `aws_access_key_id` and `aws_secret_access_key`. In the future, this will be reimplemented to use v4 auth:
+        https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html.
+      type: string
+      default: "does-not-exist"
+    - name: SBOM_TYPE
+      description: "Select the SBOM format to generate. Valid values: spdx, cyclonedx."
+      type: string
+      default: cyclonedx
+
+  results:
+    - description: Digest of the artifact just pushed
+      name: IMAGE_DIGEST
+    - description: Repository where the artifact was pushed
+      name: IMAGE_URL
+    - description: Link to the SBOM blob pushed to the registry.
+      name: SBOM_BLOB_URL
+    - name: IMAGE_REF
+      description: Image reference of the built image
+  stepTemplate:
+    env:
+      - name: OCI_COPY_FILE
+        value: $(params.OCI_COPY_FILE)
+      - name: IMAGE
+        value: $(params.IMAGE)
+      - name: SBOM_TYPE
+        value: $(params.SBOM_TYPE)
+  steps:
+    - name: prepare
+      image: quay.io/konflux-ci/yq:latest@sha256:93bb15cff64b708263055a5814b24a0b450d8724b86a7e5206396f25d81fcc21
+      script: |
+        #!/bin/bash
+        set -eu
+        set -o pipefail
+
+        oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
+
+        mkdir -p "$(workspaces.source.path)/vars/"
+
+        for entry in $(cat $oci_copy_file_path | yq '.artifacts[] | @json | @base64'); do
+          entry=$(echo $entry | base64 -d)
+          source=$(echo $entry | yq .source)
+          filename=$(echo $entry | yq .filename)
+          artifact_type=$(echo $entry | yq .type)
+          artifact_digest=$(echo $entry | yq .sha256sum)
+
+          {
+            echo "declare OCI_SOURCE=${source}";
+            echo "declare OCI_FILENAME=${filename}";
+            echo "declare OCI_ARTIFACT_TYPE=${artifact_type}";
+            echo "declare OCI_ARTIFACT_DIGEST=${artifact_digest}";
+          } > "$(workspaces.source.path)/vars/$filename"
+
+          echo "Wrote $(workspaces.source.path)/vars/$filename with contents:"
+          cat "$(workspaces.source.path)/vars/$filename"
+        done
+      workingDir: $(workspaces.source.path)
+    - name: oci-copy
+      image: quay.io/konflux-ci/oras:latest@sha256:c68c23fe7bb1ba9fc335192761ea94fc2c9beb701f3c205890581ff62fd38d80
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: 250m
+          memory: 512Mi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+      env:
+      - name: BEARER_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: $(params.BEARER_TOKEN_SECRET_NAME)
+            key: token
+            optional: true
+      - name: AWS_ACCESS_KEY_ID
+        valueFrom:
+          secretKeyRef:
+            name: $(params.AWS_SECRET_NAME)
+            key: aws_access_key_id
+            optional: true
+      - name: AWS_SECRET_ACCESS_KEY
+        valueFrom:
+          secretKeyRef:
+            name: $(params.AWS_SECRET_NAME)
+            key: aws_secret_access_key
+            optional: true
+      script: |
+        #!/bin/bash
+        set -e
+        set -o pipefail
+
+        download() {
+          url="$1"
+          file="$2"
+          method="GET"
+
+          curl_args=(--fail --silent --show-error)
+          if [ -n "${AWS_ACCESS_KEY_ID:-}" ] && [ -n "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+            echo "Found both aws credentials secret with both aws_access_key_id and aws_secret_access_key. Assuming S3 bucket"
+            # This implements v4 auth https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-auth-using-authorization-header.html
+            path=$(echo "$url" | cut -d/ -f4-)
+            echo "Bucket path is $path"
+            date="$(date -u '+%Y%m%dT%H%M%SZ')"
+            host=$(echo -n "$url" | awk -F '/' '{print $3}')
+            if [[ "$host" == *.amazonaws.com ]] ; then
+              # AWS Style
+              region=$(echo -n "$host" | awk -F '.' '{print $3}')
+            else
+              # IBM Cloud style
+              region=$(echo -n "$host" | awk -F '.' '{print $2}')
+            fi
+
+            # This e3b0c44 digest is digest of the empty string. No request body.
+            payload_digest=e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+
+            # Step 1: construct canonical request
+            IFS= read -r -d '' canonical_request <<EOF || true
+        $method
+        /$path
+
+        host:$host
+        x-amz-content-sha256:$payload_digest
+        x-amz-date:$date
+
+        host;x-amz-content-sha256;x-amz-date
+        $payload_digest
+        EOF
+            canonical_request=$(echo -n "$canonical_request" | head -c -1)  # Strip trailing newline
+            canonical_digest=$(echo -n "$canonical_request" | sha256sum | cut -d " " -f 1)
+
+            # Step 2: construct string to sign
+            IFS= read -r -d '' string_to_sign <<EOF || true
+        AWS4-HMAC-SHA256
+        $date
+        ${date%T*}/$region/s3/aws4_request
+        $canonical_digest
+        EOF
+            string_to_sign=$(echo -n "$string_to_sign" | head -c -1)  # Strip trailing newline
+
+            # Step 3: derive a signing key
+            startkey="AWS4${AWS_SECRET_ACCESS_KEY}"
+            datekey=$(echo -n "${date%T*}" | openssl dgst -sha256 -hex -hmac "${startkey}" | awk '{ print $2 }' | tr -d '\n')
+            dateregionkey=$(echo -n "${region}" | openssl dgst -sha256 -hex -mac HMAC -macopt "hexkey:${datekey}" | awk '{ print $2 }' | tr -d '\n')
+            dateregionservicekey=$(echo -n "s3" | openssl dgst -sha256 -hex -mac HMAC -macopt "hexkey:${dateregionkey}" | awk '{ print $2 }' | tr -d '\n')
+            signingkey=$(echo -n "aws4_request" | openssl dgst -sha256 -hex -mac HMAC -macopt "hexkey:${dateregionservicekey}" | awk '{ print $2 }' | tr -d '\n')
+
+            # Step 4: use the signing key
+            signature=$(echo -n "$string_to_sign" | openssl dgst -sha256 -hex -mac HMAC -macopt "hexkey:${signingkey}" | awk '{ print $2 }' | tr -d '\n')
+            authorization="AWS4-HMAC-SHA256 Credential=${AWS_ACCESS_KEY_ID}/${date%T*}/${region}/s3/aws4_request, SignedHeaders=host;x-amz-content-sha256;x-amz-date, Signature=${signature}"
+
+            curl "${curl_args[@]}" \
+                -H "X-Amz-Date: ${date}" \
+                -H "X-Amz-Content-SHA256: $payload_digest" \
+                -H "Authorization: ${authorization}" \
+                --location "$url" \
+                -o "$file"
+          elif [ -n "${BEARER_TOKEN:-}" ]; then
+            echo "Found bearer token. Using it for authentication."
+            curl "${curl_args[@]}" -H "Authorization: Bearer ${BEARER_TOKEN}" --location "$url" -o "$file"
+          else
+            echo "Proceeding with anonymous requests"
+            curl "${curl_args[@]}" --location "$url" -o "$file"
+          fi
+        }
+
+        set -u
+
+        echo "Selecting auth for $IMAGE"
+        select-oci-auth $IMAGE > auth.json
+
+        echo "Extracting artifact_type"
+        ARTIFACT_TYPE=$(cat "$(pwd)/source/$OCI_COPY_FILE" | yq '.artifact_type')
+
+        REPO=${IMAGE%:*}
+        echo "Found that ${REPO} is the repository for ${IMAGE}"
+
+        cat >artifact-manifest.json <<EOL
+        {
+          "schemaVersion": 2,
+          "mediaType": "application/vnd.oci.image.manifest.v1+json",
+          "artifactType": "${ARTIFACT_TYPE}",
+          "config": {
+            "mediaType": "application/vnd.oci.empty.v1+json",
+            "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+            "size": 2,
+            "data": "e30="
+          },
+          "layers": [],
+          "annotations": {
+            "org.opencontainers.image.created": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+        }
+        EOL
+
+        echo "Ensuring that the empty blob exists, for the image manifest config."
+        echo -n "{}" | oras blob push \
+                --registry-config auth.json \
+                ${REPO}@sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a \
+                --media-type application/vnd.oci.empty.v1+json --size 2 -
+
+        for varfile in "$(workspaces.source.path)"/vars/*; do
+          echo "Reading $varfile"
+          # shellcheck source=/dev/null
+          source $varfile
+
+          echo "Checking to see if blob $OCI_ARTIFACT_DIGEST exists"
+          if [[ $(oras blob fetch --registry-config auth.json --descriptor "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}") ]]; then
+            echo "Blob for ${OCI_FILENAME} already exists in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}. Skipping download."
+          else
+            echo "Blob for ${OCI_FILENAME} does not yet exist in the registry at ${REPO}@sha256:${OCI_ARTIFACT_DIGEST}."
+            echo "Downloading $OCI_SOURCE to $OCI_FILENAME"
+            download "$OCI_SOURCE" "$OCI_FILENAME"
+
+            echo "Confirming that digest of $OCI_FILENAME matches expected $OCI_ARTIFACT_DIGEST"
+            echo "$OCI_ARTIFACT_DIGEST $OCI_FILENAME" | sha256sum --check
+
+            echo "Pushing blob of $OCI_FILENAME of type $OCI_ARTIFACT_TYPE"
+            oras blob push --registry-config auth.json ${REPO} --media-type ${OCI_ARTIFACT_TYPE} ${OCI_FILENAME}
+
+            echo "Removing local copy of $OCI_FILENAME to save space."
+            rm ${OCI_FILENAME}
+          fi
+
+          echo "Grabbing descriptor of blob from the registry"
+          oras blob fetch --registry-config auth.json --descriptor "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}" > descriptor.json
+
+          echo "Setting mediaType to ${OCI_ARTIFACT_TYPE}"
+          yq -oj -i '.mediaType = "'${OCI_ARTIFACT_TYPE}'"' descriptor.json
+
+          echo "Inserting org.opencontainers.image.title = ${OCI_FILENAME} annotation"
+          yq -oj -i '.annotations."org.opencontainers.image.title" = "'${OCI_FILENAME}'"' descriptor.json
+
+          echo "Appending blob descriptor for ${OCI_FILENAME} to the overall artifact manifest for ${IMAGE}"
+          yq -oj -i ".layers += $(cat descriptor.json)" artifact-manifest.json
+
+          echo "Done with ${OCI_FILENAME}."
+        done
+
+        echo "Pushing complete artifact manifest to ${IMAGE}"
+        oras manifest push --no-tty --registry-config auth.json "${IMAGE}" artifact-manifest.json
+
+        RESULTING_DIGEST=$(oras resolve --registry-config auth.json "${IMAGE}")
+        echo -n "$RESULTING_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${IMAGE}@${RESULTING_DIGEST}" >"$(results.IMAGE_REF.path)"
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+      workingDir: $(workspaces.source.path)
+    - name: sbom-generate
+      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        IMAGE_URL=$(cat "$(results.IMAGE_URL.path)")
+        IMAGE_DIGEST=$(cat "$(results.IMAGE_DIGEST.path)")
+        oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
+
+        python3 /scripts/sbom_for_oci_copy_task.py "$oci_copy_file_path" \
+          --sbom-type "$SBOM_TYPE" \
+          -o sbom.json
+
+        python3 /scripts/add_image_reference.py \
+          --image-url "$IMAGE_URL" \
+          --image-digest "$IMAGE_DIGEST" \
+          --input-file sbom.json \
+          --output-file /tmp/sbom.tmp.json
+
+        mv /tmp/sbom.tmp.json sbom.json
+      workingDir: $(workspaces.source.path)
+    - name: upload-sbom
+      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      workingDir: $(workspaces.source.path)
+      script: |
+        cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+    - name: report-sbom-url
+      image: quay.io/konflux-ci/yq:latest@sha256:93bb15cff64b708263055a5814b24a0b450d8724b86a7e5206396f25d81fcc21
+      script: |
+        #!/bin/bash
+        REPO=${IMAGE%:*}
+        echo "Found that ${REPO} is the repository for ${IMAGE}"
+        SBOM_DIGEST=$(sha256sum sbom.json | awk '{ print $1 }')
+        echo "Found that ${SBOM_DIGEST} is the SBOM digest"
+        echo -n "${REPO}@sha256:${SBOM_DIGEST}" | tee $(results.SBOM_BLOB_URL.path)
+      workingDir: $(workspaces.source.path)
+  volumes:
+    - emptyDir: {}
+      name: varlibcontainers
+  workspaces:
+    - description: Workspace containing the source artifacts to copy
+      name: source

--- a/task/prefetch-dependencies-oci-ta/0.2/MIGRATION.md
+++ b/task/prefetch-dependencies-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,24 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+* Changes the default SBOM format from CycloneDX to SPDX.
+
+## Action from users
+
+In order for a typical Konflux pipeline to work well with SPDX, all the tasks
+that handle SBOMs must be SPDX-ready. Relevant tasks and required versions:
+
+* Depending on the build task you use, one of:
+  * `buildah >= 0.4`
+  * `rpm-ostree >= ? (not SPDX-ready yet)`
+  * `build-maven-zip >= ? (not SPDX-ready yet)`
+* `source-build >= 0.2`
+* `deprecated-image-check >= 0.5`
+
+> Note: the same version constraints apply even if you use the `*-oci-ta` variants
+> of these tasks or the `*-remote*` variants of the buildah task.
+
+If your pipeline uses these tasks, please make sure their versions are high enough.
+There's a good chance that the Pull Request which led you to this migration document
+has updated every relevant task in your pipelines at once.

--- a/task/prefetch-dependencies-oci-ta/0.2/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.2/README.md
@@ -36,7 +36,7 @@ params:
 |log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
 |ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
 |ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
-|sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
+|sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|spdx|false|
 
 ## Results
 |name|description|

--- a/task/prefetch-dependencies-oci-ta/0.2/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.2/README.md
@@ -1,0 +1,51 @@
+# prefetch-dependencies-oci-ta task
+
+Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+application source code are stored as a trusted artifact in the provided OCI repository.
+For additional info on Cachi2, see docs at
+https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+## Configuration
+
+Config file must be passed as a YAML string. For all available config options please check
+[available configuration parameters] page.
+
+Example of setting timeouts:
+
+```yaml
+params:
+  - name: config-file-content
+    value: |
+      ---
+      requests_timeout: 300
+      subprocess_timeout: 3600
+```
+
+[available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
+|input|Configures project packages that will have their dependencies prefetched.||true|
+|log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
+|ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
+|ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
+|sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
+
+## Results
+|name|description|
+|---|---|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
 spec:
   description: |-
     Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
@@ -76,7 +76,7 @@ spec:
     - name: sbom-type
       description: 'Select the SBOM format to generate. Valid values: spdx,
         cyclonedx.'
-      default: cyclonedx
+      default: spdx
   results:
     - name: CACHI2_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -1,0 +1,374 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: prefetch-dependencies-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: |-
+    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    application source code are stored as a trusted artifact in the provided OCI repository.
+    For additional info on Cachi2, see docs at
+    https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+    ## Configuration
+
+    Config file must be passed as a YAML string. For all available config options please check
+    [available configuration parameters] page.
+
+    Example of setting timeouts:
+
+    ```yaml
+    params:
+      - name: config-file-content
+        value: |
+          ---
+          requests_timeout: 300
+          subprocess_timeout: 3600
+    ```
+
+    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+  params:
+    - name: ACTIVATION_KEY
+      description: Name of secret which contains subscription activation key
+      type: string
+      default: activation-key
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: config-file-content
+      description: |
+        Pass configuration to cachi2.
+        Note this needs to be passed as a YAML-formatted config dump, not as a file path!
+      default: ""
+    - name: dev-package-managers
+      description: |
+        Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk.
+      default: "false"
+    - name: input
+      description: Configures project packages that will have their dependencies
+        prefetched.
+    - name: log-level
+      description: Set cachi2 log level (debug, info, warning, error)
+      default: info
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: ""
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: sbom-type
+      description: 'Select the SBOM format to generate. Valid values: spdx,
+        cyclonedx.'
+      default: cyclonedx
+  results:
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  volumes:
+    - name: activation-key
+      secret:
+        optional: true
+        secretName: $(params.ACTIVATION_KEY)
+    - name: config
+      emptyDir: {}
+    - name: etc-pki-entitlement
+      emptyDir: {}
+    - name: shared
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  workspaces:
+    - name: git-basic-auth
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file or username and password.
+        These will be copied to the user's home before any cachi2 commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to bind a Secret to this Workspace over other volume types.
+      optional: true
+    - name: netrc
+      description: |
+        Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+        performing http(s) requests.
+      optional: true
+  stepTemplate:
+    env:
+      - name: CONFIG_FILE_CONTENT
+        value: $(params.config-file-content)
+    volumeMounts:
+      - mountPath: /mnt/config
+        name: config
+      - mountPath: /shared
+        name: shared
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: skip-ta
+      image: registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155@sha256:e408de45e95eed0539fe821d31aa4288fe430d94f09a24c13c567bf99044dace
+      env:
+        - name: INPUT
+          value: $(params.input)
+        - name: SOURCE_ARTIFACT
+          value: $(params.SOURCE_ARTIFACT)
+      script: |
+        if [ -z "${INPUT}" ]; then
+          mkdir -p /var/workdir/source
+          mkdir -p /var/workdir/cachi2
+          echo "true" >/var/workdir/source/.skip-trusted-artifacts
+          echo "true" >/var/workdir/cachi2/.skip-trusted-artifacts
+          echo -n "${SOURCE_ARTIFACT}" >$(results.SOURCE_ARTIFACT.path)
+          echo -n "" >$(results.CACHI2_ARTIFACT.path)
+        fi
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: sanitize-cachi2-config-file-with-yq
+      image: quay.io/konflux-ci/yq:latest@sha256:408913942efbec9cc72f7f91cd65a4f660eaa02079a465796deff9333f07c399
+      script: |
+        if [ -n "${CONFIG_FILE_CONTENT}" ]; then
+          # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM
+          # impact of this configuration option will be:
+          # https://github.com/containerbuildsystem/cachi2/issues/577
+          yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}" >/mnt/config/config.yaml
+        fi
+    - name: prefetch-dependencies
+      image: quay.io/konflux-ci/cachi2:0.19.0@sha256:f67e7f9771c3d425bdd917313553c882d0ed942076dc31d9ce35524bdda1fb6e
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+        - mountPath: /activation-key
+          name: activation-key
+      env:
+        - name: INPUT
+          value: $(params.input)
+        - name: DEV_PACKAGE_MANAGERS
+          value: $(params.dev-package-managers)
+        - name: LOG_LEVEL
+          value: $(params.log-level)
+        - name: SBOM_TYPE
+          value: $(params.sbom-type)
+        - name: WORKSPACE_GIT_AUTH_BOUND
+          value: $(workspaces.git-basic-auth.bound)
+        - name: WORKSPACE_GIT_AUTH_PATH
+          value: $(workspaces.git-basic-auth.path)
+        - name: WORKSPACE_NETRC_BOUND
+          value: $(workspaces.netrc.bound)
+        - name: WORKSPACE_NETRC_PATH
+          value: $(workspaces.netrc.path)
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        RHSM_ORG=""
+        RHSM_ACT_KEY=""
+        ENTITLEMENT_CERT_PATH=""
+        ENTITLEMENT_CERT_KEY_PATH=""
+
+        function rhsm_unregister {
+          # best effort:
+          #   - if the system was already successfully unregistered, the command returns 1
+          #   - if unregistering failed/fails, there's not much we can do about it anyway
+          subscription-manager unregister || true
+        }
+
+        function inject_ssl_opts {
+          input="$1"
+          ssl_options="$2"
+
+          # Check if input is plain string or JSON and if the request specifies RPMs
+          if [ "$input" == "rpm" ]; then
+            input="$(
+              jq -n --argjson ssl "$ssl_options" '
+                      {
+                        type: "rpm",
+                        options: {
+                          ssl: $ssl
+                        }
+                      }'
+            )"
+          elif (jq . 2>/dev/null 1>&2 <<<"$input"); then
+            # The input JSON can be in one of these forms:
+            # 1) '[{"type": "gomod"}, {"type": "bundler"}]'
+            # 2) '{"packages": [{"type": "gomod"}, {"type": "bundler"}]}'
+            # 3) '{"type": "gomod"}'
+            input_json_has_rpm="$(jq '
+                                    if (type == "array" or type == "object") | not then
+                                      false
+                                    elif type == "array" then
+                                      any(.[]; .type == "rpm")
+                                    elif has("packages") | not then
+                                      .type == "rpm"
+                                    elif (.packages | type == "array") then
+                                      any(.packages[]; .type == "rpm")
+                                    else
+                                      false
+                                    end' <<<"$input")"
+
+            # The output JSON may need the SSL options updated for the RPM backend
+            if [ "$input_json_has_rpm" == "true" ]; then
+              input="$(
+                jq \
+                  --argjson ssl "$ssl_options" '
+                            if type == "array" then
+                              map(if .type == "rpm" then .options.ssl += $ssl else . end)
+                            elif has("packages") then
+                              .packages |= map(if .type == "rpm" then .options.ssl += $ssl else . end)
+                            else
+                              .options.ssl += $ssl
+                            end' \
+                  <<<"$input"
+              )"
+            fi
+          fi
+          echo "$input"
+        }
+
+        if [ -z "${INPUT}" ]; then
+          # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
+          echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+          exit 0
+        fi
+
+        if [ -f /mnt/config/config.yaml ]; then
+          config_flag=--config-file=/mnt/config/config.yaml
+        else
+          config_flag=""
+        fi
+
+        if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
+          dev_pacman_flag=--dev-package-managers
+        else
+          dev_pacman_flag=""
+        fi
+
+        # Copied from https://github.com/konflux-ci/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml
+        if [ "${WORKSPACE_GIT_AUTH_BOUND}" = "true" ]; then
+          if [ -f "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" ]; then
+            cp "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" "${HOME}/.git-credentials"
+            cp "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" "${HOME}/.gitconfig"
+          # Compatibility with kubernetes.io/basic-auth secrets
+          elif [ -f "${WORKSPACE_GIT_AUTH_PATH}/username" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/password" ]; then
+            HOSTNAME=$(cd "/var/workdir/source" && git remote get-url origin | awk -F/ '{print $3}')
+            echo "https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME" >"${HOME}/.git-credentials"
+            echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" >"${HOME}/.gitconfig"
+          else
+            echo "Unknown git-basic-auth workspace format"
+            exit 1
+          fi
+          chmod 400 "${HOME}/.git-credentials"
+          chmod 400 "${HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
+          cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
+        fi
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # RHSM HANDLING: REGISTER RHSM & CACHI2 CONFIGURATION
+        if [ -e /activation-key/org ]; then
+          RHSM_ORG=$(cat /activation-key/org)
+          RHSM_ACT_KEY=$(cat /activation-key/activationkey)
+
+          echo "Registering with Red Hat subscription manager."
+          subscription-manager register \
+            --org "${RHSM_ORG}" \
+            --activationkey "${RHSM_ACT_KEY}" || exit 1
+
+          trap rhsm_unregister EXIT
+
+          entitlement_files="$(ls -1 /etc/pki/entitlement/*.pem)"
+          ENTITLEMENT_CERT_KEY_PATH="$(grep -e '-key.pem$' <<<"$entitlement_files")"
+          ENTITLEMENT_CERT_PATH="$(grep -v -e '-key.pem$' <<<"$entitlement_files")"
+          CA_BUNDLE_PATH="/etc/rhsm/ca/redhat-uep.pem"
+
+          CACHI2_SSL_OPTS="$(
+            jq -n \
+              --arg key "$ENTITLEMENT_CERT_KEY_PATH" \
+              --arg cert "$ENTITLEMENT_CERT_PATH" \
+              --arg ca_bundle "$CA_BUNDLE_PATH" \
+              '{client_key: $key, client_cert: $cert, ca_bundle: $ca_bundle}'
+          )"
+
+          # We need to modify the cachi2 params in place if we're processing RPMs
+          INPUT=$(inject_ssl_opts "$INPUT" "$CACHI2_SSL_OPTS")
+        fi
+
+        cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+          $dev_pacman_flag \
+          --source=/var/workdir/source \
+          --output=/var/workdir/cachi2/output \
+          --sbom-output-type="$SBOM_TYPE" \
+          "${INPUT}"
+
+        cachi2 --log-level="$LOG_LEVEL" generate-env /var/workdir/cachi2/output \
+          --format env \
+          --for-output-dir=/cachi2/output \
+          --output /var/workdir/cachi2/cachi2.env
+
+        cachi2 --log-level="$LOG_LEVEL" inject-files /var/workdir/cachi2/output \
+          --for-output-dir=/cachi2/output
+
+        # hack: the OCI generator would delete the function since it doesn't consider trap a "usage"
+        if false; then
+          rhsm_unregister
+        fi
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi
+    - name: create-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+        - $(results.CACHI2_ARTIFACT.path)=/var/workdir/cachi2
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi

--- a/task/prefetch-dependencies-oci-ta/0.2/recipe.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,52 @@
+---
+base: ../../prefetch-dependencies/0.2/prefetch-dependencies.yaml
+add:
+  - use-source
+  - create-source
+  - create-cachi2
+additionalSteps:
+  - at: 0
+    name: skip-ta
+    image: registry.access.redhat.com/ubi9/ubi-minimal:9.5-1736404155@sha256:e408de45e95eed0539fe821d31aa4288fe430d94f09a24c13c567bf99044dace
+    env:
+    - name: INPUT
+      value: $(params.input)
+    - name: SOURCE_ARTIFACT
+      value: $(params.SOURCE_ARTIFACT)
+    script: |
+      if [ -z "${INPUT}" ]; then
+        mkdir -p /var/workdir/source
+        mkdir -p /var/workdir/cachi2
+        echo "true" > /var/workdir/source/.skip-trusted-artifacts
+        echo "true" > /var/workdir/cachi2/.skip-trusted-artifacts
+        echo -n "${SOURCE_ARTIFACT}" > $(results.SOURCE_ARTIFACT.path)
+        echo -n "" > $(results.CACHI2_ARTIFACT.path)
+      fi
+description: |-
+    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    application source code are stored as a trusted artifact in the provided OCI repository.
+    For additional info on Cachi2, see docs at
+    https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+    ## Configuration
+
+    Config file must be passed as a YAML string. For all available config options please check
+    [available configuration parameters] page.
+
+    Example of setting timeouts:
+
+    ```yaml
+    params:
+      - name: config-file-content
+        value: |
+          ---
+          requests_timeout: 300
+          subprocess_timeout: 3600
+    ```
+
+    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+preferStepTemplate: true
+removeWorkspaces:
+  - source
+replacements:
+  workspaces.source.path: /var/workdir

--- a/task/prefetch-dependencies/0.2/MIGRATION.md
+++ b/task/prefetch-dependencies/0.2/MIGRATION.md
@@ -1,0 +1,24 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+* Changes the default SBOM format from CycloneDX to SPDX.
+
+## Action from users
+
+In order for a typical Konflux pipeline to work well with SPDX, all the tasks
+that handle SBOMs must be SPDX-ready. Relevant tasks and required versions:
+
+* Depending on the build task you use, one of:
+  * `buildah >= 0.4`
+  * `rpm-ostree >= ? (not SPDX-ready yet)`
+  * `build-maven-zip >= ? (not SPDX-ready yet)`
+* `source-build >= 0.2`
+* `deprecated-image-check >= 0.5`
+
+> Note: the same version constraints apply even if you use the `*-oci-ta` variants
+> of these tasks or the `*-remote*` variants of the buildah task.
+
+If your pipeline uses these tasks, please make sure their versions are high enough.
+There's a good chance that the Pull Request which led you to this migration document
+has updated every relevant task in your pipelines at once.

--- a/task/prefetch-dependencies/0.2/README.md
+++ b/task/prefetch-dependencies/0.2/README.md
@@ -28,7 +28,7 @@ params:
 |dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
 |log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
 |config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
-|sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
+|sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|spdx|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|

--- a/task/prefetch-dependencies/0.2/README.md
+++ b/task/prefetch-dependencies/0.2/README.md
@@ -1,0 +1,41 @@
+# prefetch-dependencies task
+
+Task that uses Cachi2 to prefetch build dependencies.
+See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+## Configuration
+
+Config file must be passed as a YAML string. For all available config options please check
+[available configuration parameters] page.
+
+Example of setting timeouts:
+
+```yaml
+params:
+  - name: config-file-content
+    value: |
+      ---
+      requests_timeout: 300
+      subprocess_timeout: 3600
+```
+
+[available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|input|Configures project packages that will have their dependencies prefetched.||true|
+|dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
+|log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
+|config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|cyclonedx|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source|Workspace with the source code, cachi2 artifacts will be stored on the workspace as well|false|
+|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -1,0 +1,312 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, konflux"
+  name: prefetch-dependencies
+spec:
+  description: |-
+    Task that uses Cachi2 to prefetch build dependencies.
+    See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+
+    ## Configuration
+
+    Config file must be passed as a YAML string. For all available config options please check
+    [available configuration parameters] page.
+
+    Example of setting timeouts:
+
+    ```yaml
+    params:
+      - name: config-file-content
+        value: |
+          ---
+          requests_timeout: 300
+          subprocess_timeout: 3600
+    ```
+
+    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+  params:
+  - description: Configures project packages that will have their dependencies prefetched.
+    name: input
+  - description: >
+      Enable in-development package managers. WARNING: the behavior may change at any time without
+      notice. Use at your own risk.
+    name: dev-package-managers
+    default: "false"
+  - description: Set cachi2 log level (debug, info, warning, error)
+    name: log-level
+    default: "info"
+  - description: |
+      Pass configuration to cachi2.
+      Note this needs to be passed as a YAML-formatted config dump, not as a file path!
+    name: config-file-content
+    default: ""
+  - name: sbom-type
+    default: cyclonedx
+    description: "Select the SBOM format to generate. Valid values: spdx, cyclonedx."
+  - name: caTrustConfigMapName
+    type: string
+    description: The name of the ConfigMap to read CA bundle data from.
+    default: trusted-ca
+  - name: caTrustConfigMapKey
+    type: string
+    description: The name of the key in the ConfigMap that contains the CA bundle data.
+    default: ca-bundle.crt
+  - name: ACTIVATION_KEY
+    default: activation-key
+    description: Name of secret which contains subscription activation key
+    type: string
+
+  stepTemplate:
+    env:
+      - name: CONFIG_FILE_CONTENT
+        value: $(params.config-file-content)
+    volumeMounts:
+      - name: config
+        mountPath: /mnt/config
+      - mountPath: /shared
+        name: shared
+  steps:
+  - name: sanitize-cachi2-config-file-with-yq
+    image: quay.io/konflux-ci/yq:latest@sha256:408913942efbec9cc72f7f91cd65a4f660eaa02079a465796deff9333f07c399
+    script: |
+      if [ -n "${CONFIG_FILE_CONTENT}" ]
+      then
+        # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM
+        # impact of this configuration option will be:
+        # https://github.com/containerbuildsystem/cachi2/issues/577
+        yq 'del(.goproxy_url)' <<< "${CONFIG_FILE_CONTENT}" > /mnt/config/config.yaml
+      fi
+
+  - name: prefetch-dependencies
+    image: quay.io/konflux-ci/cachi2:0.19.0@sha256:f67e7f9771c3d425bdd917313553c882d0ed942076dc31d9ce35524bdda1fb6e
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    env:
+    - name: INPUT
+      value: $(params.input)
+    - name: DEV_PACKAGE_MANAGERS
+      value: $(params.dev-package-managers)
+    - name: LOG_LEVEL
+      value: $(params.log-level)
+    - name: SBOM_TYPE
+      value: $(params.sbom-type)
+    - name: WORKSPACE_GIT_AUTH_BOUND
+      value: $(workspaces.git-basic-auth.bound)
+    - name: WORKSPACE_GIT_AUTH_PATH
+      value: $(workspaces.git-basic-auth.path)
+    - name: WORKSPACE_NETRC_BOUND
+      value: $(workspaces.netrc.bound)
+    - name: WORKSPACE_NETRC_PATH
+      value: $(workspaces.netrc.path)
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+      - mountPath: /activation-key
+        name: activation-key
+    computeResources:
+      limits:
+        memory: 3Gi
+      requests:
+        cpu: '1'
+        memory: 3Gi
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      RHSM_ORG=""
+      RHSM_ACT_KEY=""
+      ENTITLEMENT_CERT_PATH=""
+      ENTITLEMENT_CERT_KEY_PATH=""
+
+      function rhsm_unregister {
+        # best effort:
+        #   - if the system was already successfully unregistered, the command returns 1
+        #   - if unregistering failed/fails, there's not much we can do about it anyway
+        subscription-manager unregister || true
+      }
+
+      function inject_ssl_opts
+      {
+        input="$1"
+        ssl_options="$2"
+
+        # Check if input is plain string or JSON and if the request specifies RPMs
+        if [ "$input" == "rpm" ]; then
+          input="$(jq -n --argjson ssl "$ssl_options" '
+                    {
+                      type: "rpm",
+                      options: {
+                        ssl: $ssl
+                      }
+                    }'
+                  )"
+        elif (jq . 2>/dev/null 1>&2 <<< "$input"); then
+          # The input JSON can be in one of these forms:
+          # 1) '[{"type": "gomod"}, {"type": "bundler"}]'
+          # 2) '{"packages": [{"type": "gomod"}, {"type": "bundler"}]}'
+          # 3) '{"type": "gomod"}'
+          input_json_has_rpm="$(jq '
+                                  if (type == "array" or type == "object") | not then
+                                    false
+                                  elif type == "array" then
+                                    any(.[]; .type == "rpm")
+                                  elif has("packages") | not then
+                                    .type == "rpm"
+                                  elif (.packages | type == "array") then
+                                    any(.packages[]; .type == "rpm")
+                                  else
+                                    false
+                                  end' <<< "$input")"
+
+          # The output JSON may need the SSL options updated for the RPM backend
+          if [ "$input_json_has_rpm" == "true" ]; then
+              input="$(jq \
+                        --argjson ssl "$ssl_options" '
+                          if type == "array" then
+                            map(if .type == "rpm" then .options.ssl += $ssl else . end)
+                          elif has("packages") then
+                            .packages |= map(if .type == "rpm" then .options.ssl += $ssl else . end)
+                          else
+                            .options.ssl += $ssl
+                          end' \
+                          <<< "$input"
+                      )"
+          fi
+        fi
+        echo "$input"
+      }
+
+      if [ -z "${INPUT}" ]; then
+        # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
+        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+        exit 0
+      fi
+
+      if [ -f /mnt/config/config.yaml ]; then
+        config_flag=--config-file=/mnt/config/config.yaml
+      else
+        config_flag=""
+      fi
+
+      if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
+        dev_pacman_flag=--dev-package-managers
+      else
+        dev_pacman_flag=""
+      fi
+
+      # Copied from https://github.com/konflux-ci/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml
+      if [ "${WORKSPACE_GIT_AUTH_BOUND}" = "true" ] ; then
+        if [ -f "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" ]; then
+          cp "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" "${HOME}/.git-credentials"
+          cp "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" "${HOME}/.gitconfig"
+        # Compatibility with kubernetes.io/basic-auth secrets
+        elif [ -f "${WORKSPACE_GIT_AUTH_PATH}/username" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/password" ]; then
+          HOSTNAME=$(cd "$(workspaces.source.path)/source" && git remote get-url origin | awk -F/ '{print $3}')
+          echo "https://$(cat ${WORKSPACE_GIT_AUTH_PATH}/username):$(cat ${WORKSPACE_GIT_AUTH_PATH}/password)@$HOSTNAME" > "${HOME}/.git-credentials"
+          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${HOME}/.gitconfig"
+        else
+          echo "Unknown git-basic-auth workspace format"
+          exit 1
+        fi
+        chmod 400 "${HOME}/.git-credentials"
+        chmod 400 "${HOME}/.gitconfig"
+      fi
+
+      if [ "${WORKSPACE_NETRC_BOUND}" = "true" ]; then
+        cp "${WORKSPACE_NETRC_PATH}/.netrc" "${HOME}/.netrc"
+      fi
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      # RHSM HANDLING: REGISTER RHSM & CACHI2 CONFIGURATION
+      if [ -e /activation-key/org ]; then
+        RHSM_ORG=$(cat /activation-key/org)
+        RHSM_ACT_KEY=$(cat /activation-key/activationkey)
+
+        echo "Registering with Red Hat subscription manager."
+        subscription-manager register \
+            --org "${RHSM_ORG}" \
+            --activationkey "${RHSM_ACT_KEY}" || exit 1
+
+        trap rhsm_unregister EXIT
+
+        entitlement_files="$(ls -1 /etc/pki/entitlement/*.pem)"
+        ENTITLEMENT_CERT_KEY_PATH="$(grep -e '-key.pem$' <<< "$entitlement_files")"
+        ENTITLEMENT_CERT_PATH="$(grep -v -e '-key.pem$' <<< "$entitlement_files")"
+        CA_BUNDLE_PATH="/etc/rhsm/ca/redhat-uep.pem"
+
+        CACHI2_SSL_OPTS="$(jq -n \
+                              --arg key "$ENTITLEMENT_CERT_KEY_PATH" \
+                              --arg cert "$ENTITLEMENT_CERT_PATH" \
+                              --arg ca_bundle "$CA_BUNDLE_PATH" \
+                              '{client_key: $key, client_cert: $cert, ca_bundle: $ca_bundle}'
+                          )"
+
+        # We need to modify the cachi2 params in place if we're processing RPMs
+        INPUT=$(inject_ssl_opts "$INPUT" "$CACHI2_SSL_OPTS")
+      fi
+
+      cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+      $dev_pacman_flag \
+      --source=$(workspaces.source.path)/source \
+      --output=$(workspaces.source.path)/cachi2/output \
+      --sbom-output-type="$SBOM_TYPE" \
+      "${INPUT}"
+
+      cachi2 --log-level="$LOG_LEVEL" generate-env $(workspaces.source.path)/cachi2/output \
+      --format env \
+      --for-output-dir=/cachi2/output \
+      --output $(workspaces.source.path)/cachi2/cachi2.env
+
+      cachi2 --log-level="$LOG_LEVEL" inject-files $(workspaces.source.path)/cachi2/output \
+      --for-output-dir=/cachi2/output
+
+      # hack: the OCI generator would delete the function since it doesn't consider trap a "usage"
+      if false; then
+        rhsm_unregister
+      fi
+
+  workspaces:
+  - name: source
+    description: Workspace with the source code, cachi2 artifacts will be stored on the workspace as well
+  - name: git-basic-auth
+    description: |
+      A Workspace containing a .gitconfig and .git-credentials file or username and password.
+      These will be copied to the user's home before any cachi2 commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to bind a Secret to this Workspace over other volume types.
+    optional: true
+  - name: netrc
+    description: |
+      Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+      performing http(s) requests.
+    optional: true
+  volumes:
+    - name: shared
+      emptyDir: {}
+    - name: etc-pki-entitlement
+      emptyDir: {}
+    - name: activation-key
+      secret:
+        optional: true
+        secretName: $(params.ACTIVATION_KEY)
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+    - name: config
+      emptyDir: {}

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, konflux"
@@ -46,7 +46,7 @@ spec:
     name: config-file-content
     default: ""
   - name: sbom-type
-    default: cyclonedx
+    default: spdx
     description: "Select the SBOM format to generate. Valid values: spdx, cyclonedx."
   - name: caTrustConfigMapName
     type: string

--- a/task/source-build-oci-ta/0.2/MIGRATION.md
+++ b/task/source-build-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+* Adds support for SPDX SBOMs.
+
+## Action from users
+
+No action needed. The version bump simply marks the addition of SPDX support.

--- a/task/source-build-oci-ta/0.2/README.md
+++ b/task/source-build-oci-ta/0.2/README.md
@@ -1,0 +1,20 @@
+# source-build-oci-ta task
+
+Source image build.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|BASE_IMAGES|By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.|""|false|
+|BINARY_IMAGE|Binary image name from which to generate the source image name.||true|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+
+## Results
+|name|description|
+|---|---|
+|BUILD_RESULT|Build result.|
+|IMAGE_REF|Image reference of the built image|
+|SOURCE_IMAGE_DIGEST|The source image digest.|
+|SOURCE_IMAGE_URL|The source image url.|
+

--- a/task/source-build-oci-ta/0.2/recipe.yaml
+++ b/task/source-build-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,15 @@
+---
+base: ../../source-build/0.2/source-build.yaml
+add:
+  - use-source
+  - use-cachi2
+removeWorkspaces:
+  - workspace
+removeVolumes:
+  - source-build-work-place
+regexReplacements:
+  \/var\/source-build: /var/workdir
+  \/workspace\/workspace: /var/workdir
+preferStepTemplate: true
+replacements:
+  workspaces.workspace.path: /var/workdir

--- a/task/source-build-oci-ta/0.2/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.2/source-build-oci-ta.yaml
@@ -1,0 +1,186 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: source-build-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: Source image build.
+  params:
+    - name: BASE_IMAGES
+      description: By default, the task inspects the SBOM of the binary image
+        to find the base image. With this parameter, you can override that
+        behavior and pass the base image directly. The value should be a newline-separated
+        list of images, in the same order as the FROM instructions specified
+        in a multistage Dockerfile.
+      type: string
+      default: ""
+    - name: BINARY_IMAGE
+      description: Binary image name from which to generate the source image
+        name.
+      type: string
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  results:
+    - name: BUILD_RESULT
+      description: Build result.
+    - name: IMAGE_REF
+      description: Image reference of the built image
+    - name: SOURCE_IMAGE_DIGEST
+      description: The source image digest.
+    - name: SOURCE_IMAGE_URL
+      description: The source image url.
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    env:
+      - name: BASE_IMAGES_FILE
+        value: /var/workdir/base-images.txt
+      - name: BINARY_IMAGE
+        value: $(params.BINARY_IMAGE)
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:ff35e09ff5c89e54538b50abae241a765b2b7868f05d62c4835bebf0978f3659
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    - name: get-base-images
+      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      env:
+        - name: BASE_IMAGES
+          value: $(params.BASE_IMAGES)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ -n "$BASE_IMAGES" ]]; then
+          echo "BASE_IMAGES param received:"
+          printf "%s" "$BASE_IMAGES" | tee "$BASE_IMAGES_FILE"
+          exit
+        fi
+
+        echo "BASE_IMAGES param is empty, inspecting the SBOM instead"
+
+        raw_inspect=$(skopeo inspect --raw "docker://$BINARY_IMAGE")
+        if manifest_digest=$(jq -e -r '.manifests[0].digest' <<<"$raw_inspect"); then
+          # The BINARY_IMAGE is an image index, each manifest in the list has its own SBOM.
+          # We're gonna assume the base images are the same or similar enough in all the SBOMs.
+          echo "BINARY_IMAGE ($BINARY_IMAGE) is a manifest list, picking an arbitrary image from the list"
+          image_without_digest=${BINARY_IMAGE%@*}
+          image_without_tag=${image_without_digest%:*}
+          image=${image_without_tag}@${manifest_digest}
+        else
+          # The image is a single manifest
+          image=$BINARY_IMAGE
+        fi
+
+        for i in {1..5}; do
+          echo "Downloading SBOM for $image (attempt $i)"
+          sbom=$(cosign download sbom "$image") && break
+          [[ "$i" -lt 5 ]] && sleep 1
+        done
+
+        if [[ -z "$sbom" ]]; then
+          echo "Failed to download SBOM after 5 attempts. Proceeding anyway."
+          echo "WARNING: the source image will not include sources for the base image."
+          exit 0
+        fi
+
+        echo -n "Looking for base image in SBOM"
+
+        # Note: the SBOM should contain at most one image with the is_base_image property - the
+        # base image for the last FROM instruction. That is the only base image we care about.
+        if jq -e '.bomFormat == "CycloneDX"' <<<"$sbom" >/dev/null; then
+          echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+          jq -r '
+                .formulation[]?
+                | .components[]?
+                | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
+                | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+                | .name + "@" + $matched.digest
+            ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
+        else
+          echo ' (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)'
+          jq -r '
+                .packages[]
+                | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
+                | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                | ($purls | first | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+                | .name + "@" + $matched.digest
+            ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
+        fi
+    - name: build
+      image: quay.io/konflux-ci/source-container-build:latest@sha256:9da8982d99263a7f1ee030340779ed7e7a5c95a0e82a535aeb3fe3eebc5b338c
+      workingDir: /var/workdir
+      env:
+        - name: SOURCE_DIR
+          value: /var/workdir/source
+        - name: RESULT_FILE
+          value: $(results.BUILD_RESULT.path)
+        - name: CACHI2_ARTIFACTS_DIR
+          value: /var/workdir/cachi2
+        - name: RESULT_SOURCE_IMAGE_URL
+          value: $(results.SOURCE_IMAGE_URL.path)
+        - name: RESULT_SOURCE_IMAGE_DIGEST
+          value: $(results.SOURCE_IMAGE_DIGEST.path)
+        - name: WS_BUILD_RESULT_FILE
+          value: /var/workdir/source_build_result.json
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        app_dir=/opt/source_build
+        registry_allowlist="
+        registry.access.redhat.com
+        registry.redhat.io
+        "
+
+        ## This is needed for the builds performed by the rpm-ostree task
+        ## otherwise, we can see this error:
+        ## "fatal: detected dubious ownership in repository at '/var/workdir/source'"
+        ##
+        git config --global --add safe.directory $SOURCE_DIR
+
+        base_images=$(if [[ -f "$BASE_IMAGES_FILE" ]]; then cat "$BASE_IMAGES_FILE"; fi)
+
+        ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
+          --output-binary-image "$BINARY_IMAGE" \
+          --workspace /var/workdir \
+          --source-dir "$SOURCE_DIR" \
+          --base-images "$base_images" \
+          --write-result-to "$RESULT_FILE" \
+          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
+          --registry-allowlist="$registry_allowlist"
+
+        cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
+        cat "$RESULT_FILE" | jq -j ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
+        jq -j '"\(.image_url)@\(.image_digest)"' "${RESULT_FILE}" >"$(results.IMAGE_REF.path)"
+
+        cp "$RESULT_FILE" "$WS_BUILD_RESULT_FILE"
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: 250m
+          memory: 512Mi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+        runAsUser: 0

--- a/task/source-build-oci-ta/0.2/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.2/source-build-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
 spec:
   description: Source image build.
   params:

--- a/task/source-build/0.2/MIGRATION.md
+++ b/task/source-build/0.2/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+* Adds support for SPDX SBOMs.
+
+## Action from users
+
+No action needed. The version bump simply marks the addition of SPDX support.

--- a/task/source-build/0.2/README.md
+++ b/task/source-build/0.2/README.md
@@ -1,0 +1,22 @@
+# source-build task
+
+Source image build.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|BINARY_IMAGE|Binary image name from which to generate the source image name.||true|
+|BASE_IMAGES|By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.|""|false|
+
+## Results
+|name|description|
+|---|---|
+|BUILD_RESULT|Build result.|
+|SOURCE_IMAGE_URL|The source image url.|
+|SOURCE_IMAGE_DIGEST|The source image digest.|
+|IMAGE_REF|Image reference of the built image|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|workspace|The workspace where source code is included.|false|

--- a/task/source-build/0.2/source-build.yaml
+++ b/task/source-build/0.2/source-build.yaml
@@ -1,0 +1,176 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: source-build
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+spec:
+  description: Source image build.
+  params:
+    - name: BINARY_IMAGE
+      description: Binary image name from which to generate the source image name.
+      type: string
+    - name: BASE_IMAGES
+      description: >-
+        By default, the task inspects the SBOM of the binary image to find the base image.
+        With this parameter, you can override that behavior and pass the base image directly.
+        The value should be a newline-separated list of images, in the same order as the FROM
+        instructions specified in a multistage Dockerfile.
+      type: string
+      default: ""
+  results:
+    - name: BUILD_RESULT
+      description: Build result.
+    - name: SOURCE_IMAGE_URL
+      description: The source image url.
+    - name: SOURCE_IMAGE_DIGEST
+      description: The source image digest.
+    - name: IMAGE_REF
+      description: Image reference of the built image
+  workspaces:
+    - name: workspace
+      description: The workspace where source code is included.
+  volumes:
+    - name: source-build-work-place
+      emptyDir: {}
+  stepTemplate:
+    env:
+      - name: BINARY_IMAGE
+        value: "$(params.BINARY_IMAGE)"
+      - name: BASE_IMAGES_FILE
+        value: /var/source-build/base-images.txt
+    volumeMounts:
+      - name: source-build-work-place
+        mountPath: /var/source-build
+  steps:
+    - name: get-base-images
+      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      env:
+        - name: BASE_IMAGES
+          value: "$(params.BASE_IMAGES)"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [[ -n "$BASE_IMAGES" ]]; then
+            echo "BASE_IMAGES param received:"
+            printf "%s" "$BASE_IMAGES" | tee "$BASE_IMAGES_FILE"
+            exit
+        fi
+
+        echo "BASE_IMAGES param is empty, inspecting the SBOM instead"
+
+        raw_inspect=$(skopeo inspect --raw "docker://$BINARY_IMAGE")
+        if manifest_digest=$(jq -e -r '.manifests[0].digest' <<< "$raw_inspect"); then
+            # The BINARY_IMAGE is an image index, each manifest in the list has its own SBOM.
+            # We're gonna assume the base images are the same or similar enough in all the SBOMs.
+            echo "BINARY_IMAGE ($BINARY_IMAGE) is a manifest list, picking an arbitrary image from the list"
+            image_without_digest=${BINARY_IMAGE%@*}
+            image_without_tag=${image_without_digest%:*}
+            image=${image_without_tag}@${manifest_digest}
+        else
+            # The image is a single manifest
+            image=$BINARY_IMAGE
+        fi
+
+        for i in {1..5}; do
+            echo "Downloading SBOM for $image (attempt $i)"
+            sbom=$(cosign download sbom "$image") && break
+            [[ "$i" -lt 5 ]] && sleep 1
+        done
+
+        if [[ -z "$sbom" ]]; then
+            echo "Failed to download SBOM after 5 attempts. Proceeding anyway."
+            echo "WARNING: the source image will not include sources for the base image."
+            exit 0
+        fi
+
+        echo -n "Looking for base image in SBOM"
+
+        # Note: the SBOM should contain at most one image with the is_base_image property - the
+        # base image for the last FROM instruction. That is the only base image we care about.
+        if jq -e '.bomFormat == "CycloneDX"' <<< "$sbom" >/dev/null; then
+            echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+            jq -r '
+                .formulation[]?
+                | .components[]?
+                | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
+                | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+                | .name + "@" + $matched.digest
+            ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
+        else
+            echo ' (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)'
+            jq -r '
+                .packages[]
+                | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
+                | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                | ($purls | first | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
+                | .name + "@" + $matched.digest
+            ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
+        fi
+
+    - name: build
+      image: quay.io/konflux-ci/source-container-build:latest@sha256:9da8982d99263a7f1ee030340779ed7e7a5c95a0e82a535aeb3fe3eebc5b338c
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          memory: 512Mi
+          cpu: 250m
+      workingDir: "/var/source-build"
+      securityContext:
+        runAsUser: 0
+        capabilities:
+          add:
+            - SETFCAP
+      env:
+        - name: SOURCE_DIR
+          value: "$(workspaces.workspace.path)/source"
+        - name: RESULT_FILE
+          value: "$(results.BUILD_RESULT.path)"
+        - name: CACHI2_ARTIFACTS_DIR
+          value: "$(workspaces.workspace.path)/cachi2"
+        - name: RESULT_SOURCE_IMAGE_URL
+          value: "$(results.SOURCE_IMAGE_URL.path)"
+        - name: RESULT_SOURCE_IMAGE_DIGEST
+          value: "$(results.SOURCE_IMAGE_DIGEST.path)"
+        - name: WS_BUILD_RESULT_FILE
+          value: "$(workspaces.workspace.path)/source_build_result.json"
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        app_dir=/opt/source_build
+        registry_allowlist="
+        registry.access.redhat.com
+        registry.redhat.io
+        "
+
+        ## This is needed for the builds performed by the rpm-ostree task
+        ## otherwise, we can see this error:
+        ## "fatal: detected dubious ownership in repository at '/workspace/workspace/source'"
+        ##
+        git config --global --add safe.directory $SOURCE_DIR
+
+        base_images=$(if [[ -f "$BASE_IMAGES_FILE" ]]; then cat "$BASE_IMAGES_FILE"; fi)
+
+        ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
+          --output-binary-image "$BINARY_IMAGE" \
+          --workspace /var/source-build \
+          --source-dir "$SOURCE_DIR" \
+          --base-images "$base_images" \
+          --write-result-to "$RESULT_FILE" \
+          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
+          --registry-allowlist="$registry_allowlist"
+
+        cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
+        cat "$RESULT_FILE" | jq -j ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"
+        jq -j '"\(.image_url)@\(.image_digest)"' "${RESULT_FILE}" >"$(results.IMAGE_REF.path)"
+
+        cp "$RESULT_FILE" "$WS_BUILD_RESULT_FILE"

--- a/task/source-build/0.2/source-build.yaml
+++ b/task/source-build/0.2/source-build.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: source-build
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"


### PR DESCRIPTION
Bump the versions of all SBOM-related tasks
* For SBOM producers (prefetch-dependencies, build tasks), this is to mark a breaking change - the "sbom type" parameter now defaults to SPDX
* For SBOM consumers (source-build, deprecated-image-check), this simply marks them as SPDX ready (mainly to make the MIGRATION.md files saner - checking if your task is the right version is much easier than checking if the `sha256` digest of your task is new enough)

To minimize disruption, users have to upgrade all the SBOM-related tasks at the same time. This is why these changes need to be done in a single PR, so that all the updates are built and released together and then proposed all at once by Renovate/Mintmaker