### PR TITLE
source-build/0.2: arbitrary change

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -365,7 +365,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BUILD_RESULT| Build result.| |
-|IMAGE_REF| Image reference of the built image| |
+|IMAGE_REF| Image reference of the built image.| |
 |SOURCE_IMAGE_DIGEST| The source image digest.| |
 |SOURCE_IMAGE_URL| The source image url.| |
 

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -362,7 +362,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BUILD_RESULT| Build result.| |
-|IMAGE_REF| Image reference of the built image| |
+|IMAGE_REF| Image reference of the built image.| |
 |SOURCE_IMAGE_DIGEST| The source image digest.| |
 |SOURCE_IMAGE_URL| The source image url.| |
 

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -348,7 +348,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |BUILD_RESULT| Build result.| |
-|IMAGE_REF| Image reference of the built image| |
+|IMAGE_REF| Image reference of the built image.| |
 |SOURCE_IMAGE_DIGEST| The source image digest.| |
 |SOURCE_IMAGE_URL| The source image url.| |
 

--- a/task/source-build-oci-ta/0.2/README.md
+++ b/task/source-build-oci-ta/0.2/README.md
@@ -14,7 +14,7 @@ Source image build.
 |name|description|
 |---|---|
 |BUILD_RESULT|Build result.|
-|IMAGE_REF|Image reference of the built image|
+|IMAGE_REF|Image reference of the built image.|
 |SOURCE_IMAGE_DIGEST|The source image digest.|
 |SOURCE_IMAGE_URL|The source image url.|
 

--- a/task/source-build-oci-ta/0.2/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.2/source-build-oci-ta.yaml
@@ -36,7 +36,7 @@ spec:
     - name: BUILD_RESULT
       description: Build result.
     - name: IMAGE_REF
-      description: Image reference of the built image
+      description: Image reference of the built image.
     - name: SOURCE_IMAGE_DIGEST
       description: The source image digest.
     - name: SOURCE_IMAGE_URL

--- a/task/source-build/0.2/README.md
+++ b/task/source-build/0.2/README.md
@@ -14,7 +14,7 @@ Source image build.
 |BUILD_RESULT|Build result.|
 |SOURCE_IMAGE_URL|The source image url.|
 |SOURCE_IMAGE_DIGEST|The source image digest.|
-|IMAGE_REF|Image reference of the built image|
+|IMAGE_REF|Image reference of the built image.|
 
 ## Workspaces
 |name|description|optional|

--- a/task/source-build/0.2/source-build.yaml
+++ b/task/source-build/0.2/source-build.yaml
@@ -30,7 +30,7 @@ spec:
     - name: SOURCE_IMAGE_DIGEST
       description: The source image digest.
     - name: IMAGE_REF
-      description: Image reference of the built image
+      description: Image reference of the built image.
   workspaces:
     - name: workspace
       description: The workspace where source code is included.


### PR DESCRIPTION
Needed to add the task to the data-acceptable-bundles image.

When merging https://github.com/konflux-ci/build-definitions/pull/1865, the build-acceptable-bundles failed. This meant the new versions of all tasks updated in that PR were missing from data-acceptable-bundles.

Due to the way the push pipeline is set up, making a change to the affected tasks is the only way to add them to data-acceptable-bundles.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
