### PR TITLE
feat: add possibility to skip saving the SL token

### DIFF
--- a/task/sealights-go-oci-ta/0.1/README.md
+++ b/task/sealights-go-oci-ta/0.1/README.md
@@ -26,6 +26,7 @@ The task can be triggered by different events (e.g., Pull Request, Push) and all
 | `pull-request-number` | `string` | `""`          | The Pull Request number.                                                                      |
 | `target-branch`       | `string` | `main`        | The target branch for the Pull Request (e.g., `main`, `develop`).                             |
 | `oci-storage`         | `string` | -             | The OCI repository for storing the trusted artifacts.                                         |
+| `disable-token-save`  | `string` | "false"       | Skip saving the Sealights token to the trusted artifact and container image (it will require providing the token during deployment) |
 
 ## Results
 

--- a/task/sealights-go-oci-ta/0.1/sealights-go-oci-ta.yaml
+++ b/task/sealights-go-oci-ta/0.1/sealights-go-oci-ta.yaml
@@ -73,6 +73,10 @@ spec:
       default: "false"
       description: Enable debug for Sealights scanning.
       type: string
+    - name: disable-token-save
+      default: "false"
+      description: "Skip saving the Sealights token to the trusted artifact and container image (it will require providing the token during deployment)"
+      type: string
   volumes:
     - name: sealights-credentials
       secret:
@@ -120,6 +124,8 @@ spec:
           value: $(params.target-branch)
         - name: DEBUG
           value: $(params.debug)
+        - name: DISABLE_TOKEN_SAVE
+          value: $(params.disable-token-save)
         - name: TEST_EVENT
           valueFrom:
             fieldRef:
@@ -157,7 +163,7 @@ spec:
         fi
 
         slcli scan --packages-excluded "${PACKAGES_EXCLUDED_ENUM}" --bsid buildSessionId.txt --path-to-scanner /usr/local/bin/slgoagent \
-          --workspacepath ./ --scm git --scmProvider "${SCM_PROVIDER}" --scmVersion "0" --scmBaseUrl "${REPOSITORY_URL}" --debug="${DEBUG}"
+          --workspacepath ./ --scm git --scmProvider "${SCM_PROVIDER}" --scmVersion "0" --scmBaseUrl "${REPOSITORY_URL}" --debug="${DEBUG}" --disable-token-save="${DISABLE_TOKEN_SAVE}"
 
         echo -n "$(cat buildSessionId.txt)" > "$(results.sealights-bsid.path)"
         echo -n "$BUILD_NAME" > "$(results.sealights-build-name.path)"


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KFLUXDP-180

### Description
By default we encourage users to use private images for Sealights TA and container images, because it will contain the Sealights token, which we don't want to expose in a public repo.

However Sealights CLI provides an option to disable the saving of the token and the application can be successfully deployed if it will be provided the `SEALIGHTS_TOKEN` environment variable during deployment. We will use this approach for konflux-ci component repositories.