### PR TITLE
sast-*-check: check connectivity to CEE GitLab

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -814,19 +814,17 @@ spec:
           tee coverity-results-raw.json |
           csgrep --mode=evtstat
 
-        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-        # p01 will be decommissionned due to lack of IBM support
         if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-          case "${BUILD_PLR_LOG_URL}" in
-          *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-            echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
             KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-            ;;
-          *)
-            echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
             KFP_GIT_URL=
-            ;;
-          esac
+          fi
         fi
 
         # We check if the KFP_GIT_URL variable is set to apply the filters or not

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -396,19 +396,17 @@
         | tee coverity-results-raw.json \
         | csgrep --mode=evtstat
 
-      # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-      # p01 will be decommissionned due to lack of IBM support
       if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-        case "${BUILD_PLR_LOG_URL}" in
-        *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-          echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+        PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+        echo -n "Probing ${PROBE_URL}... "
+        if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+          echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
           KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-          ;;
-        *)
-          echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+        else
+          echo "Setting KFP_GIT_URL to empty string"
           KFP_GIT_URL=
-          ;;
-        esac
+        fi
       fi
 
       # We check if the KFP_GIT_URL variable is set to apply the filters or not

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -758,19 +758,17 @@ spec:
         | tee coverity-results-raw.json \
         | csgrep --mode=evtstat
 
-      # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-      # p01 will be decommissionned due to lack of IBM support
       if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-        case "${BUILD_PLR_LOG_URL}" in
-        *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-          echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+        PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+        echo -n "Probing ${PROBE_URL}... "
+        if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+          echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
           KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-          ;;
-        *)
-          echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+        else
+          echo "Setting KFP_GIT_URL to empty string"
           KFP_GIT_URL=
-          ;;
-        esac
+        fi
       fi
 
       # We check if the KFP_GIT_URL variable is set to apply the filters or not

--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -167,19 +167,17 @@ spec:
           exit 1
         fi
 
-        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-        # p01 will be decommissionned due to lack of IBM support
         if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-          case "${BUILD_PLR_LOG_URL}" in
-          *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-            echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
             KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-            ;;
-          *)
-            echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
             KFP_GIT_URL=
-            ;;
-          esac
+          fi
         fi
 
         # Filter known false positives if KFP_GIT_URL is set

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -146,19 +146,17 @@ spec:
             exit 1
         fi
 
-        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-        # p01 will be decommissionned due to lack of IBM support
         if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-          case "${BUILD_PLR_LOG_URL}" in
-          *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-            echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
             KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-            ;;
-          *)
-            echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
             KFP_GIT_URL=
-            ;;
-          esac
+          fi
         fi
 
         # Filter known false positives if KFP_GIT_URL is set

--- a/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml
@@ -204,19 +204,17 @@ spec:
           echo "Results:"
           (set -x && csgrep --mode=evtstat sast_snyk_check_out_all_findings.json)
 
-          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-          # p01 will be decommissionned due to lack of IBM support
           if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-            case "${BUILD_PLR_LOG_URL}" in
-            *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-              echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+            # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+            PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+            echo -n "Probing ${PROBE_URL}... "
+            if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+              echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
               KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-              ;;
-            *)
-              echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+            else
+              echo "Setting KFP_GIT_URL to empty string"
               KFP_GIT_URL=
-              ;;
-            esac
+            fi
           fi
 
           # We check if the KFP_GIT_URL variable is set to apply the filters or not

--- a/task/sast-snyk-check/0.3/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.3/sast-snyk-check.yaml
@@ -180,19 +180,17 @@ spec:
           echo "Results:"
           (set -x && csgrep --mode=evtstat sast_snyk_check_out_all_findings.json)
 
-          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-          # p01 will be decommissionned due to lack of IBM support
           if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-            case "${BUILD_PLR_LOG_URL}" in
-            *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-              echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+            # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+            PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+            echo -n "Probing ${PROBE_URL}... "
+            if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+              echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
               KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-              ;;
-            *)
-              echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+            else
+              echo "Setting KFP_GIT_URL to empty string"
               KFP_GIT_URL=
-              ;;
-            esac
+            fi
           fi
 
           # We check if the KFP_GIT_URL variable is set to apply the filters or not

--- a/task/sast-unicode-check-oci-ta/0.1/sast-unicode-check-oci-ta.yaml
+++ b/task/sast-unicode-check-oci-ta/0.1/sast-unicode-check-oci-ta.yaml
@@ -210,19 +210,17 @@ spec:
 
         csgrep --mode=evtstat processed_sast_unicode_check_out.json
 
-        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-        # p01 will be decommissionned due to lack of IBM support
         if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-          case "${BUILD_PLR_LOG_URL}" in
-          *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-            echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
             KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-            ;;
-          *)
-            echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
             KFP_GIT_URL=
-            ;;
-          esac
+          fi
         fi
 
         # Filter known false positives if KFP_GIT_URL is set

--- a/task/sast-unicode-check/0.1/sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.1/sast-unicode-check.yaml
@@ -188,19 +188,17 @@ spec:
 
         csgrep --mode=evtstat processed_sast_unicode_check_out.json
 
-        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instance
-        # p01 will be decommissionned due to lack of IBM support
         if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-          case "${BUILD_PLR_LOG_URL}" in
-          *konflux.apps.stone-prod-p02.hjvn.p1.openshiftapps.com* | *konflux.apps.stone-prod-p01.wcfb.p1.openshiftapps.com*)
-            echo "the task is running within Red Hat network, set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
             KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-            ;;
-          *)
-            echo "the task is not running within Red Hat network, set KFP_GIT_URL to empty string"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
             KFP_GIT_URL=
-            ;;
-          esac
+          fi
         fi
 
         # Filter known false positives if KFP_GIT_URL is set


### PR DESCRIPTION
... when `KFP_GIT_URL` is set to `SITE_DEFAULT`, which is the default value.  This way we do not need to hardcode the list of internal Konflux clusters, as initially implemented in #1848 and #1883.

Related: https://issues.redhat.com/browse/KONFLUX-4530
Related: https://issues.redhat.com/browse/OSH-763
Resolves: https://issues.redhat.com/browse/OSH-814