### PR TITLE
build-maven-zip: support SPDX

### DIFF
--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -160,7 +160,7 @@ spec:
 
         # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
         if [ -f "/var/workdir/cachi2/output/bom.json" ]; then
-          cp -vf "/var/workdir/cachi2/output/bom.json" ./sbom-cyclonedx.json
+          cp -vf "/var/workdir/cachi2/output/bom.json" ./sbom.json
         else
           echo "The SBOM file for fetched artifacts is not found!"
           exit 1
@@ -193,7 +193,13 @@ spec:
           update-ca-trust
         fi
 
-        cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$IMAGE"
+        if jq -e '.bomFormat == "CycloneDX"' <sbom.json >/dev/null; then
+          sbom_type=cyclonedx
+        else
+          sbom_type=spdx
+        fi
+
+        cosign attach sbom --sbom sbom.json --type "$sbom_type" "$IMAGE"
 
         # Remove tag from IMAGE while allowing registry to contain a port number.
         sbom_repo="${IMAGE%:*}"

--- a/task/build-maven-zip/0.1/build-maven-zip.yaml
+++ b/task/build-maven-zip/0.1/build-maven-zip.yaml
@@ -133,7 +133,7 @@ spec:
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
       if [ -f "$(workspaces.source.path)/cachi2/output/bom.json" ]; then
-        cp -vf "$(workspaces.source.path)/cachi2/output/bom.json" ./sbom-cyclonedx.json
+        cp -vf "$(workspaces.source.path)/cachi2/output/bom.json" ./sbom.json
       else
         echo "The SBOM file for fetched artifacts is not found!"
         exit 1
@@ -159,7 +159,13 @@ spec:
         update-ca-trust
       fi
 
-      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$IMAGE"
+      if jq -e '.bomFormat == "CycloneDX"' < sbom.json >/dev/null; then
+        sbom_type=cyclonedx
+      else
+        sbom_type=spdx
+      fi
+
+      cosign attach sbom --sbom sbom.json --type "$sbom_type" "$IMAGE"
 
       # Remove tag from IMAGE while allowing registry to contain a port number.
       sbom_repo="${IMAGE%:*}"


### PR DESCRIPTION
Detect the format of the SBOM coming from the prefetch task. Use the right '--type' argument for 'cosign attach' based on the format.