### PR TITLE
Fix jq syntax error in prefetch-dependencies tasks

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -285,6 +285,8 @@ spec:
                         else
                           if has("include_summary_in_sbom") | not then
                             .include_summary_in_sbom = true
+                          else
+                            .
                           end
 
                         end' <<<"$input")"

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -285,6 +285,8 @@ spec:
                         else
                           if has("include_summary_in_sbom") | not then
                             .include_summary_in_sbom = true
+                          else
+                            .
                           end
 
                         end' <<<"$input")"

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -216,6 +216,8 @@ spec:
                       else
                         if has("include_summary_in_sbom") | not then
                           .include_summary_in_sbom = true
+                        else
+                          .
                         end
 
                       end' <<< "$input")"

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -216,6 +216,8 @@ spec:
                       else
                         if has("include_summary_in_sbom") | not then
                           .include_summary_in_sbom = true
+                        else
+                          .
                         end
 
                       end' <<< "$input")"


### PR DESCRIPTION
prefetch-dependencies has been changed recently and is currently failing on a jq syntax error

Allowing if without else-branch in jq seems to not be implemented in jq 1.6, which is used in the cachi2 image used in the prefetch-dependencies tasks

Add an else branch with '.' (identity) to fix the syntax error

This has been tested manually in the [base image used in the cachi2 image](https://github.com/hermetoproject/cachi2/blob/2235854bfc5cb76ea168cb04d50be16efce9fa0a/Dockerfile#L1)
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/b0ab5bcf-0ab7-499b-a7b0-8c5177be7f0c" />
