### PR TITLE
coverity-availability-check: deprecate the -oci-ta copy

### DIFF
--- a/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
+++ b/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
@@ -2,6 +2,9 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-31T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: Starting with version 0.2, the coverity-availability-check-oci-ta
+      task is deprecated.  Please use coverity-availability-check instead.
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux
   labels:

--- a/task/coverity-availability-check-oci-ta/0.2/kustomization.yaml
+++ b/task/coverity-availability-check-oci-ta/0.2/kustomization.yaml
@@ -9,6 +9,12 @@ patches:
     - op: replace
       path: /metadata/name
       value: coverity-availability-check-oci-ta
+    - op: add
+      path: /metadata/annotations/build.appstudio.redhat.com~1expires-on
+      value: "2025-03-31T00:00:00Z"
+    - op: add
+      path: /metadata/annotations/build.appstudio.redhat.com~1expiry-message
+      value: "Starting with version 0.2, the coverity-availability-check-oci-ta task is deprecated.  Please use coverity-availability-check instead."
   target:
     kind: Task
     name: coverity-availability-check


### PR DESCRIPTION
... to make sure that users migrate off the deprecated task so that it does not need to be maintained forever.

Resolves: https://issues.redhat.com/browse/OSH-810