### PR TITLE
sast-coverity-check: eliminate scan failures reported by users

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -31,7 +31,7 @@ sources:
         - trusted_artifacts
       exclude:
         # https://issues.redhat.com/browse/EC-1038
-        - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202412.2
+        - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202412.3
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/nodejs-$(params.nodejs-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/python-$(params.python-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/go-toolset:$(params.go-version)

--- a/policies/step-actions.yaml
+++ b/policies/step-actions.yaml
@@ -16,7 +16,7 @@ sources:
         - kind
       exclude:
         # https://issues.redhat.com/browse/EC-1038
-        - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202412.2
+        - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202412.3
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/nodejs-$(params.nodejs-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/python-$(params.python-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/go-toolset:$(params.go-version)

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -271,7 +271,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: prepare
-      image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      image: quay.io/redhat-services-prod/sast/coverity:202412.3
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /etc/secrets/cov
@@ -367,7 +367,7 @@ spec:
         chmod -v 0755 /shared/cmd-wrap.sh
 
         # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-        cstrans-df-run --verbose /shared/cmd-wrap.sh <"$dockerfile_path" >/shared/Containerfile 2>/tmp/cstrans-df-run.log
+        cstrans-df-run --shell-form --verbose /shared/cmd-wrap.sh <"$dockerfile_path" >/shared/Containerfile 2>/tmp/cstrans-df-run.log
         EC=$?
 
         # if we have no RUN lines to instrument, it is not a reason to make the task fail
@@ -378,7 +378,7 @@ spec:
           exit $EC
         fi
     - name: build
-      image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      image: quay.io/redhat-services-prod/sast/coverity:202412.3
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -709,7 +709,7 @@ spec:
           add:
             - SETFCAP
     - name: postprocess
-      image: quay.io/redhat-services-prod/sast/coverity:202412.2
+      image: quay.io/redhat-services-prod/sast/coverity:202412.3
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -336,7 +336,12 @@ spec:
 
         # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
         /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-          -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
+          -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
+          set -x
+          pwd >&2  # print CWD set by coverity
+          cd '\${PWD}'  # restore original CWD
+          \\"\\\$@\\"  # run the instrumented shell command
+          echo \\\$? >/tmp/idir/build-cmd-ec.txt" \
           - "\$@"
 
         # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -71,7 +71,7 @@
 - op: replace
   path: /spec/steps/0/image
   # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
-  value: quay.io/redhat-services-prod/sast/coverity:202412.2
+  value: quay.io/redhat-services-prod/sast/coverity:202412.3
 
 # Change build step resources
 - op: replace
@@ -161,7 +161,7 @@
   path: /spec/steps/0
   value:
     name: prepare
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+    image: quay.io/redhat-services-prod/sast/coverity:202412.3
     workingDir: $(workspaces.source.path)
     env:
       - name: COV_ANALYZE_ARGS
@@ -257,7 +257,7 @@
       chmod -v 0755 /shared/cmd-wrap.sh
 
       # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
+      cstrans-df-run --shell-form --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
       EC=$?
 
       # if we have no RUN lines to instrument, it is not a reason to make the task fail
@@ -284,7 +284,7 @@
   path: /spec/steps/2
   value:
     name: postprocess
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+    image: quay.io/redhat-services-prod/sast/coverity:202412.3
     computeResources:
       limits:
         memory: 4Gi

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -226,7 +226,12 @@
 
       # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
       /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
+        -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
+        set -x
+        pwd >&2  # print CWD set by coverity
+        cd '\${PWD}'  # restore original CWD
+        \\"\\\$@\\"  # run the instrumented shell command
+        echo \\\$? >/tmp/idir/build-cmd-ec.txt" \
         - "\$@"
 
       # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -224,7 +224,7 @@ spec:
       value: $(params.COV_ANALYZE_ARGS)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+    image: quay.io/redhat-services-prod/sast/coverity:202412.3
     name: prepare
     script: |
       #!/bin/bash
@@ -311,7 +311,7 @@ spec:
       chmod -v 0755 /shared/cmd-wrap.sh
 
       # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
-      cstrans-df-run --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
+      cstrans-df-run --shell-form --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
       EC=$?
 
       # if we have no RUN lines to instrument, it is not a reason to make the task fail
@@ -349,7 +349,7 @@ spec:
         /shared:/shared
         /shared/license.dat:/opt/coverity/bin/license.dat
         /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+    image: quay.io/redhat-services-prod/sast/coverity:202412.3
     name: build
     script: |
       #!/bin/bash
@@ -678,7 +678,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
-    image: quay.io/redhat-services-prod/sast/coverity:202412.2
+    image: quay.io/redhat-services-prod/sast/coverity:202412.3
     name: postprocess
     script: |
       #!/bin/bash -e

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -280,7 +280,12 @@ spec:
 
       # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
       /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
-        -- /bin/bash -c 'PS4="@\\\${SECONDS}s: \\\${BASH_COMMAND} --> "; set -x; "\$@"; echo \$? >/tmp/idir/build-cmd-ec.txt' \
+        -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
+        set -x
+        pwd >&2  # print CWD set by coverity
+        cd '\${PWD}'  # restore original CWD
+        \\"\\\$@\\"  # run the instrumented shell command
+        echo \\\$? >/tmp/idir/build-cmd-ec.txt" \
         - "\$@"
 
       # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)


### PR DESCRIPTION
- do not change CWD while instrumenting RUN lines
- use shell form of RUN instructions while instrumenting `Containerfile` because the exec form is not supported by the `cachi2` instrumentation implemented in the `build-container` task, which `sast-coverity-check` is derived from.

Resolves: https://issues.redhat.com/browse/OSH-813
Resolves: https://issues.redhat.com/browse/OSH-809
Related: https://issues.redhat.com/browse/KONFLUX-6806