### PR TITLE
feat: store Sealights agent/cli version in Results

### DIFF
--- a/task/sealights-go-oci-ta/0.1/sealights-go-oci-ta.yaml
+++ b/task/sealights-go-oci-ta/0.1/sealights-go-oci-ta.yaml
@@ -21,6 +21,12 @@ spec:
     - name: sealights-build-name
       type: string
       description: "A unique build name generated using the commit SHA and current date to prevent conflicts during test reruns."
+    - name: sealights-agent-version
+      type: string
+      description: "A version of the Sealights Go Agent"
+    - name: sealights-cli-version
+      type: string
+      description: "A version of the Sealights Go CLI"
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -122,6 +128,9 @@ spec:
       script: |
         #!/bin/bash
         set -euo pipefail
+
+        echo -n "${AGENT_VERSION}" > "$(results.sealights-agent-version.path)"
+        echo -n "${CLI_VERSION}" > "$(results.sealights-cli-version.path)"
 
         export SEALIGHTS_TOKEN BUILD_NAME BSID PACKAGES_EXCLUDED_ENUM
 

--- a/task/sealights-nodejs-oci-ta/0.1/sealights-nodejs-oci-ta.yaml
+++ b/task/sealights-nodejs-oci-ta/0.1/sealights-nodejs-oci-ta.yaml
@@ -79,7 +79,7 @@ spec:
       emptyDir: {}
   stepTemplate:
     volumeMounts:
-      - mountPath: /opt/app-root
+      - mountPath: /opt/app-root/src/app
         name: workdir
       - name: sealights-credentials
         mountPath: /usr/local/sealights-credentials
@@ -88,7 +88,7 @@ spec:
       image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
       args:
         - use
-        - $(params.SOURCE_ARTIFACT)=/opt/app-root/src
+        - $(params.SOURCE_ARTIFACT)=/opt/app-root/src/app
     - name: sealights-nodejs-instrumentation
       computeResources:
         limits:
@@ -98,7 +98,7 @@ spec:
           cpu: 100m
           memory: 256Mi
       image: quay.io/konflux-ci/tekton-integration-catalog/sealights-nodejs:latest@sha256:cb3ba4e3e4956bdf05fd896f55c389f429801bb62ae6bdf9fbcdd332b96d5d0c
-      workingDir: /opt/app-root/src
+      workingDir: /opt/app-root/src/app
       securityContext:
         runAsUser: 0
       env:

--- a/task/sealights-nodejs-oci-ta/0.1/sealights-nodejs-oci-ta.yaml
+++ b/task/sealights-nodejs-oci-ta/0.1/sealights-nodejs-oci-ta.yaml
@@ -146,16 +146,16 @@ spec:
         # Configures the app for Sealights using vars from your pipeline run.
         if [[ -n "${TEST_EVENT}" && "${TEST_EVENT}" == "pull_request" ]]; then
           echo "[INFO] Generate build session id from a Pull Request source code"
-          npx slnodejs prConfig --appname "${COMPONENT}" --targetBranch "${TARGET_BRANCH}" \
+          slnodejs prConfig --appname "${COMPONENT}" --targetBranch "${TARGET_BRANCH}" \
             --pullRequestNumber "${PULL_REQUEST_NUMBER}" --latestCommit "${REVISION}" --repositoryUrl "${REPOSITORY_URL}" --token "${SEALIGHTS_TOKEN}"
         else
           echo "[INFO] Creating build session ID (BSID) for app: ${COMPONENT}, branch: ${BRANCH}, build: ${BUILD_NAME}..."
-          npx slnodejs config --appname "${COMPONENT}" --branch "${BRANCH}" --build "${BUILD_NAME}" --token "${SEALIGHTS_TOKEN}"
+          slnodejs config --appname "${COMPONENT}" --branch "${BRANCH}" --build "${BUILD_NAME}" --token "${SEALIGHTS_TOKEN}"
         fi
         # Skip scanning frontend applications
         if [ "$IS_FRONTEND" != "true" ]; then
           # Scans all .js files that are not in the --excludedpaths step above and reports scan to sealights.
-          npx slnodejs scan --buildsessionidfile buildSessionId --scm "${SCM}" --scmProvider "${SCM_PROVIDER}" --excludedpaths "${PATHS_EXCLUDED_ENUM}" --build "${BUILD_NAME}" --es6Modules --workspacepath "${WORKSPACE_PATH}" --projectroot "${WORKSPACE_PATH}" --token "${SEALIGHTS_TOKEN}"
+          slnodejs scan --buildsessionidfile buildSessionId --scm "${SCM}" --scmProvider "${SCM_PROVIDER}" --excludedpaths "${PATHS_EXCLUDED_ENUM}" --build "${BUILD_NAME}" --es6Modules --workspacepath "${WORKSPACE_PATH}" --projectroot "${WORKSPACE_PATH}" --token "${SEALIGHTS_TOKEN}"
         fi
         # Stores results to be used in future tasks for testing.
         echo -n "$(cat buildSessionId)" > "$(results.sealights-bsid.path)"

--- a/task/sealights-nodejs-oci-ta/0.1/sealights-nodejs-oci-ta.yaml
+++ b/task/sealights-nodejs-oci-ta/0.1/sealights-nodejs-oci-ta.yaml
@@ -22,9 +22,9 @@ spec:
     - name: sealights-build-name
       type: string
       description: "A unique build name generated using the commit SHA and current date to prevent conflicts during test reruns."
-    - name: SOURCE_ARTIFACT
-      description: The Trusted Artifact URI pointing to the artifact with the application source code.
+    - name: sealights-agent-version
       type: string
+      description: "A version of the Sealights Node.js Agent"
   params:
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with the application source code.
@@ -130,6 +130,8 @@ spec:
       script: |
         #!/bin/bash
         set -euo pipefail
+
+        echo -n "${AGENT_VERSION}" > "$(results.sealights-agent-version.path)"
 
         export SEALIGHTS_TOKEN BUILD_NAME PATHS_EXCLUDED_ENUM
         SEALIGHTS_TOKEN="$(cat /usr/local/sealights-credentials/token)"

--- a/task/sealights-python-oci-ta/0.1/sealights-python-oci-ta.yaml
+++ b/task/sealights-python-oci-ta/0.1/sealights-python-oci-ta.yaml
@@ -22,6 +22,9 @@ spec:
     - name: sealights-build-name
       type: string
       description: "A unique build name generated using the commit SHA and current date to prevent conflicts during test reruns."
+    - name: sealights-agent-version
+      type: string
+      description: "A version of the Sealights Python Agent"
   params:
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with the application source code.
@@ -114,6 +117,8 @@ spec:
       script: |
         #!/bin/bash
         set -euo pipefail
+
+        echo -n "${AGENT_VERSION}" > "$(results.sealights-agent-version.path)"
 
         export SEALIGHTS_TOKEN BUILD_NAME EXCLUDE_ENUM
 


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KFLUXDP-208

### List of changes
* store agent/cli versions in Tekton Results - related to https://issues.redhat.com/browse/KFLUXDP-208
* [stop using npx](https://github.com/konflux-ci/build-definitions/pull/2024/commits/bd0328bf08580c932987f34117285f7166f5a98d), because npx uses the package (in this case `slnodejs`) from a remote location, if it's not installed locally - this caused an issue that the Node.js instrumentation Task was using a different version of `slnodejs` package than it was installed in the container image. The local version of the package was not found, because the installed package was overwritten by a mounted directory used for trusted artifact. Due to that I had to [change the working directory used for the trusted artifact.](https://github.com/konflux-ci/build-definitions/pull/2024/commits/1bfecef87ab6cb9342383baa345602b6e984d8cd)

### Verification
Validated in [my testing PR](https://github.com/psturc/nodejs-sl-test/pull/24):
<img width="303" alt="Screenshot 2025-03-11 at 15 30 39" src="https://github.com/user-attachments/assets/af0a6308-0ab6-4e81-9975-fe4e2072b485" />
