### PR TITLE
Let acs-image-check task pass with policy violations

### DIFF
--- a/task/acs-image-check/0.1/acs-image-check.yaml
+++ b/task/acs-image-check/0.1/acs-image-check.yaml
@@ -124,6 +124,7 @@ spec:
 
         cp roxctl_image_check_output.json /steps-shared-folder/acs-image-check.json
 
+        # Exit code 3 means the error occurred during roxctl image check, but setup was successful
         if [ "$ROXCTL_CHECK_STATUS" -ne 0 ]; then
           exit 3
         fi
@@ -135,18 +136,51 @@ spec:
           mountPath: /steps-shared-folder
       script: |
         #!/usr/bin/env bash
+        set -euo pipefail
+
         cat /steps-shared-folder/acs-image-check.json
 
-    - name: fail-if-rox-image-check-failed
-      image: registry.access.redhat.com/ubi8-minimal@sha256:d16d4445b1567f29449fba3b6d2bc37db467dc3067d33e940477e55aecdf6e8e
+    - name: fail-if-check-failed
+      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      volumeMounts:
+        - name: shared-folder
+          mountPath: /steps-shared-folder
       script: |
         #!/usr/bin/env bash
+        set -euo pipefail
+
         ROX_IMAGE_CHECK_EXIT_CODE_PATH=$(steps.step-rox-image-check.exitCode.path)
         ROX_IMAGE_CHECK_STATUS=$(cat "$ROX_IMAGE_CHECK_EXIT_CODE_PATH")
 
-        if [ "$ROX_IMAGE_CHECK_STATUS" -ne 0 ]; then
-          echo "rox-image-check step failed, please check its logs for errors"
+        if [ "$ROX_IMAGE_CHECK_STATUS" -eq 0 ]
+        then
+          echo "No errors occurred"
+          exit
+        fi
+
+        # Fail on non-zero rox-image-check step exit code
+        # Except if the error is due to policy violations (exit code 3 && at least one severe violation)
+        if [ "$ROX_IMAGE_CHECK_STATUS" -ne 3 ]
+        then
+          echo "Error occurred during setup of roxctl"
           exit "$ROX_IMAGE_CHECK_STATUS"
         fi
 
-        echo "No errors occurred in rox-image-check step"
+        # Number of policy violations with Critical and High severity parsed from the report
+        severe_violations=$(
+          jq '.summary |
+            with_entries(
+              select(.key | IN("CRITICAL", "HIGH"))
+            ) |
+            add' \
+            /steps-shared-folder/acs-image-check.json
+        )
+
+        # If roxctl image check exited with non-zero code and it is not because of policy violations, report error
+        if [ "$severe_violations" -eq 0 ]
+        then
+          echo "Error occurred during roxctl image check, please check the logs of rox-image-check step."
+          exit "$ROX_IMAGE_CHECK_STATUS"
+        fi
+
+        echo "No errors occurred"


### PR DESCRIPTION
acs-image-check task currently fails when there are Critical or High policy violations detected
The task should pass if it succeeds in creating a report and let users handle the policy violations separately themselves