### PR TITLE
Fix missing tags in pipeline bundle

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -550,8 +550,9 @@ build_push_tasks() {
             echo "$output" >&2
             echo
 
-            task_bundle_with_digest=$(grep -m 1 "^Pushed Tekton Bundle to" <<<"$output" 2>/dev/null)
-            task_bundle_with_digest=${task_bundle_with_digest##* }
+            # Grab just the digest of the bundle from the ouput. The tag is NOT included in the ouput.
+            digest="$(grep -m 1 "^Pushed Tekton Bundle to" <<<"$output" 2>/dev/null | grep -o -m 1 'sha256:[0-9a-f]*')"
+            task_bundle_with_digest="${task_bundle}@${digest}"
             cache_set "${task_bundle}-${task_file_sha}" "${task_bundle_with_digest#*@}"
         fi
 


### PR DESCRIPTION
When Tekton Bundles for the Pipeline definitions are created, the Task references are replaced with references to Task Tekton Bundles. There are two paths for which these references are determined.

If there are no changes to the Task, then the already existing Task Tekton Bundle is used. The digest is determined by querying the registry.

However, if a Task Tekton Bundle was created during the script, then that reference is used instead. The digest is determined by parsing the output of the `tkn bundle push` command. This output does not include the tag. This caused the Pipeline Tekton Bundle to include references to Task Tekton Bundles that did not include a tag.

This commit fixes the issue by only grabbing the digest from the tkn cli output instead of the full Tekton Bundle reference.

A tag in the reference is important for Conformat, see https://issues.redhat.com/browse/EC-712

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
