### PR TITLE
chore(KFLUXVNGD-157): Add custom certificate support for coverity-oci-ta task

### DIFF
--- a/task/coverity-availability-check-oci-ta/0.1/coverity-availability-check-oci-ta.yaml
+++ b/task/coverity-availability-check-oci-ta/0.1/coverity-availability-check-oci-ta.yaml
@@ -29,6 +29,15 @@ spec:
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
       type: string
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
   results:
     - name: STATUS
       description: Tekton task simple status to be later checked
@@ -45,6 +54,13 @@ spec:
         secretName: $(params.COV_LICENSE)
     - name: workdir
       emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
@@ -56,6 +72,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
     - name: coverity-availability-check
       image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
       workingDir: /var/workdir/source

--- a/task/coverity-availability-check-oci-ta/0.1/recipe.yaml
+++ b/task/coverity-availability-check-oci-ta/0.1/recipe.yaml
@@ -10,3 +10,4 @@ replacements:
   workspaces.workspace.path: /var/workdir
 regexReplacements:
   hacbs/\$\(context.task.name\): source
+useTAVolumeMount: true


### PR DESCRIPTION
Add param to support the custom certificate support for coverity-check-oci-ta task to connect to internal registry. For this we have updated the use-trusted-artifact step, which download/upload the artifact from/to a registry.

Jira-Url: https://issues.redhat.com/browse/KFLUXVNGD-157