### PR TITLE
Add support for self-signed OCI registries to clamav-scan task

### DIFF
--- a/task/clamav-scan/0.2/clamav-scan.yaml
+++ b/task/clamav-scan/0.2/clamav-scan.yaml
@@ -177,14 +177,18 @@ spec:
       workingDir: /work
       script: |
         #!/usr/bin/env bash
+        set -e
+
+        # Don't return a glob expression when no matches are found
+        shopt -s nullglob
 
         cd logs
 
-        for UPLOAD_FILE in $(find . -name "clamscan-result*.log"); do
+        for UPLOAD_FILE in clamscan-result*.log; do
           MEDIA_TYPE=text/vnd.clamav
           args+=("${UPLOAD_FILE}:${MEDIA_TYPE}")
         done
-        for UPLOAD_FILE in $(find . -name "clamscan-ec-test*.json"); do
+        for UPLOAD_FILE in clamscan-ec-test*.json; do
           MEDIA_TYPE=application/vnd.konflux.test_output+json
           args+=("${UPLOAD_FILE}:${MEDIA_TYPE}")
         done
@@ -201,6 +205,10 @@ spec:
       volumeMounts:
         - mountPath: /work
           name: work
+        - name: trusted-ca
+          mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
   volumes:
     - name: dbfolder
       emptyDir: {}


### PR DESCRIPTION
The upload step required a fix to test this. It was silently failing to find any logs because the `find` command isn't present in the oras image.
