### PR TITLE
Revert "chore(deps): update registry.redhat.io/openshift4/ose-operato…

### DIFF
--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -37,7 +37,7 @@ spec:
       description: Workspace with the source code
   steps:
     - name: operator-sdk-generate-bundle
-      image: "registry.redhat.io/openshift4/ose-operator-sdk-rhel9:v4.18"
+      image: "registry.redhat.io/openshift4/ose-operator-sdk-rhel9:v4.16"
       workingDir: $(workspaces.source.path)/source
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
…r-sdk-rhel9 docker tag to v4.18"

This reverts commit cea9fb4674e304367448a96df56411dde941d974.

SRE operators are still on v3 of kubebuilder and bumping this requires v4. Going to work on a plan to migrate the operators before this is bumped.
