### PR TITLE
push pipeline: fix appstudio-utils image ref

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -188,7 +188,7 @@ spec:
         taskSpec:
           steps:
             - name: run-create-bundle-repos
-              image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
+              image: quay.io/konflux-ci/appstudio-utils:{{revision}}
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash


### PR DESCRIPTION
Don't use the pull-request appstudio-utils image

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
