### PR TITLE
coverity-availability-check: result status ERROR -> FAILURE

### DIFF
--- a/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
+++ b/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
@@ -50,7 +50,7 @@ spec:
         echo 'No license file for Coverity was detected. Coverity scan will not be executed...'
         echo 'Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license'
         note="Task $(context.task.name) failed: No license file for Coverity was detected. Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license"
-        TEST_OUTPUT=$(make_result_json -r ERROR -t "$note" -f 1)
+        TEST_OUTPUT=$(make_result_json -r FAILURE -t "$note" -f 1)
         echo -n "failed" | tee "$(results.STATUS.path)"
         echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
         exit 0
@@ -64,7 +64,7 @@ spec:
         echo 'No authentication token for downloading Coverity image detected. Coverity scan will not be executed...'
         echo 'Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image'
         note="Task $(context.task.name) failed: No authentication token for downloading Coverity image detected. Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image"
-        TEST_OUTPUT=$(make_result_json -r ERROR -t "$note" -f 1)
+        TEST_OUTPUT=$(make_result_json -r FAILURE -t "$note" -f 1)
         echo -n "failed" | tee "$(results.STATUS.path)"
         echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
         exit 0

--- a/task/coverity-availability-check/0.2/coverity-availability-check.yaml
+++ b/task/coverity-availability-check/0.2/coverity-availability-check.yaml
@@ -63,7 +63,7 @@ spec:
           echo 'No license file for Coverity was detected. Coverity scan will not be executed...'
           echo 'Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license'
           note="Task $(context.task.name) failed: No license file for Coverity was detected. Please, create a secret called 'cov-license' with a key called 'cov-license' and the value containing the Coverity license"
-          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note" -f 1)
+          TEST_OUTPUT=$(make_result_json -r FAILURE -t "$note" -f 1)
           echo -n "failed" | tee "$(results.STATUS.path)"
           echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
           exit 0
@@ -77,7 +77,7 @@ spec:
           echo 'No authentication token for downloading Coverity image detected. Coverity scan will not be executed...'
           echo 'Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image'
           note="Task $(context.task.name) failed: No authentication token for downloading Coverity image detected. Please, create an imagePullSecret named 'auth-token-coverity-image' with the authentication token for pulling the Coverity image"
-          TEST_OUTPUT=$(make_result_json -r ERROR -t "$note" -f 1)
+          TEST_OUTPUT=$(make_result_json -r FAILURE -t "$note" -f 1)
           echo -n "failed" | tee "$(results.STATUS.path)"
           echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
           exit 0

--- a/task/coverity-availability-check/0.2/tests/test-coverity-availability-check.yaml
+++ b/task/coverity-availability-check/0.2/tests/test-coverity-availability-check.yaml
@@ -38,8 +38,8 @@ spec:
               # The current behaviour when secrets are not available is
               # - Task succeeds (exit 0)
               # - writes "failed" to the STATUS result
-              # - TEST_OUTPUT result is Error, with a single failure
+              # - TEST_OUTPUT result is FAILURE, with a single failure
               echo -n "Expected STATUS: "
               [ "$STATUS" == "failed" ] && echo "true"
               echo -n "Expected TEST_OUTPUT: "
-              echo "$TEST_OUTPUT" | jq -e '.result == "ERROR" and .failures == 1'
+              echo "$TEST_OUTPUT" | jq -e '.result == "FAILURE" and .failures == 1'


### PR DESCRIPTION
The intention of this change is the coverity-availability-check task should report failure status to users, to indicate that action is needed (add coverity secrets), but it should NOT cause the pipeline to fail.