### PR TITLE
Don't skip prefetch by default

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -219,11 +219,6 @@ spec:
     taskRef:
       name: prefetch-dependencies
       version: "0.2"
-    when:
-    - input: $(params.prefetch-input)
-      operator: notin
-      values:
-      - ""
     workspaces:
     - name: source
       workspace: workspace

--- a/pipelines/docker-build-oci-ta/patch.yaml
+++ b/pipelines/docker-build-oci-ta/patch.yaml
@@ -75,8 +75,6 @@
     value: $(params.image-expires-after)
 - op: remove
   path: /spec/tasks/2/workspaces/0
-- op: remove
-  path: /spec/tasks/2/when
 
 # build-container
 - op: replace

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -150,11 +150,6 @@ spec:
     taskRef:
       name: prefetch-dependencies
       version: "0.2"
-    when:
-    - input: $(params.prefetch-input)
-      operator: notin
-      values:
-      - ""
     workspaces:
     - name: source
       workspace: workspace

--- a/pipelines/maven-zip-build-oci-ta/patch.yaml
+++ b/pipelines/maven-zip-build-oci-ta/patch.yaml
@@ -54,8 +54,6 @@
     value: $(params.image-expires-after)
 - op: remove
   path: /spec/tasks/2/workspaces/0
-- op: remove
-  path: /spec/tasks/2/when
 
 # build-oci-artifact
 - op: replace

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -115,11 +115,6 @@ spec:
     taskRef:
       name: prefetch-dependencies
       version: "0.2"
-    when:
-    - input: $(params.prefetch-input)
-      operator: notin
-      values:
-      - ""
     workspaces:
     - name: source
       workspace: workspace

--- a/pipelines/tekton-bundle-builder-oci-ta/patch.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/patch.yaml
@@ -43,8 +43,6 @@
     value: $(params.image-expires-after)
 - op: remove
   path: /spec/tasks/2/workspaces/0
-- op: remove
-  path: /spec/tasks/2/when
 
 # build-container
 - op: replace

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -125,11 +125,6 @@ spec:
     taskRef:
       name: prefetch-dependencies
       version: "0.2"
-    when:
-    - input: $(params.prefetch-input)
-      operator: notin
-      values:
-      - ""
     workspaces:
     - name: source
       workspace: workspace

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -90,10 +90,6 @@ spec:
         - name: basic-auth
           workspace: git-auth
     - name: prefetch-dependencies
-      when:
-      - input: $(params.prefetch-input)
-        operator: notin
-        values: [""]
       params:
         - name: input
           value: $(params.prefetch-input)

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -295,7 +295,7 @@ spec:
         }
 
         if [ -z "${INPUT}" ]; then
-          # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
+          # Confirm input was provided
           echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
           exit 0
         fi

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -226,7 +226,7 @@ spec:
       }
 
       if [ -z "${INPUT}" ]; then
-        # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
+        # Confirm input was provided
         echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
         exit 0
       fi


### PR DESCRIPTION
I think it may be confusing users that if they pass `""` then the task is skipped (which may cause conforma to fail with "no skipped tasks"), even when they have no _real_ content that they want to prefetch, say for a data container like a bundle or something that just contains basic shell scripts.

With this, the prefetch task will run, but with the input of `""`, it will exit early with exit code 0.

Related: https://github.com/release-engineering/rhtap-ec-policy/pull/128
