### PR TITLE
add operator-foundry to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -55,17 +55,17 @@
 /task/clair-scan                                @konflux-ci/integration-service-maintainers
 /task/clamav-scan                               @konflux-ci/integration-service-maintainers
 /task/deprecated-image-check                    @konflux-ci/integration-service-maintainers
-/task/fbc-fips-check                            @konflux-ci/integration-service-maintainers
-/task/fbc-fips-check-oci-ta                     @konflux-ci/integration-service-maintainers
-/task/fbc-related-image-check                   @konflux-ci/integration-service-maintainers
-/task/fbc-target-index-pruning-check            @konflux-ci/integration-service-maintainers
-/task/fbc-validation                            @konflux-ci/integration-service-maintainers
+/task/fbc-fips-check                            @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
+/task/fbc-fips-check-oci-ta                     @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
+/task/fbc-related-image-check                   @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
+/task/fbc-target-index-pruning-check            @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
+/task/fbc-validation                            @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/inspect-image                             @konflux-ci/integration-service-maintainers
 /task/sbom-json-check                           @konflux-ci/integration-service-maintainers
 /task/validate-fbc                              @konflux-ci/integration-service-maintainers
-/task/fips-operator-bundle-check                @konflux-ci/integration-service-maintainers
-/task/fips-operator-bundle-check-oci-ta         @konflux-ci/integration-service-maintainers
-/stepactions/fips-operator-check-step-action    @konflux-ci/integration-service-maintainers
+/task/fips-operator-bundle-check                @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
+/task/fips-operator-bundle-check-oci-ta         @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
+/stepactions/fips-operator-check-step-action    @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 
 # renovate groupName=integration
 /task/coverity-availability-check           @konflux-ci/integration-service-maintainers @kdudka


### PR DESCRIPTION
this commit makes the operator-foundry team owners of FBC tasks and FIPS tasks.

