### PR TITLE
feat(KONFLUX-7127): Setup limits and resource for apply-tags

### DIFF
--- a/task/apply-tags/0.1/apply-tags.yaml
+++ b/task/apply-tags/0.1/apply-tags.yaml
@@ -34,6 +34,12 @@ spec:
         readOnly: true
   steps:
     - name: apply-additional-tags-from-parameter
+      resources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: registry.access.redhat.com/ubi9/skopeo:9.5-1745865345@sha256:d91eb0dac7308ddfb12193368a42009509925edba80da9ffd3b82d03427dc3ed
       args:
         - $(params.ADDITIONAL_TAGS[*])
@@ -54,6 +60,12 @@ spec:
         fi
 
     - name: apply-additional-tags-from-image-label
+      resources:
+        limits:
+        requests:
+          memory: 256Mi
+          cpu: 100m
+          memory: 256Mi
       image: registry.access.redhat.com/ubi9/skopeo:9.5-1745865345@sha256:d91eb0dac7308ddfb12193368a42009509925edba80da9ffd3b82d03427dc3ed
       env:
       - name: IMAGE

--- a/task/apply-tags/0.1/apply-tags.yaml
+++ b/task/apply-tags/0.1/apply-tags.yaml
@@ -62,10 +62,10 @@ spec:
     - name: apply-additional-tags-from-image-label
       resources:
         limits:
+          memory: 256Mi
         requests:
           memory: 256Mi
           cpu: 100m
-          memory: 256Mi
       image: registry.access.redhat.com/ubi9/skopeo:9.5-1745865345@sha256:d91eb0dac7308ddfb12193368a42009509925edba80da9ffd3b82d03427dc3ed
       env:
       - name: IMAGE


### PR DESCRIPTION
### Description

This PR updates resource limits and requests for the task **apply-tags** as part of this effort - [KONFLUX-7127](https://issues.redhat.com/browse/KONFLUX-7127). 

The new request/limit values have been defined taking into account usages observed historically (tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?gid=1735880927#gid=1735880927)) in the **stone-prd-rh01** cluster.
