### PR TITLE
use git resolver for fips task stepaction

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -190,7 +190,14 @@ spec:
           cpu: 100m
           memory: 256Mi
       ref:
-        name: fips-operator-check-step-action
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions
+          - name: revision
+            value: c366291f484f2510767a51d0f45d7bc37877e94e
+          - name: pathInRepo
+            value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+        resolver: git
     - name: parse-images-processed-result
       image: quay.io/redhat-appstudio/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
       env:

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -175,7 +175,14 @@ spec:
           memory: 256Mi
           cpu: 100m
       ref:
-        name: fips-operator-check-step-action
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions
+          - name: revision
+            value: c366291f484f2510767a51d0f45d7bc37877e94e
+          - name: pathInRepo
+            value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 
     - name: parse-images-processed-result
       image: quay.io/redhat-appstudio/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -156,7 +156,14 @@ spec:
           cpu: 100m
           memory: 256Mi
       ref:
-        name: fips-operator-check-step-action
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions
+          - name: revision
+            value: c366291f484f2510767a51d0f45d7bc37877e94e
+          - name: pathInRepo
+            value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+        resolver: git
     - name: parse-images-processed-result
       image: quay.io/redhat-appstudio/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
       script: |

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -129,7 +129,14 @@ spec:
           memory: 256Mi
           cpu: 100m
       ref:
-        name: fips-operator-check-step-action
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions
+          - name: revision
+            value: c366291f484f2510767a51d0f45d7bc37877e94e
+          - name: pathInRepo
+            value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 
     - name: parse-images-processed-result
       image: quay.io/redhat-appstudio/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623


### PR DESCRIPTION
Because the stepaction doesn't exist in the workspaces, the task image fails to run. Use the git resolver to fetch the stepaction in the task.

Refers to [KFLUXSPRT-1555](https://issues.redhat.com//browse/KFLUXSPRT-1555)

