### PR TITLE
Add bootc-rechunk task to build-definitions

### DIFF
--- a/task/bootc-rechunk/0.1/README.md
+++ b/task/bootc-rechunk/0.1/README.md
@@ -1,0 +1,22 @@
+# bootc-rechunk Task
+
+## Overview
+The `bootc-rechunk` task is a Tekton task for running the `rpm-ostree experimental build-chunked-oci` command as a separate step in the pipeline. It generates a chunked OCI image from the root filesystem.
+
+## Parameters
+- **`IMAGE_TAG`** (string) - The tag for the OCI image.
+- **`OUTPUT_PATH`** (string) - The directory to store the output OCI image (default: `/buildcontext`).
+
+## Usage
+Add this task to your Tekton pipeline to run the `bootc-rechunk` step before the final image build.
+
+Example:
+```yaml
+- name: bootc-rechunk
+  taskRef:
+    name: bootc-rechunk
+  params:
+    - name: IMAGE_TAG
+      value: "$(params.IMAGE_TAG)"
+    - name: OUTPUT_PATH
+      value: "/buildcontext"

--- a/task/bootc-rechunk/0.1/bootc-rechunk.yaml
+++ b/task/bootc-rechunk/0.1/bootc-rechunk.yaml
@@ -1,0 +1,26 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: bootc-rechunk
+  namespace: konflux-ci
+spec:
+  params:
+    - name: IMAGE_TAG
+      type: string
+      description: "Tag for the OCI image"
+    - name: OUTPUT_PATH
+      type: string
+      description: "Path to store the chunked OCI image"
+      default: "/buildcontext"
+  steps:
+    - name: rechunk
+      image: quay.io/coreos-assembler/coreos-assembler:latest
+      script: |
+        #!/bin/sh
+        set -eux
+        mkdir -p $(params.OUTPUT_PATH)
+        rpm-ostree experimental compose build-chunked-oci \
+          --bootc \
+          --format-version=1 \
+          --rootfs /target-rootfs \
+          --output oci-dir:$(params.OUTPUT_PATH)/out.ociarchive


### PR DESCRIPTION
Add the `bootc-rechunk` task to `build-definitions` to enable the build pipeline to run the [rechunker](https://coreos.github.io/rpm-ostree/experimental-build-chunked-oci/) as a separate Konflux task.