### PR TITLE
build-and-push: store all task bundle references

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -478,6 +478,7 @@ build_push_tasks() {
         if [ -n "$digest" ]; then
             task_bundle_with_digest=${task_bundle}@${digest}
             echo "info: use existing $task_bundle_with_digest" 1>&2
+            echo "$task_bundle_with_digest" >> "$OUTPUT_TASK_BUNDLE_LIST"
         else
             echo "info: push new bundle $task_bundle" 1>&2
 


### PR DESCRIPTION
The push pipeline runs the `build-and-push` script and the `build-acceptable-bundles` script (which takes `OUTPUT_TASK_BUNDLE_LIST` as input). It may happen that the `build-and-push` script succeeds while the `build-acceptable-bundles` script fails, resulting in a situation where new task bundles have been released but are not included in the `data-acceptable-bundles` image.

Previously, rerunning the push pipeline wouldn't help in those situtations. The `build-and-push` script doesn't re-push task bundles if the expected revision already exists in the registry and didn't use to record references of existing bundles in the `OUTPUT_TASK_BUNDLE_LIST`.

Always record the references of existing bundles to make it possible to fix the problem simply by rerunning the push pipeline.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
