### PR TITLE
Set preflight to SUCCESS for operator bundles

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -111,7 +111,7 @@ spec:
         . /utils.sh # gives us the make_result_json helper used below.
 
         # Generate TEST_OUTPUT
-        TEST_OUTPUT=$(make_result_json -r "SKIPPED" -t "${NOTE}")
+        TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "${NOTE}")
 
         printf "%s" "${TEST_OUTPUT}" | tee "$(step.results.test-output.path)" /bundle/konflux.results.json
       volumeMounts:


### PR DESCRIPTION
Having a SKIPPED result for `ecosystem-cert-preflight-checks` for operator bundles doesn't align with what Conforma expects.

ref: https://redhat-internal.slack.com/archives/C04PZ7H0VA8/p1739212062777609