### PR TITLE
fix: avoid attaching migration to irrelevant task bundle

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -530,7 +530,9 @@ build_push_tasks() {
         migration_file="${task_dir}/migrations/${concrete_task_version}.sh"
 
         has_migration=false
-        if [ -f "$migration_file" ]; then
+        if [ -f "$migration_file" ] && git show "$task_file_sha" --oneline --name-only | grep -q "$migration_file"; then
+            # There is a migration file matching the task concrete version and
+            # is included in the same commit with the task.
             has_migration=true
         fi
 


### PR DESCRIPTION
[STONEBLD-3353](https://issues.redhat.com//browse/STONEBLD-3353)

The problem is:

* commit 1 includes a migration, which is attached to the task bundle built from commit 1.
* then, commit 2 includes updates to the same task without bumping the version in label '.metadata.labels."app.kubernetes.io/version'.
* as a result, the migration is attached to the last bundle.
