### PR TITLE
Fix expires-on in verify-signed-rpms task

### DIFF
--- a/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
+++ b/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
@@ -3,10 +3,11 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: verify-signed-rpms
-  build.appstudio.redhat.com/expires-on: "2025-03-15T00:00:00Z"
-  build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
-    to task rpms-signature-scan
-    (https://quay.io/repository/konflux-ci/tekton-catalog/task-rpms-signature-scan)'
+  annotations:
+    build.appstudio.redhat.com/expires-on: "2025-03-15T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
+      to task rpms-signature-scan
+      (https://quay.io/repository/konflux-ci/tekton-catalog/task-rpms-signature-scan)'
 spec:
   params:
     - name: INPUT


### PR DESCRIPTION
A fixup for commit 5a8e618dc2656f2a52bfd352bc4a9fe1fb19c87e which added the keys at the wrong level.

Split out from #2011 for early merge.
