### PR TITLE
fix(KONFLUX-6999): improve logging output for FBC validation

### DIFF
--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -444,7 +444,7 @@ spec:
         if [ $status -ne 0 ]; then
           get_unreleased_fbc_related_images -i "$image_with_digest"
           echo "!FAILURE! - Could not get related images."
-          note="Step extract-and-validate failed: Could not fetch related images. Make sure you have catalog.yaml or catalog.json formatted correctly in your file-based catalog (FBC) fragment image."
+          note="Step extract-and-validate failed ($status): Could not fetch related images. Make sure you have catalog.yaml or catalog.json formatted correctly in your file-based catalog (FBC) fragment image."
           failure_num=$((failure_num + 1))
           TESTPASSED=false
         else
@@ -453,15 +453,20 @@ spec:
           # A while loop executed in a subshell so we will check for failure based
           # on whether /tmp/failedimages exists.
           echo -e "Related images detected:\n$(jq -cr '.[]' /shared/related-images.json )."
-          echo "Testing related images for validity"
+          echo -e "\nTesting related images for validity:"
           # cycle through those related images and show outputs
           jq -cr '.[]' /shared/related-images.json | while read -r image; do
-            if ! skopeo inspect --no-tags "docker://${image}" 2>/dev/null; then
-              echo "Skopeo inspect failed on related image: ${image}." | tee -a /tmp/failedimages
+            echo "skopeo inspect --raw docker://${image}"
+            if ! skopeo inspect --raw "docker://${image}" 2>/dev/null; then
+              echo "FAILED to inspect related image: ${image}." | tee -a /tmp/failedimages
+            else
+              echo # the skopeo inspect command doesn't have a newline. Add that here.
             fi
           done
 
           if [ -s /tmp/failedimages ]; then
+            echo "These related images have failed validation:"
+            cat /tmp/failedimages
             note="Step extract-and-validate failed: Command skopeo inspect could not inspect images. For details, check Tekton task log."
             failure_num=$((failure_num + 1))
             TESTPASSED=false


### PR DESCRIPTION
There is often a lot of text output when validating the related images. In order to enable better troubleshooting, we will augment the normal output to add additional details.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
