### PR TITLE
fix: update konflux-tooling image in patch.yaml

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -239,12 +239,12 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^task/.*/recipe\\.yaml$"
+        "^task/.*/recipe\\.yaml$",
+        "^task/.+/patch\\.yaml$"
       ],
       "matchStrings": [
-        "image: (?:['\"])?(?<depName>.*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})(?:['\"])?"
+        "(?:image: |tooling-image=)(?:['\"])?(?<depName>[0-9a-z.\/-]+)(?::(?<currentValue>[0-9a-z.-]+))?@(?<currentDigest>sha256:[a-f0-9]{64})(?:['\"])?"
       ],
-      "autoReplaceStringTemplate": "image: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
       "datasourceTemplate": "docker"
     },
     {


### PR DESCRIPTION
[STONEBLD-3351](https://issues.redhat.com//browse/STONEBLD-3351)

The customeManager for recipe.yaml is extended to work for patch.yaml files under task/ directory.

The regex is rewritten since the original for reciple.yaml does not work for images which do not include tag. For example, for given image app@sha256:1234, the matched depName is app@sha256.
