### PR TITLE
Fix mismatched task versions

### DIFF
--- a/task/acs-deploy-check/0.1/acs-deploy-check.yaml
+++ b/task/acs-deploy-check/0.1/acs-deploy-check.yaml
@@ -7,6 +7,8 @@ metadata:
     task.results.type: roxctl-deployment-check
     task.results.container: step-report
     task.output.location: logs
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: >-
     Policy check a deployment with StackRox/RHACS This tasks allows you to check

--- a/task/acs-image-check/0.1/acs-image-check.yaml
+++ b/task/acs-image-check/0.1/acs-image-check.yaml
@@ -7,6 +7,8 @@ metadata:
     task.results.type: roxctl-image-check
     task.results.container: step-report
     task.output.location: logs
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Policy check an image with StackRox/RHACS This tasks allows you to
     check an image against build-time policies and apply enforcement to fail builds.

--- a/task/acs-image-scan/0.1/acs-image-scan.yaml
+++ b/task/acs-image-scan/0.1/acs-image-scan.yaml
@@ -8,6 +8,8 @@ metadata:
     task.results.key: SCAN_OUTPUT
     task.results.container: step-report
     task.output.location: logs
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Policy check an image with StackRox/RHACS This tasks allows you to
     check an image against build-time policies and apply enforcement to fail builds.

--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: 0.3.1
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: 0.3.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: 0.3.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     build.appstudio.redhat.com/expires-on: "2025-03-01T00:00:00Z"

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: 0.3.1
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     build.appstudio.redhat.com/expires-on: "2025-03-31T00:00:00Z"

--- a/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
+++ b/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
@@ -9,7 +9,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   name: coverity-availability-check-oci-ta
 spec:
   description: This task performs needed checks in order to use Coverity image in

--- a/task/coverity-availability-check/0.2/coverity-availability-check.yaml
+++ b/task/coverity-availability-check/0.2/coverity-availability-check.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
+++ b/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     tekton.dev/tags: "sbom, attestation, cosign"
   name: download-sbom-from-url-in-attestation
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: |-
     Get the SBOM for an image by downloading the OCI blob referenced in the image attestation.

--- a/task/eaas-provision-space/0.1/eaas-provision-space.yaml
+++ b/task/eaas-provision-space/0.1/eaas-provision-space.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: eaas-provision-space
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: >-
     Provisions an ephemeral namespace on an EaaS cluster using a crossplane namespace claim.

--- a/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: ecosystem-cert-preflight-checks
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: >-
     Scans container images for certification readiness

--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: ecosystem-cert-preflight-checks
+  labels:
+    app.kubernetes.io/version: "0.2"
 spec:
   description: >-
     Scans container images for certification readiness. Note that running this

--- a/task/gather-deploy-images/0.1/gather-deploy-images.yaml
+++ b/task/gather-deploy-images/0.1/gather-deploy-images.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: gather-deploy-images
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Extract images from deployment YAML to pass to EC for validation
   workspaces:

--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: operator-sdk-generate-bundle
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Generate an OLM bundle using the operator-sdk
   params:

--- a/task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
+++ b/task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: opm-get-bundle-version
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Fetch the current version of the provided OLM bundle image
   params:

--- a/task/opm-render-bundles/0.1/opm-render-bundles.yaml
+++ b/task/opm-render-bundles/0.1/opm-render-bundles.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: opm-render-bundles
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Create a catalog index and render the provided bundles into it
   params:

--- a/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
+++ b/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: rpm-ostree
     build.appstudio.redhat.com/multi-platform-required: "true"
 spec:

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: rpm-ostree
     build.appstudio.redhat.com/multi-platform-required: "true"
   name: rpm-ostree

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -5,6 +5,8 @@ metadata:
   name: sbom-json-check
   annotations:
     build.appstudio.redhat.com/expires-on: 2025-09-30T00:00:00Z
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: >-
     Verifies the integrity and security of the Software Bill of Materials (SBOM) file in JSON format using CyloneDX tool.

--- a/task/sbom-json-check/0.2/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.2/sbom-json-check.yaml
@@ -5,6 +5,8 @@ metadata:
   name: sbom-json-check
   annotations:
     build.appstudio.redhat.com/expires-on: 2025-09-30T00:00:00Z
+  labels:
+    app.kubernetes.io/version: "0.2"
 spec:
   description: >-
     Verifies the integrity and security of the Software Bill of Materials (SBOM) file in JSON format using CyloneDX tool.

--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: update-deployment
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Task to update deployment with newly built image in gitops repository.
   params:

--- a/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
+++ b/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     tekton.dev/tags: "sbom, trustification"
   name: upload-sbom-to-trustification
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: |-
     Upload an SBOM file to [Trustification] using the [BOMbastic] API.

--- a/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
+++ b/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
@@ -8,6 +8,8 @@ metadata:
     build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
       to task rpms-signature-scan
       (https://quay.io/repository/konflux-ci/tekton-catalog/task-rpms-signature-scan)'
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   params:
     - name: INPUT


### PR DESCRIPTION
My original goal was to fix the missing label on the `rpms-signature-scan` task, since it causes problems for freshly onboarded components, see [here for example](https://github.com/enterprise-contract/ec-cli/pull/2368#pullrequestreview-2665779489). I've also seen multiple user support requests from users with the exact same problem.

I noticed there were a few other tasks with the version label missing, and some with copy/pasted and inconsistent values, so I decided to try fixing all of them. There might be some side effects of this change that I'm not aware of, so please give that it some consideration before merging.

The reason I think this label is important is because of [this code](https://github.com/konflux-ci/build-definitions/blob/eb11ac8800f6d42848e1635e9d0141fe2417b1a9/hack/build-and-push.sh#L244-L248), but I'm not sure exactly what the impact of incorrect or missing version labels.

See also:

* #2012 which contains a different fix for missing labels in pipeline definitions.
* The `hack/check-task-version-labels.sh` script added in #2048 which was used to help identify the version labels that are missing or incorrect.