### PR TITLE
Added source build task parameter

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -275,6 +275,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BASE_IMAGES| By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.| | |
 |BINARY_IMAGE| Binary image name from which to generate the source image name.| None| '$(params.output-image)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
+|IGNORE_UNSIGNED_IMAGE| When set to "true", source build task won't fail when source image is missing signatures (this can be used for development)| false| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 
 ## Results

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -272,6 +272,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BASE_IMAGES| By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.| | |
 |BINARY_IMAGE| Binary image name from which to generate the source image name.| None| '$(params.output-image)'|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| | '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
+|IGNORE_UNSIGNED_IMAGE| When set to "true", source build task won't fail when source image is missing signatures (this can be used for development)| false| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 
 ## Results

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -258,6 +258,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |BASE_IMAGES| By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.| | |
 |BINARY_IMAGE| Binary image name from which to generate the source image name.| None| '$(params.output-image)'|
+|IGNORE_UNSIGNED_IMAGE| When set to "true", source build task won't fail when source image is missing signatures (this can be used for development)| false| |
 ### summary:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/task/source-build-oci-ta/0.2/README.md
+++ b/task/source-build-oci-ta/0.2/README.md
@@ -8,6 +8,7 @@ Source image build.
 |BASE_IMAGES|By default, the task inspects the SBOM of the binary image to find the base image. With this parameter, you can override that behavior and pass the base image directly. The value should be a newline-separated list of images, in the same order as the FROM instructions specified in a multistage Dockerfile.|""|false|
 |BINARY_IMAGE|Binary image name from which to generate the source image name.||true|
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|IGNORE_UNSIGNED_IMAGE|When set to "true", source build task won't fail when source image is missing signatures (this can be used for development)|false|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 
 ## Results

--- a/task/source-build-oci-ta/0.2/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.2/source-build-oci-ta.yaml
@@ -28,6 +28,11 @@ spec:
         the prefetched dependencies.
       type: string
       default: ""
+    - name: IGNORE_UNSIGNED_IMAGE
+      description: When set to "true", source build task won't fail when source
+        image is missing signatures (this can be used for development)
+      type: string
+      default: "false"
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -141,6 +146,8 @@ spec:
           value: $(results.SOURCE_IMAGE_DIGEST.path)
         - name: WS_BUILD_RESULT_FILE
           value: /var/workdir/source_build_result.json
+        - name: IGNORE_UNSIGNED_IMAGE
+          value: $(params.IGNORE_UNSIGNED_IMAGE)
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -159,14 +166,20 @@ spec:
 
         base_images=$(if [[ -f "$BASE_IMAGES_FILE" ]]; then cat "$BASE_IMAGES_FILE"; fi)
 
-        ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
-          --output-binary-image "$BINARY_IMAGE" \
-          --workspace /var/workdir \
-          --source-dir "$SOURCE_DIR" \
-          --base-images "$base_images" \
-          --write-result-to "$RESULT_FILE" \
-          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
+        args=(
+          --output-binary-image "$BINARY_IMAGE"
+          --workspace /var/workdir
+          --source-dir "$SOURCE_DIR"
+          --base-images "$base_images"
+          --write-result-to "$RESULT_FILE"
+          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR"
           --registry-allowlist="$registry_allowlist"
+        )
+        if [ "$IGNORE_UNSIGNED_IMAGE" == "true" ]; then
+          args+=(--ignore-unsigned-image)
+        fi
+
+        ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py "${args[@]}"
 
         cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
         cat "$RESULT_FILE" | jq -j ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"

--- a/task/source-build/0.2/source-build.yaml
+++ b/task/source-build/0.2/source-build.yaml
@@ -22,6 +22,12 @@ spec:
         instructions specified in a multistage Dockerfile.
       type: string
       default: ""
+    - name: IGNORE_UNSIGNED_IMAGE
+      description: When set to "true", source build task won't fail
+        when source image is missing signatures (this can be used for
+        development)
+      type: string
+      default: "false"
   results:
     - name: BUILD_RESULT
       description: Build result.
@@ -142,6 +148,8 @@ spec:
           value: "$(results.SOURCE_IMAGE_DIGEST.path)"
         - name: WS_BUILD_RESULT_FILE
           value: "$(workspaces.workspace.path)/source_build_result.json"
+        - name: IGNORE_UNSIGNED_IMAGE
+          value: $(params.IGNORE_UNSIGNED_IMAGE)
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -160,14 +168,20 @@ spec:
 
         base_images=$(if [[ -f "$BASE_IMAGES_FILE" ]]; then cat "$BASE_IMAGES_FILE"; fi)
 
-        ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py \
-          --output-binary-image "$BINARY_IMAGE" \
-          --workspace /var/source-build \
-          --source-dir "$SOURCE_DIR" \
-          --base-images "$base_images" \
-          --write-result-to "$RESULT_FILE" \
-          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
+        args=(
+          --output-binary-image "$BINARY_IMAGE"
+          --workspace /var/source-build
+          --source-dir "$SOURCE_DIR"
+          --base-images "$base_images"
+          --write-result-to "$RESULT_FILE"
+          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR"
           --registry-allowlist="$registry_allowlist"
+        )
+        if [ "$IGNORE_UNSIGNED_IMAGE" == "true" ]; then
+          args+=(--ignore-unsigned-image)
+        fi
+
+        ${app_dir}/appenv/bin/python3 ${app_dir}/source_build.py "${args[@]}"
 
         cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"
         cat "$RESULT_FILE" | jq -j ".image_digest" >"$RESULT_SOURCE_IMAGE_DIGEST"


### PR DESCRIPTION
Enable users to pass IGNORE_MISSING_SIGNATURES parameter. 
When "true" source_build.py won't fail when source image has missing signatures

This is the implementation of the original [PR](https://github.com/konflux-ci/build-tasks-dockerfiles/pull/240) in build-tasks-dockerfiles and the parameter is passed to the source_build.py

This PR works hand in hand with: https://github.com/konflux-ci/build-tasks-dockerfiles/pull/257
