### PR TITLE
deprecated-image-check/0.5: arbitrary change

### DIFF
--- a/task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -205,6 +205,7 @@ spec:
         mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
         subPath: ca-bundle.crt
         readOnly: true
+
   volumes:
   - name: trusted-ca
     configMap:


### PR DESCRIPTION
Needed to add the task to the data-acceptable-bundles image.

When merging https://github.com/konflux-ci/build-definitions/pull/1865, the build-acceptable-bundles failed. This meant the new versions of all tasks updated in that PR were missing from data-acceptable-bundles.

Due to the way the push pipeline is set up, making a change to the affected tasks is the only way to add them to data-acceptable-bundles.
