### PR TITLE
fix: generated files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -242,7 +242,9 @@
     },
     {
       "customType": "regex",
-      "fileMatch": ["^task/build-vm-image/.*/build-vm-image.yaml"],
+      "fileMatch": [
+        "^task/build-vm-image/.*/build-vm-image.yaml"
+      ],
       "matchStrings": [
         "BUILDAH_IMAGE\\s*\\n\\s*value:\\s*['\"]?(?<depName>[^'\":]+):(?<currentValue>[^'\":\\s]+)['\"]?"
       ],

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -1,3 +1,4 @@
+# WARNING: This is an auto generated file, do not modify this file directly
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:


### PR DESCRIPTION
Running generate-everything.sh with no changes results in changes. This fails CI for other PRs.
