### PR TITLE
feat(STONEINTG-1069): add additional task version change guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,18 @@ The StepActions can be found in the `stepactions` directory. StepActions are not
 
 ### Versioning
 
-When a task update changes the interface (e.g., change of parameters, workspaces or results names), a new version of the task should be created. The folder with the new version must contain `MIGRATION.md` with instructions on how to update the current pipeline file in user's `.tekton` folder.
+When a task update changes the interface (e.g., change of parameters, workspaces or results names), a new version of the task should be created.
+We restructure the task definitions so that each version is maintained in its own directory. Instead of a single flat task file, the task is now versioned by placing its YAML into a version-specific folder.
+Within the newly versioned YAMLs a label should be added to the tasks metadata for identifying the specific version of the task.
+The folder with the new version must contain `MIGRATION.md` with instructions on how to update the current pipeline file in user's `.tekton` folder.
+Since tasks are now organized by version, any pipelines that reference these tasks must be updated to point to the newly versioned path.
+
+If the task update affects the results which are checked by [e2e tests](https://github.com/konflux-ci/e2e-tests/tree/main), 
+then the corresponding e2e test code needs to be updated as well.
+The main place to check for task results which are being checked by e2e is the 
+[task_results.go](https://github.com/konflux-ci/e2e-tests/blob/main/pkg/utils/build/task_results.go), 
+though it's good practice to check all tests in that repository.
+In case the PRs handling this change get blocked by each other, consult [the guide for PR pairing](https://github.com/konflux-ci/e2e-tests/blob/main/docs/Installation.md#konflux-in-openshift-ci-and-branch-pairing) in e2e tests.
 
 Adding a new parameter with a default value does not require a task version increase.
 


### PR DESCRIPTION
Add some additional information about specific changes needed to update a build-definition task along with
possible e2e test changes.

A follow on to #1978 

Signed-off-by: dirgim <kpavic@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
