### PR TITLE
Upgrade appstudio-utils image in EaaS stepactions

### DIFF
--- a/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
+++ b/stepactions/eaas-copy-secrets-to-ephemeral-cluster/0.1/eaas-copy-secrets-to-ephemeral-cluster.yaml
@@ -6,7 +6,7 @@ spec:
   description: >-
     This StepAction copies Secrets from the current namespace into a configurable namespace on an
     ephemeral cluster. The name and content of each Secret is unaltered in the process.
-  image: quay.io/redhat-appstudio/appstudio-utils@sha256:586149e3f18d966f681d956ab074b4e1d8433663d615ed86e19a3804ba952dfe
+  image: quay.io/konflux-ci/appstudio-utils@sha256:ae8cf015eee19adef1ae5b7a6b346fb1a74acd59bfff55e57744527f283cf1f0
   params:
     - name: credentials
       type: string

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
@@ -6,7 +6,7 @@ spec:
   description: >-
     This StepAction provisions an ephemeral cluster using Hypershift with 3 worker nodes in AWS.
     It does so by creating a ClusterTemplateInstance in a space on an EaaS cluster.
-  image: quay.io/konflux-ci/appstudio-utils:5d8df82bdad43c3a71c9eb1a525a25e946777dc4@sha256:0901c58b85d6a05f75782bd8dd64b849a5b7d44f9f36c78a6ee33161278c96a4
+  image: quay.io/konflux-ci/appstudio-utils@sha256:ae8cf015eee19adef1ae5b7a6b346fb1a74acd59bfff55e57744527f283cf1f0
   params:
     - name: eaasSpaceSecretRef
       type: string

--- a/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+++ b/stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   description: >-
     This StepAction queries an OpenShift CI API to get the latest version for a release stream.
-  image: quay.io/redhat-appstudio/appstudio-utils@sha256:586149e3f18d966f681d956ab074b4e1d8433663d615ed86e19a3804ba952dfe
+  image: quay.io/konflux-ci/appstudio-utils@sha256:ae8cf015eee19adef1ae5b7a6b346fb1a74acd59bfff55e57744527f283cf1f0
   params:
     - name: prefix
       type: string

--- a/stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+++ b/stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
@@ -7,7 +7,7 @@ spec:
   description: >-
     This StepAction queries the EaaS hub cluster used to provision ephemeral clusters for testing.
     It returns a list of supported versions stored in a hypershift ConfigMap.
-  image: quay.io/redhat-appstudio/appstudio-utils@sha256:586149e3f18d966f681d956ab074b4e1d8433663d615ed86e19a3804ba952dfe
+  image: quay.io/konflux-ci/appstudio-utils@sha256:ae8cf015eee19adef1ae5b7a6b346fb1a74acd59bfff55e57744527f283cf1f0
   params:
     - name: eaasSpaceSecretRef
       type: string


### PR DESCRIPTION
This is a followup to #1918.

Commit tags are removed from the pull specs so renovate can identify newer versions.