### PR TITLE
Remove unnecessary tasks from the RHTAP build

### DIFF
--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -5,13 +5,13 @@
 |---|---|---|---|
 |build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.1:BUILD_ARGS|
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.1:BUILD_ARGS_FILE|
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.1:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.1:DOCKERFILE|
 |event-type| Event that triggered the pipeline run, e.g. push, pull_request| push| |
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; acs-deploy-check:0.1:gitops-repo-url ; update-deployment:0.1:gitops-repo-url|
 |gitops-auth-secret-name| Secret name to enable this pipeline to update the gitops repo with the new image. | gitops-auth-secret| update-deployment:0.1:gitops-auth-secret-name|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; acs-image-check:0.1:image ; acs-image-scan:0.1:image|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |stackrox-secret| | rox-api-token| acs-image-check:0.1:rox-secret-name ; acs-image-scan:0.1:rox-secret-name ; acs-deploy-check:0.1:rox-secret-name|
@@ -39,13 +39,6 @@
 |image-digest| Digest of the image to scan | None| '$(tasks.build-container.results.IMAGE_DIGEST)'|
 |insecure-skip-tls-verify| When set to `"true"`, skip verifying the TLS certs of the Central endpoint.  Defaults to `"false"`. | false| 'true'|
 |rox-secret-name| Secret containing the StackRox server endpoint and API token with CI permissions under rox-api-endpoint and rox-api-token keys. For example: rox-api-endpoint: rox.stackrox.io:443 ; rox-api-token: eyJhbGciOiJS... | None| '$(params.stackrox-secret)'|
-### apply-tags:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ADDITIONAL_TAGS| Additional tags that will be applied to the image in the registry.| []| |
-|CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|IMAGE| Reference of image that was pushed to registry in the buildah task.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### buildah-rhtap:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -85,34 +78,6 @@
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| |
-### push-dockerfile:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ARTIFACT_TYPE| Artifact type of the Dockerfile image.| application/vnd.konflux.dockerfile| |
-|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
-|DOCKERFILE| Path to the Dockerfile.| ./Dockerfile| '$(params.dockerfile)'|
-|IMAGE| The built binary image. The Dockerfile is pushed to the same image repository alongside.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|IMAGE_DIGEST| The built binary image digest, which is used to construct the tag of Dockerfile image.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|TAG_SUFFIX| Suffix of the Dockerfile image tag.| .dockerfile| |
-### rpms-signature-scan:0.2 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-unicode-check:0.1 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|FIND_UNICODE_CONTROL_ARGS| arguments for find-unicode-control command.| -p bidi -v -d -t| |
-|FIND_UNICODE_CONTROL_GIT_URL| URL from repository to find unicode control.| https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58| |
-|KFP_GIT_URL| URL from repository to download known false positives files.| | |
-|PROJECT_NAME| Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.| | |
-|RECORD_EXCLUDED| Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. | false| |
-|caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### show-sbom-rhdh:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -165,20 +130,6 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### push-dockerfile:0.1 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGE_REF| Digest-pinned image reference to the Dockerfile image.| |
-### rpms-signature-scan:0.2 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|IMAGES_PROCESSED| Images processed in the task.| |
-|RPMS_DATA| Information about signed and unsigned RPMs| |
-|TEST_OUTPUT| Tekton task test output.| |
-### sast-unicode-check:0.1 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|TEST_OUTPUT| Tekton task test output.| |
 ### show-sbom-rhdh:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -188,7 +139,7 @@
 |name|description|optional|used in tasks
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; build-container:0.1:source ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; build-container:0.1:source|
 ## Available workspaces from tasks
 ### acs-deploy-check:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -204,14 +155,6 @@
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |output| The git repo will be cloned onto the volume backing this Workspace.| False| workspace|
 |ssh-directory| A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. | True| |
-### push-dockerfile:0.1 task workspaces
-|name|description|optional|workspace from pipeline
-|---|---|---|---|
-|workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
-### sast-unicode-check:0.1 task workspaces
-|name|description|optional|workspace from pipeline
-|---|---|---|---|
-|workspace| | False| workspace|
 ### summary:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -127,18 +127,30 @@
 #      8  ecosystem-cert-preflight-checks
 #      9  sast-snyk-check
 #     10  clamav-scan
-#     11  apply-tags
-#     12  push-dockerfile
-#     13  rpms-signature-scan
+#     11  sast-coverity-check
+#     12  coverity-availability-check
+#     13  sast-shell-check
+#     14  sast-unicode-check
+#     15  apply-tags
+#     16  push-dockerfile
+#     17  rpms-signature-scan
 - op: replace
-  path: /spec/tasks/3/runAfter/0
+  path: /spec/tasks/3/runAfter/0  # build-container
   value: clone-repository
 - op: remove
-  path: /spec/tasks/13  # rpms-signature-scan
+  path: /spec/tasks/17  # rpms-signature-scan
 - op: remove
-  path: /spec/tasks/12  # push-dockerfile
+  path: /spec/tasks/16  # push-dockerfile
 - op: remove
-  path: /spec/tasks/11  # apply-tags
+  path: /spec/tasks/15  # apply-tags
+- op: remove
+  path: /spec/tasks/14  # sast-unicode-check
+- op: remove
+  path: /spec/tasks/13  # sast-shell-check
+- op: remove
+  path: /spec/tasks/12  # coverity-availability-check
+- op: remove
+  path: /spec/tasks/11  # sast-coverity-check
 - op: remove
   path: /spec/tasks/10  # clamav-scan
 - op: remove


### PR DESCRIPTION
This changes removes various Tasks that have been added to template-build and thus automatically added to the docker-build-rhtap pipeline.

NOTE: At this point, it is probably not worth using kustomize to generate the docker-build-rhtap pipeline -- only three of the 20 tasks are reused. It probably also makes sense to remove this pipeline and all other RHTAP specific tasks out of this repository.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
