### PR TITLE
feat(): Migrate sealights tasks from integration catalog to build-definitions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -95,6 +95,10 @@
 /stepactions/eaas-get-supported-ephemeral-cluster-versions  @amisstea @avi-biton @hmariset @omeramsc @yftacherzog
 /task/eaas-provision-space                                  @amisstea @avi-biton @hmariset @omeramsc @yftacherzog
 
+# renovate groupName=sealights
+/task/sealights-go         @ascerra @flacatus @psturc @dbaez
+/task/sealights-python     @ascerra @flacatus @psturc @dbaez
+
 # renovate groupName=build-vm-image
 /task/build-vm-image    @arewm @brianwcook @ralphbean @scoheb
 

--- a/renovate.json
+++ b/renovate.json
@@ -189,6 +189,13 @@
       "matchFileNames": [
         "task/build-paketo-builder-oci-ta/**"
       ]
+    },
+    {
+      "groupName": "sealights",
+      "matchFileNames": [
+        "task/sealights-go/**",
+        "task/sealights-python/**"
+      ]
     }
   ],
   "postUpdateOptions": [

--- a/task/sealights-go/0.1/README.md
+++ b/task/sealights-go/0.1/README.md
@@ -1,0 +1,75 @@
+# Sealights Go Instrumentation Tekton Task
+
+This Tekton task automates the process of instrumenting Go code with Sealights for quality analytics and testing. It retrieves source code from a trusted artifact, instruments it with Sealights, and creates a new trusted artifact with the instrumented code. This task supports Pull Request and Push events and provides flexibility to exclude specific Go packages from instrumentation.
+
+## Overview
+
+This task performs the following steps:
+
+1. **Retrieves** the source code from a trusted artifact.
+2. **Instruments** the Go code using Sealights.
+3. **Creates** a new trusted artifact containing the instrumented code.
+
+The task can be triggered by different events (e.g., Pull Request, Push) and allows users to exclude specific Go packages from the instrumentation process.
+
+## Parameters
+
+| Name                  | Type     | Default       | Description                                                                                   |
+|-----------------------|----------|---------------|-----------------------------------------------------------------------------------------------|
+| `source-artifact`     | `string` | -             | The Trusted Artifact URI pointing to the source code.                                         |
+| `go-version`          | `string` | -             | The Go version to use (e.g., `1.21.3`).                                                       |
+| `sealights-secret`    | `string` | -             | The name of the OpenShift secret containing Sealights credentials.                            |
+| `component`           | `string` | -             | The name of the Konflux component associated with the integration tests.                      |
+| `scm-provider`        | `string` | `github`      | The SCM provider (e.g., `github`, `gitlab`).                                                  |
+| `packages-excluded`   | `array`  | `[]`          | List of Go packages to exclude from instrumentation (e.g., `pkg1`, `github.com/lib/concurrent`). |
+| `repository-url`      | `string` | `""`          | URL of the source code repository (e.g., `github.com/org/repo`).                              |
+| `branch`              | `string` | `main`        | The Git branch to use (e.g., `main`, `feature-branch`).                                       |
+| `revision`            | `string` | -             | The Git revision (commit SHA).                                                                |
+| `pull-request-number` | `string` | `""`          | The Pull Request number.                                                                      |
+| `target-branch`       | `string` | `main`        | The target branch for the Pull Request (e.g., `main`, `develop`).                             |
+| `oci-storage`         | `string` | -             | The OCI repository for storing the trusted artifacts.                                         |
+
+## Results
+
+| Name                | Type     | Description                                                                 |
+|---------------------|----------|-----------------------------------------------------------------------------|
+| `build-session-id`  | `string` | A unique identifier for the Sealights build session.                       |
+| `build-name`        | `string` | A unique build name generated using the commit SHA and current date.       |
+| `source-artifact`   | `string` | The URI of the trusted artifact with the application source code.          |
+
+## Volumes
+
+| Name                  | Description                                                    |
+|-----------------------|----------------------------------------------------------------|
+| `sealights-credentials` | Stores Sealights credentials from the specified secret.         |
+| `workdir`             | Temporary working directory for source code operations.        |
+
+## Steps
+
+### 1. `use-trusted-artifact`
+
+Retrieves the source code from a trusted artifact.
+
+### 2. `sealights-go-instrumentation`
+
+Instruments the Go code with Sealights.
+
+### 3. `create-trusted-artifact`
+
+Creates a new trusted artifact containing the instrumented code and stores it in the specified OCI repository.
+
+## Usage Instructions
+
+### Create the Sealights Secret
+
+Ensure you have a Kubernetes secret containing your Sealights credentials. For example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sealights-credentials
+type: Opaque
+data:
+  token: <BASE64_ENCODED_SEALIGHTS_TOKEN>
+```

--- a/task/sealights-go/0.1/sealights-go.yaml
+++ b/task/sealights-go/0.1/sealights-go.yaml
@@ -1,0 +1,160 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: sealights-go-instrumentation
+  labels:
+    konflux-ci/sealights: "true"
+    konflux-ci/sealights-language: "go"
+spec:
+  description: >-
+    This Tekton task automates the process of instrumenting Go code with Sealights for quality analytics and testing.
+    It retrieves the source code from a trusted artifact, instruments the code with Sealights, and then creates
+    a new trusted artifact with the instrumented code. The task can be triggered by either Pull Request or other events.
+  results:
+    - name: sealights-bsid
+      type: string
+      description: "A unique identifier generated for the current sealights build session."
+    - name: sealights-build-name
+      type: string
+      description: "A unique build name generated using the commit SHA and current date to prevent conflicts during test reruns."
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+  params:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: go-version
+      type: string
+      description: >-
+        "The Go version to use with the 'ubi8/go-toolset' image, in the format '1.x.y' (e.g., '1.21.3'). The go version should be
+        compatible with tags from the Red Hat catalog: https://catalog.redhat.com/software/containers/ubi8/go-toolset/5ce8713aac3db925c03774d1"
+    - name: sealights-secret
+      type: string
+      description: >-
+        "The name of the Openshift secret containing Sealights credentials. The credentials will expect to have us key secret the token. More information
+        on how to obtain the Sealights token credentials can be found at https://sealights.atlassian.net/wiki/spaces/SUP/pages/25591812/Generating+a+token."
+    - name: component
+      type: string
+      description: "The name of the Konflux component associated with the integration tests."
+    - name: scm-provider
+      type: string
+      default: "github"
+      description: "The source control management (SCM) provider used for the project, such as 'github', 'gitlab'."
+    - name: packages-excluded
+      type: array
+      default: []
+      description: "A list of Go packages to exclude from Sealights instrumentation during the code scan. Specify package paths to prevent them from being analyzed (e.g., 'pkg1', 'github.com/modern-go/concurrent')."
+    - name: repository-url
+      type: string
+      description: "The name or URL of the source code repository (e.g., 'github.com/org/repo')."
+      default: ""
+    - name: branch
+      type: string
+      description: "The name of the Git branch to use for the operation (e.g., 'main' or 'feature-branch')."
+      default: "main"
+    - name: revision
+      type: string
+      description: "The Git revision (commit SHA) from which the test pipeline is originating."
+    - name: pull-request-number
+      type: string
+      description: "The identifier number of the pull request/merge request."
+      default: ""
+    - name: target-branch
+      type: string
+      description: "The name of the target branch for the pull request, typically the branch into which the changes will be merged (e.g., 'main', 'develop')."
+      default: "main"
+    - name: oci-storage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+  volumes:
+    - name: sealights-credentials
+      secret:
+        secretName: sealights-credentials
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - name: sealights-credentials
+        mountPath: /usr/local/sealights-credentials
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:52f1391e6f1c472fd10bb838f64fae2ed3320c636f536014978a5ddbdfc6b3af
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: sealights-go-instrumentation
+      image: registry.access.redhat.com/ubi8/go-toolset:$(params.go-version)
+      workingDir: /var/workdir/source
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: COMPONENT
+          value: $(params.component)
+        - name: SCM_PROVIDER
+          value: $(params.scm-provider)
+        - name: REPOSITORY_URL
+          value: $(params.repository-url)
+        - name: BRANCH
+          value: $(params.branch)
+        - name: REVISION
+          value: $(params.revision)
+        - name: PULL_REQUEST_NUMBER
+          value: $(params.pull-request-number)
+        - name: TARGET_BRANCH
+          value: $(params.target-branch)
+        - name: TEST_EVENT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/event-type']
+      args: ["$(params.packages-excluded[*])"]
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        export SEALIGHTS_TOKEN BUILD_NAME BSID PACKAGES_EXCLUDED_ENUM
+
+        SEALIGHTS_TOKEN="$(cat /usr/local/sealights-credentials/token)"
+        BUILD_NAME="${REVISION}_$(date +'%y%m%d.%H%M')"
+        PACKAGES_EXCLUDED_ENUM="$(IFS=,; printf "%s," "$@" | sed 's/,$//')"
+
+        wget -qO- https://agents.sealights.co/slgoagent/latest/slgoagent-linux-amd64.tar.gz | tar -xzv -C /usr/local/bin
+        wget -qO- https://agents.sealights.co/slcli/latest/slcli-linux-amd64.tar.gz | tar -xzv -C /usr/local/bin
+
+        slcli config init --lang go --token "${SEALIGHTS_TOKEN}"
+
+        # In case is coming from /retest event then it's a pull_request
+        # if event type is not push and pull_request_number is not empty then is a pull_request
+        echo "[INFO] Tekton Event Type received: ${TEST_EVENT}"
+        if [ "$TEST_EVENT" != "push" ] && [ -n "$PULL_REQUEST_NUMBER" ]; then
+          TEST_EVENT="pull_request"
+        fi
+
+        if [ -n "${TEST_EVENT}" ] && [ "${TEST_EVENT}" = "pull_request" ]; then
+          echo "[INFO] Creating build session id from a ${TEST_EVENT} event source code: [ component: ${COMPONENT}, target-branch: ${TARGET_BRANCH}, pull-request-number ${PULL_REQUEST_NUMBER}, latest-commit: ${REVISION} ]"
+          slcli config create-pr-bsid --app "${COMPONENT}" --target-branch "${TARGET_BRANCH}" \
+            --pull-request-number "${PULL_REQUEST_NUMBER}" --latest-commit "${REVISION}" --repository-url "${REPOSITORY_URL}"
+        else
+          echo "[INFO] Creating build session ID (BSID) ${TEST_EVENT} event source code [ component: ${COMPONENT}, branch: ${BRANCH}, build: ${BUILD_NAME} ]"
+          slcli config create-bsid --app "${COMPONENT}" --branch "${BRANCH}" --build "${BUILD_NAME}"
+        fi
+
+        slcli scan --packages-excluded "${PACKAGES_EXCLUDED_ENUM}" --bsid buildSessionId.txt --path-to-scanner /usr/local/bin/slgoagent \
+          --workspacepath ./ --scm git --scmProvider "${SCM_PROVIDER}" --scmVersion "0" --scmBaseUrl "${REPOSITORY_URL}"
+
+        echo -n "$(cat buildSessionId.txt)" > "$(results.sealights-bsid.path)"
+        echo -n "$BUILD_NAME" > "$(results.sealights-build-name.path)"
+
+        # Temporary solution. Remove tokens to not build them
+        rm -rf build.json slcmd_config.json
+    - name: create-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:52f1391e6f1c472fd10bb838f64fae2ed3320c636f536014978a5ddbdfc6b3af
+      args:
+        - create
+        - --store
+        - $(params.oci-storage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source

--- a/task/sealights-python/0.1/README.md
+++ b/task/sealights-python/0.1/README.md
@@ -1,0 +1,75 @@
+# Sealights Python Instrumentation Tekton Task
+
+This Tekton task automates the process of instrumenting python code with Sealights for quality analytics and testing. It retrieves the source code from a trusted artifact, installs Python Sealights agent, configures the app for Sealights using vars from your PipelineRun, scans all .py files, reports scan to Sealights, and stores results to be used later on in testing. The task can be triggered by either Pull Request or other events.
+
+## Overview
+
+This task performs the following steps:
+
+1. **Retrieves** the source code from a trusted artifact.
+2. **Configures & Scans** the Python application using Sealights.
+
+The task can be triggered by different events (e.g., Pull Request, Push) and allows users to exclude specific paths from the configuration process.
+
+## Parameters
+
+| Name                  | Type     | Default       | Description                                                                                   |
+|-----------------------|----------|---------------|-----------------------------------------------------------------------------------------------|
+| `source-artifact`     | `string` | -             | The Trusted Artifact URI pointing to the source code.                                         |
+| `python-version`      | `string` | -             | The Python version to use with the 'ubi8/python' image, in the format (e.g., '311').          |                                             |
+| `component`           | `string` | -             | The name of the Konflux component associated with the integration tests.                      |
+| `scm-provider`        | `string` | `Github`         | The SCM provider (e.g., `Github`).                                                               |
+| `exclude`   | `array`  | `[]`          | A list of paths to exclude from Sealights instrumentation during the code scan. Specify paths to prevent them from being analyzed (e.g., '/app/source/tests/*,/app/examples/*'). |
+| `repository-url`      | `string` | `""`          | URL of the source code repository (e.g., `github.com/org/repo`).                              |
+| `branch`              | `string` | `main`        | The Git branch to use (e.g., `main`, `feature-branch`).                                       |
+| `revision`            | `string` | -             | The Git revision (commit SHA).                                                                |
+| `pull-request-number` | `string` | `""`          | The Pull Request number.                                                                      |
+| `target-branch`       | `string` | `main`        | The target branch for the Pull Request (e.g., `main`, `develop`).                             |
+| `workspace-path`      | `string` | `/app`        | The path to the root of your repository.                                                      |
+
+
+## Results
+
+| Name                | Type     | Description                                                                 |
+|---------------------|----------|-----------------------------------------------------------------------------|
+| `sealights-bsid`    | `string` | A unique identifier for the Sealights build session.                       |
+| `sealights-build-name`        | `string` | A unique build name generated using the commit SHA and current date.       |
+
+## Volumes
+
+| Name                  | Description                                                    |
+|-----------------------|----------------------------------------------------------------|
+| `sealights-credentials` | Stores Sealights credentials from the specified secret.         |
+| `workdir`             | Temporary working directory for source code operations.        |
+
+## Steps
+
+### 1. `use-trusted-artifact`
+
+Retrieves the source code from a trusted artifact.
+
+### 2. `sealights-python-instrumentation`
+
+Configures and Scans the Python application using Sealights.
+
+## Usage Instructions
+
+### Create the Sealights Secret (REQUIRED)
+
+Ensure you have a Kubernetes secret named **sealights-credentials** containing your Sealights agent token.
+
+We assign the SEALIGHTS_TOKEN var in the script with this command.
+```SEALIGHTS_TOKEN="$(cat /usr/local/sealights-credentials/token)"```
+>NOTE: you must name the value of the secret **token**.
+
+For example:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sealights-credentials
+type: Opaque
+data:
+  token: <BASE64_ENCODED_SEALIGHTS_TOKEN>
+```

--- a/task/sealights-python/0.1/sealights-python.yaml
+++ b/task/sealights-python/0.1/sealights-python.yaml
@@ -1,0 +1,140 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: sealights-python
+  labels:
+    konflux-ci/sealights: "true"
+    konflux-ci/sealights-language: "python"
+spec:
+  description: >-
+    This Tekton task automates the process of configuring your Python application with Sealights for quality analytics and testing.
+    It retrieves the source code from a trusted artifact, installs Python Sealights agent, configures the app for Sealights using
+    vars from your PipelineRun, scans all .py files, reports scan to Sealights, and stores results to be used later on in testing.
+    The task can be triggered by either Pull Request or other events.
+  results:
+    - name: sealights-bsid
+      type: string
+      description: "A unique identifier generated for the current Sealights build session."
+    - name: sealights-build-name
+      type: string
+      description: "A unique build name generated using the commit SHA and current date to prevent conflicts during test reruns."
+  params:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with the application source code.
+      type: string
+    - name: python-version
+      type: string
+      description: "The Python version to use with the 'ubi8/python' image, in the format (e.g., '311')."
+    - name: component
+      type: string
+      description: "The name of the Konflux component associated with the integration tests."
+    - name: scm-provider
+      type: string
+      default: "github"
+      description: "The source control management (SCM) provider used for the project, such as 'Github', 'Gitlab'."
+    - name: exclude
+      type: array
+      default: []
+      description: "A list of paths to exclude from Sealights instrumentation during the code scan. Specify paths to prevent them from being analyzed (e.g., '/app/source/tests/*','/app/examples/*')."
+    - name: repository-url
+      type: string
+      description: "The name or URL of the source code repository (e.g., 'github.com/org/repo')."
+      default: ""
+    - name: branch
+      type: string
+      description: "The name of the Git branch to use for the operation (e.g., 'main' or 'feature-branch')."
+      default: "main"
+    - name: revision
+      type: string
+      description: "The Git revision (commit SHA) from which the test pipeline is originating."
+    - name: pull-request-number
+      type: string
+      description: "The identifier number of the pull request/merge request."
+      default: ""
+    - name: target-branch
+      type: string
+      description: "The name of the target branch for the pull request, typically the branch into which the changes will be merged (e.g., 'main', 'develop')."
+      default: "main"
+    - name: workspace-path
+      type: string
+      description: "The path to the root of your repository."
+  volumes:
+    - name: sealights-credentials
+      secret:
+        secretName: sealights-credentials
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /app
+        name: workdir
+      - name: sealights-credentials
+        mountPath: /usr/local/sealights-credentials
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:52f1391e6f1c472fd10bb838f64fae2ed3320c636f536014978a5ddbdfc6b3af
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/app/source
+    - name: sealights-python-instrumentation
+      image: registry.access.redhat.com/ubi8/python-$(params.python-version):latest
+      workingDir: /app/source
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: COMPONENT
+          value: $(params.component)
+        - name: SCM_PROVIDER
+          value: $(params.scm-provider)
+        - name: REPOSITORY_URL
+          value: $(params.repository-url)
+        - name: BRANCH
+          value: $(params.branch)
+        - name: REVISION
+          value: $(params.revision)
+        - name: PULL_REQUEST_NUMBER
+          value: $(params.pull-request-number)
+        - name: TARGET_BRANCH
+          value: $(params.target-branch)
+        - name: WORKSPACE_PATH
+          value: $(params.workspace-path)
+        - name: TEST_EVENT
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['pipelinesascode.tekton.dev/event-type']
+      args: ["$(params.exclude[*])"]
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        export SEALIGHTS_TOKEN BUILD_NAME EXCLUDE_ENUM
+
+        SEALIGHTS_TOKEN="$(cat /usr/local/sealights-credentials/token)"
+        BUILD_NAME="${REVISION}_$(date +'%y%m%d.%H%M')"
+        EXCLUDE_ENUM="$(IFS=,; printf "%s," "$@" | sed 's/,$//')"
+
+        # Installs Sealights Python agent.
+        pip install sealights-python-agent
+
+        # In case build is coming from a /retest event then it's a pull_request
+        # if event type is not push and pull_request_number is not empty then is a pull_request
+        if [ "$TEST_EVENT" != "push" ] && [ -n "$PULL_REQUEST_NUMBER" ]; then
+          TEST_EVENT="pull_request"
+        fi
+
+        # Configures the app for sealights using vars from your pipeline run.
+        if [[ -n "${TEST_EVENT}" && "${TEST_EVENT}" == "pull_request" ]]; then
+          echo "[INFO] Generate build session id from a Pull Request source code"
+          sl-python prConfig --appname "${COMPONENT}" --targetbranch "${TARGET_BRANCH}" \
+            --pullrequestnumber "${PULL_REQUEST_NUMBER}" --latestcommit "${REVISION}" --repourl "${REPOSITORY_URL}" --buildname "${BUILD_NAME}" --exclude "${EXCLUDE_ENUM}" --workspacepath "${WORKSPACE_PATH}" --token "${SEALIGHTS_TOKEN}"
+        else
+          echo "[INFO] Creating build session ID (BSID) for app: ${COMPONENT}, branch: ${BRANCH}, build: ${BUILD_NAME}..."
+          sl-python config --appname "${COMPONENT}" --branchname "${TARGET_BRANCH}" --buildname "${BUILD_NAME}" --exclude "${EXCLUDE_ENUM}" --workspacepath "${WORKSPACE_PATH}" --token "${SEALIGHTS_TOKEN}"
+        fi
+
+        # Scans all .py files that are not in the --exclude step above and reports scan to sealights.
+        sl-python scan --buildsessionidfile buildSessionId.txt --scmprovider "${SCM_PROVIDER}" --token "${SEALIGHTS_TOKEN}"
+
+        # Stores results to be used in future tasks for testing.
+        echo -n "$(cat buildSessionId.txt)" > "$(results.sealights-bsid.path)"
+        echo -n "$BUILD_NAME" > "$(results.sealights-build-name.path)"


### PR DESCRIPTION
I open this Pull Request to migrate the current Sealights tasks that are living currently in [tekton-integration-catalog](https://github.com/konflux-ci/tekton-integration-catalog/tree/main/tasks/sealights). The reason of migration is that we cannot use the tasks from catalog due to EC violations during builds. For now this migration is temporary until Konflux support https://issues.redhat.com/browse/KONFLUX-4530.

@ascerra @Dannyb48 @psturc @arewm @lcarva @konflux-ci/build-maintainers   FYI