### PR TITLE
fix: replace quay.io/redhat-appstudio/github-app-token image with ubi

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -116,7 +116,7 @@ spec:
                 echo $? > partner-tasks-code.out
                 cat partner-tasks.out
             - name: create-comment
-              image: quay.io/redhat-appstudio/github-app-token@sha256:b4f2af12e9beea68055995ccdbdb86cfe1be97688c618117e5da2243dc1da18e
+              image: registry.access.redhat.com/ubi9/python-39:9.5-1737460369@sha256:9a31f03f8b27d9065c3488bbd3650c67271c3b868eacf816ddea07ababd9fbc0
               volumeMounts:
                 - name: infra-deployments-pr-creator
                   mountPath: /secrets/deploy-key


### PR DESCRIPTION
Since we are getting rid of images from `quay.io/redhat-appstudio` , using python based image in the CI