### PR TITLE
fix: use CSV annotations for fips compliance of a bundle

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -124,17 +124,16 @@ spec:
             fi
             subscription_label=$(echo "${bundle_out}" | jq -r '.properties[] | select(.value.annotations["operators.openshift.io/valid-subscription"] != null) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
 
-            bundle_labels=$(get_image_labels "${bundle}")
-            fips_label=$(echo "${bundle_labels}" | grep '^features.operators.openshift.io/fips-compliant=' | cut -d= -f2 || true)
+            fips_annotation=$(echo "${bundle_out}" | jq -r '.properties[] | select(.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true") | .value.annotations["features.operators.openshift.io/fips-compliant"]')
 
             if ! echo "${subscription_label}" | grep -e "OpenShift Kubernetes Engine" -e "OpenShift Container Platform" -e "OpenShift Platform Plus"; then
               echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are not present in operators.openshift.io/valid-subscription."
               echo "Subscription labels are : $subscription_label"
-              if [ -z "${fips_label}" ] || [ "${fips_label}" != "true" ]; then
-                echo "The label features.operators.openshift.io/fips-compliant is also not set to true. Skipping the FIPS static check for ${bundle}"
+              if [ -z "${fips_annotation}" ] || [ "${fips_annotation}" != "true" ]; then
+                echo "The annotation features.operators.openshift.io/fips-compliant is also not set to true. Skipping the FIPS static check for ${bundle}"
                 continue
               else
-                echo "The label features.operators.openshift.io/fips-compliant is set to true. Running the FIPS static check..."
+                echo "The annotation features.operators.openshift.io/fips-compliant is set to true. Running the FIPS static check..."
               fi
             else
               echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are present in operators.openshift.io/valid-subscription. Running the FIPS static check..."

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -121,17 +121,16 @@ spec:
             fi
             subscription_label=$(echo "${bundle_out}" | jq -r '.properties[] | select(.value.annotations["operators.openshift.io/valid-subscription"] != null) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
 
-            bundle_labels=$(get_image_labels "${bundle}")
-            fips_label=$(echo "${bundle_labels}" | grep '^features.operators.openshift.io/fips-compliant=' | cut -d= -f2 || true)
+            fips_annotation=$(echo "${bundle_out}" | jq -r '.properties[] | select(.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true") | .value.annotations["features.operators.openshift.io/fips-compliant"]')
 
             if ! echo "${subscription_label}" | grep -e "OpenShift Kubernetes Engine" -e "OpenShift Container Platform" -e "OpenShift Platform Plus"; then
               echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are not present in operators.openshift.io/valid-subscription."
               echo "Subscription labels are : $subscription_label"
-              if [ -z "${fips_label}" ] || [ "${fips_label}" != "true" ]; then
-                echo "The label features.operators.openshift.io/fips-compliant is also not set to true. Skipping the FIPS static check for ${bundle}"
+              if [ -z "${fips_annotation}" ] || [ "${fips_annotation}" != "true" ]; then
+                echo "The annotation features.operators.openshift.io/fips-compliant is also not set to true. Skipping the FIPS static check for ${bundle}"
                 continue
               else
-                echo "The label features.operators.openshift.io/fips-compliant is set to true. Running the FIPS static check..."
+                echo "The annotation features.operators.openshift.io/fips-compliant is set to true. Running the FIPS static check..."
               fi
             else
               echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are present in operators.openshift.io/valid-subscription. Running the FIPS static check..."

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -78,16 +78,16 @@ spec:
         # Run the FIPS check only if the bundle is part of the Openshift Subscription or has the fips label set
         image_and_digest_render_out=$(opm render "$image_and_digest")
         subscription_label=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select(.value.annotations["operators.openshift.io/valid-subscription"] != null) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
-        fips_label=$(echo "${image_and_digest_labels}" | grep '^features.operators.openshift.io/fips-compliant=' | cut -d= -f2 || true)
+        fips_annotation=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select(.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true") | .value.annotations["features.operators.openshift.io/fips-compliant"]')
 
         if ! echo "${subscription_label}" | grep -e "OpenShift Kubernetes Engine" -e "OpenShift Container Platform" -e "OpenShift Platform Plus"; then
           echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are not present in operators.openshift.io/valid-subscription."
           echo "Subscription labels are : $subscription_label"
-          if [ -z "${fips_label}" ] || [ "${fips_label}" != "true" ]; then
-            echo "The label features.operators.openshift.io/fips-compliant is also not set to true. Skipping the FIPS static check..."
+          if [ -z "${fips_annotation}" ] || [ "${fips_annotation}" != "true" ]; then
+            echo "The annotation features.operators.openshift.io/fips-compliant is also not set to true. Skipping the FIPS static check..."
             exit 0
           else
-            echo "The label features.operators.openshift.io/fips-compliant is set to true. Running the FIPS static check..."
+            echo "The annotation features.operators.openshift.io/fips-compliant is set to true. Running the FIPS static check..."
           fi
         else
           echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are present in operators.openshift.io/valid-subscription. Running the FIPS static check..."

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -63,16 +63,16 @@ spec:
         # Run the FIPS check only if the bundle is part of the Openshift Subscription or has the fips label set
         image_and_digest_render_out=$(opm render "$image_and_digest")
         subscription_label=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select(.value.annotations["operators.openshift.io/valid-subscription"] != null) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
-        fips_label=$(echo "${image_and_digest_labels}" | grep '^features.operators.openshift.io/fips-compliant=' | cut -d= -f2 || true)
+        fips_annotation=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select(.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true") | .value.annotations["features.operators.openshift.io/fips-compliant"]')
 
         if ! echo "${subscription_label}" | grep -e "OpenShift Kubernetes Engine" -e "OpenShift Container Platform" -e "OpenShift Platform Plus"; then
           echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are not present in operators.openshift.io/valid-subscription."
           echo "Subscription labels are : $subscription_label"
-          if [ -z "${fips_label}" ] || [ "${fips_label}" != "true" ]; then
-            echo "The label features.operators.openshift.io/fips-compliant is also not set to true. Skipping the FIPS static check..."
+          if [ -z "${fips_annotation}" ] || [ "${fips_annotation}" != "true" ]; then
+            echo "The annotation features.operators.openshift.io/fips-compliant is also not set to true. Skipping the FIPS static check..."
             exit 0
           else
-            echo "The label features.operators.openshift.io/fips-compliant is set to true. Running the FIPS static check..."
+            echo "The annotation features.operators.openshift.io/fips-compliant is set to true. Running the FIPS static check..."
           fi
         else
           echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are present in operators.openshift.io/valid-subscription. Running the FIPS static check..."


### PR DESCRIPTION
previously, the FIPS compliance tasks checked image labels to identify if an operator bundle claims to be fips compliant. Not all product teams include it as labels. A more robust way is to check the CSV annotations. This commit implements that fix.

Refers to [KONFLUX-6664](https://issues.redhat.com//browse/KONFLUX-6664)

