### PR TITLE
sast-coverity-check: kill orphan background processes

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -350,12 +350,16 @@ spec:
         # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
         /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
           -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
-          set -x
+          set -mx
           pwd >&2  # print CWD set by coverity
           cd '\${PWD}'  # restore original CWD
-          \\"\\\$@\\"  # run the instrumented shell command
-          echo \\\$? >/tmp/idir/build-cmd-ec.txt" \
-          - "\$@"
+          \\"\\\$@\\" &  # run the instrumented shell command in background (to create a process group)
+          pid=\\\$!  # store its PID
+          wait \\\${pid}  # wait for the command to finish
+          ec=\\\$?  # store its exit status
+          kill -KILL -\\\${pid} 2>/dev/null  # kill orphan background processes
+          echo \\\${ec} >/tmp/idir/build-cmd-ec.txt  # propagate the exit status
+          " - "\$@"
 
         # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
         $(declare -p COV_ANALYZE_ARGS)

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -233,12 +233,16 @@
       # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
       /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
         -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
-        set -x
+        set -mx
         pwd >&2  # print CWD set by coverity
         cd '\${PWD}'  # restore original CWD
-        \\"\\\$@\\"  # run the instrumented shell command
-        echo \\\$? >/tmp/idir/build-cmd-ec.txt" \
-        - "\$@"
+        \\"\\\$@\\" &  # run the instrumented shell command in background (to create a process group)
+        pid=\\\$!  # store its PID
+        wait \\\${pid}  # wait for the command to finish
+        ec=\\\$?  # store its exit status
+        kill -KILL -\\\${pid} 2>/dev/null  # kill orphan background processes
+        echo \\\${ec} >/tmp/idir/build-cmd-ec.txt  # propagate the exit status
+        " - "\$@"
 
       # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
       $(declare -p COV_ANALYZE_ARGS)

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -293,12 +293,16 @@ spec:
       # wrap the RUN command with "coverity capture" and record exit code of the wrapped command
       /opt/coverity/bin/coverity --ticker-mode=no-spin capture --dir=/tmp/idir --project-dir="\$proj_dir" \
         -- /bin/bash -c "PS4='@\\\${SECONDS}s: \\\${BASH_COMMAND} --> '
-        set -x
+        set -mx
         pwd >&2  # print CWD set by coverity
         cd '\${PWD}'  # restore original CWD
-        \\"\\\$@\\"  # run the instrumented shell command
-        echo \\\$? >/tmp/idir/build-cmd-ec.txt" \
-        - "\$@"
+        \\"\\\$@\\" &  # run the instrumented shell command in background (to create a process group)
+        pid=\\\$!  # store its PID
+        wait \\\${pid}  # wait for the command to finish
+        ec=\\\$?  # store its exit status
+        kill -KILL -\\\${pid} 2>/dev/null  # kill orphan background processes
+        echo \\\${ec} >/tmp/idir/build-cmd-ec.txt  # propagate the exit status
+        " - "\$@"
 
       # serialize COV_ANALYZE_ARGS declaration into the wrapper script (to avoid shell injection)
       $(declare -p COV_ANALYZE_ARGS)


### PR DESCRIPTION
... so that `coverity capture` does not wait for them to finish.

The behavior of `sast-coverity-check` needs to be compatible with the behavior of `build-container`, which does not wait for the background processes to finish.  Otherwise a container image that takes 6 minutes to build natively, takes 2 hours to timeout with `sast-coverity-check`.

Resolves: https://issues.redhat.com/browse/KFLUXSPRT-2157