### PR TITLE
chore(KFLUXVNGD-183): add retries to tkn bundle push

### DIFF
--- a/task/tkn-bundle-oci-ta/0.1/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.1/tkn-bundle-oci-ta.yaml
@@ -150,8 +150,25 @@ spec:
           exit 1
         exec 3>&1
 
+        retry() {
+          local status
+          local retry=0
+          local -r interval=${RETRY_INTERVAL:-5}
+          local -r max_retries=5
+          while true; do
+            "$@" && break
+            status=$?
+            ((retry += 1))
+            if [ $retry -gt $max_retries ]; then
+              return $status
+            fi
+            echo "info: Waiting for a while, then retry ..." 1>&2
+            sleep "$interval"
+          done
+        }
+
         # shellcheck disable=SC2046
-        OUT="$(tkn bundle push "$IMAGE" \
+        OUT="$(retry tkn bundle push "$IMAGE" \
           $(printf ' -f %s' "${FILES[@]}") |
           tee /proc/self/fd/3)"
         echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"

--- a/task/tkn-bundle/0.1/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.1/tkn-bundle.yaml
@@ -132,8 +132,25 @@ spec:
         && exit 1
       exec 3>&1;
 
+      retry() {
+          local status
+          local retry=0
+          local -r interval=${RETRY_INTERVAL:-5}
+          local -r max_retries=5
+          while true; do
+              "$@" && break
+              status=$?
+              ((retry+=1))
+              if [ $retry -gt $max_retries ]; then
+                  return $status
+              fi
+              echo "info: Waiting for a while, then retry ..." 1>&2
+              sleep "$interval"
+          done
+      }
+
       # shellcheck disable=SC2046
-      OUT="$(tkn bundle push "$IMAGE" \
+      OUT="$(retry tkn bundle push "$IMAGE" \
         $(printf ' -f %s' "${FILES[@]}") \
         |tee /proc/self/fd/3)"
       echo -n "$IMAGE" > "$(results.IMAGE_URL.path)"


### PR DESCRIPTION
Add retry to tkn bundle push command

The tkn bundle push command fails from time to time, but succeeds when rerun.
Adding retries might reduce the errors we are seeing.
