### PR TITLE
sast-coverity-check: request 4 GiB of RAM

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -1,3 +1,4 @@
+# WARNING: This is an auto generated file, do not modify this file directly
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -733,7 +733,6 @@ spec:
         done
       computeResources:
         limits:
-          cpu: "16"
           memory: 16Gi
         requests:
           cpu: "4"
@@ -913,7 +912,7 @@ spec:
         fi
       computeResources:
         limits:
-          memory: 4Gi
+          memory: 16Gi
         requests:
-          cpu: "2"
-          memory: 2Gi
+          cpu: "4"
+          memory: 4Gi

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -75,9 +75,6 @@
 
 # Change build step resources
 - op: replace
-  path: /spec/steps/0/computeResources/limits/cpu
-  value: 16
-- op: replace
   path: /spec/steps/0/computeResources/limits/memory
   value: 16Gi
 - op: replace
@@ -302,10 +299,10 @@
     image: quay.io/redhat-services-prod/sast/coverity:202412.5
     computeResources:
       limits:
-        memory: 4Gi
+        memory: 16Gi
       requests:
-        memory: 2Gi
-        cpu: 2
+        memory: 4Gi
+        cpu: 4
     volumeMounts:
       - name: trusted-ca
         mountPath: "/mnt/trusted-ca"

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -357,7 +357,6 @@ spec:
     - $(params.ANNOTATIONS[*])
     computeResources:
       limits:
-        cpu: 16
         memory: 16Gi
       requests:
         cpu: 4
@@ -684,10 +683,10 @@ spec:
     workingDir: $(workspaces.source.path)
   - computeResources:
       limits:
-        memory: 4Gi
+        memory: 16Gi
       requests:
-        cpu: 2
-        memory: 2Gi
+        cpu: 4
+        memory: 4Gi
     env:
     - name: IMAGE_URL
       value: $(params.image-url)


### PR DESCRIPTION
... in the post-process step, too, and do not set any limit on CPUs.

The increased resources are needed in the `post-process` step, too, because Coverity runs there in case the buildful capture fails.  We have reports about Coverity being OOM killed in the step.  I wish we could ask for more memory and CPUs but then the `sast-coverit-check` task is not started at all.

Related: https://github.com/konflux-ci/build-definitions/pull/1821
Related: https://issues.redhat.com/browse/KFLUXSPRT-2167
Related: https://issues.redhat.com/browse/KFLUXSPRT-2181