### PR TITLE
feat: stop checking related image accessibility in validate-fbc

### DIFF
--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -450,27 +450,10 @@ spec:
         else
           echo -n "$related_images" > /shared/related-images.json
 
-          # A while loop executed in a subshell so we will check for failure based
-          # on whether /tmp/failedimages exists.
+          # We have moved verification of the related images to a Conformal policy. This enables
+          # the results of this task to be stable in time (i.e. it doesn't need to be re-run after
+          # any other images have been released).
           echo -e "Related images detected:\n$(jq -cr '.[]' /shared/related-images.json )."
-          echo -e "\nTesting related images for validity:"
-          # cycle through those related images and show outputs
-          jq -cr '.[]' /shared/related-images.json | while read -r image; do
-            echo "skopeo inspect --raw docker://${image}"
-            if ! skopeo inspect --raw "docker://${image}" 2>/dev/null; then
-              echo "FAILED to inspect related image: ${image}." | tee -a /tmp/failedimages
-            else
-              echo # the skopeo inspect command doesn't have a newline. Add that here.
-            fi
-          done
-
-          if [ -s /tmp/failedimages ]; then
-            echo "These related images have failed validation:"
-            cat /tmp/failedimages
-            note="Step extract-and-validate failed: Command skopeo inspect could not inspect images. For details, check Tekton task log."
-            failure_num=$((failure_num + 1))
-            TESTPASSED=false
-          fi
         fi
 
         if [ $TESTPASSED == false ]; then


### PR DESCRIPTION
With EC-965, we created a policy which can verify a set of related images that have been idenified by this task and attached to the FBC image. Since we can check validity with Conforma, we no longer need to check validity here.

This enables users to produce a FBC catalog while ignoring unreleased related images until it actually matters (i.e. until the fragment is about to be pushed to production).

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
