### PR TITLE
fix: avoid downloading Sealights Agents binaries

### DIFF
--- a/task/sealights-nodejs-oci-ta/0.1/README.md
+++ b/task/sealights-nodejs-oci-ta/0.1/README.md
@@ -17,7 +17,6 @@ The task can be triggered by different events (e.g., Pull Request, Push) and all
 | Name                  | Type     | Default       | Description                                                                                   |
 |-----------------------|----------|---------------|-----------------------------------------------------------------------------------------------|
 | `SOURCE_ARTIFACT`     | `string` | -             | The Trusted Artifact URI pointing to the source code.                                         |
-| `nodejs-version`      | `string` | -             | The Node.js version to use with the 'ubi8/nodejs' image, in the format (e.g., '311').          |                                             |
 | `component`           | `string` | -             | The name of the Konflux component associated with the integration tests.                      |
 | `is-frontend`           | `string` | "false"             | In case of frontend application the scanning part is skipped (it needs to be performed during deployment)                      |
 | `scm-provider`        | `string` | `Github`         | The SCM provider (e.g., `Github`).                                                               |

--- a/task/sealights-nodejs-oci-ta/0.1/sealights-nodejs-oci-ta.yaml
+++ b/task/sealights-nodejs-oci-ta/0.1/sealights-nodejs-oci-ta.yaml
@@ -29,9 +29,6 @@ spec:
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with the application source code.
       type: string
-    - name: nodejs-version
-      type: string
-      description: "The Node.js version to use with the 'ubi8/nodejs' image, in the format (e.g., '20')."
     - name: component
       type: string
       description: "The name of the Konflux component associated with the integration tests."
@@ -100,7 +97,7 @@ spec:
         requests:
           cpu: 100m
           memory: 256Mi
-      image: registry.access.redhat.com/ubi8/nodejs-$(params.nodejs-version):latest
+      image: quay.io/konflux-ci/tekton-integration-catalog/sealights-nodejs:latest@sha256:f66fae63d45959c98e142bdd4c9fed14f970183257d631c372965de6e963df0f
       workingDir: /opt/app-root/src
       securityContext:
         runAsUser: 0
@@ -138,15 +135,6 @@ spec:
         SEALIGHTS_TOKEN="$(cat /usr/local/sealights-credentials/token)"
         BUILD_NAME="${REVISION}_$(date +'%y%m%d.%H%M')"
         PATHS_EXCLUDED_ENUM="$(IFS=,; printf "%s," "$@" | sed 's/,$//')"
-
-        # Download jq in order to help determine the Agent version below
-        curl -Lso jq https://github.com/stedolan/jq/releases/download/jq-1.7.1/jq-linux64 && chmod +x jq && mkdir -p /opt/app-root/bin && mv jq /opt/app-root/bin/jq
-
-        # Installs Sealights Node.js agent.
-        # Fetch Agent version defined in Sealights dashboard settings
-        SL_VERSION=$(curl -X GET "https://redhat.sealights.co/api/v2/agents/slnodejs/recommended" -H "accept: application/json" -H "Authorization: Bearer $SEALIGHTS_TOKEN" -L | jq -r .agent.version)
-        # Install Sealights Agent (Recommended version)
-        npm i -g "slnodejs@$SL_VERSION"
 
         # In case build is coming from a /retest event then it's a pull_request
         # if event type is not push and pull_request_number is not empty then is a pull_request

--- a/task/sealights-python-oci-ta/0.1/README.md
+++ b/task/sealights-python-oci-ta/0.1/README.md
@@ -16,7 +16,6 @@ The task can be triggered by different events (e.g., Pull Request, Push) and all
 | Name                  | Type     | Default       | Description                                                                                   |
 |-----------------------|----------|---------------|-----------------------------------------------------------------------------------------------|
 | `SOURCE_ARTIFACT`     | `string` | -             | The Trusted Artifact URI pointing to the source code.                                         |
-| `python-version`      | `string` | -             | The Python version to use with the 'ubi8/python' image, in the format (e.g., '311').          |                                             |
 | `component`           | `string` | -             | The name of the Konflux component associated with the integration tests.                      |
 | `scm-provider`        | `string` | `Github`         | The SCM provider (e.g., `Github`).                                                               |
 | `exclude`   | `array`  | `[]`          | A list of paths to exclude from Sealights instrumentation during the code scan. Specify paths to prevent them from being analyzed (e.g., '/app/source/tests/*,/app/examples/*'). |

--- a/task/sealights-python-oci-ta/0.1/sealights-python-oci-ta.yaml
+++ b/task/sealights-python-oci-ta/0.1/sealights-python-oci-ta.yaml
@@ -26,9 +26,6 @@ spec:
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with the application source code.
       type: string
-    - name: python-version
-      type: string
-      description: "The Python version to use with the 'ubi8/python' image, in the format (e.g., '311')."
     - name: component
       type: string
       description: "The name of the Konflux component associated with the integration tests."
@@ -88,7 +85,7 @@ spec:
         requests:
           cpu: 100m
           memory: 256Mi
-      image: registry.access.redhat.com/ubi8/python-$(params.python-version):latest
+      image: quay.io/konflux-ci/tekton-integration-catalog/sealights-python:latest@sha256:b26ce3d6237492d61edc13e73693c3d4d0e7b9446c4f02fa9ee04fbc0fcf9297
       workingDir: /app/source
       securityContext:
         runAsUser: 0
@@ -123,9 +120,6 @@ spec:
         SEALIGHTS_TOKEN="$(cat /usr/local/sealights-credentials/token)"
         BUILD_NAME="${REVISION}_$(date +'%y%m%d.%H%M')"
         EXCLUDE_ENUM="$(IFS=,; printf "%s," "$@" | sed 's/,$//')"
-
-        # Installs Sealights Python agent.
-        pip install sealights-python-agent
 
         # In case build is coming from a /retest event then it's a pull_request
         # if event type is not push and pull_request_number is not empty then is a pull_request


### PR DESCRIPTION
* use dedicated images from quay.io/konflux-ci/tekton-integration-catalog/sealights-python and quay.io/konflux-ci/tekton-integration-catalog/sealights-nodejs that already contain those binaries
* also use the latest ubi9 images by default (hence no need to specify python-version and nodejs-version)
