### PR TITLE
pnc-prebuild-git-clone: add build team to owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -25,6 +25,7 @@
 /task/git-clone                             @konflux-ci/build-maintainers
 /task/git-clone-oci-ta                      @konflux-ci/build-maintainers
 /task/init                                  @konflux-ci/build-maintainers
+/task/pnc-prebuild-git-clone-oci-ta         @konflux-ci/build-maintainers @rnc
 /task/push-dockerfile                       @konflux-ci/build-maintainers
 /task/push-dockerfile-oci-ta                @konflux-ci/build-maintainers
 /task/show-sbom                             @konflux-ci/build-maintainers
@@ -116,9 +117,6 @@
 # renovate groupName=maven
 /task/build-maven-zip           @ligangty @yma96
 /task/build-maven-zip-oci-ta    @ligangty @yma96
-
-# renovate groupName=pnc
-/task/pnc-prebuild-git-clone-oci-ta           @rnc
 
 # renovate groupName=oci-copy
 /task/oci-copy          @ralphbean

--- a/renovate.json
+++ b/renovate.json
@@ -52,6 +52,7 @@
         "task/git-clone-oci-ta/**",
         "task/git-clone/**",
         "task/init/**",
+        "task/pnc-prebuild-git-clone-oci-ta/**",
         "task/prefetch-dependencies-oci-ta/**",
         "task/prefetch-dependencies/**",
         "task/push-dockerfile-oci-ta/**",
@@ -197,12 +198,6 @@
         "task/sealights-go-oci-ta/**",
         "task/sealights-nodejs-oci-ta/**",
         "task/sealights-python-oci-ta/**"
-      ]
-    },
-    {
-      "groupName": "pnc",
-      "matchFileNames": [
-        "task/pnc-prebuild-git-clone-oci-ta/**"
       ]
     }
   ],


### PR DESCRIPTION
The task is generated from the git-clone task => changes to the git-clone task will always require corresponding changes to the PNC task.

Add build team to the CODEOWNERS of this task to avoid git-clone changes being blocked on reviews from the PNC team.

Also move this task to the same Renovate group as git-clone. Otherwise Renovate PRs would fail CI because they would only update the git-clone task and not the PNC task.
