### PR TITLE
fix: execute github actions CI inside merge_queue

### DIFF
--- a/.github/workflows/check-buildah-remote.yaml
+++ b/.github/workflows/check-buildah-remote.yaml
@@ -2,6 +2,8 @@ name: Validate PR - buildah-remote
 'on':
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 jobs:
   go:
     name: Check Buildah Remote

--- a/.github/workflows/check-kustomize-build.yaml
+++ b/.github/workflows/check-kustomize-build.yaml
@@ -2,6 +2,8 @@ name: Validate PR - kustomize manifests
 'on':
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 jobs:
   kustomize-build:
     name: Check Kustomize Build of Task and Pipelines

--- a/.github/workflows/check-readmes.yaml
+++ b/.github/workflows/check-readmes.yaml
@@ -2,6 +2,8 @@ name: Validate PR - check READMEs
 'on':
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 jobs:
   check:
     name: Check READMEs

--- a/.github/workflows/check-ta.yaml
+++ b/.github/workflows/check-ta.yaml
@@ -2,6 +2,8 @@ name: Validate PR - Trusted Artifact variants
 'on':
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 jobs:
   go:
     name: Check Trusted Artifact variants

--- a/.github/workflows/check-task-migration.yaml
+++ b/.github/workflows/check-task-migration.yaml
@@ -2,6 +2,8 @@ name: Check task migrations
 "on":
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 jobs:
   check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/check-task-owners.yaml
+++ b/.github/workflows/check-task-owners.yaml
@@ -2,6 +2,8 @@ name: Validate PR - check task owners
 'on':
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 jobs:
   check:
     name: Check Task OWNERS

--- a/.github/workflows/checkton.yaml
+++ b/.github/workflows/checkton.yaml
@@ -2,7 +2,8 @@ name: Checkton
 "on":
   pull_request:
     branches: [main]
-
+  merge_group:
+    types: [checks_requested]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -2,6 +2,8 @@ name: Validate PR - golang CI
 "on":
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -6,6 +6,8 @@ name: Run Task Tests
       - opened
       - synchronize
       - reopened
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   run-task-tests:

--- a/.github/workflows/yaml-lint.yaml
+++ b/.github/workflows/yaml-lint.yaml
@@ -3,6 +3,8 @@ name: yamllint
 "on":
   pull_request:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
 jobs:
   yamllint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Execute all the github actions CI inside merge queue, to validate the correctness of the checks again
