### PR TITLE
fix(KONFLUX-6914): adding image digest to oras uploads

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -464,13 +464,15 @@ spec:
       workspace: workspace
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     runAfter:
     - build-image-index
     taskRef:
       name: sast-unicode-check
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -392,6 +392,8 @@ spec:
       - "false"
   - name: sast-coverity-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE
@@ -417,7 +419,7 @@ spec:
     - coverity-availability-check
     taskRef:
       name: sast-coverity-check
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -365,7 +365,7 @@ spec:
     - build-image-index
     taskRef:
       name: sast-snyk-check
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -236,7 +236,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-digest| Image digest to report findings for.| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
-### sast-snyk-check-oci-ta:0.3 task parameters
+### sast-snyk-check-oci-ta:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ARGS| Append arguments.| | |
@@ -346,8 +346,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.4:CACHI2_ARTIFACT ; build-source-image:0.2:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.4:SOURCE_ARTIFACT ; build-source-image:0.2:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-images:0.4:CACHI2_ARTIFACT ; build-source-image:0.2:CACHI2_ARTIFACT ; sast-snyk-check:0.4:CACHI2_ARTIFACT ; sast-coverity-check:0.3:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.2:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-images:0.4:SOURCE_ARTIFACT ; build-source-image:0.2:SOURCE_ARTIFACT ; sast-snyk-check:0.4:SOURCE_ARTIFACT ; sast-coverity-check:0.3:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.2:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -366,11 +366,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-snyk-check-oci-ta:0.3 task results
+### sast-snyk-check-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-unicode-check-oci-ta:0.1 task results
+### sast-unicode-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -7,12 +7,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.4:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.4:BUILD_ARGS ; sast-coverity-check:0.3:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.3:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.4:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
@@ -181,7 +181,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-coverity-check-oci-ta:0.2 task parameters
+### sast-coverity-check-oci-ta:0.3 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -291,9 +291,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-remote-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -334,7 +334,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
-|commit| The precise commit SHA that was fetched by this Task.| build-images:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
+|commit| The precise commit SHA that was fetched by this Task.| build-images:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.3:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
@@ -358,7 +358,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-coverity-check-oci-ta:0.2 task results
+### sast-coverity-check-oci-ta:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -250,8 +250,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
-### sast-unicode-check-oci-ta:0.1 task parameters
+|image-digest| Digest of the image to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+### sast-unicode-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -14,11 +14,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-images:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-images:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.4:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-images:0.4:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-images:0.4:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-images:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.3:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.4:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-images:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-images:0.4:PRIVILEGED_NESTED|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
@@ -222,7 +222,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| | None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|image-digest| Digest of the image to which the scan results should be associated.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|image-url| URL of the image to which the scan results should be associated.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-shell-check-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -264,6 +265,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -329,6 +329,8 @@ spec:
       - "false"
   - name: sast-coverity-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE
@@ -358,7 +360,7 @@ spec:
     - coverity-availability-check
     taskRef:
       name: sast-coverity-check-oci-ta
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -304,7 +304,7 @@ spec:
     - build-image-index
     taskRef:
       name: sast-snyk-check-oci-ta
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -405,6 +405,8 @@ spec:
     workspaces: []
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
@@ -415,7 +417,7 @@ spec:
     - build-image-index
     taskRef:
       name: sast-unicode-check-oci-ta
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -233,7 +233,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-digest| Image digest to report findings for.| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
-### sast-snyk-check-oci-ta:0.3 task parameters
+### sast-snyk-check-oci-ta:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ARGS| Append arguments.| | |
@@ -363,11 +363,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-snyk-check-oci-ta:0.3 task results
+### sast-snyk-check-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-unicode-check-oci-ta:0.1 task results
+### sast-unicode-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -13,11 +13,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-container:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.4:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-container:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.3:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.4:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.4:PRIVILEGED_NESTED|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
@@ -219,7 +219,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| | None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|image-digest| Digest of the image to which the scan results should be associated.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|image-url| URL of the image to which the scan results should be associated.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-shell-check-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -261,6 +262,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|
@@ -332,7 +334,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
-|commit| The precise commit SHA that was fetched by this Task.| build-container:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
+|commit| The precise commit SHA that was fetched by this Task.| build-container:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.3:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -247,8 +247,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
-### sast-unicode-check-oci-ta:0.1 task parameters
+|image-digest| Digest of the image to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+### sast-unicode-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -7,11 +7,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.4:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.4:BUILD_ARGS ; sast-coverity-check:0.3:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.3:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
@@ -178,7 +178,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-coverity-check-oci-ta:0.2 task parameters
+### sast-coverity-check-oci-ta:0.3 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -288,9 +288,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -343,8 +343,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.4:CACHI2_ARTIFACT ; build-source-image:0.2:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.4:SOURCE_ARTIFACT ; build-source-image:0.2:SOURCE_ARTIFACT ; sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-container:0.4:CACHI2_ARTIFACT ; build-source-image:0.2:CACHI2_ARTIFACT ; sast-snyk-check:0.4:CACHI2_ARTIFACT ; sast-coverity-check:0.3:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.2:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.4:SOURCE_ARTIFACT ; build-source-image:0.2:SOURCE_ARTIFACT ; sast-snyk-check:0.4:SOURCE_ARTIFACT ; sast-coverity-check:0.3:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.2:SOURCE_ARTIFACT ; push-dockerfile:0.1:SOURCE_ARTIFACT|
 ### push-dockerfile-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -355,7 +355,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-coverity-check-oci-ta:0.2 task results
+### sast-coverity-check-oci-ta:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -316,6 +316,8 @@ spec:
       - "false"
   - name: sast-coverity-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE
@@ -345,7 +347,7 @@ spec:
     - coverity-availability-check
     taskRef:
       name: sast-coverity-check-oci-ta
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -392,6 +392,8 @@ spec:
     workspaces: []
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
@@ -402,7 +404,7 @@ spec:
     - build-image-index
     taskRef:
       name: sast-unicode-check-oci-ta
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -291,7 +291,7 @@ spec:
     - build-image-index
     taskRef:
       name: sast-snyk-check-oci-ta
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -224,7 +224,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-digest| Image digest to report findings for.| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
-### sast-snyk-check:0.3 task parameters
+### sast-snyk-check:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ARGS| Append arguments.| | |
@@ -280,9 +280,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.3:image-digest ; clamav-scan:0.2:image-digest ; sast-shell-check:0.1:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -349,11 +349,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-snyk-check:0.3 task results
+### sast-snyk-check:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-unicode-check:0.1 task results
+### sast-unicode-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
@@ -370,7 +370,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.2:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.4:source ; build-source-image:0.2:workspace ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace ; push-dockerfile:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.4:source ; build-source-image:0.2:workspace ; sast-snyk-check:0.4:workspace ; sast-coverity-check:0.3:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.2:workspace ; push-dockerfile:0.1:workspace|
 ## Available workspaces from tasks
 ### buildah:0.4 task workspaces
 |name|description|optional|workspace from pipeline
@@ -400,11 +400,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|
-### sast-snyk-check:0.3 task workspaces
+### sast-snyk-check:0.4 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|
-### sast-unicode-check:0.1 task workspaces
+### sast-unicode-check:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -13,11 +13,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
-|hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.2:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.4:CONTEXT ; sast-coverity-check:0.2:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.2:PREFETCH_INPUT|
+|hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.4:IMAGE ; build-image-index:0.1:IMAGE ; build-source-image:0.2:BINARY_IMAGE ; sast-coverity-check:0.3:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.4:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
+|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.4:PRIVILEGED_NESTED|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
@@ -212,7 +212,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| | None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+|image-digest| Digest of the image to which the scan results should be associated.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|image-url| URL of the image to which the scan results should be associated.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-shell-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -248,6 +249,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |RECORD_EXCLUDED| Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. | false| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|
@@ -323,7 +325,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
-|commit| The precise commit SHA that was fetched by this Task.| build-container:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
+|commit| The precise commit SHA that was fetched by this Task.| build-container:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.3:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -7,11 +7,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.4:BUILD_ARGS ; sast-coverity-check:0.2:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.2:BUILD_ARGS_FILE|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-container:0.4:BUILD_ARGS ; sast-coverity-check:0.3:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.3:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.2:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.2:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.2:IMAGE_EXPIRES_AFTER|
@@ -173,7 +173,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-coverity-check:0.2 task parameters
+### sast-coverity-check:0.3 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -341,7 +341,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-coverity-check:0.2 task results
+### sast-coverity-check:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
@@ -392,7 +392,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| Workspace containing the source code from where the Dockerfile is discovered.| False| workspace|
-### sast-coverity-check:0.2 task workspaces
+### sast-coverity-check:0.3 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |source| Workspace containing the source code to build.| False| workspace|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -236,8 +236,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
-### sast-unicode-check:0.1 task parameters
+|image-digest| Digest of the image to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+### sast-unicode-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |FIND_UNICODE_CONTROL_ARGS| arguments for find-unicode-control command.| -p bidi -v -d -t| |

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -298,7 +298,7 @@ spec:
     - build-image-index
     taskRef:
       name: sast-snyk-check
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -397,13 +397,15 @@ spec:
       workspace: workspace
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     runAfter:
     - build-image-index
     taskRef:
       name: sast-unicode-check
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -325,6 +325,8 @@ spec:
       - "false"
   - name: sast-coverity-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE
@@ -350,7 +352,7 @@ spec:
     - coverity-availability-check
     taskRef:
       name: sast-coverity-check
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -130,7 +130,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-digest| Image digest to report findings for.| | '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
-### sast-snyk-check-oci-ta:0.3 task parameters
+### sast-snyk-check-oci-ta:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ARGS| Append arguments.| | |
@@ -214,11 +214,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-snyk-check-oci-ta:0.3 task results
+### sast-snyk-check-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-unicode-check-oci-ta:0.1 task results
+### sast-unicode-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -144,8 +144,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| Image URL.| | '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
-### sast-unicode-check-oci-ta:0.1 task parameters
+|image-digest| Digest of the image to scan.| None| '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
+### sast-unicode-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -75,7 +75,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
-### sast-coverity-check-oci-ta:0.2 task parameters
+### sast-coverity-check-oci-ta:0.3 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -177,9 +177,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### build-maven-zip-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-shell-check:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.4:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest|
 |IMAGE_REF| OCI-Artifact reference of the built OCI-Artifact| |
-|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
+|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.4:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -204,9 +204,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-oci-artifact:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.3:CACHI2_ARTIFACT ; sast-coverity-check:0.2:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| sast-snyk-check:0.3:SOURCE_ARTIFACT ; sast-coverity-check:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT|
-### sast-coverity-check-oci-ta:0.2 task results
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| build-oci-artifact:0.1:CACHI2_ARTIFACT ; sast-snyk-check:0.4:CACHI2_ARTIFACT ; sast-coverity-check:0.3:CACHI2_ARTIFACT ; sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.2:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| sast-snyk-check:0.4:SOURCE_ARTIFACT ; sast-coverity-check:0.3:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.2:SOURCE_ARTIFACT|
+### sast-coverity-check-oci-ta:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -116,7 +116,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| | None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
+|image-digest| Digest of the image to which the scan results should be associated.| None| '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
+|image-url| URL of the image to which the scan results should be associated.| None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
 ### sast-shell-check-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -158,6 +159,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest| | '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -211,6 +211,8 @@ spec:
     workspaces: []
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-oci-artifact.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
@@ -221,7 +223,7 @@ spec:
     - build-oci-artifact
     taskRef:
       name: sast-unicode-check-oci-ta
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -145,7 +145,7 @@ spec:
     - build-oci-artifact
     taskRef:
       name: sast-snyk-check-oci-ta
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -154,6 +154,8 @@ spec:
     workspaces: []
   - name: sast-coverity-check
     params:
+    - name: image-digest
+      value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-oci-artifact.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
@@ -164,7 +166,7 @@ spec:
     - coverity-availability-check
     taskRef:
       name: sast-coverity-check-oci-ta
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -111,7 +111,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| | None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
+|image-digest| Digest of the image to which the scan results should be associated.| None| '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
+|image-url| URL of the image to which the scan results should be associated.| None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
 ### sast-shell-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -147,6 +148,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |RECORD_EXCLUDED| Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. | false| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest| | '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -123,7 +123,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-digest| Image digest to report findings for.| | '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
-### sast-snyk-check:0.3 task parameters
+### sast-snyk-check:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ARGS| Append arguments.| | |
@@ -173,9 +173,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### build-maven-zip:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.3:image-digest ; sast-shell-check:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the OCI-Artifact just built| sast-snyk-check:0.4:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest|
 |IMAGE_REF| OCI-Artifact reference of the built OCI-Artifact| |
-|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.3:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url|
+|IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| show-sbom:0.1:IMAGE_URL ; sast-snyk-check:0.4:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### coverity-availability-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -244,11 +244,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|
-### sast-snyk-check:0.3 task workspaces
+### sast-snyk-check:0.4 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|
-### sast-unicode-check:0.1 task workspaces
+### sast-unicode-check:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -72,7 +72,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
-### sast-coverity-check:0.2 task parameters
+### sast-coverity-check:0.3 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
@@ -196,7 +196,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
-### sast-coverity-check:0.2 task results
+### sast-coverity-check:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
@@ -218,7 +218,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.2:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.3:workspace ; sast-coverity-check:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.4:workspace ; sast-coverity-check:0.3:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.2:workspace|
 ## Available workspaces from tasks
 ### build-maven-zip:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -236,7 +236,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
 |source| Workspace with the source code, cachi2 artifacts will be stored on the workspace as well| False| workspace|
-### sast-coverity-check:0.2 task workspaces
+### sast-coverity-check:0.3 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |source| Workspace containing the source code to build.| False| workspace|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -135,8 +135,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SNYK_SECRET| Name of secret which contains Snyk token.| snyk-secret| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-url| Image URL.| | '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
-### sast-unicode-check:0.1 task parameters
+|image-digest| Digest of the image to scan.| None| '$(tasks.build-oci-artifact.results.IMAGE_DIGEST)'|
+|image-url| Image URL.| None| '$(tasks.build-oci-artifact.results.IMAGE_URL)'|
+### sast-unicode-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |FIND_UNICODE_CONTROL_ARGS| arguments for find-unicode-control command.| -p bidi -v -d -t| |
@@ -204,11 +205,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-snyk-check:0.3 task results
+### sast-snyk-check:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-unicode-check:0.1 task results
+### sast-unicode-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -156,7 +156,7 @@ spec:
     - build-oci-artifact
     taskRef:
       name: sast-snyk-check
-      version: "0.3"
+      version: "0.4"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -220,13 +220,15 @@ spec:
       workspace: workspace
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-oci-artifact.results.IMAGE_URL)
     runAfter:
     - build-oci-artifact
     taskRef:
       name: sast-unicode-check
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -167,13 +167,15 @@ spec:
       workspace: workspace
   - name: sast-coverity-check
     params:
+    - name: image-digest
+      value: $(tasks.build-oci-artifact.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-oci-artifact.results.IMAGE_URL)
     runAfter:
     - coverity-availability-check
     taskRef:
       name: sast-coverity-check
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/maven-zip-build/patch.yaml
+++ b/pipelines/maven-zip-build/patch.yaml
@@ -143,6 +143,9 @@
 # Replace the params set and runAfter of sast-unicode-check
 - op: replace
   path: /spec/tasks/8/params/0/value
+  value: "$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
+- op: replace
+  path: /spec/tasks/8/params/1/value
   value: "$(tasks.build-oci-artifact.results.IMAGE_URL)"
 - op: replace
   path: /spec/tasks/8/runAfter

--- a/pipelines/maven-zip-build/patch.yaml
+++ b/pipelines/maven-zip-build/patch.yaml
@@ -120,6 +120,9 @@
 # Replace the params set and runAfter of sast-coverity-check
 - op: replace
   path: /spec/tasks/5/params/0/value
+  value: "$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
+- op: replace
+  path: /spec/tasks/5/params/1/value
   value: "$(tasks.build-oci-artifact.results.IMAGE_URL)"
 # Replace the params set and runAfter of coverity-availability-check
 - op: replace

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -104,6 +104,7 @@
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### summary:0.2 task parameters
 |name|description|default value|already set by|
@@ -135,9 +136,9 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| sast-shell-check:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE|
+|IMAGE_URL| Image repository and tag where the built image was pushed| sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.1:IMAGE|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### git-clone-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -158,7 +159,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.2:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.2:SOURCE_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.2:SOURCE_ARTIFACT|
 ### sast-shell-check-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -92,7 +92,7 @@
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-digest| Image digest to report findings for.| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
-### sast-unicode-check-oci-ta:0.1 task parameters
+### sast-unicode-check-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
@@ -157,13 +157,13 @@
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
-|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT|
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.2:CACHI2_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.2:SOURCE_ARTIFACT|
 ### sast-shell-check-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-unicode-check-oci-ta:0.1 task results
+### sast-unicode-check-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -205,6 +205,8 @@ spec:
     workspaces: []
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
@@ -215,7 +217,7 @@ spec:
     - build-image-index
     taskRef:
       name: sast-unicode-check-oci-ta
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -88,7 +88,7 @@
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-digest| Image digest to report findings for.| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
-### sast-unicode-check:0.1 task parameters
+### sast-unicode-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |FIND_UNICODE_CONTROL_ARGS| arguments for find-unicode-control command.| -p bidi -v -d -t| |
@@ -98,6 +98,7 @@
 |RECORD_EXCLUDED| Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. | false| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|image-digest| Image digest| | '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| | '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### summary:0.2 task parameters
 |name|description|default value|already set by|
@@ -150,7 +151,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-unicode-check:0.1 task results
+### sast-unicode-check:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
@@ -184,7 +185,7 @@
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|
-### sast-unicode-check:0.1 task workspaces
+### sast-unicode-check:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| | False| workspace|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -129,9 +129,9 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| sast-shell-check:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE|
+|IMAGE_URL| Image repository and tag where the built image was pushed| sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.1:IMAGE|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -167,7 +167,7 @@
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.2:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.2:workspace|
 ## Available workspaces from tasks
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -204,13 +204,15 @@ spec:
       workspace: workspace
   - name: sast-unicode-check
     params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
     runAfter:
     - build-image-index
     taskRef:
       name: sast-unicode-check
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -296,11 +296,13 @@ spec:
         - build-image-index
       taskRef:
         name: sast-unicode-check
-        version: "0.1"
+        version: "0.2"
       workspaces:
         - name: workspace
           workspace: workspace
       params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: apply-tags

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -250,8 +250,10 @@ spec:
         - coverity-availability-check
       taskRef:
         name: sast-coverity-check
-        version: "0.2"
+        version: "0.3"
       params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
         - name: image-url
           value: $(tasks.build-image-index.results.IMAGE_URL)
       workspaces:

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -214,7 +214,7 @@ spec:
         - build-image-index
       taskRef:
         name: sast-snyk-check
-        version: "0.3"
+        version: "0.4"
       workspaces:
       - name: workspace
         workspace: workspace

--- a/task/clamav-scan/0.2/clamav-scan.yaml
+++ b/task/clamav-scan/0.2/clamav-scan.yaml
@@ -202,7 +202,7 @@ spec:
         echo "Selecting auth"
         select-oci-auth $IMAGE_URL > $HOME/auth.json
         echo "Attaching to ${IMAGE_URL}"
-         oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type application/vnd.clamav "${IMAGE_URL}" "${args[@]}"
+         oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type application/vnd.clamav "${IMAGE_URL}@${IMAGE_DIGEST}" "${args[@]}"
       volumeMounts:
         - mountPath: /work
           name: work

--- a/task/sast-coverity-check-oci-ta/0.3/MIGRATION.md
+++ b/task/sast-coverity-check-oci-ta/0.3/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration from 0.2 to 0.3
+
+- The `IMAGE_DIGEST` parameter has been added.
+
+## Action from users
+
+- All resources used task `sast-coverity-check-oci-ta` should be directed to use new `0.3` version.
+- The `IMAGE_DIGEST` parameter definition is required to be added for this task in the build pipeline.

--- a/task/sast-coverity-check-oci-ta/0.3/README.md
+++ b/task/sast-coverity-check-oci-ta/0.3/README.md
@@ -1,0 +1,53 @@
+# sast-coverity-check-oci-ta task
+
+Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Coverity.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
+|ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
+|ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
+|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
+|BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
+|BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|COMMIT_SHA|The image is built from this commit.|""|false|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|COV_ANALYZE_ARGS|Arguments to be appended to the cov-analyze command|--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096|false|
+|COV_LICENSE|Name of secret which contains the Coverity license|cov-license|false|
+|DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|HERMETIC|Determines if build will be executed without network access.|false|false|
+|IMAGE|Reference of the image buildah will produce.||true|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|IMP_FINDINGS_ONLY|Report only important findings. Default is true. To report all findings, specify "false"|true|false|
+|KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
+|LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
+|PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|
+|PROJECT_NAME||""|false|
+|RECORD_EXCLUDED||false|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
+|SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
+|SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
+|TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
+|YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
+|YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|image-digest|Image digest to scan, default is empty string.|""|false|
+|image-url|Image URL to scan.||true|
+
+## Results
+|name|description|
+|---|---|
+|TEST_OUTPUT|Tekton task test output.|
+

--- a/task/sast-coverity-check-oci-ta/0.3/README.md
+++ b/task/sast-coverity-check-oci-ta/0.3/README.md
@@ -43,8 +43,8 @@ Scans source code for security vulnerabilities, including common issues such as 
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
-|image-digest|Image digest to scan, default is empty string.|""|false|
-|image-url|Image URL to scan.||true|
+|image-digest|Digest of the image to which the scan results should be associated.||true|
+|image-url|URL of the image to which the scan results should be associated.||true|
 
 ## Results
 |name|description|

--- a/task/sast-coverity-check-oci-ta/0.3/recipe.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/recipe.yaml
@@ -1,0 +1,13 @@
+---
+base: ../../sast-coverity-check/0.3/sast-coverity-check.yaml
+removeParams:
+  - BUILDER_IMAGE
+add:
+  - use-source
+  - use-cachi2
+removeWorkspaces:
+  - source
+replacements:
+  workspaces.source.path: /var/workdir
+regexReplacements:
+  "/workspace(/.*)": /var/workdir$1

--- a/task/sast-coverity-check-oci-ta/0.3/recipe.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/recipe.yaml
@@ -11,3 +11,4 @@ replacements:
   workspaces.source.path: /var/workdir
 regexReplacements:
   "/workspace(/.*)": /var/workdir$1
+useTAVolumeMount: true

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -188,11 +188,11 @@ spec:
       type: string
       default: trusted-ca
     - name: image-digest
-      description: Image digest to scan, default is empty string.
+      description: Digest of the image to which the scan results should be
+        associated.
       type: string
-      default: ""
     - name: image-url
-      description: Image URL to scan.
+      description: URL of the image to which the scan results should be associated.
       type: string
   results:
     - name: TEST_OUTPUT
@@ -284,13 +284,18 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:635a890e9f0211b4eb5b8c811d6f06b3ed9ff7da952ebad236fbfe52ba36dbf7
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
     - name: prepare
-      image: quay.io/redhat-services-prod/sast/coverity:202412.5
+      image: quay.io/redhat-services-prod/sast/coverity:202412.6
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /etc/secrets/cov
@@ -419,7 +424,7 @@ spec:
           exit $EC
         fi
     - name: build
-      image: quay.io/redhat-services-prod/sast/coverity:202412.5
+      image: quay.io/redhat-services-prod/sast/coverity:202412.6
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -495,7 +500,12 @@ spec:
         dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
         cp "$dockerfile_path" "$dockerfile_copy"
 
-        echo "[$(date --utc -Ins)] Prepare system"
+        # Inject the image content manifest into the container we are producing.
+        # This will generate the content-sets.json file and copy it by appending a COPY
+        # instruction to the Containerfile.
+        inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+
+        echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
         # Fixing group permission on /var/lib/containers
         chown root:root /var/lib/containers
@@ -741,6 +751,7 @@ spec:
         find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
         echo "[$(date --utc -Ins)] Run buildah build"
+        echo "[$(date --utc -Ins)] ${command}"
 
         unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 
@@ -782,7 +793,7 @@ spec:
           add:
             - SETFCAP
     - name: postprocess
-      image: quay.io/redhat-services-prod/sast/coverity:202412.5
+      image: quay.io/redhat-services-prod/sast/coverity:202412.6
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -1,0 +1,960 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sast-coverity-check-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.3"
+    build.appstudio.redhat.com/build_type: docker
+spec:
+  description: Scans source code for security vulnerabilities, including common
+    issues such as SQL injection, cross-site scripting (XSS), and code injection
+    attacks using Coverity.
+  params:
+    - name: ACTIVATION_KEY
+      description: Name of secret which contains subscription activation key
+      type: string
+      default: activation-key
+    - name: ADDITIONAL_BASE_IMAGES
+      description: Additional base image references to include to the SBOM.
+        Array of image_reference_with_digest strings
+      type: array
+      default: []
+    - name: ADDITIONAL_SECRET
+      description: Name of a secret which will be made available to the build
+        with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
+      type: string
+      default: does-not-exist
+    - name: ADD_CAPABILITIES
+      description: Comma separated list of extra capabilities to add when
+        running 'buildah build'
+      type: string
+      default: ""
+    - name: ANNOTATIONS
+      description: Additional key=value annotations that should be applied
+        to the image
+      type: array
+      default: []
+    - name: BUILDAH_FORMAT
+      description: The format for the resulting image's mediaType. Valid values
+        are oci (default) or docker.
+      type: string
+      default: oci
+    - name: BUILD_ARGS
+      description: Array of --build-arg values ("arg=value" strings)
+      type: array
+      default: []
+    - name: BUILD_ARGS_FILE
+      description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+      type: string
+      default: ""
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: COMMIT_SHA
+      description: The image is built from this commit.
+      type: string
+      default: ""
+    - name: CONTEXT
+      description: Path to the directory to use as context.
+      type: string
+      default: .
+    - name: COV_ANALYZE_ARGS
+      description: Arguments to be appended to the cov-analyze command
+      type: string
+      default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
+    - name: COV_LICENSE
+      description: Name of secret which contains the Coverity license
+      type: string
+      default: cov-license
+    - name: DOCKERFILE
+      description: Path to the Dockerfile to build.
+      type: string
+      default: ./Dockerfile
+    - name: ENTITLEMENT_SECRET
+      description: Name of secret which contains the entitlement certificates
+      type: string
+      default: etc-pki-entitlement
+    - name: HERMETIC
+      description: Determines if build will be executed without network access.
+      type: string
+      default: "false"
+    - name: IMAGE
+      description: Reference of the image buildah will produce.
+      type: string
+    - name: IMAGE_EXPIRES_AFTER
+      description: Delete image tag after specified time. Empty means to keep
+        the image tag. Time values could be something like 1h, 2d, 3w for
+        hours, days, and weeks, respectively.
+      type: string
+      default: ""
+    - name: IMP_FINDINGS_ONLY
+      description: Report only important findings. Default is true. To report
+        all findings, specify "false"
+      type: string
+      default: "true"
+    - name: KFP_GIT_URL
+      description: Known False Positives (KFP) git URL (optionally taking
+        a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+        the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        for internal Konflux instance and empty string for external Konflux
+        instance. If set to an empty string, the KFP filtering is disabled.
+      type: string
+      default: SITE_DEFAULT
+    - name: LABELS
+      description: Additional key=value labels that should be applied to the
+        image
+      type: array
+      default: []
+    - name: PREFETCH_INPUT
+      description: In case it is not empty, the prefetched content should
+        be made available to the build.
+      type: string
+      default: ""
+    - name: PRIVILEGED_NESTED
+      description: Whether to enable privileged mode, should be used only
+        with remote VMs
+      type: string
+      default: "false"
+    - name: PROJECT_NAME
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      type: string
+      default: "false"
+    - name: SBOM_TYPE
+      description: 'Select the SBOM format to generate. Valid values: spdx,
+        cyclonedx. Note: the SBOM from the prefetch task - if there is one
+        - must be in the same format.'
+      type: string
+      default: spdx
+    - name: SKIP_SBOM_GENERATION
+      description: Skip SBOM-related operations. This will likely cause EC
+        policies to fail if enabled
+      type: string
+      default: "false"
+    - name: SKIP_UNUSED_STAGES
+      description: Whether to skip stages in Containerfile that seem unused
+        by subsequent stages
+      type: string
+      default: "true"
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: SQUASH
+      description: Squash all new and previous layers added as a part of this
+        build, as per --squash
+      type: string
+      default: "false"
+    - name: STORAGE_DRIVER
+      description: Storage driver to configure for buildah
+      type: string
+      default: vfs
+    - name: TARGET_STAGE
+      description: Target stage in Dockerfile to build. If not specified,
+        the Dockerfile is processed entirely to (and including) its last stage.
+      type: string
+      default: ""
+    - name: TLSVERIFY
+      description: Verify the TLS on the registry endpoint (for push/pull
+        to a non-TLS registry)
+      type: string
+      default: "true"
+    - name: YUM_REPOS_D_FETCHED
+      description: Path in source workspace where dynamically-fetched repos
+        are present
+      default: fetched.repos.d
+    - name: YUM_REPOS_D_SRC
+      description: Path in the git repository in which yum repository files
+        are stored
+      default: repos.d
+    - name: YUM_REPOS_D_TARGET
+      description: Target path on the container in which yum repository files
+        should be made available
+      default: /etc/yum.repos.d
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: image-digest
+      description: Image digest to scan, default is empty string.
+      type: string
+      default: ""
+    - name: image-url
+      description: Image URL to scan.
+      type: string
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+  volumes:
+    - name: activation-key
+      secret:
+        optional: true
+        secretName: $(params.ACTIVATION_KEY)
+    - name: additional-secret
+      secret:
+        optional: true
+        secretName: $(params.ADDITIONAL_SECRET)
+    - name: cov-license
+      secret:
+        optional: false
+        secretName: $(params.COV_LICENSE)
+    - name: etc-pki-entitlement
+      secret:
+        optional: true
+        secretName: $(params.ENTITLEMENT_SECRET)
+    - name: shared
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: varlibcontainers
+      emptyDir: {}
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    env:
+      - name: ACTIVATION_KEY
+        value: $(params.ACTIVATION_KEY)
+      - name: ADDITIONAL_SECRET
+        value: $(params.ADDITIONAL_SECRET)
+      - name: ADD_CAPABILITIES
+        value: $(params.ADD_CAPABILITIES)
+      - name: BUILD_ARGS_FILE
+        value: $(params.BUILD_ARGS_FILE)
+      - name: CONTEXT
+        value: $(params.CONTEXT)
+      - name: ENTITLEMENT_SECRET
+        value: $(params.ENTITLEMENT_SECRET)
+      - name: HERMETIC
+        value: $(params.HERMETIC)
+      - name: IMAGE
+        value: $(params.IMAGE)
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.IMAGE_EXPIRES_AFTER)
+      - name: PRIVILEGED_NESTED
+        value: $(params.PRIVILEGED_NESTED)
+      - name: SBOM_TYPE
+        value: $(params.SBOM_TYPE)
+      - name: SKIP_SBOM_GENERATION
+        value: $(params.SKIP_SBOM_GENERATION)
+      - name: SKIP_UNUSED_STAGES
+        value: $(params.SKIP_UNUSED_STAGES)
+      - name: SOURCE_CODE_DIR
+        value: source
+      - name: SQUASH
+        value: $(params.SQUASH)
+      - name: STORAGE_DRIVER
+        value: $(params.STORAGE_DRIVER)
+      - name: TARGET_STAGE
+        value: $(params.TARGET_STAGE)
+      - name: TLSVERIFY
+        value: $(params.TLSVERIFY)
+      - name: YUM_REPOS_D_FETCHED
+        value: $(params.YUM_REPOS_D_FETCHED)
+      - name: YUM_REPOS_D_SRC
+        value: $(params.YUM_REPOS_D_SRC)
+      - name: YUM_REPOS_D_TARGET
+        value: $(params.YUM_REPOS_D_TARGET)
+    volumeMounts:
+      - mountPath: /shared
+        name: shared
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    - name: prepare
+      image: quay.io/redhat-services-prod/sast/coverity:202412.5
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /etc/secrets/cov
+          name: cov-license
+          readOnly: true
+      env:
+        - name: COV_ANALYZE_ARGS
+          value: $(params.COV_ANALYZE_ARGS)
+        - name: DOCKERFILE
+          value: $(params.DOCKERFILE)
+      script: |
+        #!/bin/bash
+
+        # FIXME: Dockerfile discovery logic is copied from buildah task
+        SOURCE_CODE_DIR=source
+        if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+        elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+        elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+          echo "Fetch Dockerfile from $DOCKERFILE"
+          dockerfile_path=$(mktemp --suffix=-Dockerfile)
+          http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+          if [ "$http_code" != 200 ]; then
+            echo "No Dockerfile is fetched. Server responds $http_code"
+            exit 1
+          fi
+          http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+          if [ "$http_code" = 200 ]; then
+            echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+            mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          fi
+        else
+          echo "Cannot find Dockerfile $DOCKERFILE"
+          exit 1
+        fi
+
+        # install Coverity license file
+        install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
+
+        # pre-create directory for SAST scanning results
+        install -vm1777 -d /shared/sast-results
+
+        # create a wrapper script to instrument RUN lines
+        tee /shared/cmd-wrap.sh >&2 <<EOF
+        #!/bin/bash -x
+        id >&2
+
+        # use current directory as project directory by default
+        proj_dir=\$(pwd)
+
+        # if current directory is "/", fallback to an empty temp directory
+        [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
+
+        # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
+        if ! [ -x /usr/bin/file ]; then
+          if [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
+            install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
+          elif [ -e /opt/cov-sa-2024.12/bin/cov-override-access.so ]; then
+            export LD_PRELOAD="/opt/cov-sa-2024.12/bin/cov-override-access.so"
+            export PATH="\${PATH}:/opt/cov-sa-2024.12/bin"
+          fi
+        fi
+
+        # the COVERITY_* environment variables and their effective values can be found in /tmp/idir/build-log.txt after the capture
+
+        # avoid tracing "dnf --installroot" because it would break the build due to unreachable /tmp/idir in the chroot
+        export COVERITY_DISENGAGE_EXES="dnf;microdnf;yum"
+
+        # always use a fresh temp directory for Coverity to avoid "Permission denied" errors on reuse
+        export COVERITY_TEMP="\$(mktemp -d /tmp/cov-XXXXXXXX)"
+
+        # always remove Coverity's intermediate directory so that it can be recreated with different ownership
+        trap 'rm -fr /tmp/idir' EXIT
+
+        # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
+        /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
+          -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
+          set -mx
+          pwd >&2  # print CWD set by coverity
+          cd '\${PWD}'  # restore original CWD
+          \\"\\\$@\\" &  # run the instrumented shell command in background (to create a process group)
+          pid=\\\$!  # store its PID
+          wait \\\${pid}  # wait for the command to finish
+          ec=\\\$?  # store its exit status
+          kill -KILL -\\\${pid} 2>/dev/null  # kill orphan background processes
+          echo \\\${ec} >/tmp/idir/build-cmd-ec.txt  # propagate the exit status
+          " - "\$@"
+
+        # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
+        $(declare -p COV_ANALYZE_ARGS)
+
+        # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
+        /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
+
+        if [ \$? -eq 0 ]; then
+          # assign a unique file name for scan results
+          json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+
+          # obtain capture stats to process them later on
+          /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
+
+          # export scan results and embed source code context into the scan results
+          /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+            | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
+            > "\${json_file}"
+        fi
+
+        # propagate the original exit code of the wrapped command
+        exit "\$(</tmp/idir/build-cmd-ec.txt)"
+        EOF
+        echo >&2
+
+        # make the wrapper script executable
+        chmod -v 0755 /shared/cmd-wrap.sh
+
+        # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
+        cstrans-df-run --shell-form --verbose /shared/cmd-wrap.sh <"$dockerfile_path" >/shared/Containerfile 2>/tmp/cstrans-df-run.log
+        EC=$?
+
+        # if we have no RUN lines to instrument, it is not a reason to make the task fail
+        if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
+          echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
+        else
+          cat /tmp/cstrans-df-run.log >&2
+          exit $EC
+        fi
+    - name: build
+      image: quay.io/redhat-services-prod/sast/coverity:202412.5
+      args:
+        - --build-args
+        - $(params.BUILD_ARGS[*])
+        - --labels
+        - $(params.LABELS[*])
+        - --annotations
+        - $(params.ANNOTATIONS[*])
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /var/lib/containers
+          name: varlibcontainers
+        - mountPath: /entitlement
+          name: etc-pki-entitlement
+        - mountPath: /activation-key
+          name: activation-key
+        - mountPath: /additional-secret
+          name: additional-secret
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: COMMIT_SHA
+          value: $(params.COMMIT_SHA)
+        - name: DOCKERFILE
+          value: /shared/Containerfile
+        - name: ADDITIONAL_VOLUME_MOUNTS
+          value: |-
+            /opt/coverity:/opt/coverity
+            /opt/cov-sa-2024.12:/opt/cov-sa-2024.12
+            /shared:/shared
+            /shared/license.dat:/opt/coverity/bin/license.dat
+            /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        echo "[$(date --utc -Ins)] Update CA trust"
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        echo "[$(date --utc -Ins)] Prepare Dockerfile"
+
+        if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+        elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+          dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+        elif [ -e "$DOCKERFILE" ]; then
+          # Instrumented builds (SAST) use this custom dockerfile step as their base
+          dockerfile_path="$DOCKERFILE"
+        elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+          echo "Fetch Dockerfile from $DOCKERFILE"
+          dockerfile_path=$(mktemp --suffix=-Dockerfile)
+          http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+          if [ "$http_code" != 200 ]; then
+            echo "No Dockerfile is fetched. Server responds $http_code"
+            exit 1
+          fi
+          http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+          if [ "$http_code" = 200 ]; then
+            echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+            mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+          fi
+        else
+          echo "Cannot find Dockerfile $DOCKERFILE"
+          exit 1
+        fi
+
+        dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
+        cp "$dockerfile_path" "$dockerfile_copy"
+
+        echo "[$(date --utc -Ins)] Prepare system"
+
+        # Fixing group permission on /var/lib/containers
+        chown root:root /var/lib/containers
+
+        sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+        # Setting new namespace to run buildah - 2^32-2
+        echo 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid
+
+        build_args=()
+        if [ -n "${BUILD_ARGS_FILE}" ]; then
+          # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+          echo "Parsing ARGs from $BUILD_ARGS_FILE"
+          mapfile -t build_args < <(
+            # https://www.mankier.com/1/buildah-build#--build-arg-file
+            # delete lines that start with #
+            # delete blank lines
+            sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+          )
+        fi
+
+        LABELS=()
+        ANNOTATIONS=()
+        # Split `args` into two sets of arguments.
+        while [[ $# -gt 0 ]]; do
+          case $1 in
+          --build-args)
+            shift
+            # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+            # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+            # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              build_args+=("$1")
+              shift
+            done
+            ;;
+          --labels)
+            shift
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              LABELS+=("--label" "$1")
+              shift
+            done
+            ;;
+          --annotations)
+            shift
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              ANNOTATIONS+=("--annotation" "$1")
+              shift
+            done
+            ;;
+          *)
+            echo "unexpected argument: $1" >&2
+            exit 2
+            ;;
+          esac
+        done
+
+        BUILD_ARG_FLAGS=()
+        for build_arg in "${build_args[@]}"; do
+          BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+        done
+
+        dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
+        BASE_IMAGES=$(
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        BUILDAH_ARGS=()
+        UNSHARE_ARGS=()
+
+        if [ "${HERMETIC}" == "true" ]; then
+          BUILDAH_ARGS+=("--pull=never")
+          UNSHARE_ARGS+=("--net")
+
+          for image in $BASE_IMAGES; do
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          done
+          echo "Build will be executed with network isolation"
+        fi
+
+        if [ -n "${TARGET_STAGE}" ]; then
+          BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+        fi
+
+        BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+        if [ "${PRIVILEGED_NESTED}" == "true" ]; then
+          BUILDAH_ARGS+=("--security-opt=label=disable")
+          BUILDAH_ARGS+=("--cap-add=all")
+          BUILDAH_ARGS+=("--device=/dev/fuse")
+        fi
+
+        if [ -n "${ADD_CAPABILITIES}" ]; then
+          BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+        fi
+
+        if [ "${SQUASH}" == "true" ]; then
+          BUILDAH_ARGS+=("--squash")
+        fi
+
+        if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
+          BUILDAH_ARGS+=("--skip-unused-stages=false")
+        fi
+
+        VOLUME_MOUNTS=()
+
+        echo "[$(date --utc -Ins)] Setup prefetched"
+
+        if [ -f "/var/workdir/cachi2/cachi2.env" ]; then
+          cp -r "/var/workdir/cachi2" /tmp/
+          chmod -R go+rwX /tmp/cachi2
+          VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)
+          # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+          # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+          sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_copy"
+          echo "Prefetched content will be made available"
+
+          prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+          if [ -f "$prefetched_repo_for_my_arch" ]; then
+            echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+            mkdir -p "$YUM_REPOS_D_FETCHED"
+            if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+              cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+            fi
+          fi
+        fi
+
+        # if yum repofiles stored in git, copy them to mount point outside the source dir
+        if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+          mkdir -p "${YUM_REPOS_D_FETCHED}"
+          cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+        fi
+
+        # if anything in the repofiles mount point (either fetched or from git), mount it
+        if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+          chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+          mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+          VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
+        fi
+
+        DEFAULT_LABELS=(
+          "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+          "--label" "architecture=$(uname -m)"
+          "--label" "vcs-type=git"
+        )
+        [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+        [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+        # Concatenate defaults and explicit labels. If a label appears twice, the last one wins.
+        LABELS=("${DEFAULT_LABELS[@]}" "${LABELS[@]}")
+
+        echo "[$(date --utc -Ins)] Register sub-man"
+
+        ACTIVATION_KEY_PATH="/activation-key"
+        ENTITLEMENT_PATH="/entitlement"
+
+        # 0. if hermetic=true, skip all subscription related stuff
+        # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+        # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+        # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+        # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+        #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+        #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
+
+        if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
+          cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+          mkdir -p /shared/rhsm/etc/pki/entitlement
+          mkdir -p /shared/rhsm/etc/pki/consumer
+
+          VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key
+            -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z
+            -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)
+          echo "Adding activation key to the build"
+
+          if ! grep -E "^[^#]*subscription-manager.[^#]*register" "$dockerfile_path"; then
+            # user is not running registration in the Containerfile: pre-register.
+            echo "Pre-registering with subscription manager."
+            subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+            trap 'subscription-manager unregister || true' EXIT
+
+            # copy generated certificates to /shared volume
+            cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement
+            cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer
+
+            # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+            VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)
+          fi
+
+        elif [ "${HERMETIC}" != "true" ] && find /entitlement -name "*.pem" >>null; then
+          cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+          VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
+          echo "Adding the entitlement to the build"
+        fi
+
+        if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
+          # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+          # Instrumented builds (SAST) use this step as their base and add some other tools.
+          while read -r volume_mount; do
+            VOLUME_MOUNTS+=("--volume=$volume_mount")
+          done <<<"$ADDITIONAL_VOLUME_MOUNTS"
+        fi
+
+        echo "[$(date --utc -Ins)] Add secrets"
+
+        ADDITIONAL_SECRET_PATH="/additional-secret"
+        ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+        if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+          cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+          while read -r filename; do
+            echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+            BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+          done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+        fi
+
+        # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
+        declare IMAGE
+
+        buildah_cmd_array=(
+          buildah build
+          "${VOLUME_MOUNTS[@]}"
+          "${BUILDAH_ARGS[@]}"
+          "${LABELS[@]}"
+          "${ANNOTATIONS[@]}"
+          --tls-verify="$TLSVERIFY" --no-cache
+          --ulimit nofile=4096:4096
+          -f "$dockerfile_copy" -t "$IMAGE" .
+        )
+        buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
+
+        if [ "${HERMETIC}" == "true" ]; then
+          # enabling loopback adapter enables Bazel builds to work in hermetic mode.
+          command="ip link set lo up && $buildah_cmd"
+        else
+          command="$buildah_cmd"
+        fi
+
+        # disable host subcription manager integration
+        find /usr/share/rhel/secrets -type l -exec unlink {} \;
+
+        echo "[$(date --utc -Ins)] Run buildah build"
+
+        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+
+        echo "[$(date --utc -Ins)] Add metadata"
+
+        container=$(buildah from --pull-never "$IMAGE")
+
+        # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+        if [ -f "/tmp/cachi2/output/bom.json" ]; then
+          echo "Making copy of sbom-cachi2.json"
+          cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        fi
+
+        buildah mount "$container" | tee /shared/container_path
+        # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+        find $(cat /shared/container_path) -xtype l -delete
+        echo $container >/shared/container_name
+
+        touch /shared/base_images_digests
+        echo "Recording base image digests used"
+        for image in $BASE_IMAGES; do
+          base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+          # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
+          # if buildah did not use that particular image during build because it was skipped
+          if [ -n "$base_image_digest" ]; then
+            echo "$image $base_image_digest" | tee -a /shared/base_images_digests
+          fi
+        done
+
+        echo "[$(date --utc -Ins)] End build"
+      computeResources:
+        limits:
+          memory: 16Gi
+        requests:
+          cpu: "4"
+          memory: 4Gi
+      securityContext:
+        capabilities:
+          add:
+            - SETFCAP
+    - name: postprocess
+      image: quay.io/redhat-services-prod/sast/coverity:202412.5
+      workingDir: /var/workdir
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+        - name: COV_ANALYZE_ARGS
+          value: $(params.COV_ANALYZE_ARGS)
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: IMP_FINDINGS_ONLY
+          value: $(params.IMP_FINDINGS_ONLY)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+        - name: BUILD_PLR_LOG_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+      script: |
+        #!/bin/bash -e
+        # shellcheck source=/dev/null
+        set -o pipefail
+
+        . /usr/local/share/konflux-test/utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        # Installation of Red Hat certificates for cloning Red Hat internal repositories
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        if [ -z "$(ls /shared/sast-results/)" ]; then (
+          set +e
+          set -x
+
+          # fallback to buildless scan if we have no scan results from buildful
+          # shellcheck disable=SC2086
+          env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "/var/workdir"
+
+          /opt/coverity/bin/coverity list --dir=/tmp/idir >"/shared/sast-results/coverity-buildless-summary.txt"
+
+          # install Coverity license file
+          install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+          # shellcheck disable=SC2086
+          /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+          # export scan results
+          /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout |
+            csgrep --mode=json --embed-context=3 \
+              >/shared/sast-results/coverity-buildless.json
+        ); fi
+
+        # collect capture stats (FIXME: this doe not take findings deduplication into account)
+        set +e
+        for file in /shared/sast-results/*-summary.txt; do
+          ((SUCCEEDED += $(grep "^ *SUCCEEDED:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+          ((INCOMPLETE += $(grep "^ *INCOMPLETE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+          ((FAILED += $(grep "^ *FAILED:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+          ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+        done
+
+        # calculate the total number of files
+        ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
+
+        # calculate the ratio of successful files to total files
+        ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
+        set -e
+
+        # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
+        IMP_LEVEL=1
+        if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+          IMP_LEVEL=0
+        fi
+
+        # collect scan results
+        (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
+          --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+          --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+          --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+          --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") |
+          tee coverity-results-raw.json |
+          csgrep --mode=evtstat
+
+        if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+            KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
+            KFP_GIT_URL=
+          fi
+        fi
+
+        # We check if the KFP_GIT_URL variable is set to apply the filters or not
+        if [[ -z "${KFP_GIT_URL}" ]]; then
+          echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+          mv coverity-results{-raw,}.json
+        else
+          echo "Filtering false positives in results files using csfilter-kfp..."
+          CMD=(
+            csfilter-kfp
+            --verbose
+            --kfp-git-url="${KFP_GIT_URL}"
+            --project-nvr="${PROJECT_NAME}"
+          )
+
+          if [ "${RECORD_EXCLUDED}" == "true" ]; then
+            CMD+=(--record-excluded="excluded-findings.json")
+          fi
+
+          "${CMD[@]}" coverity-results-raw.json |
+            tee coverity-results.json |
+            csgrep --mode=evtstat
+        fi
+
+        # convert the scan results into SARIF
+        csgrep --mode=sarif coverity-results.json >"/var/workdir/coverity-results.sarif"
+
+        if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
+          note="Task $(context.task.name) success: No finding was detected"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        else
+          TEST_OUTPUT=
+          parse_test_output "$(context.task.name)" sarif "/var/workdir/coverity-results.sarif" || true
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+        fi
+
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+
+        # upload scan results
+        echo "Selecting auth for upload of scan results"
+        select-oci-auth "${IMAGE_URL}" >"${HOME}/auth.json"
+
+        upload_file() (
+          set -x
+          UPLOAD_FILE="$1"
+          MEDIA_TYPE="$2"
+          oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        )
+
+        echo "Attaching scan results to ${IMAGE_URL}"
+        upload_file "coverity-results.sarif" "application/sarif+json"
+
+        # upload excluded-findings.json if enabled
+        if [ -f "excluded-findings.json" ]; then
+          upload_file "excluded-findings.json" "application/json"
+        fi
+      computeResources:
+        limits:
+          memory: 16Gi
+        requests:
+          cpu: "4"
+          memory: 4Gi

--- a/task/sast-coverity-check/0.3/MIGRATION.md
+++ b/task/sast-coverity-check/0.3/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.2 to 0.3
+
+- The required `IMAGE_DIGEST` parameter has been added back.
+
+## Action from users
+
+- All resources used task `sast-coverity-check` should be directed to use new `0.3` version.
+- The `IMAGE_DIGEST` parameter definition is required to be added for this task in the build pipeline.
+

--- a/task/sast-coverity-check/0.3/README.md
+++ b/task/sast-coverity-check/0.3/README.md
@@ -2,18 +2,16 @@
 
 ## Description:
 
-The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST). In this task, we use the buildless mode, where Coverity has the ability to capture source code without the need of building the product.
+The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST).
 
 The documentation for this mode can be found here: https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
 
 The characteristics of these tasks are:
 
-- Perform buildless scanning with Coverity
-- The whole source code is scanned (by scanning `$(workspaces.source.path)` )
+- Perform buildful scanning with Coverity
 - Only important findings are reported by default.  A parameter ( `IMP_FINDINGS_ONLY`) is provided to override this configuration.
 - The csdiff/v1 SARIF fingerprints are provided for all findings
 - A parameter ( `KFP_GIT_URL`) is provided to remove false positives providing a known false positives repository. By default, no repository is provided.
-- The stats of the scan are embedded into the result's SARIF file
 
 > NOTE: This task is executed only if there is a Coverity license set up in the environment. Please check coverity-availability-check task for more information.
 
@@ -25,10 +23,11 @@ The characteristics of these tasks are:
 | COV_LICENSE               | Name of secret which contains the Coverity license                                                                                    | cov-license               | no       |
 | AUTH_TOKEN_COVERITY_IMAGE | Name of secret which contains the authentication token for pulling the Coverity image                                                 | auth-token-coverity-image | no       |
 | IMP_FINDINGS_ONLY         | Report only important findings. Default is true. To report all findings, specify "false"                                              | true                      | no       |
-| KFP_GIT_URL               | Known False Positives git URL, optionally taking a revision delimited by #; If empty, filtering of known false positives is disabled. | ""                        | no       |
+| KFP_GIT_URL               | Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 | PROJECT_NAME              | Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.                       | ""                        | no       |
 | RECORD_EXCLUDED           | If set to `true`, excluded findings will be written to a file named `excluded-findings.json` for auditing purposes.                   | false                     | no       |
-
+|image-digest|Digest of the image to which the scan results should be associated.||true|
+|image-url|URL of the image to which the scan results should be associated.||true|
 ## Results:
 
 | name              | description              |

--- a/task/sast-coverity-check/0.3/README.md
+++ b/task/sast-coverity-check/0.3/README.md
@@ -1,0 +1,46 @@
+# sast-coverity-check task
+
+## Description:
+
+The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST). In this task, we use the buildless mode, where Coverity has the ability to capture source code without the need of building the product.
+
+The documentation for this mode can be found here: https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
+
+The characteristics of these tasks are:
+
+- Perform buildless scanning with Coverity
+- The whole source code is scanned (by scanning `$(workspaces.source.path)` )
+- Only important findings are reported by default.  A parameter ( `IMP_FINDINGS_ONLY`) is provided to override this configuration.
+- The csdiff/v1 SARIF fingerprints are provided for all findings
+- A parameter ( `KFP_GIT_URL`) is provided to remove false positives providing a known false positives repository. By default, no repository is provided.
+- The stats of the scan are embedded into the result's SARIF file
+
+> NOTE: This task is executed only if there is a Coverity license set up in the environment. Please check coverity-availability-check task for more information.
+
+## Params:
+
+| name                      | description                                                                                                                           | default value             | required |                                                                                                                   
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------------------------|----------|
+| COV_ANALYZE_ARGS          | Append arguments to the cov-analyze CLI command                                                                                       | ""                        | no       |
+| COV_LICENSE               | Name of secret which contains the Coverity license                                                                                    | cov-license               | no       |
+| AUTH_TOKEN_COVERITY_IMAGE | Name of secret which contains the authentication token for pulling the Coverity image                                                 | auth-token-coverity-image | no       |
+| IMP_FINDINGS_ONLY         | Report only important findings. Default is true. To report all findings, specify "false"                                              | true                      | no       |
+| KFP_GIT_URL               | Known False Positives git URL, optionally taking a revision delimited by #; If empty, filtering of known false positives is disabled. | ""                        | no       |
+| PROJECT_NAME              | Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.                       | ""                        | no       |
+| RECORD_EXCLUDED           | If set to `true`, excluded findings will be written to a file named `excluded-findings.json` for auditing purposes.                   | false                     | no       |
+
+## Results:
+
+| name              | description              |
+|-------------------|--------------------------|
+| TEST_OUTPUT       | Tekton task test output. |
+
+## Source repository for image:
+
+// TODO: Add reference to private repo for the container image once the task is migrated to repo
+
+
+## Additional links:
+
+* https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
+* https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/cli/topics/options_reference.html

--- a/task/sast-coverity-check/0.3/kustomization.yaml
+++ b/task/sast-coverity-check/0.3/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../buildah/0.4
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Task

--- a/task/sast-coverity-check/0.3/migrations/0.3.sh
+++ b/task/sast-coverity-check/0.3/migrations/0.3.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: sast-coverity-check@0.3
+# Creation time: 2025-03-28T10:28:54Z
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# Determine the correct image-digest and image-url values based on task presence
+if yq -e '.spec.tasks[] | select(.name == "build-oci-artifact")' "$pipeline_file" >/dev/null; then
+    image_digest_value="\$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
+    image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+elif yq -e '.spec.tasks[] | select(.name == "build-image-index")' "$pipeline_file" >/dev/null; then
+    image_digest_value="\$(tasks.build-image-index.results.IMAGE_DIGEST)"
+    image_url_value="\$(tasks.build-image-index.results.IMAGE_URL)"
+else
+    echo "Neither build-oci-artifact nor build-image-index tasks found."
+    exit 0
+fi
+
+# Check if image-digest parameter already exists using precise path
+if ! yq -e '.spec.tasks[] | select(.name == "sast-coverity-check").params[] | select(.name == "image-digest")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-digest parameter to sast-coverity-check task"
+    yq -i "(.spec.tasks[] | select(.name == \"sast-coverity-check\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+else
+    echo "image-digest parameter already exists in sast-coverity-check task. No changes needed."
+fi
+
+# Check if image-url parameter already exists using precise path
+if ! yq -e '.spec.tasks[] | select(.name == "sast-coverity-check").params[] | select(.name == "image-url")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-url parameter to sast-coverity-check task"
+    yq -i "(.spec.tasks[] | select(.name == \"sast-coverity-check\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+else
+    echo "image-url parameter already exists in sast-coverity-check task. No changes needed."
+fi

--- a/task/sast-coverity-check/0.3/patch.yaml
+++ b/task/sast-coverity-check/0.3/patch.yaml
@@ -29,36 +29,29 @@
 
 # upload-sbom
 - op: test
-  path: /spec/steps/5/name
-  value: upload-sbom
-- op: remove
-  path: /spec/steps/5
-
-# prepare-sboms
-- op: test
   path: /spec/steps/4/name
-  value: prepare-sboms
+  value: upload-sbom
 - op: remove
   path: /spec/steps/4
 
-# sbom-syft-generate
+# prepare-sboms
 - op: test
   path: /spec/steps/3/name
-  value: sbom-syft-generate
+  value: prepare-sboms
 - op: remove
   path: /spec/steps/3
 
-# push
+# sbom-syft-generate
 - op: test
   path: /spec/steps/2/name
-  value: push
+  value: sbom-syft-generate
 - op: remove
   path: /spec/steps/2
 
-# icm
+# push
 - op: test
   path: /spec/steps/1/name
-  value: icm
+  value: push
 - op: remove
   path: /spec/steps/1
 
@@ -71,7 +64,7 @@
 - op: replace
   path: /spec/steps/0/image
   # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
-  value: quay.io/redhat-services-prod/sast/coverity:202412.5
+  value: quay.io/redhat-services-prod/sast/coverity:202412.6
 
 # Change build step resources
 - op: replace
@@ -90,14 +83,13 @@
   value:
     name: image-digest
     type: string
-    default: ""
-    description: Image digest to scan, default is empty string.
+    description: Digest of the image to which the scan results should be associated.
 - op: add
   path: /spec/params/-
   value:
     name: image-url
     type: string
-    description: Image URL to scan.
+    description: URL of the image to which the scan results should be associated.
 - op: add
   path: /spec/params/-
   value:
@@ -167,7 +159,7 @@
   path: /spec/steps/0
   value:
     name: prepare
-    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    image: quay.io/redhat-services-prod/sast/coverity:202412.6
     workingDir: $(workspaces.source.path)
     env:
       - name: COV_ANALYZE_ARGS
@@ -312,7 +304,7 @@
   path: /spec/steps/2
   value:
     name: postprocess
-    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    image: quay.io/redhat-services-prod/sast/coverity:202412.6
     computeResources:
       limits:
         memory: 16Gi

--- a/task/sast-coverity-check/0.3/patch.yaml
+++ b/task/sast-coverity-check/0.3/patch.yaml
@@ -1,0 +1,491 @@
+# Task name
+- op: replace
+  path: /metadata/name
+  value: sast-coverity-check
+
+# Task version
+- op: replace
+  path: /metadata/labels/app.kubernetes.io~1version
+  value: "0.3"
+
+# Task description
+- op: replace
+  path: /spec/description
+  value: |-
+    Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Coverity.
+
+# Replace task results
+- op: replace
+  path: /spec/results
+  value:
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+
+###################
+# Task steps
+###################
+
+# Remove all buildah task steps except build
+
+# upload-sbom
+- op: test
+  path: /spec/steps/5/name
+  value: upload-sbom
+- op: remove
+  path: /spec/steps/5
+
+# prepare-sboms
+- op: test
+  path: /spec/steps/4/name
+  value: prepare-sboms
+- op: remove
+  path: /spec/steps/4
+
+# sbom-syft-generate
+- op: test
+  path: /spec/steps/3/name
+  value: sbom-syft-generate
+- op: remove
+  path: /spec/steps/3
+
+# push
+- op: test
+  path: /spec/steps/2/name
+  value: push
+- op: remove
+  path: /spec/steps/2
+
+# icm
+- op: test
+  path: /spec/steps/1/name
+  value: icm
+- op: remove
+  path: /spec/steps/1
+
+# Tune the build step (the only one left).
+- op: test
+  path: /spec/steps/0/name
+  value: build
+
+# Change build step image
+- op: replace
+  path: /spec/steps/0/image
+  # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
+  value: quay.io/redhat-services-prod/sast/coverity:202412.5
+
+# Change build step resources
+- op: replace
+  path: /spec/steps/0/computeResources/limits/memory
+  value: 16Gi
+- op: replace
+  path: /spec/steps/0/computeResources/requests/cpu
+  value: 4
+- op: replace
+  path: /spec/steps/0/computeResources/requests/memory
+  value: 4Gi
+
+# Additional parameters
+- op: add
+  path: /spec/params/-
+  value:
+    name: image-digest
+    type: string
+    default: ""
+    description: Image digest to scan, default is empty string.
+- op: add
+  path: /spec/params/-
+  value:
+    name: image-url
+    type: string
+    description: Image URL to scan.
+- op: add
+  path: /spec/params/-
+  value:
+    name: COV_LICENSE
+    type: string
+    description: Name of secret which contains the Coverity license
+    default: "cov-license"
+- op: add
+  path: /spec/params/-
+  value:
+    name: PROJECT_NAME
+    type: string
+    default: ""
+- op: add
+  path: /spec/params/-
+  value:
+    name: RECORD_EXCLUDED
+    type: string
+    default: "false"
+- op: add
+  path: /spec/params/-
+  value:
+    description: Arguments to be appended to the cov-analyze command
+    name: COV_ANALYZE_ARGS
+    type: string
+    default: "--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096"
+- op: add
+  path: /spec/params/-
+  value:
+    name: IMP_FINDINGS_ONLY
+    type: string
+    description: Report only important findings. Default is true. To report all findings, specify "false"
+    default: "true"
+- op: add
+  path: /spec/params/-
+  value:
+    name: KFP_GIT_URL
+    type: string
+    description: Known False Positives (KFP) git URL (optionally taking
+      a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+      the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux
+      instance and empty string for external Konflux instance.
+      If set to an empty string, the KFP filtering is disabled.
+    default: "SITE_DEFAULT"
+
+# Additional volumes
+- op: add
+  path: /spec/volumes/-
+  value:
+    name: cov-license
+    secret:
+      secretName: $(params.COV_LICENSE)
+      optional: false
+- op: add
+  path: /spec/steps/0/env/-
+  value:
+    name: ADDITIONAL_VOLUME_MOUNTS
+    value: |-
+      /opt/coverity:/opt/coverity
+      /opt/cov-sa-2024.12:/opt/cov-sa-2024.12
+      /shared:/shared
+      /shared/license.dat:/opt/coverity/bin/license.dat
+      /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
+
+# Add prepare step
+- op: add
+  path: /spec/steps/0
+  value:
+    name: prepare
+    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    workingDir: $(workspaces.source.path)
+    env:
+      - name: COV_ANALYZE_ARGS
+        value: $(params.COV_ANALYZE_ARGS)
+      - name: DOCKERFILE
+        value: $(params.DOCKERFILE)
+    volumeMounts:
+      - name: cov-license
+        mountPath: "/etc/secrets/cov"
+        readOnly: true
+    script: |
+      #!/bin/bash
+
+      # FIXME: Dockerfile discovery logic is copied from buildah task
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      # install Coverity license file
+      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
+
+      # pre-create directory for SAST scanning results
+      install -vm1777 -d /shared/sast-results
+
+      # create a wrapper script to instrument RUN lines
+      tee /shared/cmd-wrap.sh >&2 << EOF
+      #!/bin/bash -x
+      id >&2
+
+      # use current directory as project directory by default
+      proj_dir=\$(pwd)
+
+      # if current directory is "/", fallback to an empty temp directory
+      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
+
+      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
+      if ! [ -x /usr/bin/file ]; then
+        if [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
+          install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
+        elif [ -e /opt/cov-sa-2024.12/bin/cov-override-access.so ]; then
+          export LD_PRELOAD="/opt/cov-sa-2024.12/bin/cov-override-access.so"
+          export PATH="\${PATH}:/opt/cov-sa-2024.12/bin"
+        fi
+      fi
+
+      # the COVERITY_* environment variables and their effective values can be found in /tmp/idir/build-log.txt after the capture
+
+      # avoid tracing "dnf --installroot" because it would break the build due to unreachable /tmp/idir in the chroot
+      export COVERITY_DISENGAGE_EXES="dnf;microdnf;yum"
+
+      # always use a fresh temp directory for Coverity to avoid "Permission denied" errors on reuse
+      export COVERITY_TEMP="\$(mktemp -d /tmp/cov-XXXXXXXX)"
+
+      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
+      trap 'rm -fr /tmp/idir' EXIT
+
+      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
+      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
+        -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
+        set -mx
+        pwd >&2  # print CWD set by coverity
+        cd '\${PWD}'  # restore original CWD
+        \\"\\\$@\\" &  # run the instrumented shell command in background (to create a process group)
+        pid=\\\$!  # store its PID
+        wait \\\${pid}  # wait for the command to finish
+        ec=\\\$?  # store its exit status
+        kill -KILL -\\\${pid} 2>/dev/null  # kill orphan background processes
+        echo \\\${ec} >/tmp/idir/build-cmd-ec.txt  # propagate the exit status
+        " - "\$@"
+
+      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
+      $(declare -p COV_ANALYZE_ARGS)
+
+      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
+      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
+
+      if [ \$? -eq 0 ]; then
+        # assign a unique file name for scan results
+        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+
+        # obtain capture stats to process them later on
+        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
+
+        # export scan results and embed source code context into the scan results
+        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
+          > "\${json_file}"
+      fi
+
+      # propagate the original exit code of the wrapped command
+      exit "\$(</tmp/idir/build-cmd-ec.txt)"
+      EOF
+      echo >&2
+
+      # make the wrapper script executable
+      chmod -v 0755 /shared/cmd-wrap.sh
+
+      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
+      cstrans-df-run --shell-form --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
+      EC=$?
+
+      # if we have no RUN lines to instrument, it is not a reason to make the task fail
+      if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
+        echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
+      else
+        cat /tmp/cstrans-df-run.log >&2
+        exit $EC
+      fi
+
+# Make the buildah task use the instrumented Dockerfile
+- op: test
+  path: /spec/steps/1/env/1/name
+  value: DOCKERFILE
+- op: replace
+  path: /spec/steps/1/env/1/value  # steps -> build -> env -> DOCKERFILE
+  value: /shared/Containerfile
+
+# Add postprocess step
+- op: test
+  path: /spec/steps/1/name
+  value: build
+- op: add
+  path: /spec/steps/2
+  value:
+    name: postprocess
+    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    computeResources:
+      limits:
+        memory: 16Gi
+      requests:
+        memory: 4Gi
+        cpu: 4
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: "/mnt/trusted-ca"
+        readOnly: true
+    env:
+      - name: IMAGE_URL
+        value: $(params.image-url)
+      - name: IMAGE_DIGEST
+        value: $(params.image-digest)
+      - name: COV_ANALYZE_ARGS
+        value: $(params.COV_ANALYZE_ARGS)
+      - name: KFP_GIT_URL
+        value: $(params.KFP_GIT_URL)
+      - name: IMP_FINDINGS_ONLY
+        value: $(params.IMP_FINDINGS_ONLY)
+      - name: PROJECT_NAME
+        value: $(params.PROJECT_NAME)
+      - name: RECORD_EXCLUDED
+        value: $(params.RECORD_EXCLUDED)
+      - name: COMPONENT_LABEL
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.labels['appstudio.openshift.io/component']
+      - name: BUILD_PLR_LOG_URL
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+
+    workingDir: $(workspaces.source.path)
+    script: |
+      #!/bin/bash -e
+      # shellcheck source=/dev/null
+      set -o pipefail
+
+      . /usr/local/share/konflux-test/utils.sh
+      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
+      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+      # Installation of Red Hat certificates for cloning Red Hat internal repositories
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -z "$(ls /shared/sast-results/)" ]; then (
+        set +e
+        set -x
+
+        # fallback to buildless scan if we have no scan results from buildful
+        # shellcheck disable=SC2086
+        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
+
+        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
+
+        # install Coverity license file
+        install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+        # shellcheck disable=SC2086
+        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+        # export scan results
+        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+          | csgrep --mode=json --embed-context=3 \
+          > /shared/sast-results/coverity-buildless.json
+      ) fi
+
+      # collect capture stats (FIXME: this doe not take findings deduplication into account)
+      set +e
+      for file in /shared/sast-results/*-summary.txt; do
+        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+      done
+
+      # calculate the total number of files
+      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
+
+      # calculate the ratio of successful files to total files
+      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
+      set -e
+
+      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
+      IMP_LEVEL=1
+      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+        IMP_LEVEL=0
+      fi
+
+      # collect scan results
+      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
+        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
+        | tee coverity-results-raw.json \
+        | csgrep --mode=evtstat
+
+      if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+        PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+        echo -n "Probing ${PROBE_URL}... "
+        if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+          echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        else
+          echo "Setting KFP_GIT_URL to empty string"
+          KFP_GIT_URL=
+        fi
+      fi
+
+      # We check if the KFP_GIT_URL variable is set to apply the filters or not
+      if [[ -z "${KFP_GIT_URL}" ]]; then
+        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+        mv coverity-results{-raw,}.json
+      else
+        echo "Filtering false positives in results files using csfilter-kfp..."
+        CMD=(
+          csfilter-kfp
+          --verbose
+          --kfp-git-url="${KFP_GIT_URL}"
+          --project-nvr="${PROJECT_NAME}"
+        )
+
+        if [ "${RECORD_EXCLUDED}" == "true" ]; then
+          CMD+=(--record-excluded="excluded-findings.json")
+        fi
+
+        "${CMD[@]}" coverity-results-raw.json \
+          | tee coverity-results.json \
+          | csgrep --mode=evtstat
+      fi
+
+      # convert the scan results into SARIF
+      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+
+      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
+        note="Task $(context.task.name) success: No finding was detected"
+        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      else
+        TEST_OUTPUT=
+        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
+        note="Task $(context.task.name) failed: For details, check Tekton task log."
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      fi
+
+      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+
+      # upload scan results
+      echo "Selecting auth for upload of scan results"
+      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+
+      upload_file() (
+        set -x
+        UPLOAD_FILE="$1"
+        MEDIA_TYPE="$2"
+        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+      )
+
+      echo "Attaching scan results to ${IMAGE_URL}"
+      upload_file "coverity-results.sarif" "application/sarif+json"
+
+      # upload excluded-findings.json if enabled
+      if [ -f "excluded-findings.json" ]; then
+        upload_file "excluded-findings.json" "application/json"
+      fi

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -147,11 +147,10 @@ spec:
       image_reference_with_digest strings
     name: ADDITIONAL_BASE_IMAGES
     type: array
-  - default: ""
-    description: Image digest to scan, default is empty string.
+  - description: Digest of the image to which the scan results should be associated.
     name: image-digest
     type: string
-  - description: Image URL to scan.
+  - description: URL of the image to which the scan results should be associated.
     name: image-url
     type: string
   - default: cov-license
@@ -243,7 +242,7 @@ spec:
       value: $(params.COV_ANALYZE_ARGS)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    image: quay.io/redhat-services-prod/sast/coverity:202412.6
     name: prepare
     script: |
       #!/bin/bash
@@ -392,7 +391,7 @@ spec:
         /shared:/shared
         /shared/license.dat:/opt/coverity/bin/license.dat
         /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    image: quay.io/redhat-services-prod/sast/coverity:202412.6
     name: build
     script: |
       #!/bin/bash
@@ -437,7 +436,12 @@ spec:
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
 
-      echo "[$(date --utc -Ins)] Prepare system"
+      # Inject the image content manifest into the container we are producing.
+      # This will generate the content-sets.json file and copy it by appending a COPY
+      # instruction to the Containerfile.
+      inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+
+      echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -674,6 +678,7 @@ spec:
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
       echo "[$(date --utc -Ins)] Run buildah build"
+      echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 
@@ -750,7 +755,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
-    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    image: quay.io/redhat-services-prod/sast/coverity:202412.6
     name: postprocess
     script: |
       #!/bin/bash -e

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -1,0 +1,931 @@
+# WARNING: This is an auto generated file, do not modify this file directly
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.3"
+    build.appstudio.redhat.com/build_type: docker
+  name: sast-coverity-check
+spec:
+  description: Scans source code for security vulnerabilities, including common issues
+    such as SQL injection, cross-site scripting (XSS), and code injection attacks
+    using Coverity.
+  params:
+  - description: Reference of the image buildah will produce.
+    name: IMAGE
+    type: string
+  - default: ./Dockerfile
+    description: Path to the Dockerfile to build.
+    name: DOCKERFILE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - default: "true"
+    description: Verify the TLS on the registry endpoint (for push/pull to a non-TLS
+      registry)
+    name: TLSVERIFY
+    type: string
+  - default: "false"
+    description: Determines if build will be executed without network access.
+    name: HERMETIC
+    type: string
+  - default: ""
+    description: In case it is not empty, the prefetched content should be made available
+      to the build.
+    name: PREFETCH_INPUT
+    type: string
+  - default: ""
+    description: Delete image tag after specified time. Empty means to keep the image
+      tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks,
+      respectively.
+    name: IMAGE_EXPIRES_AFTER
+    type: string
+  - default: ""
+    description: The image is built from this commit.
+    name: COMMIT_SHA
+    type: string
+  - default: repos.d
+    description: Path in the git repository in which yum repository files are stored
+    name: YUM_REPOS_D_SRC
+  - default: fetched.repos.d
+    description: Path in source workspace where dynamically-fetched repos are present
+    name: YUM_REPOS_D_FETCHED
+  - default: /etc/yum.repos.d
+    description: Target path on the container in which yum repository files should
+      be made available
+    name: YUM_REPOS_D_TARGET
+  - default: ""
+    description: Target stage in Dockerfile to build. If not specified, the Dockerfile
+      is processed entirely to (and including) its last stage.
+    name: TARGET_STAGE
+    type: string
+  - default: etc-pki-entitlement
+    description: Name of secret which contains the entitlement certificates
+    name: ENTITLEMENT_SECRET
+    type: string
+  - default: activation-key
+    description: Name of secret which contains subscription activation key
+    name: ACTIVATION_KEY
+    type: string
+  - default: does-not-exist
+    description: Name of a secret which will be made available to the build with 'buildah
+      build --secret' at /run/secrets/$ADDITIONAL_SECRET
+    name: ADDITIONAL_SECRET
+    type: string
+  - default: []
+    description: Array of --build-arg values ("arg=value" strings)
+    name: BUILD_ARGS
+    type: array
+  - default: ""
+    description: Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: BUILD_ARGS_FILE
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: ""
+    description: Comma separated list of extra capabilities to add when running 'buildah
+      build'
+    name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Squash all new and previous layers added as a part of this build,
+      as per --squash
+    name: SQUASH
+    type: string
+  - default: vfs
+    description: Storage driver to configure for buildah
+    name: STORAGE_DRIVER
+    type: string
+  - default: "true"
+    description: Whether to skip stages in Containerfile that seem unused by subsequent
+      stages
+    name: SKIP_UNUSED_STAGES
+    type: string
+  - default: []
+    description: Additional key=value labels that should be applied to the image
+    name: LABELS
+    type: array
+  - default: []
+    description: Additional key=value annotations that should be applied to the image
+    name: ANNOTATIONS
+    type: array
+  - default: "false"
+    description: Whether to enable privileged mode, should be used only with remote
+      VMs
+    name: PRIVILEGED_NESTED
+    type: string
+  - default: "false"
+    description: Skip SBOM-related operations. This will likely cause EC policies
+      to fail if enabled
+    name: SKIP_SBOM_GENERATION
+    type: string
+  - default: spdx
+    description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
+      Note: the SBOM from the prefetch task - if there is one - must be in the same
+      format.'
+    name: SBOM_TYPE
+    type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci (default) or docker.
+    name: BUILDAH_FORMAT
+    type: string
+  - default: []
+    description: Additional base image references to include to the SBOM. Array of
+      image_reference_with_digest strings
+    name: ADDITIONAL_BASE_IMAGES
+    type: array
+  - default: ""
+    description: Image digest to scan, default is empty string.
+    name: image-digest
+    type: string
+  - description: Image URL to scan.
+    name: image-url
+    type: string
+  - default: cov-license
+    description: Name of secret which contains the Coverity license
+    name: COV_LICENSE
+    type: string
+  - default: ""
+    name: PROJECT_NAME
+    type: string
+  - default: "false"
+    name: RECORD_EXCLUDED
+    type: string
+  - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
+    description: Arguments to be appended to the cov-analyze command
+    name: COV_ANALYZE_ARGS
+    type: string
+  - default: "true"
+    description: Report only important findings. Default is true. To report all findings,
+      specify "false"
+    name: IMP_FINDINGS_ONLY
+    type: string
+  - default: SITE_DEFAULT
+    description: Known False Positives (KFP) git URL (optionally taking a revision
+      delimited by \#). Defaults to "SITE_DEFAULT", which means the default value
+      "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux
+      instance and empty string for external Konflux instance. If set to an empty
+      string, the KFP filtering is disabled.
+    name: KFP_GIT_URL
+    type: string
+  results:
+  - description: Tekton task test output.
+    name: TEST_OUTPUT
+  stepTemplate:
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: "1"
+        memory: 1Gi
+    env:
+    - name: STORAGE_DRIVER
+      value: $(params.STORAGE_DRIVER)
+    - name: HERMETIC
+      value: $(params.HERMETIC)
+    - name: SOURCE_CODE_DIR
+      value: source
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: YUM_REPOS_D_SRC
+      value: $(params.YUM_REPOS_D_SRC)
+    - name: YUM_REPOS_D_FETCHED
+      value: $(params.YUM_REPOS_D_FETCHED)
+    - name: YUM_REPOS_D_TARGET
+      value: $(params.YUM_REPOS_D_TARGET)
+    - name: TARGET_STAGE
+      value: $(params.TARGET_STAGE)
+    - name: ENTITLEMENT_SECRET
+      value: $(params.ENTITLEMENT_SECRET)
+    - name: ACTIVATION_KEY
+      value: $(params.ACTIVATION_KEY)
+    - name: ADDITIONAL_SECRET
+      value: $(params.ADDITIONAL_SECRET)
+    - name: BUILD_ARGS_FILE
+      value: $(params.BUILD_ARGS_FILE)
+    - name: ADD_CAPABILITIES
+      value: $(params.ADD_CAPABILITIES)
+    - name: SQUASH
+      value: $(params.SQUASH)
+    - name: SKIP_UNUSED_STAGES
+      value: $(params.SKIP_UNUSED_STAGES)
+    - name: PRIVILEGED_NESTED
+      value: $(params.PRIVILEGED_NESTED)
+    - name: SKIP_SBOM_GENERATION
+      value: $(params.SKIP_SBOM_GENERATION)
+    - name: SBOM_TYPE
+      value: $(params.SBOM_TYPE)
+    volumeMounts:
+    - mountPath: /shared
+      name: shared
+  steps:
+  - env:
+    - name: COV_ANALYZE_ARGS
+      value: $(params.COV_ANALYZE_ARGS)
+    - name: DOCKERFILE
+      value: $(params.DOCKERFILE)
+    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    name: prepare
+    script: |
+      #!/bin/bash
+
+      # FIXME: Dockerfile discovery logic is copied from buildah task
+      SOURCE_CODE_DIR=source
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      # install Coverity license file
+      install -vm0644 /etc/secrets/cov/cov-license /shared/license.dat
+
+      # pre-create directory for SAST scanning results
+      install -vm1777 -d /shared/sast-results
+
+      # create a wrapper script to instrument RUN lines
+      tee /shared/cmd-wrap.sh >&2 << EOF
+      #!/bin/bash -x
+      id >&2
+
+      # use current directory as project directory by default
+      proj_dir=\$(pwd)
+
+      # if current directory is "/", fallback to an empty temp directory
+      [ / = "\$proj_dir" ] && proj_dir=\$(mktemp -d)
+
+      # /usr/bin/file needs to be available for cov-build to work in Coverity 2024.12
+      if ! [ -x /usr/bin/file ]; then
+        if [ -w /usr/bin/ ] && [ -x /opt/cov-sa-2024.12/bin/file ]; then
+          install -vm0755 /opt/cov-sa-2024.12/bin/file /usr/bin/file
+        elif [ -e /opt/cov-sa-2024.12/bin/cov-override-access.so ]; then
+          export LD_PRELOAD="/opt/cov-sa-2024.12/bin/cov-override-access.so"
+          export PATH="\${PATH}:/opt/cov-sa-2024.12/bin"
+        fi
+      fi
+
+      # the COVERITY_* environment variables and their effective values can be found in /tmp/idir/build-log.txt after the capture
+
+      # avoid tracing "dnf --installroot" because it would break the build due to unreachable /tmp/idir in the chroot
+      export COVERITY_DISENGAGE_EXES="dnf;microdnf;yum"
+
+      # always use a fresh temp directory for Coverity to avoid "Permission denied" errors on reuse
+      export COVERITY_TEMP="\$(mktemp -d /tmp/cov-XXXXXXXX)"
+
+      # always remove Coverity's intermediate directory so that it can be recreated with different ownership
+      trap 'rm -fr /tmp/idir' EXIT
+
+      # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
+      /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
+        -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
+        set -mx
+        pwd >&2  # print CWD set by coverity
+        cd '\${PWD}'  # restore original CWD
+        \\"\\\$@\\" &  # run the instrumented shell command in background (to create a process group)
+        pid=\\\$!  # store its PID
+        wait \\\${pid}  # wait for the command to finish
+        ec=\\\$?  # store its exit status
+        kill -KILL -\\\${pid} 2>/dev/null  # kill orphan background processes
+        echo \\\${ec} >/tmp/idir/build-cmd-ec.txt  # propagate the exit status
+        " - "\$@"
+
+      # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
+      $(declare -p COV_ANALYZE_ARGS)
+
+      # use cov-analyze instead of "coverity analyze" so that we can handle COV_ANALYZE_ARGS
+      /opt/coverity/bin/cov-analyze --dir=/tmp/idir \$COV_ANALYZE_ARGS
+
+      if [ \$? -eq 0 ]; then
+        # assign a unique file name for scan results
+        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+
+        # obtain capture stats to process them later on
+        /opt/coverity/bin/coverity list --dir=/tmp/idir --project-dir="\$proj_dir" > "\${json_file%.json}-summary.txt"
+
+        # export scan results and embed source code context into the scan results
+        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+          | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
+          > "\${json_file}"
+      fi
+
+      # propagate the original exit code of the wrapped command
+      exit "\$(</tmp/idir/build-cmd-ec.txt)"
+      EOF
+      echo >&2
+
+      # make the wrapper script executable
+      chmod -v 0755 /shared/cmd-wrap.sh
+
+      # instrument all RUN lines in Dockerfile to be executed through cmd-wrap.sh
+      cstrans-df-run --shell-form --verbose /shared/cmd-wrap.sh < "$dockerfile_path" > /shared/Containerfile 2> /tmp/cstrans-df-run.log
+      EC=$?
+
+      # if we have no RUN lines to instrument, it is not a reason to make the task fail
+      if [ $EC -eq 1 ] && [ "cstrans-df-run: error: no RUN line found" = "$(</tmp/cstrans-df-run.log)" ]; then
+        echo "no RUN directive found in \"$dockerfile_path\", falling back to buildless capture..." >&2
+      else
+        cat /tmp/cstrans-df-run.log >&2
+        exit $EC
+      fi
+    volumeMounts:
+    - mountPath: /etc/secrets/cov
+      name: cov-license
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - args:
+    - --build-args
+    - $(params.BUILD_ARGS[*])
+    - --labels
+    - $(params.LABELS[*])
+    - --annotations
+    - $(params.ANNOTATIONS[*])
+    computeResources:
+      limits:
+        memory: 16Gi
+      requests:
+        cpu: 4
+        memory: 4Gi
+    env:
+    - name: COMMIT_SHA
+      value: $(params.COMMIT_SHA)
+    - name: DOCKERFILE
+      value: /shared/Containerfile
+    - name: ADDITIONAL_VOLUME_MOUNTS
+      value: |-
+        /opt/coverity:/opt/coverity
+        /opt/cov-sa-2024.12:/opt/cov-sa-2024.12
+        /shared:/shared
+        /shared/license.dat:/opt/coverity/bin/license.dat
+        /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
+    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    name: build
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      echo "[$(date --utc -Ins)] Update CA trust"
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      echo "[$(date --utc -Ins)] Prepare Dockerfile"
+
+      if [ -e "$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$CONTEXT/$DOCKERFILE"
+      elif [ -e "$SOURCE_CODE_DIR/$DOCKERFILE" ]; then
+        dockerfile_path="$(pwd)/$SOURCE_CODE_DIR/$DOCKERFILE"
+      elif [ -e "$DOCKERFILE" ]; then
+        # Instrumented builds (SAST) use this custom dockerfile step as their base
+        dockerfile_path="$DOCKERFILE"
+      elif echo "$DOCKERFILE" | grep -q "^https\?://"; then
+        echo "Fetch Dockerfile from $DOCKERFILE"
+        dockerfile_path=$(mktemp --suffix=-Dockerfile)
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path" "$DOCKERFILE")
+        if [ "$http_code" != 200 ]; then
+          echo "No Dockerfile is fetched. Server responds $http_code"
+          exit 1
+        fi
+        http_code=$(curl -s -S -L -w "%{http_code}" --output "$dockerfile_path.dockerignore.tmp" "$DOCKERFILE.dockerignore")
+        if [ "$http_code" = 200 ]; then
+          echo "Fetched .dockerignore from $DOCKERFILE.dockerignore"
+          mv "$dockerfile_path.dockerignore.tmp" "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        fi
+      else
+        echo "Cannot find Dockerfile $DOCKERFILE"
+        exit 1
+      fi
+
+      dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
+      cp "$dockerfile_path" "$dockerfile_copy"
+
+      echo "[$(date --utc -Ins)] Prepare system"
+
+      # Fixing group permission on /var/lib/containers
+      chown root:root /var/lib/containers
+
+      sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
+
+      # Setting new namespace to run buildah - 2^32-2
+      echo 'root:1:4294967294' | tee -a /etc/subuid >> /etc/subgid
+
+      build_args=()
+      if [ -n "${BUILD_ARGS_FILE}" ]; then
+        # Parse BUILD_ARGS_FILE ourselves because dockerfile-json doesn't support it
+        echo "Parsing ARGs from $BUILD_ARGS_FILE"
+        mapfile -t build_args < <(
+          # https://www.mankier.com/1/buildah-build#--build-arg-file
+          # delete lines that start with #
+          # delete blank lines
+          sed -e '/^#/d' -e '/^\s*$/d' "${SOURCE_CODE_DIR}/${BUILD_ARGS_FILE}"
+        )
+      fi
+
+      LABELS=()
+      ANNOTATIONS=()
+      # Split `args` into two sets of arguments.
+      while [[ $# -gt 0 ]]; do
+          case $1 in
+              --build-args)
+                  shift
+                  # Note: this may result in multiple --build-arg=KEY=value flags with the same KEY being
+                  # passed to buildah. In that case, the *last* occurrence takes precedence. This is why
+                  # we append BUILD_ARGS after the content of the BUILD_ARGS_FILE
+                  while [[ $# -gt 0 && $1 != --* ]]; do build_args+=("$1"); shift; done
+                  ;;
+              --labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do LABELS+=("--label" "$1"); shift; done
+                  ;;
+              --annotations)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do ANNOTATIONS+=("--annotation" "$1"); shift; done
+                  ;;
+              *)
+                  echo "unexpected argument: $1" >&2
+                  exit 2
+                  ;;
+          esac
+      done
+
+      BUILD_ARG_FLAGS=()
+      for build_arg in "${build_args[@]}"; do
+        BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
+      done
+
+      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
+      BASE_IMAGES=$(
+          jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+      )
+
+      BUILDAH_ARGS=()
+      UNSHARE_ARGS=()
+
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILDAH_ARGS+=("--pull=never")
+        UNSHARE_ARGS+=("--net")
+
+        for image in $BASE_IMAGES; do
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+        done
+        echo "Build will be executed with network isolation"
+      fi
+
+      if [ -n "${TARGET_STAGE}" ]; then
+        BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+      fi
+
+      BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      if [ "${PRIVILEGED_NESTED}" == "true" ]; then
+        BUILDAH_ARGS+=("--security-opt=label=disable")
+        BUILDAH_ARGS+=("--cap-add=all")
+        BUILDAH_ARGS+=("--device=/dev/fuse")
+      fi
+
+      if [ -n "${ADD_CAPABILITIES}" ]; then
+        BUILDAH_ARGS+=("--cap-add=${ADD_CAPABILITIES}")
+      fi
+
+      if [ "${SQUASH}" == "true" ]; then
+        BUILDAH_ARGS+=("--squash")
+      fi
+
+      if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
+        BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      VOLUME_MOUNTS=()
+
+      echo "[$(date --utc -Ins)] Setup prefetched"
+
+      if [ -f "$(workspaces.source.path)/cachi2/cachi2.env" ]; then
+        cp -r "$(workspaces.source.path)/cachi2" /tmp/
+        chmod -R go+rwX /tmp/cachi2
+        VOLUME_MOUNTS+=(--volume /tmp/cachi2:/cachi2)
+        # Read in the whole file (https://unix.stackexchange.com/questions/533277), then
+        # for each RUN ... line insert the cachi2.env command *after* any options like --mount
+        sed -E -i \
+            -e 'H;1h;$!d;x' \
+            -e 's@^\s*(run((\s|\\\n)+-\S+)*(\s|\\\n)+)@\1. /cachi2/cachi2.env \&\& \\\n    @igM' \
+            "$dockerfile_copy"
+        echo "Prefetched content will be made available"
+
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        if [ -f "$prefetched_repo_for_my_arch" ]; then
+          echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
+          mkdir -p "$YUM_REPOS_D_FETCHED"
+          if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+            cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          fi
+        fi
+      fi
+
+      # if yum repofiles stored in git, copy them to mount point outside the source dir
+      if [ -d "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}" ]; then
+        mkdir -p "${YUM_REPOS_D_FETCHED}"
+        cp -r "${SOURCE_CODE_DIR}/${YUM_REPOS_D_SRC}"/* "${YUM_REPOS_D_FETCHED}"
+      fi
+
+      # if anything in the repofiles mount point (either fetched or from git), mount it
+      if [ -d "${YUM_REPOS_D_FETCHED}" ]; then
+        chmod -R go+rwX "${YUM_REPOS_D_FETCHED}"
+        mount_point=$(realpath "${YUM_REPOS_D_FETCHED}")
+        VOLUME_MOUNTS+=(--volume "${mount_point}:${YUM_REPOS_D_TARGET}")
+      fi
+
+      DEFAULT_LABELS=(
+        "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
+        "--label" "architecture=$(uname -m)"
+        "--label" "vcs-type=git"
+      )
+      [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")
+      [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
+      # Concatenate defaults and explicit labels. If a label appears twice, the last one wins.
+      LABELS=("${DEFAULT_LABELS[@]}" "${LABELS[@]}")
+
+      echo "[$(date --utc -Ins)] Register sub-man"
+
+      ACTIVATION_KEY_PATH="/activation-key"
+      ENTITLEMENT_PATH="/entitlement"
+
+      # 0. if hermetic=true, skip all subscription related stuff
+      # 1. do not enable activation key and entitlement at same time. If both vars are provided, prefer activation key.
+      # 2. Activation-keys will be used when the key 'org' exists in the activation key secret.
+      # 3. try to pre-register and mount files to the correct location so that users do no need to modify Dockerfiles.
+      # 3. If the Dockerfile contains the string "subcription-manager register", add the activation-keys volume
+      #    to buildah but don't pre-register for backwards compatibility. Mount an empty directory on
+      #    shared emptydir volume to "/etc/pki/entitlement" to prevent certificates from being included
+
+      if [ "${HERMETIC}" != "true" ] && [ -e /activation-key/org ]; then
+        cp -r --preserve=mode "$ACTIVATION_KEY_PATH" /tmp/activation-key
+        mkdir -p /shared/rhsm/etc/pki/entitlement
+        mkdir -p /shared/rhsm/etc/pki/consumer
+
+        VOLUME_MOUNTS+=(-v /tmp/activation-key:/activation-key \
+                        -v /shared/rhsm/etc/pki/entitlement:/etc/pki/entitlement:Z \
+                        -v /shared/rhsm/etc/pki/consumer:/etc/pki/consumer:Z)
+        echo "Adding activation key to the build"
+
+        if ! grep -E "^[^#]*subscription-manager.[^#]*register" "$dockerfile_path"; then
+          # user is not running registration in the Containerfile: pre-register.
+          echo "Pre-registering with subscription manager."
+          subscription-manager register --org "$(cat /tmp/activation-key/org)" --activationkey "$(cat /tmp/activation-key/activationkey)"
+          trap 'subscription-manager unregister || true' EXIT
+
+          # copy generated certificates to /shared volume
+          cp /etc/pki/entitlement/*.pem /shared/rhsm/etc/pki/entitlement
+          cp /etc/pki/consumer/*.pem /shared/rhsm/etc/pki/consumer
+
+          # and then mount get /etc/rhsm/ca/redhat-uep.pem into /run/secrets/rhsm/ca
+          VOLUME_MOUNTS+=(--volume /etc/rhsm/ca/redhat-uep.pem:/etc/rhsm/ca/redhat-uep.pem:Z)
+        fi
+
+      elif [ "${HERMETIC}" != "true" ] && find /entitlement -name "*.pem" >> null; then
+        cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
+        VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
+        echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
+        # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
+        # Instrumented builds (SAST) use this step as their base and add some other tools.
+        while read -r volume_mount; do
+          VOLUME_MOUNTS+=("--volume=$volume_mount")
+        done <<< "$ADDITIONAL_VOLUME_MOUNTS"
+      fi
+
+      echo "[$(date --utc -Ins)] Add secrets"
+
+      ADDITIONAL_SECRET_PATH="/additional-secret"
+      ADDITIONAL_SECRET_TMP="/tmp/additional-secret"
+      if [ -d "$ADDITIONAL_SECRET_PATH" ]; then
+        cp -r --preserve=mode -L "$ADDITIONAL_SECRET_PATH" $ADDITIONAL_SECRET_TMP
+        while read -r filename; do
+          echo "Adding the secret ${ADDITIONAL_SECRET}/${filename} to the build, available at /run/secrets/${ADDITIONAL_SECRET}/${filename}"
+          BUILDAH_ARGS+=("--secret=id=${ADDITIONAL_SECRET}/${filename},src=$ADDITIONAL_SECRET_TMP/${filename}")
+        done < <(find $ADDITIONAL_SECRET_TMP -maxdepth 1 -type f -exec basename {} \;)
+      fi
+
+      # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
+      declare IMAGE
+
+      buildah_cmd_array=(
+          buildah build
+          "${VOLUME_MOUNTS[@]}"
+          "${BUILDAH_ARGS[@]}"
+          "${LABELS[@]}"
+          "${ANNOTATIONS[@]}"
+          --tls-verify="$TLSVERIFY" --no-cache
+          --ulimit nofile=4096:4096
+          -f "$dockerfile_copy" -t "$IMAGE" .
+      )
+      buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
+
+      if [ "${HERMETIC}" == "true" ]; then
+        # enabling loopback adapter enables Bazel builds to work in hermetic mode.
+        command="ip link set lo up && $buildah_cmd"
+      else
+        command="$buildah_cmd"
+      fi
+
+      # disable host subcription manager integration
+      find /usr/share/rhel/secrets -type l -exec unlink {} \;
+
+      echo "[$(date --utc -Ins)] Run buildah build"
+
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+
+      echo "[$(date --utc -Ins)] Add metadata"
+
+      container=$(buildah from --pull-never "$IMAGE")
+
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      if [ -f "/tmp/cachi2/output/bom.json" ]; then
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+      fi
+
+      buildah mount "$container" | tee /shared/container_path
+      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
+      find $(cat /shared/container_path) -xtype l -delete
+      echo $container > /shared/container_name
+
+      touch /shared/base_images_digests
+      echo "Recording base image digests used"
+      for image in $BASE_IMAGES; do
+        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
+        # if buildah did not use that particular image during build because it was skipped
+        if [ -n "$base_image_digest" ]; then
+          echo "$image $base_image_digest" | tee -a /shared/base_images_digests
+        fi
+      done
+
+      echo "[$(date --utc -Ins)] End build"
+    securityContext:
+      capabilities:
+        add:
+        - SETFCAP
+    volumeMounts:
+    - mountPath: /var/lib/containers
+      name: varlibcontainers
+    - mountPath: /entitlement
+      name: etc-pki-entitlement
+    - mountPath: /activation-key
+      name: activation-key
+    - mountPath: /additional-secret
+      name: additional-secret
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  - computeResources:
+      limits:
+        memory: 16Gi
+      requests:
+        cpu: 4
+        memory: 4Gi
+    env:
+    - name: IMAGE_URL
+      value: $(params.image-url)
+    - name: IMAGE_DIGEST
+      value: $(params.image-digest)
+    - name: COV_ANALYZE_ARGS
+      value: $(params.COV_ANALYZE_ARGS)
+    - name: KFP_GIT_URL
+      value: $(params.KFP_GIT_URL)
+    - name: IMP_FINDINGS_ONLY
+      value: $(params.IMP_FINDINGS_ONLY)
+    - name: PROJECT_NAME
+      value: $(params.PROJECT_NAME)
+    - name: RECORD_EXCLUDED
+      value: $(params.RECORD_EXCLUDED)
+    - name: COMPONENT_LABEL
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.labels['appstudio.openshift.io/component']
+    - name: BUILD_PLR_LOG_URL
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+    image: quay.io/redhat-services-prod/sast/coverity:202412.5
+    name: postprocess
+    script: |
+      #!/bin/bash -e
+      # shellcheck source=/dev/null
+      set -o pipefail
+
+      . /usr/local/share/konflux-test/utils.sh
+      trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+      [ -n "${PROJECT_NAME}" ] || PROJECT_NAME="${COMPONENT_LABEL}"
+      echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+      # Installation of Red Hat certificates for cloning Red Hat internal repositories
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
+      if [ -z "$(ls /shared/sast-results/)" ]; then (
+        set +e
+        set -x
+
+        # fallback to buildless scan if we have no scan results from buildful
+        # shellcheck disable=SC2086
+        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
+
+        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
+
+        # install Coverity license file
+        install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+        # shellcheck disable=SC2086
+        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+        # export scan results
+        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+          | csgrep --mode=json --embed-context=3 \
+          > /shared/sast-results/coverity-buildless.json
+      ) fi
+
+      # collect capture stats (FIXME: this doe not take findings deduplication into account)
+      set +e
+      for file in /shared/sast-results/*-summary.txt; do
+        ((SUCCEEDED     += $(grep "^ *SUCCEEDED:"     "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((INCOMPLETE    += $(grep "^ *INCOMPLETE:"    "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((FAILED        += $(grep "^ *FAILED:"        "${file}" | grep -oE '[0-9]+' || echo 0)))
+        ((LINES_OF_CODE += $(grep "^ *LINES OF CODE:" "${file}" | grep -oE '[0-9]+' || echo 0)))
+      done
+
+      # calculate the total number of files
+      ((TOTAL_FILES = SUCCEEDED + INCOMPLETE + FAILED))
+
+      # calculate the ratio of successful files to total files
+      ((COVERAGE_RATIO = (TOTAL_FILES == 0) ? 0 : (SUCCEEDED * 100 / TOTAL_FILES)))
+      set -e
+
+      # reflect the IMP_FINDINGS_ONLY parameter in csgrep arguments
+      IMP_LEVEL=1
+      if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
+        IMP_LEVEL=0
+      fi
+
+      # collect scan results
+      (set -x && csgrep --mode=json --imp-level="$IMP_LEVEL" --remove-duplicates --file-glob '/shared/sast-results/*.json' \
+        --set-scan-prop cov-scanned-files-coverage:"${COVERAGE_RATIO}" \
+        --set-scan-prop cov-scanned-files-success:"${SUCCEEDED}" \
+        --set-scan-prop cov-scanned-files-total:"${TOTAL_FILES}" \
+        --set-scan-prop cov-scanned-lines:"${LINES_OF_CODE}") \
+        | tee coverity-results-raw.json \
+        | csgrep --mode=evtstat
+
+      if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+        # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+        PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+        echo -n "Probing ${PROBE_URL}... "
+        if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+          echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        else
+          echo "Setting KFP_GIT_URL to empty string"
+          KFP_GIT_URL=
+        fi
+      fi
+
+      # We check if the KFP_GIT_URL variable is set to apply the filters or not
+      if [[ -z "${KFP_GIT_URL}" ]]; then
+        echo "KFP_GIT_URL variable not defined. False positives won't be filtered"
+        mv coverity-results{-raw,}.json
+      else
+        echo "Filtering false positives in results files using csfilter-kfp..."
+        CMD=(
+          csfilter-kfp
+          --verbose
+          --kfp-git-url="${KFP_GIT_URL}"
+          --project-nvr="${PROJECT_NAME}"
+        )
+
+        if [ "${RECORD_EXCLUDED}" == "true" ]; then
+          CMD+=(--record-excluded="excluded-findings.json")
+        fi
+
+        "${CMD[@]}" coverity-results-raw.json \
+          | tee coverity-results.json \
+          | csgrep --mode=evtstat
+      fi
+
+      # convert the scan results into SARIF
+      csgrep --mode=sarif coverity-results.json > "$(workspaces.source.path)/coverity-results.sarif"
+
+      if [[ -z "$(csgrep --mode=stat coverity-results.json)" ]]; then
+        note="Task $(context.task.name) success: No finding was detected"
+        ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      else
+        TEST_OUTPUT=
+        parse_test_output "$(context.task.name)" sarif "$(workspaces.source.path)/coverity-results.sarif" || true
+        note="Task $(context.task.name) failed: For details, check Tekton task log."
+        echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+      fi
+
+      echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+
+      # upload scan results
+      echo "Selecting auth for upload of scan results"
+      select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+
+      upload_file() (
+        set -x
+        UPLOAD_FILE="$1"
+        MEDIA_TYPE="$2"
+        oras attach --no-tty --registry-config "${HOME}/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+      )
+
+      echo "Attaching scan results to ${IMAGE_URL}"
+      upload_file "coverity-results.sarif" "application/sarif+json"
+
+      # upload excluded-findings.json if enabled
+      if [ -f "excluded-findings.json" ]; then
+        upload_file "excluded-findings.json" "application/json"
+      fi
+    volumeMounts:
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    workingDir: $(workspaces.source.path)
+  volumes:
+  - emptyDir: {}
+    name: varlibcontainers
+  - emptyDir: {}
+    name: shared
+  - name: etc-pki-entitlement
+    secret:
+      optional: true
+      secretName: $(params.ENTITLEMENT_SECRET)
+  - name: activation-key
+    secret:
+      optional: true
+      secretName: $(params.ACTIVATION_KEY)
+  - name: additional-secret
+    secret:
+      optional: true
+      secretName: $(params.ADDITIONAL_SECRET)
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  - name: cov-license
+    secret:
+      optional: false
+      secretName: $(params.COV_LICENSE)
+  workspaces:
+  - description: Workspace containing the source code to build.
+    name: source

--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -265,5 +265,5 @@ spec:
           echo "Selecting auth"
           select-oci-auth "$IMAGE_URL" >"$HOME/auth.json"
           echo "Attaching to ${IMAGE_URL}"
-          oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+          oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -239,7 +239,7 @@ spec:
             echo "Selecting auth"
             select-oci-auth "$IMAGE_URL" > "$HOME/auth.json"
             echo "Attaching to ${IMAGE_URL}"
-            oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+            oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done
   workspaces:
   - name: workspace

--- a/task/sast-snyk-check-oci-ta/0.4/MIGRATION.md
+++ b/task/sast-snyk-check-oci-ta/0.4/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration from 0.3 to 0.4
+
+Version 0.4:
+
+- The `IMAGE_DIGEST` parameter has been introduced back, to be used in ORAS uploading.
+## Action from users
+- The `IMAGE_DIGEST` parameter definition is required to be added for this task in the build pipeline.
+ 

--- a/task/sast-snyk-check-oci-ta/0.4/README.md
+++ b/task/sast-snyk-check-oci-ta/0.4/README.md
@@ -1,0 +1,32 @@
+# sast-snyk-check-oci-ta task
+
+Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
+
+Follow the steps given [here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
+
+The snyk binary used in this Task comes from a container image defined in https://github.com/konflux-ci/konflux-test
+
+See https://snyk.io/product/snyk-code/ and https://snyk.io/ for more information about the snyk tool.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ARGS|Append arguments.|""|false|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|IGNORE_FILE_PATHS|Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.|""|false|
+|IMP_FINDINGS_ONLY|Report only important findings. Default is true. To report all findings, specify "false"|true|false|
+|KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
+|PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
+|RECORD_EXCLUDED|Write excluded records in file. Useful for auditing (defaults to false).|false|false|
+|SNYK_SECRET|Name of secret which contains Snyk token.|snyk-secret|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|image-digest|Digest of the image to scan.||true|
+|image-url|Image URL.||true|
+
+## Results
+|name|description|
+|---|---|
+|TEST_OUTPUT|Tekton task test output.|
+

--- a/task/sast-snyk-check-oci-ta/0.4/README.md
+++ b/task/sast-snyk-check-oci-ta/0.4/README.md
@@ -2,7 +2,7 @@
 
 Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
 
-Follow the steps given [here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
+Follow the steps given [here](https://konflux-ci.dev/docs/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
 
 The snyk binary used in this Task comes from a container image defined in https://github.com/konflux-ci/konflux-test
 

--- a/task/sast-snyk-check-oci-ta/0.4/recipe.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/recipe.yaml
@@ -1,0 +1,12 @@
+---
+base: ../../sast-snyk-check/0.4/sast-snyk-check.yaml
+add:
+  - use-source
+  - use-cachi2
+preferStepTemplate: true
+removeWorkspaces:
+  - workspace
+replacements:
+  workspaces.workspace.path: /var/workdir
+regexReplacements:
+  hacbs/\$\(context.task.name\): source

--- a/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -1,89 +1,119 @@
+---
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  labels:
-    app.kubernetes.io/version: "0.3"
+  name: sast-snyk-check-oci-ta
   annotations:
-    tekton.dev/pipelines.minVersion: "0.12.1"
-    tekton.dev/tags: "konflux"
-  name: sast-snyk-check
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.4"
 spec:
   description: |-
     Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
 
-    Follow the steps given [here](https://konflux-ci.dev/docs/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
+    Follow the steps given [here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
 
     The snyk binary used in this Task comes from a container image defined in https://github.com/konflux-ci/konflux-test
 
     See https://snyk.io/product/snyk-code/ and https://snyk.io/ for more information about the snyk tool.
-  results:
-    - description: Tekton task test output.
-      name: TEST_OUTPUT
   params:
+    - name: ARGS
+      description: Append arguments.
+      type: string
+      default: ""
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: IGNORE_FILE_PATHS
+      description: Directories or files to be excluded from Snyk scan (Comma-separated).
+        Useful to split the directories of a git repo across multiple components.
+      type: string
+      default: ""
+    - name: IMP_FINDINGS_ONLY
+      description: Report only important findings. Default is true. To report
+        all findings, specify "false"
+      type: string
+      default: "true"
+    - name: KFP_GIT_URL
+      description: Known False Positives (KFP) git URL (optionally taking
+        a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+        the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        for internal Konflux instance and empty string for external Konflux
+        instance. If set to an empty string, the KFP filtering is disabled.
+      type: string
+      default: SITE_DEFAULT
+    - name: PROJECT_NAME
+      description: Name of the scanned project, used to find path exclusions.
+        By default, the Konflux component name will be used.
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      description: Write excluded records in file. Useful for auditing (defaults
+        to false).
+      type: string
+      default: "false"
     - name: SNYK_SECRET
       description: Name of secret which contains Snyk token.
       default: snyk-secret
-    - name: ARGS
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
       type: string
-      description: Append arguments.
-      default: ""
-    - description: Image URL.
-      name: image-url
-      type: string
-      # In a future 0.4 version of the task, drop the default to make this required
-      default: ""
-    - name: caTrustConfigMapName
-      type: string
-      description: The name of the ConfigMap to read CA bundle data from.
-      default: trusted-ca
     - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
       type: string
-      description: The name of the key in the ConfigMap that contains the CA bundle data.
       default: ca-bundle.crt
-    - name: IMP_FINDINGS_ONLY
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
       type: string
-      description: Report only important findings. Default is true. To report all findings, specify "false"
-      default: "true"
-    - name: KFP_GIT_URL
+      default: trusted-ca
+    - name: image-digest
+      description: Digest of the image to scan.
       type: string
-      description: Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.
-      default: "SITE_DEFAULT"
-    - name: PROJECT_NAME
+    - name: image-url
+      description: Image URL.
       type: string
-      description: Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.
-      default: ""
-    - name: RECORD_EXCLUDED
-      type: string
-      description: Write excluded records in file. Useful for auditing (defaults to false).
-      default: "false"
-    - name: IGNORE_FILE_PATHS
-      type: string
-      description: Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.
-      default: ""
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
   volumes:
     - name: snyk-secret
       secret:
-        secretName: $(params.SNYK_SECRET)
         optional: true
+        secretName: $(params.SNYK_SECRET)
     - name: trusted-ca
       configMap:
-        name: $(params.caTrustConfigMapName)
         items:
           - key: $(params.caTrustConfigMapKey)
             path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
         optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
   steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: sast-snyk-check
-      image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
-      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-      # the cluster will set imagePullPolicy to IfNotPresent
-      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
+      workingDir: /var/workdir/source
       volumeMounts:
-        - name: snyk-secret
-          mountPath: "/etc/secrets"
+        - mountPath: /etc/secrets
+          name: snyk-secret
           readOnly: true
-        - name: trusted-ca
-          mountPath: /mnt/trusted-ca
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
           readOnly: true
       env:
         - name: SNYK_SECRET
@@ -117,7 +147,7 @@ spec:
         trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
 
         if [[ -z "${PROJECT_NAME}" ]]; then
-            PROJECT_NAME=${COMPONENT_LABEL}
+          PROJECT_NAME=${COMPONENT_LABEL}
         fi
 
         echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
@@ -138,7 +168,7 @@ spec:
         else
           # According to shellcheck documentation, the following error can be ignored as it is ignored through indirection: https://www.shellcheck.net/wiki/SC2034
           # shellcheck disable=SC2034
-          to_enable_snyk='[here](https://konflux-ci.dev/docs/testing/build/snyk/)'
+          to_enable_snyk='[here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/)'
           note="Task $(context.task.name) skipped: If you wish to use the Snyk code SAST task, please create a secret name snyk-secret with the key 'snyk_token' containing the Snyk token by following the steps given ${to_enable_snyk}"
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
@@ -146,7 +176,7 @@ spec:
         fi
 
         SNYK_EXIT_CODE=0
-        SOURCE_CODE_DIR=$(workspaces.workspace.path)
+        SOURCE_CODE_DIR=/var/workdir
         SEVERITY_THRESHOLD="high"
         if [ "${IMP_FINDINGS_ONLY}" == "false" ]; then
           SEVERITY_THRESHOLD="low"
@@ -160,7 +190,7 @@ spec:
         set +e
         # We do want to expand ARGS (it can be multiple CLI flags, not just one)
         # shellcheck disable=SC2086
-        snyk code test $ARGS --severity-threshold="$SEVERITY_THRESHOLD" "$SOURCE_CODE_DIR" --max-depth=1 --sarif-file-output="${SOURCE_CODE_DIR}"/sast_snyk_check_out.json 1>&2>> stdout.txt
+        snyk code test $ARGS --severity-threshold="$SEVERITY_THRESHOLD" "$SOURCE_CODE_DIR" --max-depth=1 --sarif-file-output="${SOURCE_CODE_DIR}"/sast_snyk_check_out.json 1>&2 >>stdout.txt
         SNYK_EXIT_CODE=$?
         set -e
         test_not_skipped=0
@@ -169,9 +199,9 @@ spec:
 
         if [[ "$SNYK_EXIT_CODE" -eq 0 ]] || [[ "$SNYK_EXIT_CODE" -eq 1 ]]; then
           # In order to generate csdiff/v1, we need to add the whole path of the source code as Snyk only provides an URI to embed the context
-          (cd  "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) \
-            | csgrep --mode=json --strip-path-prefix="source/"  \
-            > sast_snyk_check_out_all_findings.json
+          (cd "${SOURCE_CODE_DIR}" && csgrep --mode=json --embed-context=3 "${SOURCE_CODE_DIR}"/sast_snyk_check_out.json) |
+            csgrep --mode=json --strip-path-prefix="source/" \
+              >sast_snyk_check_out_all_findings.json
 
           echo "Results:"
           (set -x && csgrep --mode=evtstat sast_snyk_check_out_all_findings.json)
@@ -208,7 +238,7 @@ spec:
             fi
 
             set +e
-            "${CMD[@]}" sast_snyk_check_out_all_findings.json > filtered_sast_snyk_check_out.json
+            "${CMD[@]}" sast_snyk_check_out_all_findings.json >filtered_sast_snyk_check_out.json
             status=$?
             set -e
             if [ "$status" -ne 0 ]; then
@@ -236,18 +266,18 @@ spec:
           fi
 
           coverage_ratio=0
-          if (( total_files > 0 )); then
-              coverage_ratio=$((supported_files * 100 / total_files))
+          if ((total_files > 0)); then
+            coverage_ratio=$((supported_files * 100 / total_files))
           fi
 
           # embed stats in results file and convert to SARIF
           csgrep --mode=sarif --set-scan-prop snyk-scanned-files-coverage:"${coverage_ratio}" \
-                              --set-scan-prop snyk-scanned-files-success:"${supported_files}"  \
-                              --set-scan-prop snyk-scanned-files-total:"${total_files}" \
-                              filtered_sast_snyk_check_out.json  > sast_snyk_check_out.sarif
+            --set-scan-prop snyk-scanned-files-success:"${supported_files}" \
+            --set-scan-prop snyk-scanned-files-total:"${total_files}" \
+            filtered_sast_snyk_check_out.json >sast_snyk_check_out.sarif
 
           TEST_OUTPUT=
-          parse_test_output "$(context.task.name)" sarif sast_snyk_check_out.sarif  || true
+          parse_test_output "$(context.task.name)" sarif sast_snyk_check_out.sarif || true
 
         # When the test is skipped, the "SNYK_EXIT_CODE" is 3 and it can also be 3 in some other situation
         elif [[ "$test_not_skipped" -eq 0 ]]; then
@@ -261,16 +291,13 @@ spec:
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
     - name: upload
-      image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
-      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
-      volumeMounts:
-        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
-          name: trusted-ca
-          readOnly: true
-          subPath: ca-bundle.crt
+      image: quay.io/konflux-ci/oras:latest@sha256:76f2f7682d32902fec34753c11f414756d0e88070d07658a35e71760ef928b71
+      workingDir: /var/workdir/source
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
       script: |
         #!/usr/bin/env bash
 
@@ -281,19 +308,17 @@ spec:
 
         UPLOAD_FILES="sast_snyk_check_out.sarif excluded-findings.json"
         for UPLOAD_FILE in ${UPLOAD_FILES}; do
-            if [ ! -f "${UPLOAD_FILE}" ]; then
-              echo "No ${UPLOAD_FILE} exists. Skipping upload."
-              continue
-            fi
-            if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
-                MEDIA_TYPE=application/json
-            else
-                MEDIA_TYPE=application/sarif+json
-            fi
-            echo "Selecting auth"
-            select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
-            echo "Attaching to ${IMAGE_URL}"
-            oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+          if [ ! -f "${UPLOAD_FILE}" ]; then
+            echo "No ${UPLOAD_FILE} exists. Skipping upload."
+            continue
+          fi
+          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+            MEDIA_TYPE=application/json
+          else
+            MEDIA_TYPE=application/sarif+json
+          fi
+          echo "Selecting auth"
+          select-oci-auth "${IMAGE_URL}" >"${HOME}/auth.json"
+          echo "Attaching to ${IMAGE_URL}"
+          oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done
-  workspaces:
-    - name: workspace

--- a/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -12,7 +12,7 @@ spec:
   description: |-
     Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
 
-    Follow the steps given [here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
+    Follow the steps given [here](https://konflux-ci.dev/docs/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
 
     The snyk binary used in this Task comes from a container image defined in https://github.com/konflux-ci/konflux-test
 
@@ -100,13 +100,13 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:635a890e9f0211b4eb5b8c811d6f06b3ed9ff7da952ebad236fbfe52ba36dbf7
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: sast-snyk-check
-      image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
+      image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
       workingDir: /var/workdir/source
       volumeMounts:
         - mountPath: /etc/secrets
@@ -168,7 +168,7 @@ spec:
         else
           # According to shellcheck documentation, the following error can be ignored as it is ignored through indirection: https://www.shellcheck.net/wiki/SC2034
           # shellcheck disable=SC2034
-          to_enable_snyk='[here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/)'
+          to_enable_snyk='[here](https://konflux-ci.dev/docs/testing/build/snyk/)'
           note="Task $(context.task.name) skipped: If you wish to use the Snyk code SAST task, please create a secret name snyk-secret with the key 'snyk_token' containing the Snyk token by following the steps given ${to_enable_snyk}"
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
@@ -291,8 +291,13 @@ spec:
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
     - name: upload
-      image: quay.io/konflux-ci/oras:latest@sha256:76f2f7682d32902fec34753c11f414756d0e88070d07658a35e71760ef928b71
+      image: quay.io/konflux-ci/oras:latest@sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
       workingDir: /var/workdir/source
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
       env:
         - name: IMAGE_URL
           value: $(params.image-url)

--- a/task/sast-snyk-check/0.4/MIGRATION.md
+++ b/task/sast-snyk-check/0.4/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.3 to 0.4
+
+Version 0.4:
+
+- The `image-digest` parameter has been introduced back, to be used in ORAS uploading.
+- The `image-url` default value was removed, thus it become required  
+## Action from users
+- The `image-digest` parameter definition can optionally be added for this task in the build pipeline.
+- User must provide the `image-url` parameter's value.

--- a/task/sast-snyk-check/0.4/README.md
+++ b/task/sast-snyk-check/0.4/README.md
@@ -24,7 +24,7 @@ Snyk's SAST tool uses a combination of static analysis and machine learning tech
 
 ## How to obtain a snyk-token and enable snyk task on the pipeline:
 
-Follow the steps given [here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/)
+Follow the steps given [here](https://konflux-ci.dev/docs/testing/build/snyk/)
 
 ## Results:
 

--- a/task/sast-snyk-check/0.4/README.md
+++ b/task/sast-snyk-check/0.4/README.md
@@ -1,0 +1,42 @@
+# sast-snyk-check task
+
+## Description:
+
+The sast-snyk-check task uses Snyk Code tool to perform Static Application Security Testing (SAST) for Snyk, a popular cloud-native application security platform.
+
+Snyk's SAST tool uses a combination of static analysis and machine learning techniques to scan an application's source code for potential security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks.
+
+> NOTE: This task is executed only if the user provides a Snyk token stored in a secret in their namespace. The name of the secret then needs to be supplied in the `snyk-secret` pipeline parameter.
+
+## Params:
+
+| name               | description                                                                                                                                      | default value | required |
+|--------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|---------------|----------|
+| SNYK_SECRET        | Name of secret which contains Snyk token.                                                                                                        | snyk-secret   | true     |
+| ARGS               | Append arguments.                                                                                                                                | ""            | false    |
+| IGNORE_FILE_PATHS  | Directories or files to be excluded from Snyk scan (Comma-separated). Useful to split the directories of a git repo across multiple components.  | ""            | false    |
+| IMP_FINDINGS_ONLY  | Report only important findings.  To report all findings, specify "false"                                                                         | true          | true     |
+| KFP_GIT_URL        | Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
+| PROJECT_NAME       | Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.                                  | ""            | false    |
+| RECORD_EXCLUDED    | Write excluded records in file. Useful for auditing.                                                                                             | false         | false    |
+|image-digest|Digest of the image to scan.||true|
+|image-url|Image URL.||true|
+
+## How to obtain a snyk-token and enable snyk task on the pipeline:
+
+Follow the steps given [here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/)
+
+## Results:
+
+| name          | description                |
+|---------------|----------------------------|
+| TEST_OUTPUT   | Tekton task test output.   |
+
+## Source repository for image:
+
+https://github.com/konflux-ci/konflux-test
+
+## Additional links:
+
+* https://snyk.io/product/snyk-code/
+* https://snyk.io/

--- a/task/sast-snyk-check/0.4/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.4/sast-snyk-check.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"
@@ -11,7 +11,7 @@ spec:
   description: |-
     Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
 
-    Follow the steps given [here](https://konflux-ci.dev/docs/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
+    Follow the steps given [here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
 
     The snyk binary used in this Task comes from a container image defined in https://github.com/konflux-ci/konflux-test
 
@@ -30,8 +30,9 @@ spec:
     - description: Image URL.
       name: image-url
       type: string
-      # In a future 0.4 version of the task, drop the default to make this required
-      default: ""
+    - name: image-digest
+      description: Digest of the image to scan.
+      type: string
     - name: caTrustConfigMapName
       type: string
       description: The name of the ConfigMap to read CA bundle data from.
@@ -46,7 +47,11 @@ spec:
       default: "true"
     - name: KFP_GIT_URL
       type: string
-      description: Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.
+      description: Known False Positives (KFP) git URL (optionally taking
+        a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+        the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux
+        instance and empty string for external Konflux instance.
+        If set to an empty string, the KFP filtering is disabled.
       default: "SITE_DEFAULT"
     - name: PROJECT_NAME
       type: string
@@ -74,7 +79,7 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
-      image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
+      image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
@@ -138,7 +143,7 @@ spec:
         else
           # According to shellcheck documentation, the following error can be ignored as it is ignored through indirection: https://www.shellcheck.net/wiki/SC2034
           # shellcheck disable=SC2034
-          to_enable_snyk='[here](https://konflux-ci.dev/docs/testing/build/snyk/)'
+          to_enable_snyk='[here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/)'
           note="Task $(context.task.name) skipped: If you wish to use the Snyk code SAST task, please create a secret name snyk-secret with the key 'snyk_token' containing the Snyk token by following the steps given ${to_enable_snyk}"
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
@@ -260,17 +265,15 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+
     - name: upload
-      image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
+      image: quay.io/konflux-ci/oras:latest@sha256:76f2f7682d32902fec34753c11f414756d0e88070d07658a35e71760ef928b71
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
-      volumeMounts:
-        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
-          name: trusted-ca
-          readOnly: true
-          subPath: ca-bundle.crt
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
       script: |
         #!/usr/bin/env bash
 
@@ -293,7 +296,8 @@ spec:
             echo "Selecting auth"
             select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
             echo "Attaching to ${IMAGE_URL}"
-            oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+            oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done
+
   workspaces:
     - name: workspace

--- a/task/sast-snyk-check/0.4/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.4/sast-snyk-check.yaml
@@ -11,7 +11,7 @@ spec:
   description: |-
     Scans source code for security vulnerabilities, including common issues such as SQL injection, cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application Security Testing (SAST) tool.
 
-    Follow the steps given [here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
+    Follow the steps given [here](https://konflux-ci.dev/docs/testing/build/snyk/) to obtain a snyk-token and to enable the snyk task in a Pipeline.
 
     The snyk binary used in this Task comes from a container image defined in https://github.com/konflux-ci/konflux-test
 
@@ -52,6 +52,7 @@ spec:
         the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux
         instance and empty string for external Konflux instance.
         If set to an empty string, the KFP filtering is disabled.
+
       default: "SITE_DEFAULT"
     - name: PROJECT_NAME
       type: string
@@ -79,7 +80,7 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
-      image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
+      image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
@@ -143,7 +144,7 @@ spec:
         else
           # According to shellcheck documentation, the following error can be ignored as it is ignored through indirection: https://www.shellcheck.net/wiki/SC2034
           # shellcheck disable=SC2034
-          to_enable_snyk='[here](https://konflux-ci.dev/docs/how-tos/testing/build/snyk/)'
+          to_enable_snyk='[here](https://konflux-ci.dev/docs/testing/build/snyk/)'
           note="Task $(context.task.name) skipped: If you wish to use the Snyk code SAST task, please create a secret name snyk-secret with the key 'snyk_token' containing the Snyk token by following the steps given ${to_enable_snyk}"
           TEST_OUTPUT=$(make_result_json -r SKIPPED -t "$note")
           echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
@@ -265,10 +266,14 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
-
     - name: upload
-      image: quay.io/konflux-ci/oras:latest@sha256:76f2f7682d32902fec34753c11f414756d0e88070d07658a35e71760ef928b71
+      image: quay.io/konflux-ci/oras:latest@sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -298,6 +303,5 @@ spec:
             echo "Attaching to ${IMAGE_URL}"
             oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done
-
   workspaces:
     - name: workspace

--- a/task/sast-snyk-check/0.4/tests/test-sast-snyk-check-no-token.yaml
+++ b/task/sast-snyk-check/0.4/tests/test-sast-snyk-check-no-token.yaml
@@ -27,11 +27,11 @@ spec:
         - name: workspace
           workspace: tests-workspace
       params:
-      - name: results
-        value: $(tasks.scan-with-snyk.results.TEST_OUTPUT)
+        - name: results
+          value: $(tasks.scan-with-snyk.results.TEST_OUTPUT)
       taskSpec:
         params:
-        - name: results
+          - name: results
         steps:
           - name: check-result
             image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623

--- a/task/sast-snyk-check/0.4/tests/test-sast-snyk-check-no-token.yaml
+++ b/task/sast-snyk-check/0.4/tests/test-sast-snyk-check-no-token.yaml
@@ -15,6 +15,11 @@ spec:
           workspace: tests-workspace
       taskRef:
         name: sast-snyk-check
+      params:
+        - name: image-url
+          value: quay.io/repository/redhat-user-workloads/kalem-tenant/devfile-sample-python-basic@sha256:a6e305864fefbce727a3d8cc9f0277eede5f0617696f9cda486b1f6b3b94f7cb
+        - name: image-digest
+          value: sha256:a6e305864fefbce727a3d8cc9f0277eede5f0617696f9cda486b1f6b3b94f7cb
     - name: check-result
       runAfter:
         - scan-with-snyk
@@ -22,11 +27,11 @@ spec:
         - name: workspace
           workspace: tests-workspace
       params:
-        - name: results
-          value: $(tasks.scan-with-snyk.results.TEST_OUTPUT)
+      - name: results
+        value: $(tasks.scan-with-snyk.results.TEST_OUTPUT)
       taskSpec:
         params:
-          - name: results
+        - name: results
         steps:
           - name: check-result
             image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623

--- a/task/sast-unicode-check-oci-ta/0.2/MIGRATION.md
+++ b/task/sast-unicode-check-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.1 to 0.2
+
+- The `IMAGE_DIGEST` parameter has been added.
+
+## Action from users
+
+- The `IMAGE_DIGEST` parameter definition can optionally be added for this task in the build pipeline.
+
+

--- a/task/sast-unicode-check-oci-ta/0.2/README.md
+++ b/task/sast-unicode-check-oci-ta/0.2/README.md
@@ -1,0 +1,24 @@
+# sast-unicode-check-oci-ta task
+
+Scans source code for non-printable unicode characters in all text files.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|FIND_UNICODE_CONTROL_ARGS|arguments for find-unicode-control command.|-p bidi -v -d -t|false|
+|FIND_UNICODE_CONTROL_GIT_URL|URL from repository to find unicode control.|https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58|false|
+|KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
+|PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
+|RECORD_EXCLUDED|Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. |false|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|image-digest|Image digest|""|false|
+|image-url|Image URL.|""|false|
+
+## Results
+|name|description|
+|---|---|
+|TEST_OUTPUT|Tekton task test output.|
+

--- a/task/sast-unicode-check-oci-ta/0.2/recipe.yaml
+++ b/task/sast-unicode-check-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,13 @@
+---
+base: ../../sast-unicode-check/0.2/sast-unicode-check.yaml
+add:
+  - use-source
+  - use-cachi2
+preferStepTemplate: true
+removeWorkspaces:
+  - workspace
+replacements:
+  workspaces.workspace.path: /var/workdir
+regexReplacements:
+  hacbs/\$\(context.task.name\): source
+useTAVolumeMount: true

--- a/task/sast-unicode-check-oci-ta/0.2/sast-unicode-check-oci-ta.yaml
+++ b/task/sast-unicode-check-oci-ta/0.2/sast-unicode-check-oci-ta.yaml
@@ -1,0 +1,324 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sast-unicode-check-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.2"
+spec:
+  description: Scans source code for non-printable unicode characters in all
+    text files.
+  params:
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: FIND_UNICODE_CONTROL_ARGS
+      description: arguments for find-unicode-control command.
+      type: string
+      default: -p bidi -v -d -t
+    - name: FIND_UNICODE_CONTROL_GIT_URL
+      description: URL from repository to find unicode control.
+      type: string
+      default: https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58
+    - name: KFP_GIT_URL
+      description: Known False Positives (KFP) git URL (optionally taking
+        a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+        the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        for internal Konflux instance and empty string for external Konflux
+        instance. If set to an empty string, the KFP filtering is disabled.
+      type: string
+      default: SITE_DEFAULT
+    - name: PROJECT_NAME
+      description: Name of the scanned project, used to find path exclusions.
+        By default, the Konflux component name will be used.
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      description: |
+        Whether to record the excluded findings (defaults to false).
+        If `true`, the excluded findings will be stored in `excluded-findings.json`.
+      type: string
+      default: "false"
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: image-digest
+      description: Image digest
+      type: string
+      default: ""
+    - name: image-url
+      description: Image URL.
+      type: string
+      default: ""
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:23953da08db809f841120214055aeb238bc553368e366feb58495d5a5493b19a
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+    - name: sast-unicode-check
+      image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
+      workingDir: /var/workdir/source
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: FIND_UNICODE_CONTROL_GIT_URL
+          value: $(params.FIND_UNICODE_CONTROL_GIT_URL)
+        - name: FIND_UNICODE_CONTROL_ARGS
+          value: $(params.FIND_UNICODE_CONTROL_ARGS)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: SOURCE_CODE_DIR
+          value: /var/workdir
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+        - name: BUILD_PLR_LOG_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+      script: |
+        #!/usr/bin/env bash
+        set -exuo pipefail
+
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          PROJECT_NAME=${COMPONENT_LABEL}
+        fi
+
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        SCAN_PROP=""
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # Clone the source code from upstream repo
+        GIT_URL=$(echo "${FIND_UNICODE_CONTROL_GIT_URL}" | awk -F'#' '{print $1}')
+        REV=$(echo "${FIND_UNICODE_CONTROL_GIT_URL}" | awk -F'#' '{print $2}')
+
+        # Clone find-unicode-control repository
+        if ! git clone "${GIT_URL}" find-unicode-control; then
+          echo "Failed to clone the repository: ${GIT_URL}" >&2
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 1
+        fi
+
+        if [[ -n "${REV}" ]]; then
+          if ! git -C ./find-unicode-control/ checkout "${REV}"; then
+            echo "Failed to checkout the repository: ${GIT_URL} to ${REV}" >&2
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+          fi
+          SCAN_PROP="find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}"
+        else
+          git_url_suffix=$(git -C ./find-unicode-control/ rev-parse HEAD)
+          SCAN_PROP="find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}#${git_url_suffix}"
+        fi
+
+        # Find unicode control
+        FUC_EXIT_CODE=0
+
+        # shellcheck disable=SC2086
+        LANG=en_US.utf8 ./find-unicode-control/find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${SOURCE_CODE_DIR}/source" \
+          >raw_sast_unicode_check_out.txt \
+          2>raw_sast_unicode_check_out.log ||
+          FUC_EXIT_CODE=$?
+        if [[ "${FUC_EXIT_CODE}" -ne 0 ]] && [[ "${FUC_EXIT_CODE}" -ne 1 ]]; then
+          echo "Failed to run find-unicode-control command" >&2
+          cat raw_sast_unicode_check_out.log
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 1
+        fi
+
+        # Translate the output format
+        if ! sed -i raw_sast_unicode_check_out.txt -E -e 's|(.*:[0-9]+)(.*)|\1: warning:\2|' -e 's|^|Error: UNICONTROL_WARNING:\n|'; then
+          echo "Error: failed to translate the unicontrol output format" >&2
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 1
+        fi
+
+        # Process all results as configured with CSGERP_OPTS
+        CSGERP_OPTS=(
+          --mode=json
+          --remove-duplicates
+          --embed-context=3
+          --set-scan-prop="${SCAN_PROP}"
+          --strip-path-prefix="${SOURCE_CODE_DIR}"/source/
+        )
+        # In order to generate csdiff/v1, we need to add the whole path of the source code as
+        # sast-unicode-check only provides an URI to embed the context
+        if ! csgrep "${CSGERP_OPTS[@]}" raw_sast_unicode_check_out.txt >processed_sast_unicode_check_out.json 2>processed_sast_unicode_check_out.err; then
+          echo "Error occurred while running csgrep with CSGERP_OPTS:"
+          cat processed_sast_unicode_check_out.err
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 1
+        fi
+
+        csgrep --mode=evtstat processed_sast_unicode_check_out.json
+
+        if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+            KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
+            KFP_GIT_URL=
+          fi
+        fi
+
+        # Filter known false positives if KFP_GIT_URL is set
+        if [ -n "${KFP_GIT_URL}" ]; then
+          echo "Filtering false positives in results files using ${KFP_GIT_URL}..." >&2
+
+          # Build initial csfilter-kfp command
+          csfilter_kfp_cmd=(
+            csfilter-kfp
+            --verbose
+            --kfp-git-url="${KFP_GIT_URL}"
+          )
+
+          # Append --project-nvr option if PROJECT_NVR is set
+          if [[ -n "${PROJECT_NAME}" ]]; then
+            csfilter_kfp_cmd+=(--project-nvr="${PROJECT_NAME}")
+          fi
+
+          # Append --record-excluded option if RECORD_EXCLUDED is true
+          if [[ "${RECORD_EXCLUDED}" == "true" ]]; then
+            csfilter_kfp_cmd+=(--record-excluded="excluded-findings.json")
+          fi
+
+          if ! "${csfilter_kfp_cmd[@]}" processed_sast_unicode_check_out.json >sast_unicode_check_out.json 2>sast_unicode_check_out.error; then
+            echo "Failed to filter known false positives" >&2
+            cat sast_unicode_check_out.error
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+          fi
+        else
+          echo "KFP_GIT_URL is not set. Skipping false positive filtering." >&2
+          mv processed_sast_unicode_check_out.json sast_unicode_check_out.json
+        fi
+
+        # Generate sarif report
+        csgrep --mode=sarif sast_unicode_check_out.json >sast_unicode_check_out.sarif
+        if [[ "${FUC_EXIT_CODE}" -eq 0 ]]; then
+          note="Task $(context.task.name) success: No finding was detected"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        elif [[ "${FUC_EXIT_CODE}" -eq 1 ]] && [[ ! -s sast_unicode_check_out.sarif ]]; then
+          note="Task $(context.task.name) success: Some findings were detected, but filtered by known false positive"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        else
+          echo "sast-unicode-check test failed because of the following issues:"
+          cat sast_unicode_check_out.json
+          TEST_OUTPUT=
+          parse_test_output "$(context.task.name)" sarif sast_unicode_check_out.sarif || true
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        fi
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+    - name: upload
+      image: quay.io/konflux-ci/oras:latest@sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
+      workingDir: /var/workdir/source
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      script: |
+        #!/usr/bin/env bash
+
+        if [ -z "${IMAGE_URL}" ]; then
+          echo 'No image-url param provided. Skipping upload.'
+          exit 0
+        fi
+
+        UPLOAD_FILES="sast_unicode_check_out.sarif excluded-findings.json"
+        for UPLOAD_FILE in ${UPLOAD_FILES}; do
+          if [ ! -f "${UPLOAD_FILE}" ]; then
+            echo "No ${UPLOAD_FILE} exists. Skipping upload."
+            continue
+          fi
+
+          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+            MEDIA_TYPE=application/json
+          else
+            MEDIA_TYPE=application/sarif+json
+          fi
+
+          echo "Selecting auth"
+          select-oci-auth "${IMAGE_URL}" >"${HOME}/auth.json"
+          echo "Attaching to ${IMAGE_URL}"
+          oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        done

--- a/task/sast-unicode-check/0.2/MIGRATION.md
+++ b/task/sast-unicode-check/0.2/MIGRATION.md
@@ -1,0 +1,8 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2:
+
+- The `image-digest` parameter has been introduced back, to be used in ORAS uploading.
+## Action from users
+- The `image-digest` parameter definition is required to be added for this task in the build pipeline.
+

--- a/task/sast-unicode-check/0.2/README.md
+++ b/task/sast-unicode-check/0.2/README.md
@@ -1,0 +1,31 @@
+# sast-unicode-check task
+
+## Description:
+
+The sast-unicode-check task uses [find-unicode-control](https://github.com/siddhesh/find-unicode-control.git) tool to perform Static Application Security Testing (SAST) to look for non-printable unicode characters in all text files in a source tree.
+
+## Parameters:
+
+| name                         | description                                                                                                                                   | Default Value                                                                                   | Required |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|----------|
+| FIND_UNICODE_CONTROL_GIT_URL | URL from repository to find unicode control.                                                                                                  | "https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58" | No       |
+| FIND_UNICODE_CONTROL_ARGS    | arguments for find-unicode-control command.                                                                                                   | "-p bidi -v -d -t"                                                                              | No       |
+| KFP_GIT_URL                  | Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
+| PROJECT_NAME                 | Name of the scanned project, used to find path exclusions. If set to an empty string, the Konflux component name will be used.                | ""                                                                                              | No       |
+| RECORD_EXCLUDED              | Whether to record the excluded findings (defaults to false). If `true`, the the excluded findings will be stored in `excluded-findings.json`. | "false"                                                                                         | No       |
+| image-digest | Image digest that will be uploaded with ORAS control.                                                                                                  | | YES                                                                                          | true       |
+
+
+## Results:
+
+| name          | description                              |
+|---------------|------------------------------------------|
+| TEST_OUTPUT   | Tekton task test output.                 |
+
+## Source repository for image:
+
+https://github.com/konflux-ci/konflux-test
+
+## Additional links:
+
+* https://github.com/siddhesh/find-unicode-control.git

--- a/task/sast-unicode-check/0.2/sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.2/sast-unicode-check.yaml
@@ -1,0 +1,299 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: sast-unicode-check
+spec:
+  description: >-
+    Scans source code for non-printable unicode characters in all text files.
+  results:
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+  params:
+    - name: image-digest
+      description: Image digest
+      type: string
+      default: ""
+    - name: image-url
+      type: string
+      description: Image URL.
+      default: ""
+    - name: FIND_UNICODE_CONTROL_GIT_URL
+      type: string
+      description: URL from repository to find unicode control.
+      default: "https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58"
+    - name: FIND_UNICODE_CONTROL_ARGS
+      type: string
+      description: arguments for find-unicode-control command.
+      default: "-p bidi -v -d -t"
+    - name: KFP_GIT_URL
+      type: string
+      description: Known False Positives (KFP) git URL (optionally taking
+        a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+        the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux
+        instance and empty string for external Konflux instance.
+        If set to an empty string, the KFP filtering is disabled.
+      default: "SITE_DEFAULT"
+    - name: PROJECT_NAME
+      description: Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      type: string
+      description: |
+        Whether to record the excluded findings (defaults to false).
+        If `true`, the excluded findings will be stored in `excluded-findings.json`.
+      default: "false"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  steps:
+    - name: sast-unicode-check
+      image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: FIND_UNICODE_CONTROL_GIT_URL
+          value: $(params.FIND_UNICODE_CONTROL_GIT_URL)
+        - name: FIND_UNICODE_CONTROL_ARGS
+          value: $(params.FIND_UNICODE_CONTROL_ARGS)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: SOURCE_CODE_DIR
+          value: $(workspaces.workspace.path)
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+        - name: BUILD_PLR_LOG_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+      script: |
+        #!/usr/bin/env bash
+        set -exuo pipefail
+
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        if [[ -z "${PROJECT_NAME}" ]]; then
+            PROJECT_NAME=${COMPONENT_LABEL}
+        fi
+
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        SCAN_PROP=""
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # Clone the source code from upstream repo
+        GIT_URL=$(echo "${FIND_UNICODE_CONTROL_GIT_URL}" | awk -F'#' '{print $1}')
+        REV=$(echo "${FIND_UNICODE_CONTROL_GIT_URL}" | awk -F'#' '{print $2}')
+
+        # Clone find-unicode-control repository
+        if ! git clone "${GIT_URL}" find-unicode-control; then
+            echo "Failed to clone the repository: ${GIT_URL}" >&2
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+        fi
+
+        if [[ -n "${REV}" ]]; then
+            if ! git -C ./find-unicode-control/ checkout "${REV}"; then
+                echo "Failed to checkout the repository: ${GIT_URL} to ${REV}" >&2
+                note="Task $(context.task.name) failed: For details, check Tekton task log."
+                ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+                echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+                exit 1
+            fi
+            SCAN_PROP="find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}"
+        else
+            git_url_suffix=$(git -C ./find-unicode-control/ rev-parse HEAD)
+            SCAN_PROP="find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}#${git_url_suffix}"
+        fi
+
+        # Find unicode control
+        FUC_EXIT_CODE=0
+
+        # shellcheck disable=SC2086
+        LANG=en_US.utf8 ./find-unicode-control/find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${SOURCE_CODE_DIR}/source" \
+            >raw_sast_unicode_check_out.txt \
+            2>raw_sast_unicode_check_out.log \
+            || FUC_EXIT_CODE=$?
+        if [[ "${FUC_EXIT_CODE}" -ne 0 ]] && [[ "${FUC_EXIT_CODE}" -ne 1 ]]; then
+            echo "Failed to run find-unicode-control command" >&2
+            cat raw_sast_unicode_check_out.log
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+        fi
+
+        # Translate the output format
+        if ! sed -i raw_sast_unicode_check_out.txt -E -e 's|(.*:[0-9]+)(.*)|\1: warning:\2|' -e 's|^|Error: UNICONTROL_WARNING:\n|'; then
+            echo "Error: failed to translate the unicontrol output format" >&2
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+        fi
+
+        # Process all results as configured with CSGERP_OPTS
+        CSGERP_OPTS=(
+            --mode=json
+            --remove-duplicates
+            --embed-context=3
+            --set-scan-prop="${SCAN_PROP}"
+            --strip-path-prefix="${SOURCE_CODE_DIR}"/source/
+        )
+        # In order to generate csdiff/v1, we need to add the whole path of the source code as
+        # sast-unicode-check only provides an URI to embed the context
+        if ! csgrep "${CSGERP_OPTS[@]}" raw_sast_unicode_check_out.txt > processed_sast_unicode_check_out.json 2> processed_sast_unicode_check_out.err; then
+            echo "Error occurred while running csgrep with CSGERP_OPTS:"
+            cat processed_sast_unicode_check_out.err
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+        fi
+
+        csgrep --mode=evtstat processed_sast_unicode_check_out.json
+
+        if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+            KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
+            KFP_GIT_URL=
+          fi
+        fi
+
+        # Filter known false positives if KFP_GIT_URL is set
+        if [ -n "${KFP_GIT_URL}" ]; then
+            echo "Filtering false positives in results files using ${KFP_GIT_URL}..." >&2
+
+            # Build initial csfilter-kfp command
+            csfilter_kfp_cmd=(
+                csfilter-kfp
+                --verbose
+                --kfp-git-url="${KFP_GIT_URL}"
+            )
+
+            # Append --project-nvr option if PROJECT_NVR is set
+            if [[ -n "${PROJECT_NAME}" ]]; then
+                csfilter_kfp_cmd+=(--project-nvr="${PROJECT_NAME}")
+            fi
+
+            # Append --record-excluded option if RECORD_EXCLUDED is true
+            if [[ "${RECORD_EXCLUDED}" == "true" ]]; then
+                csfilter_kfp_cmd+=(--record-excluded="excluded-findings.json")
+            fi
+
+            if ! "${csfilter_kfp_cmd[@]}" processed_sast_unicode_check_out.json > sast_unicode_check_out.json 2> sast_unicode_check_out.error; then
+                echo "Failed to filter known false positives" >&2
+                cat sast_unicode_check_out.error
+                note="Task $(context.task.name) failed: For details, check Tekton task log."
+                ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+                echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+                exit 1
+            fi
+        else
+            echo "KFP_GIT_URL is not set. Skipping false positive filtering." >&2
+            mv processed_sast_unicode_check_out.json sast_unicode_check_out.json
+        fi
+
+        # Generate sarif report
+        csgrep --mode=sarif sast_unicode_check_out.json > sast_unicode_check_out.sarif
+        if [[ "${FUC_EXIT_CODE}" -eq 0 ]]; then
+            note="Task $(context.task.name) success: No finding was detected"
+            ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        elif [[ "${FUC_EXIT_CODE}" -eq 1 ]] && [[ ! -s  sast_unicode_check_out.sarif ]]; then
+            note="Task $(context.task.name) success: Some findings were detected, but filtered by known false positive"
+            ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        else
+            echo "sast-unicode-check test failed because of the following issues:"
+            cat sast_unicode_check_out.json
+            TEST_OUTPUT=
+            parse_test_output "$(context.task.name)" sarif sast_unicode_check_out.sarif  || true
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        fi
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+    - name: upload
+      image: quay.io/konflux-ci/oras:latest@sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      script: |
+        #!/usr/bin/env bash
+
+        if [ -z "${IMAGE_URL}" ]; then
+          echo 'No image-url param provided. Skipping upload.'
+          exit 0;
+        fi
+
+        UPLOAD_FILES="sast_unicode_check_out.sarif excluded-findings.json"
+        for UPLOAD_FILE in ${UPLOAD_FILES}; do
+            if [ ! -f "${UPLOAD_FILE}" ]; then
+              echo "No ${UPLOAD_FILE} exists. Skipping upload."
+              continue
+            fi
+
+            if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+                MEDIA_TYPE=application/json
+            else
+                MEDIA_TYPE=application/sarif+json
+            fi
+
+            echo "Selecting auth"
+            select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+            echo "Attaching to ${IMAGE_URL}"
+            oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        done
+  workspaces:
+  - name: workspace

--- a/task/sast-unicode-check/0.2/tests/test-sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.2/tests/test-sast-unicode-check.yaml
@@ -1,0 +1,83 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sast-unicode-check
+spec:
+  description: |
+    Test the sast-unicode-check task with a customer repository
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: init
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/init/0.2/init.yaml
+      params:
+        - name: image-url
+          value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-unicode-check:latest"
+        - name: image-digest
+          value: sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
+    - name: clone-repository
+      runAfter:
+        - init
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/test-data-sast
+        - name: revision
+          value: main
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+    - name: scan-with-unicode
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      runAfter:
+        - clone-repository
+      taskRef:
+        name: sast-unicode-check
+      params:
+        - name: image-url
+          value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-unicode-check:latest"
+    - name: check-result
+      runAfter:
+        - scan-with-unicode
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/konflux-test:v1.4.12@sha256:b42202199805420527c2552dea22b02ab0f051b79a4b69fbec9a77f8832e5623
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              echo "Check-result"
+              # Extract findings stats from the resulting SARIF data
+              output=$(csgrep --mode=evtstat "$(workspaces.workspace.path)"/hacbs/sast-unicode-check/sast_unicode_check_out.sarif | tr -d '\n')
+              expected="    196	UNICONTROL_WARNING                              	warning"
+              # Compare output with expected string
+              if [[ "$output" == "$expected" ]]; then
+                echo "Test passed!"
+              else
+                echo "Test failed!"
+                echo "Actual output: [$output]"
+                echo "Expected output: [$expected]"
+                return 1
+              fi

--- a/task/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/task/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -193,12 +193,12 @@ spec:
         - name: SNAPSHOT_PATH
           value: $(params.HOMEDIR)/snapshot.json
       image: registry.redhat.io/rhtas/ec-rhel9:0.6
-      onError: continue # progress even if the step fails so we can see the debug logs
+      onError: continue  # progress even if the step fails so we can see the debug logs
       command: [reduce-snapshot.sh]
 
     - name: validate
       image: registry.redhat.io/rhtas/ec-rhel9:0.6
-      onError: continue # progress even if the step fails so we can see the debug logs
+      onError: continue  # progress even if the step fails so we can see the debug logs
       command: [ec]
       args:
         - validate


### PR DESCRIPTION
oras attach of the images in the security tasks was missing imgae-digest, as [discovered in thread](https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1738860626486219) , for more details. 
we will add the image-digest parameter to tasks and add it to the command oras attach for tasks : 

sast-coverity-check
sast-shell-check
sast-snyk-check
sast-unicode-check

and  update accordingly pipelines and all required 
 

[KONFLUX-6914](https://issues.redhat.com/browse/KONFLUX-6914)