### PR TITLE
Add test-sast-snyk-check-no-token.yaml

### DIFF
--- a/task/sast-snyk-check/0.3/tests/test-sast-snyk-check-no-token.yaml
+++ b/task/sast-snyk-check/0.3/tests/test-sast-snyk-check-no-token.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sast-snyk-check-no-token
+spec:
+  description: |
+    Test the sast-snyk-check task is skipped when no token is available
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: scan-with-snyk
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      taskRef:
+        name: sast-snyk-check
+    - name: check-result
+      runAfter:
+        - scan-with-snyk
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      params:
+      - name: results
+        value: $(tasks.scan-with-snyk.results.TEST_OUTPUT)
+      taskSpec:
+        params:
+        - name: results
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
+            env:
+            - name: RESULTS
+              value: $(params.results)
+            script: |
+              #!/bin/bash
+
+              set -e
+
+              echo "$RESULTS"
+              # snyk check should skip because snyk_token is unavailable in ephemeral clusters
+              echo -n "Expected result: "
+              echo "$RESULTS" | jq -e '.result == "SKIPPED" and (.note | contains("snyk_token")) and .successes == 0 and .failures == 0 and .warnings == 0'


### PR DESCRIPTION
Because we can't do a real run of snyk in tests due to the secret token requirement, this test just ensures the snyk check is skipped in the expected fashion. A test source code repository is not cloned for this test, as it would not change the behaviour of the skipped snyk check task.

Supports [PSSECAUT-954](https://issues.redhat.com//browse/PSSECAUT-954)