### PR TITLE
coverity-availability-check-oci-ta/0.2: fix name, improve migration doc

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -32,6 +32,7 @@ sources:
       exclude:
         # https://issues.redhat.com/browse/EC-1038
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202412.2
+        - step_images.step_images_accessible:registry.access.redhat.com/ubi8/nodejs-$(params.nodejs-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/python-$(params.python-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/go-toolset:$(params.go-version)
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity@sha256:0d1b96fb08a901b2d0e340599c7fee7e1de25e2d6ba58f3d95db4983f32b5a3c

--- a/policies/step-actions.yaml
+++ b/policies/step-actions.yaml
@@ -17,6 +17,7 @@ sources:
       exclude:
         # https://issues.redhat.com/browse/EC-1038
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202412.2
+        - step_images.step_images_accessible:registry.access.redhat.com/ubi8/nodejs-$(params.nodejs-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/python-$(params.python-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/go-toolset:$(params.go-version)
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity@sha256:0d1b96fb08a901b2d0e340599c7fee7e1de25e2d6ba58f3d95db4983f32b5a3c

--- a/task/coverity-availability-check-oci-ta/0.2/MIGRATION.md
+++ b/task/coverity-availability-check-oci-ta/0.2/MIGRATION.md
@@ -1,3 +1,28 @@
 # Migration from 0.1 to 0.2
 
 Starting with version 0.2, the `coverity-availability-check-oci-ta` task is deprecated.  Please use `coverity-availability-check` instead.
+
+## Action from users
+
+In your pipelines, find the references to `coverity-availability-check-oci-ta` and replace them with `coverity-availability-check`.
+For the task bundle (the `quay.io/...` reference), you will also need to change the sha256 digest. Example:
+
+```diff
+       taskRef:
+         resolver: bundles
+         params:
+         - name: name
+-          value: coverity-availability-check-oci-ta
++          value: coverity-availability-check
+         - name: bundle
+-          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check-oci-ta:0.2@sha256:8653d290298593e4db9457ab00d9160738c31c384b7615ee30626ccab6f96ed8
++          value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:91ba738df7ec548d4127163e07a88de06568a350fbf581405cc8fc8498f6153c
+         - name: kind
+           value: task
+```
+
+If you would prefer to use the latest digest rather than the one which was latest at the time of writing this doc, get it with:
+
+```bash
+skopeo inspect --no-tags --format '{{.Digest}}' docker://quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2
+```

--- a/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
+++ b/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
@@ -1,1 +1,88 @@
-../../coverity-availability-check/0.2/coverity-availability-check.yaml
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+  name: coverity-availability-check-oci-ta
+spec:
+  description: This task performs needed checks in order to use Coverity image in
+    the pipeline. It will check for a Coverity license secret and an authentication
+    secret for pulling the image.
+  params:
+  - default: cov-license
+    description: Name of secret which contains the Coverity license
+    name: COV_LICENSE
+  - default: auth-token-coverity-image
+    description: Name of secret which contains the authentication token for pulling
+      the Coverity image.
+    name: AUTH_TOKEN_COVERITY_IMAGE
+  results:
+  - description: Tekton task result output.
+    name: TEST_OUTPUT
+  - description: Tekton task simple status to be later checked
+    name: STATUS
+  steps:
+  - env:
+    - name: COV_LICENSE
+      value: $(params.COV_LICENSE)
+    - name: AUTH_TOKEN_COVERITY_IMAGE
+      value: $(params.AUTH_TOKEN_COVERITY_IMAGE)
+    image: quay.io/konflux-ci/konflux-test:v1.4.8@sha256:2224fabdb0a28a415d4af4c58ae53d7c4c53c83c315f12e07d1d7f48a80bfa70
+    name: coverity-availability-check
+    script: |
+      #!/usr/bin/env bash
+      set -eo pipefail
+      # shellcheck source=/dev/null
+      . /utils.sh
+      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+      # Checking Coverity license
+      COV_LICENSE_PATH=/etc/secrets/cov/cov-license
+      if [ -f "${COV_LICENSE_PATH}" ] && [ -s "${COV_LICENSE_PATH}" ]; then
+        echo "Coverity license detected!"
+      else
+        echo 'No license file for Coverity was detected. Coverity scan will not be executed...'
+        echo 'Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license'
+        note="Task $(context.task.name) failed: No license file for Coverity was detected. Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license"
+        TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        echo -n "failed" | tee "$(results.STATUS.path)"
+        exit 0
+      fi
+
+      # Checking authentication token for downloading coverity image
+      AUTH_TOKEN_COVERITY_IMAGE_PATH=/etc/secrets/auth/config.json
+      if [ -f "${AUTH_TOKEN_COVERITY_IMAGE_PATH}" ] && [ -s "${AUTH_TOKEN_COVERITY_IMAGE_PATH}" ]; then
+        echo "Authentication token detected!"
+      else
+        echo 'No authentication token for downloading Coverity image detected. Coverity scan will not be executed...'
+        echo 'Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image'
+        note="Task $(context.task.name) failed: No authentication token for downloading Coverity image detected. Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image"
+        TEST_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        echo -n "failed" | tee "$(results.STATUS.path)"
+        exit 0
+      fi
+
+      note="Task $(context.task.name) completed: Coverity availability checks finished succesfully."
+      # shellcheck disable=SC2034
+      TEST_OUTPUT=$(make_result_json -r SUCCESS -s 1 -t "$note")
+      echo -n "success" | tee "$(results.STATUS.path)"
+      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+    volumeMounts:
+    - mountPath: /etc/secrets/cov
+      name: cov-license
+      readOnly: true
+    - mountPath: /etc/secrets/auth/config.json
+      name: auth-token-coverity-image
+      subPath: .dockerconfigjson
+  volumes:
+  - name: cov-license
+    secret:
+      optional: true
+      secretName: $(params.COV_LICENSE)
+  - name: auth-token-coverity-image
+    secret:
+      optional: true
+      secretName: $(params.AUTH_TOKEN_COVERITY_IMAGE)

--- a/task/coverity-availability-check-oci-ta/0.2/kustomization.yaml
+++ b/task/coverity-availability-check-oci-ta/0.2/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- ../../coverity-availability-check/0.2
+
+patches:
+- patch: |-
+    - op: replace
+      path: /metadata/name
+      value: coverity-availability-check-oci-ta
+  target:
+    kind: Task
+    name: coverity-availability-check

--- a/task/coverity-availability-check/0.2/kustomization.yaml
+++ b/task/coverity-availability-check/0.2/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- coverity-availability-check.yaml


### PR DESCRIPTION
Previously, coverity-availability-check-oci-ta.yaml was just a symlink to coverity-availability-check.yaml. Which means .metadata.name was 'coverity-availability-check'. This caused pipelines referencing coverity-availability-check-oci-ta:0.2 to fail with

    Couldn't retrieve Task ...
    could not find object in image with kind: task and name: coverity-availability-check-oci-ta

Generate coverity-availability-check-oci-ta.yaml from coverity-availability-check.yaml via kustomize, set the .metadata.name to the expected name.

Add kustomization.yaml to coverity-availability-check as well, otherwise coverity-availability-check-oci-ta wouldn't be able to use it as a base.

Explain how to switch from coverity-availability-check-oci-ta to
coverity-availability-check