### PR TITLE
chore(KFLUXVNGD-221): deprecate task verify-signed-rpms

### DIFF
--- a/task/verify-signed-rpms/0.1/README.md
+++ b/task/verify-signed-rpms/0.1/README.md
@@ -1,5 +1,14 @@
 # verify-signed-rpms.yaml task
 
+## Deprecation notice
+
+This task is deprecated with set deprecation date on 2025-03-15.
+
+As it was never included in any Conforma policy under the current name, there are no
+expected changes in the way violations are reported for using the task.
+
+Please use [task rpms-signature-scan](https://quay.io/repository/konflux-ci/tekton-catalog/task-rpms-signature-scan) instead.
+
 ## Description:
 This tasks checks whether the images it is provided with contain any unsigned RPMs.
 

--- a/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
+++ b/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
@@ -3,6 +3,10 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: verify-signed-rpms
+  build.appstudio.redhat.com/expires-on: "2025-03-15T00:00:00Z"
+  build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+    to task rpms-signature-scan
+    (https://quay.io/repository/konflux-ci/tekton-catalog/task-rpms-signature-scan)'
 spec:
   params:
     - name: INPUT


### PR DESCRIPTION
The task was renamed and the task under the old name is not maintained anymore and should not be used.
