### PR TITLE
Allow specifying startup directory

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -82,9 +82,16 @@ function should_skip_repo() {
     [ "$http_code" != "200" ]
 }
 
+: "${HERE:=}"
+
 # local dev build script
-SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cd "$SCRIPTDIR/.." || exit 1
+
+if [ -z "$HERE" ]; then
+    SCRIPTDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+    cd "$SCRIPTDIR/.." || exit 1
+else
+    cd "$HERE" || exit 1
+fi
 
 WORKDIR=$(mktemp -d --suffix "-$(basename "${BASH_SOURCE[0]}" .sh)")
 declare -r WORKDIR


### PR DESCRIPTION
This change can benefit other scripts that want to reuse this script to build bundles at a differet location rather than from inside build-definitions repo. It may be for testing purpose without writing custom code to repeat the logic of build-and-push process. For example of a use case: https://github.com/konflux-ci/pipeline-migration-tool/pull/10