### PR TITLE
chore(deps): update prefetch

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -162,7 +162,7 @@ spec:
           yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}" >/mnt/config/config.yaml
         fi
     - name: prefetch-dependencies
-      image: quay.io/konflux-ci/cachi2:0.20.0@sha256:80402886bbc0f6b4deba65cf5f66dfe9a2c01ae0b57bf3454e3ea58e1a395720
+      image: quay.io/konflux-ci/cachi2:0.21.0@sha256:dabaeed7101209cfc7066e26301b12de2b72a2d943691537f598f7ad8c818dc9
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -83,7 +83,7 @@ spec:
       fi
 
   - name: prefetch-dependencies
-    image: quay.io/konflux-ci/cachi2:0.20.0@sha256:80402886bbc0f6b4deba65cf5f66dfe9a2c01ae0b57bf3454e3ea58e1a395720
+    image: quay.io/konflux-ci/cachi2:0.21.0@sha256:dabaeed7101209cfc7066e26301b12de2b72a2d943691537f598f7ad8c818dc9
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     env:


### PR DESCRIPTION
Bump cachi2 release to 0.21.0 [1].

[1] https://github.com/containerbuildsystem/cachi2/releases/tag/0.21.0

Most notably, this enables Go 1.24 support in prefetch, hence proposed separately from https://github.com/konflux-ci/build-definitions/pull/1932 for early adoption.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
