### PR TITLE
chore: pin tj-actions/changed-files to sha

### DIFF
--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Get all changed files in the PR from task directory
         id: changed-dirs
-        uses: tj-actions/changed-files@v45
+        uses: tj-actions/changed-files@531f5f7d163941f0c1c04e0ff4d8bb243ac4366f
         with:
           files: |
             # Any task yaml or script (including its tests) is changed


### PR DESCRIPTION
Using tag has potential downside when the github action experience major vulnerability like [this one](https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised), instead  using sha to pin the github action could help here, currently renovate update sha weekly, by the time we will get the update and merge it, there is a chance that vulnerability might be published and resolved
