### PR TITLE
feat(KONFLUX-7125): Change buildah task to use overlay2 storage driver

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -73,7 +73,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
@@ -217,7 +217,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -70,7 +70,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
@@ -214,7 +214,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -68,7 +68,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
@@ -207,7 +207,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -72,7 +72,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -109,7 +109,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -104,7 +104,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |

--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -295,12 +295,16 @@ echo "Build on remote host $SSH_HOST finished"
 
 echo "[$(date --utc -Ins)] Final touches"
 
-buildah images
+buildah images`
+		if taskVersion == "0.1" || taskVersion == "0.2" || taskVersion == "0.3" {
+			ret += `
 container=$(buildah from --pull-never "$IMAGE")
 buildah mount "$container" | tee /shared/container_path
 # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
 find $(cat /shared/container_path) -xtype l -delete
-echo $container > /shared/container_name
+echo $container > /shared/container_name`
+		}
+		ret += `
 echo "[$(date --utc -Ins)] End remote"`
 
 		for _, i := range strings.Split(ret, "\n") {

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -105,7 +105,7 @@ spec:
       as per --squash
     name: SQUASH
     type: string
-  - default: vfs
+  - default: overlay
     description: Storage driver to configure for buildah
     name: STORAGE_DRIVER
     type: string
@@ -368,7 +368,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -538,22 +538,15 @@ spec:
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
-      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
       echo "[$(date --utc -Ins)] Add metadata"
-
-      container=$(buildah from --pull-never "$IMAGE")
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
-
-      buildah mount "$container" | tee /shared/container_path
-      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-      find $(cat /shared/container_path) -xtype l -delete
-      echo $container > /shared/container_name
 
       touch /shared/base_images_digests
       echo "Recording base image digests used"
@@ -565,6 +558,10 @@ spec:
           echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
+
+      image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+      echo "/shared/$image_name.tar" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
     securityContext:
@@ -687,8 +684,8 @@ spec:
 
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-source.json"
-      echo "Running syft on the image filesystem"
-      syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
+      echo "Running syft on the image"
+      syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:
@@ -696,6 +693,10 @@ spec:
       name: varlibcontainers
     - mountPath: /shared
       name: shared
+    - mountPath: /etc/pki/tls/certs/ca-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
     workingDir: $(workspaces.source.path)/source
   - args:
     - --additional-base-images

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -32,7 +32,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
-|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -134,7 +134,7 @@ spec:
     - name: STORAGE_DRIVER
       description: Storage driver to configure for buildah
       type: string
-      default: vfs
+      default: overlay
     - name: TARGET_STAGE
       description: Target stage in Dockerfile to build. If not specified,
         the Dockerfile is processed entirely to (and including) its last stage.
@@ -436,7 +436,7 @@ spec:
           UNSHARE_ARGS+=("--net")
 
           for image in $BASE_IMAGES; do
-            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
           done
           echo "Build will be executed with network isolation"
         fi
@@ -606,22 +606,15 @@ spec:
         echo "[$(date --utc -Ins)] Run buildah build"
         echo "[$(date --utc -Ins)] ${command}"
 
-        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
         echo "[$(date --utc -Ins)] Add metadata"
-
-        container=$(buildah from --pull-never "$IMAGE")
 
         # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
         if [ -f "/tmp/cachi2/output/bom.json" ]; then
           echo "Making copy of sbom-cachi2.json"
           cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
         fi
-
-        buildah mount "$container" | tee /shared/container_path
-        # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-        find $(cat /shared/container_path) -xtype l -delete
-        echo $container >/shared/container_name
 
         touch /shared/base_images_digests
         echo "Recording base image digests used"
@@ -633,6 +626,10 @@ spec:
             echo "$image $base_image_digest" | tee -a /shared/base_images_digests
           fi
         done
+
+        image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+        buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+        echo "/shared/$image_name.tar" >/shared/container_path
 
         echo "[$(date --utc -Ins)] End build"
       computeResources:
@@ -731,6 +728,10 @@ spec:
           name: varlibcontainers
         - mountPath: /shared
           name: shared
+        - mountPath: /etc/pki/tls/certs/ca-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
       script: |
         echo "[$(date --utc -Ins)] Generate SBOM"
 
@@ -754,8 +755,8 @@ spec:
 
         echo "Running syft on the source directory"
         syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="/var/workdir/sbom-source.json"
-        echo "Running syft on the image filesystem"
-        syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
+        echo "Running syft on the image"
+        syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
 
         echo "[$(date --utc -Ins)] End sbom-syft-generate"
     - name: prepare-sboms

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -129,7 +129,7 @@ spec:
       as per --squash
     name: SQUASH
     type: string
-  - default: vfs
+  - default: overlay
     description: Storage driver to configure for buildah
     name: STORAGE_DRIVER
     type: string
@@ -475,7 +475,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -645,22 +645,15 @@ spec:
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
-      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
       echo "[$(date --utc -Ins)] Add metadata"
-
-      container=$(buildah from --pull-never "$IMAGE")
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
-
-      buildah mount "$container" | tee /shared/container_path
-      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-      find $(cat /shared/container_path) -xtype l -delete
-      echo $container >/shared/container_name
 
       touch /shared/base_images_digests
       echo "Recording base image digests used"
@@ -672,6 +665,10 @@ spec:
           echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
+
+      image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+      echo "/shared/$image_name.tar" >/shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
 
@@ -750,11 +747,6 @@ spec:
       echo "[$(date --utc -Ins)] Final touches"
 
       buildah images
-      container=$(buildah from --pull-never "$IMAGE")
-      buildah mount "$container" | tee /shared/container_path
-      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-      find $(cat /shared/container_path) -xtype l -delete
-      echo $container > /shared/container_name
       echo "[$(date --utc -Ins)] End remote"
     securityContext:
       capabilities:
@@ -891,8 +883,8 @@ spec:
 
       echo "Running syft on the source directory"
       syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="/var/workdir/sbom-source.json"
-      echo "Running syft on the image filesystem"
-      syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
+      echo "Running syft on the image"
+      syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:
@@ -900,6 +892,10 @@ spec:
       name: varlibcontainers
     - mountPath: /shared
       name: shared
+    - mountPath: /etc/pki/tls/certs/ca-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
     workingDir: /var/workdir/source
   - args:
     - --additional-base-images

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -105,7 +105,7 @@ spec:
       as per --squash
     name: SQUASH
     type: string
-  - default: vfs
+  - default: overlay
     description: Storage driver to configure for buildah
     name: STORAGE_DRIVER
     type: string
@@ -443,7 +443,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -613,22 +613,15 @@ spec:
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
-      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
       echo "[$(date --utc -Ins)] Add metadata"
-
-      container=$(buildah from --pull-never "$IMAGE")
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
-
-      buildah mount "$container" | tee /shared/container_path
-      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-      find $(cat /shared/container_path) -xtype l -delete
-      echo $container > /shared/container_name
 
       touch /shared/base_images_digests
       echo "Recording base image digests used"
@@ -640,6 +633,10 @@ spec:
           echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
+
+      image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+      echo "/shared/$image_name.tar" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
 
@@ -718,11 +715,6 @@ spec:
       echo "[$(date --utc -Ins)] Final touches"
 
       buildah images
-      container=$(buildah from --pull-never "$IMAGE")
-      buildah mount "$container" | tee /shared/container_path
-      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-      find $(cat /shared/container_path) -xtype l -delete
-      echo $container > /shared/container_name
       echo "[$(date --utc -Ins)] End remote"
     securityContext:
       capabilities:
@@ -859,8 +851,8 @@ spec:
 
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-source.json"
-      echo "Running syft on the image filesystem"
-      syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
+      echo "Running syft on the image"
+      syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:
@@ -868,6 +860,10 @@ spec:
       name: varlibcontainers
     - mountPath: /shared
       name: shared
+    - mountPath: /etc/pki/tls/certs/ca-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
     workingDir: $(workspaces.source.path)/source
   - args:
     - --additional-base-images

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -97,7 +97,7 @@ spec:
   - name: STORAGE_DRIVER
     description: Storage driver to configure for buildah
     type: string
-    default: vfs
+    default: overlay
   - name: SKIP_UNUSED_STAGES
     description: Whether to skip stages in Containerfile that seem unused by subsequent stages
     type: string
@@ -354,7 +354,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -524,22 +524,15 @@ spec:
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
-      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
       echo "[$(date --utc -Ins)] Add metadata"
-
-      container=$(buildah from --pull-never "$IMAGE")
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
-
-      buildah mount "$container" | tee /shared/container_path
-      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-      find $(cat /shared/container_path) -xtype l -delete
-      echo $container > /shared/container_name
 
       touch /shared/base_images_digests
       echo "Recording base image digests used"
@@ -551,6 +544,10 @@ spec:
           echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
+
+      image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+      echo "/shared/$image_name.tar" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
 
@@ -679,8 +676,8 @@ spec:
 
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-source.json"
-      echo "Running syft on the image filesystem"
-      syft dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
+      echo "Running syft on the image"
+      syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:
@@ -688,6 +685,10 @@ spec:
       name: varlibcontainers
     - mountPath: /shared
       name: shared
+    - mountPath: /etc/pki/tls/certs/ca-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
 
   - name: prepare-sboms
     image: quay.io/konflux-ci/sbom-utility-scripts@sha256:5e0c5996f77b877c4d6027b64bb0217f85716408a59821c3e48ba49e2556440d

--- a/task/sast-coverity-check-oci-ta/0.2/README.md
+++ b/task/sast-coverity-check-oci-ta/0.2/README.md
@@ -36,7 +36,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
-|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -160,7 +160,7 @@ spec:
     - name: STORAGE_DRIVER
       description: Storage driver to configure for buildah
       type: string
-      default: vfs
+      default: overlay
     - name: TARGET_STAGE
       description: Target stage in Dockerfile to build. If not specified,
         the Dockerfile is processed entirely to (and including) its last stage.
@@ -596,7 +596,7 @@ spec:
           UNSHARE_ARGS+=("--net")
 
           for image in $BASE_IMAGES; do
-            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
           done
           echo "Build will be executed with network isolation"
         fi
@@ -766,22 +766,15 @@ spec:
         echo "[$(date --utc -Ins)] Run buildah build"
         echo "[$(date --utc -Ins)] ${command}"
 
-        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
         echo "[$(date --utc -Ins)] Add metadata"
-
-        container=$(buildah from --pull-never "$IMAGE")
 
         # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
         if [ -f "/tmp/cachi2/output/bom.json" ]; then
           echo "Making copy of sbom-cachi2.json"
           cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
         fi
-
-        buildah mount "$container" | tee /shared/container_path
-        # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-        find $(cat /shared/container_path) -xtype l -delete
-        echo $container >/shared/container_name
 
         touch /shared/base_images_digests
         echo "Recording base image digests used"
@@ -793,6 +786,10 @@ spec:
             echo "$image $base_image_digest" | tee -a /shared/base_images_digests
           fi
         done
+
+        image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+        buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+        echo "/shared/$image_name.tar" >/shared/container_path
 
         echo "[$(date --utc -Ins)] End build"
       computeResources:

--- a/task/sast-coverity-check-oci-ta/0.3/README.md
+++ b/task/sast-coverity-check-oci-ta/0.3/README.md
@@ -36,7 +36,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
-|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -160,7 +160,7 @@ spec:
     - name: STORAGE_DRIVER
       description: Storage driver to configure for buildah
       type: string
-      default: vfs
+      default: overlay
     - name: TARGET_STAGE
       description: Target stage in Dockerfile to build. If not specified,
         the Dockerfile is processed entirely to (and including) its last stage.
@@ -601,7 +601,7 @@ spec:
           UNSHARE_ARGS+=("--net")
 
           for image in $BASE_IMAGES; do
-            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+            unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
           done
           echo "Build will be executed with network isolation"
         fi
@@ -771,22 +771,15 @@ spec:
         echo "[$(date --utc -Ins)] Run buildah build"
         echo "[$(date --utc -Ins)] ${command}"
 
-        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+        unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
         echo "[$(date --utc -Ins)] Add metadata"
-
-        container=$(buildah from --pull-never "$IMAGE")
 
         # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
         if [ -f "/tmp/cachi2/output/bom.json" ]; then
           echo "Making copy of sbom-cachi2.json"
           cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
         fi
-
-        buildah mount "$container" | tee /shared/container_path
-        # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-        find $(cat /shared/container_path) -xtype l -delete
-        echo $container >/shared/container_name
 
         touch /shared/base_images_digests
         echo "Recording base image digests used"
@@ -798,6 +791,10 @@ spec:
             echo "$image $base_image_digest" | tee -a /shared/base_images_digests
           fi
         done
+
+        image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+        buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+        echo "/shared/$image_name.tar" >/shared/container_path
 
         echo "[$(date --utc -Ins)] End build"
       computeResources:

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -104,7 +104,7 @@ spec:
       as per --squash
     name: SQUASH
     type: string
-  - default: vfs
+  - default: overlay
     description: Storage driver to configure for buildah
     name: STORAGE_DRIVER
     type: string
@@ -524,7 +524,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -694,22 +694,15 @@ spec:
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
-      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
       echo "[$(date --utc -Ins)] Add metadata"
-
-      container=$(buildah from --pull-never "$IMAGE")
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
-
-      buildah mount "$container" | tee /shared/container_path
-      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-      find $(cat /shared/container_path) -xtype l -delete
-      echo $container > /shared/container_name
 
       touch /shared/base_images_digests
       echo "Recording base image digests used"
@@ -721,6 +714,10 @@ spec:
           echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
+
+      image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+      echo "/shared/$image_name.tar" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
     securityContext:

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -104,7 +104,7 @@ spec:
       as per --squash
     name: SQUASH
     type: string
-  - default: vfs
+  - default: overlay
     description: Storage driver to configure for buildah
     name: STORAGE_DRIVER
     type: string
@@ -528,7 +528,7 @@ spec:
         UNSHARE_ARGS+=("--net")
 
         for image in $BASE_IMAGES; do
-          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -- buildah pull "$image"
+          unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull "$image"
         done
         echo "Build will be executed with network isolation"
       fi
@@ -698,22 +698,15 @@ spec:
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
-      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
+      unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
 
       echo "[$(date --utc -Ins)] Add metadata"
-
-      container=$(buildah from --pull-never "$IMAGE")
 
       # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
         echo "Making copy of sbom-cachi2.json"
         cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
-
-      buildah mount "$container" | tee /shared/container_path
-      # delete symlinks - they may point outside the container rootfs, messing with SBOM scanners
-      find $(cat /shared/container_path) -xtype l -delete
-      echo $container > /shared/container_name
 
       touch /shared/base_images_digests
       echo "Recording base image digests used"
@@ -725,6 +718,10 @@ spec:
           echo "$image $base_image_digest" | tee -a /shared/base_images_digests
         fi
       done
+
+      image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
+      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
+      echo "/shared/$image_name.tar" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
     securityContext:


### PR DESCRIPTION
It aims to make it able to build image with overlay2 storage driver.

As of right now, buildah-remote-oci-it can only build images using the VFS storage driver. We'd like it's able to support overlay2 as well, because overlay2 performs better than VFS in performance. We did a performance test to compare both (see https://issues.redhat.com/browse/KONFLUX-6577).

Arches | Duration - vfs | Duration overlay2 | % Change
-- | -- | -- | --
linux/amd64 | 0:00:34 | 0:00:20 | -41.52%
linux/arm64 | 0:01:57 | 0:01:12 | -38.30%
linux/ppc64le | 0:09:05 | 0:05:59 | -34.18%

Above result shows, compared to vfs storage drivers, duration of building image with overlay2 is reduced by around 30% to 40%.

**Note that the PR is not completed yet**.  It requires "buildah-task" modification [1], which makes buildah run with overlay2 storage by default, and "rh-syft" change[2], which can execute "buildah mount $container" to feed data for syft. 

After the two dependencies complete, the buildah-task image used by "build" step will be updated with the new image generated by "buildah-task" modification [1], and the "syft-rhel9" image used by "sbom-syft-generate" step will be replaced by the new image generated by "rh-syft" change[2] as well.

[1] https://github.com/konflux-ci/buildah-container/pull/116.
[2] https://github.com/redhat-appstudio/rh-syft/pull/124.

