### PR TITLE
feat(KONFLUX-7127): Setup limits and resource for ecosystem-cert-preflight-checks task

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
@@ -23,7 +23,7 @@ spec:
     - name: check-container
       image: quay.io/opdev/preflight:stable@sha256:3f5b988200a3fd490e0a102a4851e0a81f2f41e724e7482a726b79b9d5ccd3b6
       args: ["check", "container", "$(params.image-url)"]
-      computeResources:
+      resources:
         limits:
           memory: 4Gi
         requests:
@@ -41,7 +41,7 @@ spec:
           readOnly: true
     - name: gather-pflt-results
       image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
-      computeResources:
+      resources:
         limits:
           memory: 256Mi
         requests:

--- a/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
@@ -23,6 +23,12 @@ spec:
     - name: check-container
       image: quay.io/opdev/preflight:stable@sha256:3f5b988200a3fd490e0a102a4851e0a81f2f41e724e7482a726b79b9d5ccd3b6
       args: ["check", "container", "$(params.image-url)"]
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 4Gi
       env:
         - name: PFLT_DOCKERCONFIG
           value: /root/.docker/config.json
@@ -35,6 +41,12 @@ spec:
           readOnly: true
     - name: gather-pflt-results
       image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       volumeMounts:
         - name: pfltoutputdir
           mountPath: /artifacts

--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -34,6 +34,12 @@ spec:
       value: $(steps.introspect.results.artifact-type-set-by)
   steps:
     - name: introspect
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          cpu: 100m
+          memory: 512Mi
       image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
       results:
         - name: artifact-type
@@ -90,6 +96,12 @@ spec:
         echo "Introspection concludes that this artifact is of type \"${_ARTIFACT_TYPE}\"."
 
     - name: set-skip-for-bundles
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/redhat-appstudio/konflux-test:v1.4.8@sha256:2224fabdb0a28a415d4af4c58ae53d7c4c53c83c315f12e07d1d7f48a80bfa70
       results:
       - name: test-output
@@ -121,6 +133,12 @@ spec:
     - name: app-check
       image: quay.io/opdev/preflight:stable@sha256:3f5b988200a3fd490e0a102a4851e0a81f2f41e724e7482a726b79b9d5ccd3b6
       args: ["check", "container", "$(params.image-url)"]
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 4Gi
       env:
         - name: PFLT_DOCKERCONFIG
           value: /root/.docker/config.json
@@ -137,6 +155,12 @@ spec:
         values: ["application"]
 
     - name: app-set-outcome
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
       results:
       - name: test-output
@@ -201,6 +225,12 @@ spec:
         echo -n "${TEST_OUTPUT}" | tee "$(step.results.test-output.path)" /artifacts/konflux.results.json
 
     - name: final-outcome
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
       results:
         - name: test-output

--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -34,7 +34,7 @@ spec:
       value: $(steps.introspect.results.artifact-type-set-by)
   steps:
     - name: introspect
-      computeResources:
+      resources:
         limits:
           memory: 512Mi
         requests:
@@ -96,7 +96,7 @@ spec:
         echo "Introspection concludes that this artifact is of type \"${_ARTIFACT_TYPE}\"."
 
     - name: set-skip-for-bundles
-      computeResources:
+      resources:
         limits:
           memory: 256Mi
         requests:
@@ -133,7 +133,7 @@ spec:
     - name: app-check
       image: quay.io/opdev/preflight:stable@sha256:3f5b988200a3fd490e0a102a4851e0a81f2f41e724e7482a726b79b9d5ccd3b6
       args: ["check", "container", "$(params.image-url)"]
-      computeResources:
+      resources:
         limits:
           memory: 4Gi
         requests:
@@ -155,7 +155,7 @@ spec:
         values: ["application"]
 
     - name: app-set-outcome
-      computeResources:
+      resources:
         limits:
           memory: 256Mi
         requests:
@@ -225,7 +225,7 @@ spec:
         echo -n "${TEST_OUTPUT}" | tee "$(step.results.test-output.path)" /artifacts/konflux.results.json
 
     - name: final-outcome
-      computeResources:
+      resources:
         limits:
           memory: 256Mi
         requests:

--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -137,7 +137,7 @@ spec:
         limits:
           memory: 4Gi
         requests:
-          cpu: 1
+          cpu: '1'
           memory: 4Gi
       env:
         - name: PFLT_DOCKERCONFIG

--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -137,7 +137,7 @@ spec:
         limits:
           memory: 4Gi
         requests:
-          cpu: 100m
+          cpu: 1
           memory: 4Gi
       env:
         - name: PFLT_DOCKERCONFIG


### PR DESCRIPTION
### Description

This PR updates resource limits and requests for the task **ecosystem-cert-preflight-checks** as part of this effort - [KONFLUX-7127](https://issues.redhat.com/browse/KONFLUX-7127). 

The new request/limit values have been defined taking into account usages observed historically (tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?gid=1735880927#gid=1735880927)) in the **stone-prd-rh01** cluster.
