### PR TITLE
Deprecate old buildah tasks

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -197,7 +197,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
 |PROJECT_NAME| | | |
 |RECORD_EXCLUDED| | false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -194,7 +194,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
 |PROJECT_NAME| | | |
 |RECORD_EXCLUDED| | false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -188,7 +188,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
 |PROJECT_NAME| | | |
 |RECORD_EXCLUDED| | false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -98,7 +98,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
 |PROJECT_NAME| | | |
 |RECORD_EXCLUDED| | false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -94,7 +94,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
 |PROJECT_NAME| | | |
 |RECORD_EXCLUDED| | false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -115,7 +115,7 @@
 |PRIVILEGED_NESTED| Whether to enable privileged mode| false| |
 |PROJECT_NAME| | | |
 |RECORD_EXCLUDED| | false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| cyclonedx| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |

--- a/task/buildah-min/0.2/buildah-min.yaml
+++ b/task/buildah-min/0.2/buildah-min.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-01T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:

--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -4,6 +4,7 @@ kind: Task
 metadata:
   name: buildah-oci-ta
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-01T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:

--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -4,6 +4,7 @@ kind: Task
 metadata:
   name: buildah-oci-ta
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-01T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-01T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/version: "0.2.1"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-01T00:00:00Z"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, konflux"
   name: buildah

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -5,6 +5,7 @@ metadata:
     app.kubernetes.io/version: "0.2.1"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, konflux"
   name: buildah

--- a/task/sast-coverity-check-oci-ta/0.2/README.md
+++ b/task/sast-coverity-check-oci-ta/0.2/README.md
@@ -27,7 +27,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
 |PROJECT_NAME||""|false|
 |RECORD_EXCLUDED||false|false|
-|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: Scans source code for security vulnerabilities, including common
@@ -116,7 +116,7 @@ spec:
         cyclonedx. Note: the SBOM from the prefetch task - if there is one
         - must be in the same format.'
       type: string
-      default: cyclonedx
+      default: spdx
     - name: SKIP_SBOM_GENERATION
       description: Skip SBOM-related operations. This will likely cause EC
         policies to fail if enabled

--- a/task/sast-coverity-check/0.2/kustomization.yaml
+++ b/task/sast-coverity-check/0.2/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../buildah/0.3
+  - ../../buildah/0.4
 
 patches:
 - path: patch.yaml

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -3,6 +3,11 @@
   path: /metadata/name
   value: sast-coverity-check
 
+# Task version
+- op: replace
+  path: /metadata/labels/app.kubernetes.io~1version
+  value: "0.2"
+
 # Task description
 - op: replace
   path: /spec/description

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: docker
   name: sast-coverity-check
 spec:
@@ -125,7 +125,7 @@ spec:
       to fail if enabled
     name: SKIP_SBOM_GENERATION
     type: string
-  - default: cyclonedx
+  - default: spdx
     description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
       Note: the SBOM from the prefetch task - if there is one - must be in the same
       format.'


### PR DESCRIPTION
Deprecate buildah/0.2 on 1st March 2025

Deprecate buildah/0.3 on 31st March 2025

This mainly to "motivate" users to update to the version that switched the default SBOM type to SPDX

Also update the sast-coverity-check task to be based on buildah 0.4 rather than 0.3, to avoid inheriting the deprecation annotation. And fix the version label in the task.