### PR TITLE
Revert the revert of "Nvidia GPU support in the buildah-remote task"

### DIFF
--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -232,6 +232,10 @@ if ! [[ $IS_LOCALHOST ]]; then
 		ret += "\nbuildah push \"$IMAGE\" \"oci:konflux-final-image:$IMAGE\""
 		ret += "\nREMOTESSHEOF"
 		ret += "\nchmod +x " + script + "\n"
+		ret += "\nPODMAN_NVIDIA_ARGS=()"
+		ret += "\nif [[ \"$PLATFORM\" == \"linux-g\"* ]]; then"
+		ret += "\n    PODMAN_NVIDIA_ARGS+=(\"--device=nvidia.com/gpu=all\" \"--security-opt=label=disable\")"
+		ret += "\nfi\n"
 
 		if task.Spec.StepTemplate != nil {
 			for _, e := range task.Spec.StepTemplate.Env {
@@ -255,7 +259,7 @@ if ! [[ $IS_LOCALHOST ]]; then
 		}
 		podmanArgs += "    -v \"$BUILD_DIR/scripts:/scripts:Z\" \\\n"
 		podmanArgs += "    \"${PRIVILEGED_NESTED_FLAGS[@]}\" \\\n"
-		ret += "\n  # shellcheck disable=SC2086\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run " + env + "" + podmanArgs + "    --user=0  --rm  \"$BUILDER_IMAGE\" /" + containerScript + ` "$@"`
+		ret += "\n  # shellcheck disable=SC2086\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run " + env + "" + podmanArgs + "    --user=0 \"${PODMAN_NVIDIA_ARGS[@]}\" --rm \"$BUILDER_IMAGE\" /" + containerScript + ` "$@"`
 
 		// Sync the contents of the workspaces back so subsequent tasks can use them
 		for _, workspace := range task.Spec.Workspaces {

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -446,6 +446,11 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
+      PODMAN_NVIDIA_ARGS=()
+      if [[ "$PLATFORM" == "linux-g"* ]]; then
+          PODMAN_NVIDIA_ARGS+=("--device=nvidia.com/gpu=all" "--security-opt=label=disable")
+      fi
+
       if ! [[ $IS_LOCALHOST ]]; then
         PRIVILEGED_NESTED_FLAGS=()
         if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
@@ -488,7 +493,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -608,6 +608,11 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
+      PODMAN_NVIDIA_ARGS=()
+      if [[ "$PLATFORM" == "linux-g"* ]]; then
+          PODMAN_NVIDIA_ARGS+=("--device=nvidia.com/gpu=all" "--security-opt=label=disable")
+      fi
+
       if ! [[ $IS_LOCALHOST ]]; then
         PRIVILEGED_NESTED_FLAGS=()
         if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
@@ -654,7 +659,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -604,6 +604,11 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
+      PODMAN_NVIDIA_ARGS=()
+      if [[ "$PLATFORM" == "linux-g"* ]]; then
+          PODMAN_NVIDIA_ARGS+=("--device=nvidia.com/gpu=all" "--security-opt=label=disable")
+      fi
+
       if ! [[ $IS_LOCALHOST ]]; then
         PRIVILEGED_NESTED_FLAGS=()
         if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
@@ -651,7 +656,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -603,6 +603,11 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
+      PODMAN_NVIDIA_ARGS=()
+      if [[ "$PLATFORM" == "linux-g"* ]]; then
+          PODMAN_NVIDIA_ARGS+=("--device=nvidia.com/gpu=all" "--security-opt=label=disable")
+      fi
+
       if ! [[ $IS_LOCALHOST ]]; then
         PRIVILEGED_NESTED_FLAGS=()
         if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
@@ -650,7 +655,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -438,6 +438,11 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
+      PODMAN_NVIDIA_ARGS=()
+      if [[ "$PLATFORM" == "linux-g"* ]]; then
+          PODMAN_NVIDIA_ARGS+=("--device=nvidia.com/gpu=all" "--security-opt=label=disable")
+      fi
+
       if ! [[ $IS_LOCALHOST ]]; then
         PRIVILEGED_NESTED_FLAGS=()
         if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
@@ -481,7 +486,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -579,6 +579,11 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
+      PODMAN_NVIDIA_ARGS=()
+      if [[ "$PLATFORM" == "linux-g"* ]]; then
+          PODMAN_NVIDIA_ARGS+=("--device=nvidia.com/gpu=all" "--security-opt=label=disable")
+      fi
+
       if ! [[ $IS_LOCALHOST ]]; then
         PRIVILEGED_NESTED_FLAGS=()
         if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
@@ -625,7 +630,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -575,6 +575,11 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
+      PODMAN_NVIDIA_ARGS=()
+      if [[ "$PLATFORM" == "linux-g"* ]]; then
+          PODMAN_NVIDIA_ARGS+=("--device=nvidia.com/gpu=all" "--security-opt=label=disable")
+      fi
+
       if ! [[ $IS_LOCALHOST ]]; then
         PRIVILEGED_NESTED_FLAGS=()
         if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
@@ -622,7 +627,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -574,6 +574,11 @@ spec:
       REMOTESSHEOF
       chmod +x scripts/script-build.sh
 
+      PODMAN_NVIDIA_ARGS=()
+      if [[ "$PLATFORM" == "linux-g"* ]]; then
+          PODMAN_NVIDIA_ARGS+=("--device=nvidia.com/gpu=all" "--security-opt=label=disable")
+      fi
+
       if ! [[ $IS_LOCALHOST ]]; then
         PRIVILEGED_NESTED_FLAGS=()
         if [[ "${PRIVILEGED_NESTED}" == "true" ]]; then
@@ -621,7 +626,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0  --rm  "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/" "/tekton/results/"


### PR DESCRIPTION
Re-enable Nvidia GPU support in the buildah-remote tasks

It was initially introduced in #1529 and reverted in #1638

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
