### PR TITLE
fix: retry git fetch --tags on fail

### DIFF
--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -261,7 +261,10 @@ spec:
 
         if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
           echo "Fetching tags"
-          git fetch --tags
+          if ! git fetch --tags; then
+            echo "Retrying fetch command..."
+            git fetch --tags
+          fi
         fi
       securityContext:
         runAsUser: 0

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -257,7 +257,10 @@ spec:
 
       if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
         echo "Fetching tags"
-        git fetch --tags
+        if ! git fetch --tags; then
+          echo "Retrying fetch command..."
+          git fetch --tags
+        fi
       fi
 
   - name: symlink-check

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -245,7 +245,10 @@ spec:
 
       if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
         echo "Fetching tags"
-        git fetch --tags
+        if ! git fetch --tags; then
+          echo "Retrying fetch command..."
+          git fetch --tags
+        fi
       fi
     securityContext:
       runAsUser: 0


### PR DESCRIPTION
Git fetch tags currently fail, when a repo has submodules. 
Fetching for the second time works as a workaround.