### PR TITLE
feat(KONFLUX-7127): Update limits/resources for task build-image-index

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -82,9 +82,9 @@ spec:
     name: build
     computeResources:
       limits:
-        memory: 4Gi
+        memory: 1Gi
       requests:
-        memory: 512Mi
+        memory: 1Gi
         cpu: 250m
     args: ["$(params.IMAGES[*])"]
     script: |
@@ -179,7 +179,7 @@ spec:
     name: create-sbom
     computeResources:
       limits:
-        memory: 512Mi
+        memory: 256Mi
       requests:
         memory: 256Mi
         cpu: 100m
@@ -223,7 +223,7 @@ spec:
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
     computeResources:
       limits:
-        memory: 512Mi
+        memory: 256Mi
       requests:
         memory: 256Mi
         cpu: 100m

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -85,10 +85,10 @@ spec:
     - $(params.IMAGES[*])
     computeResources:
       limits:
-        memory: 4Gi
+        memory: 1Gi
       requests:
         cpu: 250m
-        memory: 512Mi
+        memory: 1Gi
     image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     name: build
     script: |
@@ -180,7 +180,7 @@ spec:
         - SETFCAP
   - computeResources:
       limits:
-        memory: 512Mi
+        memory: 256Mi
       requests:
         cpu: 100m
         memory: 256Mi
@@ -206,7 +206,7 @@ spec:
         --output-path /index-build-data/sbom-results.json
   - computeResources:
       limits:
-        memory: 512Mi
+        memory: 256Mi
       requests:
         cpu: 100m
         memory: 256Mi


### PR DESCRIPTION
This PR updates resource limits and requests for the task build-image-index as part of this effort - [KONFLUX-7127](https://issues.redhat.com/browse/KONFLUX-7127).

The new request/limit values have been defined taking into account usages observed historically (tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?gid=1735880927#gid=1735880927)) in the stone-prd-rh01 cluster.