### PR TITLE
feat(KONFLUX-6858): add support for generating docker mediaType

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -35,6 +35,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-images.results.IMAGE_REF[*])']'|
@@ -47,6 +48,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
@@ -178,6 +180,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -34,6 +34,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
@@ -46,6 +47,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
@@ -175,6 +177,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -34,6 +34,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
@@ -46,6 +47,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|
@@ -170,6 +172,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -35,6 +35,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-images.results.IMAGE_REF[*])']'|
@@ -47,6 +48,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -79,6 +79,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | |
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -76,6 +76,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | |
 |COMMIT_SHA| The image is built from this commit.| | |

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -28,6 +28,7 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|

--- a/task/build-image-index/0.1/README.md
+++ b/task/build-image-index/0.1/README.md
@@ -12,6 +12,7 @@ This takes existing Image Manifests and combines them in an Image Index.
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |ALWAYS_BUILD_INDEX|Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.|true|false|
 |STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 
 ## Results
 |name|description|

--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -38,6 +38,10 @@ spec:
     description: Storage driver to configure for buildah
     type: string
     default: vfs
+  - name: BUILDAH_FORMAT
+    description: The format for the resulting image's mediaType. Valid values are oci (default) or docker.
+    type: string
+    default: oci
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -57,7 +61,7 @@ spec:
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
-      value: oci
+      value: $(params.BUILDAH_FORMAT)
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     - name: IMAGE
@@ -121,6 +125,13 @@ spec:
         buildah manifest add $IMAGE "docker://$TOADD" --all
       done
 
+      # While the BUILDAH_FORMAT environment variable can define the push
+      # format, lets be explicit about the format that we want when we push.
+      push_format=oci
+      if [ "${BUILDAH_FORMAT}" == "docker" ]; then
+        push_format=docker
+      fi
+
       status=-1
       max_run=5
       sleep_sec=10
@@ -129,6 +140,7 @@ spec:
         [ "$run" -gt 1 ] && sleep $sleep_sec
         echo "Pushing image to registry"
         buildah manifest push \
+          --format="$push_format" \
           --tls-verify=$TLSVERIFY \
           --digestfile image-digest $IMAGE \
           docker://$IMAGE && break || status=$?
@@ -154,10 +166,10 @@ spec:
       } > "$(results.IMAGE_REF.path)"
       echo -n "${image_manifests:1:-1}" > "$(results.IMAGES.path)"
 
-      IMAGE_DIGEST=$(cat image-digest)
-
-      INDEX_IMAGE_PULLSPEC="${IMAGE}@${IMAGE_DIGEST}"
-      buildah manifest inspect "$INDEX_IMAGE_PULLSPEC" > /index-build-data/manifest_data.json
+      # buildah manifest inspect will always give precedence to the local image.
+      # Since we built this image in the same place as we are inspecting it, we can
+      # just inspect it instead of finding the digest and inspecting the remote image.
+      buildah manifest inspect "$IMAGE" > /index-build-data/manifest_data.json
     securityContext:
       capabilities:
         add:

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -43,6 +43,11 @@ spec:
     description: Storage driver to configure for buildah
     name: STORAGE_DRIVER
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci (default) or docker.
+    name: BUILDAH_FORMAT
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -60,7 +65,7 @@ spec:
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
-      value: oci
+      value: $(params.BUILDAH_FORMAT)
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
     - name: IMAGE
@@ -123,6 +128,13 @@ spec:
         buildah manifest add $IMAGE "docker://$TOADD" --all
       done
 
+      # While the BUILDAH_FORMAT environment variable can define the push
+      # format, lets be explicit about the format that we want when we push.
+      push_format=oci
+      if [ "${BUILDAH_FORMAT}" == "docker" ]; then
+        push_format=docker
+      fi
+
       status=-1
       max_run=5
       sleep_sec=10
@@ -131,6 +143,7 @@ spec:
         [ "$run" -gt 1 ] && sleep $sleep_sec
         echo "Pushing image to registry"
         buildah manifest push \
+          --format="$push_format" \
           --tls-verify=$TLSVERIFY \
           --digestfile image-digest $IMAGE \
           docker://$IMAGE && break || status=$?
@@ -156,10 +169,10 @@ spec:
       } > "$(results.IMAGE_REF.path)"
       echo -n "${image_manifests:1:-1}" > "$(results.IMAGES.path)"
 
-      IMAGE_DIGEST=$(cat image-digest)
-
-      INDEX_IMAGE_PULLSPEC="${IMAGE}@${IMAGE_DIGEST}"
-      buildah manifest inspect "$INDEX_IMAGE_PULLSPEC" > /index-build-data/manifest_data.json
+      # buildah manifest inspect will always give precedence to the local image.
+      # Since we built this image in the same place as we are inspecting it, we can
+      # just inspect it instead of finding the digest and inspecting the remote image.
+      buildah manifest inspect "$IMAGE" > /index-build-data/manifest_data.json
     securityContext:
       capabilities:
         add:

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -132,6 +132,11 @@ spec:
       format.'
     name: SBOM_TYPE
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci (default) or docker.
+    name: BUILDAH_FORMAT
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -151,8 +156,6 @@ spec:
         cpu: 100m
         memory: 512Mi
     env:
-    - name: BUILDAH_FORMAT
-      value: oci
     - name: STORAGE_DRIVER
       value: $(params.STORAGE_DRIVER)
     - name: HERMETIC
@@ -232,7 +235,7 @@ spec:
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
       elif [ -e "$DOCKERFILE" ]; then
-        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        # Instrumented builds (SAST) use this custom dockerfile step as their base
         dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
@@ -531,7 +534,10 @@ spec:
     - mountPath: /var/lib/containers
       name: varlibcontainers
     workingDir: $(workspaces.source.path)
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+  - env:
+    - name: BUILDAH_FORMAT
+      value: $(params.BUILDAH_FORMAT)
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: push
     script: |
       #!/bin/bash
@@ -544,10 +550,19 @@ spec:
         update-ca-trust
       fi
 
+      # While we can build images with the desired format, we will simplify any local
+      # and remote build differences by just performing any necessary conversions at
+      # push time.
+      push_format=oci
+      if [ "${BUILDAH_FORMAT}" == "docker" ]; then
+        push_format=docker
+      fi
+
       retries=5
       # Push to a unique tag based on the TaskRun name to avoid race conditions
       echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
       if ! buildah push \
+        --format="$push_format" \
         --retry "$retries" \
         --tls-verify="$TLSVERIFY" \
         "$IMAGE" \
@@ -560,6 +575,7 @@ spec:
       # Push to a tag based on the git revision
       echo "Pushing to ${IMAGE}"
       if ! buildah push \
+        --format="$push_format" \
         --retry "$retries" \
         --tls-verify="$TLSVERIFY" \
         --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -10,6 +10,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -29,6 +29,11 @@ spec:
         running 'buildah build'
       type: string
       default: ""
+    - name: BUILDAH_FORMAT
+      description: The format for the resulting image's mediaType. Valid values
+        are oci (default) or docker.
+      type: string
+      default: oci
     - name: BUILD_ARGS
       description: Array of --build-arg values ("arg=value" strings)
       type: array
@@ -196,8 +201,6 @@ spec:
         value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
         value: $(params.ADD_CAPABILITIES)
-      - name: BUILDAH_FORMAT
-        value: oci
       - name: BUILD_ARGS_FILE
         value: $(params.BUILD_ARGS_FILE)
       - name: CONTEXT
@@ -291,7 +294,7 @@ spec:
         elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
           dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
         elif [ -e "$DOCKERFILE" ]; then
-          # Instrumented builds (SAST) use this custom dockerffile step as their base
+          # Instrumented builds (SAST) use this custom dockerfile step as their base
           dockerfile_path="$DOCKERFILE"
         elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
           echo "Fetch Dockerfile from $DOCKERFILE"
@@ -598,6 +601,9 @@ spec:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
+      env:
+        - name: BUILDAH_FORMAT
+          value: $(params.BUILDAH_FORMAT)
       script: |
         #!/bin/bash
         set -e
@@ -609,10 +615,19 @@ spec:
           update-ca-trust
         fi
 
+        # While we can build images with the desired format, we will simplify any local
+        # and remote build differences by just performing any necessary conversions at
+        # push time.
+        push_format=oci
+        if [ "${BUILDAH_FORMAT}" == "docker" ]; then
+          push_format=docker
+        fi
+
         retries=5
         # Push to a unique tag based on the TaskRun name to avoid race conditions
         echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
         if ! buildah push \
+          --format="$push_format" \
           --retry "$retries" \
           --tls-verify="$TLSVERIFY" \
           "$IMAGE" \
@@ -624,6 +639,7 @@ spec:
         # Push to a tag based on the git revision
         echo "Pushing to ${IMAGE}"
         if ! buildah push \
+          --format="$push_format" \
           --retry "$retries" \
           --tls-verify="$TLSVERIFY" \
           --digestfile "/var/workdir/image-digest" "$IMAGE" \

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -29,6 +29,11 @@ spec:
       build'
     name: ADD_CAPABILITIES
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci (default) or docker.
+    name: BUILDAH_FORMAT
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings)
     name: BUILD_ARGS
@@ -175,8 +180,6 @@ spec:
       value: $(params.ADDITIONAL_SECRET)
     - name: ADD_CAPABILITIES
       value: $(params.ADD_CAPABILITIES)
-    - name: BUILDAH_FORMAT
-      value: oci
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: CONTEXT
@@ -324,7 +327,7 @@ spec:
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
       elif [ -e "$DOCKERFILE" ]; then
-        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        # Instrumented builds (SAST) use this custom dockerfile step as their base
         dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
@@ -619,7 +622,6 @@ spec:
           -e ACTIVATION_KEY="$ACTIVATION_KEY" \
           -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
           -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
           -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
           -e CONTEXT="$CONTEXT" \
           -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
@@ -706,6 +708,9 @@ spec:
       name: varlibcontainers
     workingDir: /var/workdir
   - computeResources: {}
+    env:
+    - name: BUILDAH_FORMAT
+      value: $(params.BUILDAH_FORMAT)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: push
     script: |
@@ -723,10 +728,19 @@ spec:
         update-ca-trust
       fi
 
+      # While we can build images with the desired format, we will simplify any local
+      # and remote build differences by just performing any necessary conversions at
+      # push time.
+      push_format=oci
+      if [ "${BUILDAH_FORMAT}" == "docker" ]; then
+        push_format=docker
+      fi
+
       retries=5
       # Push to a unique tag based on the TaskRun name to avoid race conditions
       echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
       if ! buildah push \
+        --format="$push_format" \
         --retry "$retries" \
         --tls-verify="$TLSVERIFY" \
         "$IMAGE" \
@@ -738,6 +752,7 @@ spec:
       # Push to a tag based on the git revision
       echo "Pushing to ${IMAGE}"
       if ! buildah push \
+        --format="$push_format" \
         --retry "$retries" \
         --tls-verify="$TLSVERIFY" \
         --digestfile "/var/workdir/image-digest" "$IMAGE" \

--- a/task/buildah-remote/0.4/README.md
+++ b/task/buildah-remote/0.4/README.md
@@ -33,7 +33,8 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
-|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
+|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |PLATFORM|The platform to build on||true|
 |IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
 

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -133,6 +133,11 @@ spec:
       format.'
     name: SBOM_TYPE
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci (default) or docker.
+    name: BUILDAH_FORMAT
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -160,8 +165,6 @@ spec:
         cpu: "1"
         memory: 1Gi
     env:
-    - name: BUILDAH_FORMAT
-      value: oci
     - name: STORAGE_DRIVER
       value: $(params.STORAGE_DRIVER)
     - name: HERMETIC
@@ -301,7 +304,7 @@ spec:
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
       elif [ -e "$DOCKERFILE" ]; then
-        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        # Instrumented builds (SAST) use this custom dockerfile step as their base
         dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
@@ -587,7 +590,6 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
           -e STORAGE_DRIVER="$STORAGE_DRIVER" \
           -e HERMETIC="$HERMETIC" \
           -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
@@ -677,6 +679,9 @@ spec:
       name: varlibcontainers
     workingDir: $(workspaces.source.path)
   - computeResources: {}
+    env:
+    - name: BUILDAH_FORMAT
+      value: $(params.BUILDAH_FORMAT)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: push
     script: |
@@ -694,10 +699,19 @@ spec:
         update-ca-trust
       fi
 
+      # While we can build images with the desired format, we will simplify any local
+      # and remote build differences by just performing any necessary conversions at
+      # push time.
+      push_format=oci
+      if [ "${BUILDAH_FORMAT}" == "docker" ]; then
+        push_format=docker
+      fi
+
       retries=5
       # Push to a unique tag based on the TaskRun name to avoid race conditions
       echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
       if ! buildah push \
+        --format="$push_format" \
         --retry "$retries" \
         --tls-verify="$TLSVERIFY" \
         "$IMAGE" \
@@ -710,6 +724,7 @@ spec:
       # Push to a tag based on the git revision
       echo "Pushing to ${IMAGE}"
       if ! buildah push \
+        --format="$push_format" \
         --retry "$retries" \
         --tls-verify="$TLSVERIFY" \
         --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \

--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -34,6 +34,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PRIVILEGED_NESTED|Whether to enable privileged mode|false|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
+|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -120,6 +120,10 @@ spec:
       Note: the SBOM from the prefetch task - if there is one - must be in the same format.
     type: string
     default: spdx
+  - name: BUILDAH_FORMAT
+    description: The format for the resulting image's mediaType. Valid values are oci (default) or docker.
+    type: string
+    default: oci
 
   results:
   - description: Digest of the image just built
@@ -142,8 +146,6 @@ spec:
       - mountPath: /shared
         name: shared
     env:
-    - name: BUILDAH_FORMAT
-      value: oci
     - name: STORAGE_DRIVER
       value: $(params.STORAGE_DRIVER)
     - name: HERMETIC
@@ -222,7 +224,7 @@ spec:
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
       elif [ -e "$DOCKERFILE" ]; then
-        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        # Instrumented builds (SAST) use this custom dockerfile step as their base
         dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"
@@ -524,6 +526,9 @@ spec:
       /scripts/inject-icm.sh "$IMAGE"
   - name: push
     image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    env:
+    - name: BUILDAH_FORMAT
+      value: $(params.BUILDAH_FORMAT)
     script: |
       #!/bin/bash
       set -e
@@ -535,10 +540,19 @@ spec:
         update-ca-trust
       fi
 
+      # While we can build images with the desired format, we will simplify any local
+      # and remote build differences by just performing any necessary conversions at
+      # push time.
+      push_format=oci
+      if [ "${BUILDAH_FORMAT}" == "docker" ]; then
+        push_format=docker
+      fi
+
       retries=5
       # Push to a unique tag based on the TaskRun name to avoid race conditions
       echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
       if ! buildah push \
+        --format="$push_format" \
         --retry "$retries" \
         --tls-verify="$TLSVERIFY" \
         "$IMAGE" \
@@ -551,6 +565,7 @@ spec:
       # Push to a tag based on the git revision
       echo "Pushing to ${IMAGE}"
       if ! buildah push \
+        --format="$push_format" \
         --retry "$retries" \
         --tls-verify="$TLSVERIFY" \
         --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \

--- a/task/sast-coverity-check-oci-ta/0.2/README.md
+++ b/task/sast-coverity-check-oci-ta/0.2/README.md
@@ -8,6 +8,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -28,6 +28,11 @@ spec:
         running 'buildah build'
       type: string
       default: ""
+    - name: BUILDAH_FORMAT
+      description: The format for the resulting image's mediaType. Valid values
+        are oci (default) or docker.
+      type: string
+      default: oci
     - name: BUILD_ARGS
       description: Array of --build-arg values ("arg=value" strings)
       type: array
@@ -220,8 +225,6 @@ spec:
         value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
         value: $(params.ADD_CAPABILITIES)
-      - name: BUILDAH_FORMAT
-        value: oci
       - name: BUILD_ARGS_FILE
         value: $(params.BUILD_ARGS_FILE)
       - name: CONTEXT
@@ -423,7 +426,7 @@ spec:
         elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
           dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
         elif [ -e "$DOCKERFILE" ]; then
-          # Instrumented builds (SAST) use this custom dockerffile step as their base
+          # Instrumented builds (SAST) use this custom dockerfile step as their base
           dockerfile_path="$DOCKERFILE"
         elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
           echo "Fetch Dockerfile from $DOCKERFILE"

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -131,6 +131,11 @@ spec:
       format.'
     name: SBOM_TYPE
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci (default) or docker.
+    name: BUILDAH_FORMAT
+    type: string
   - name: image-url
     type: string
   - default: cov-license
@@ -171,8 +176,6 @@ spec:
         cpu: "1"
         memory: 1Gi
     env:
-    - name: BUILDAH_FORMAT
-      value: oci
     - name: STORAGE_DRIVER
       value: $(params.STORAGE_DRIVER)
     - name: HERMETIC
@@ -366,7 +369,7 @@ spec:
       elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
         dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
       elif [ -e "$DOCKERFILE" ]; then
-        # Instrumented builds (SAST) use this custom dockerffile step as their base
+        # Instrumented builds (SAST) use this custom dockerfile step as their base
         dockerfile_path="$DOCKERFILE"
       elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
         echo "Fetch Dockerfile from $DOCKERFILE"

--- a/task/show-sbom/0.1/show-sbom.yaml
+++ b/task/show-sbom/0.1/show-sbom.yaml
@@ -63,11 +63,11 @@ spec:
       }
 
       RAW_OUTPUT=$(skopeo inspect --no-tags --raw docker://${IMAGE_URL})
-      if [ $(jq -r '.mediaType' <<< $RAW_OUTPUT) == "application/vnd.oci.image.manifest.v1+json" ] ; then
-        ARCHES=""
-      else
+      if [ "$(jq 'has("manifests")' <<< "$RAW_OUTPUT")" == "true" ] ; then
         # Multi arch
         ARCHES=$(jq -r '.manifests[].platform.architecture' <<< $RAW_OUTPUT)
+      else
+        ARCHES=""
       fi
 
       if [ -z "${ARCHES}" ] ; then


### PR DESCRIPTION
While we still produce images with an OCI mediaType by default, some users may need to generate docker mediaTypes in order to remain compatible with older functionality. This change lets that setting be configured.

We are not exposing it as a pipeline parameter by default to encourage the continued use of OCI mediaTypes.
