### PR TITLE
CODEOWNERS: add Jeremy Choi and Sam Fowler

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -68,16 +68,16 @@
 /stepactions/fips-operator-check-step-action    @konflux-ci/integration-service-maintainers
 
 # renovate groupName=integration
-/task/coverity-availability-check           @konflux-ci/integration-service-maintainers @kdudka
-/task/coverity-availability-check-oci-ta    @konflux-ci/integration-service-maintainers @kdudka
-/task/sast-coverity-check                   @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @kdudka
-/task/sast-coverity-check-oci-ta            @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @kdudka
-/task/sast-shell-check                      @konflux-ci/integration-service-maintainers @kdudka
-/task/sast-shell-check-oci-ta               @konflux-ci/integration-service-maintainers @kdudka
-/task/sast-snyk-check                       @konflux-ci/integration-service-maintainers @kdudka
-/task/sast-snyk-check-oci-ta                @konflux-ci/integration-service-maintainers @kdudka
-/task/sast-unicode-check                    @konflux-ci/integration-service-maintainers @kdudka
-/task/sast-unicode-check-oci-ta             @konflux-ci/integration-service-maintainers @kdudka
+/task/coverity-availability-check           @konflux-ci/integration-service-maintainers @kdudka @jeremychoi @sfowl
+/task/coverity-availability-check-oci-ta    @konflux-ci/integration-service-maintainers @kdudka @jeremychoi @sfowl
+/task/sast-coverity-check                   @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @kdudka @jeremychoi @sfowl
+/task/sast-coverity-check-oci-ta            @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @kdudka @jeremychoi @sfowl
+/task/sast-shell-check                      @konflux-ci/integration-service-maintainers @kdudka @jeremychoi @sfowl
+/task/sast-shell-check-oci-ta               @konflux-ci/integration-service-maintainers @kdudka @jeremychoi @sfowl
+/task/sast-snyk-check                       @konflux-ci/integration-service-maintainers @kdudka @jeremychoi @sfowl
+/task/sast-snyk-check-oci-ta                @konflux-ci/integration-service-maintainers @kdudka @jeremychoi @sfowl
+/task/sast-unicode-check                    @konflux-ci/integration-service-maintainers @kdudka @jeremychoi @sfowl
+/task/sast-unicode-check-oci-ta             @konflux-ci/integration-service-maintainers @kdudka @jeremychoi @sfowl
 
 # renovate groupName=preflight
 /task/ecosystem-cert-preflight-checks   @acornett21 @bcrochet @komish @skattoju


### PR DESCRIPTION
... as code owners of the `sast-*-check` tasks.  They are going to be the primary maintainers of these task definitions.

Related: https://issues.redhat.com/browse/PSSECAUT-943