### PR TITLE
fix(KONFLUX-7346): buildah: check if cachi2.repo file exists

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -379,7 +379,9 @@ spec:
         if [ -f "$prefetched_repo_for_my_arch" ]; then
           echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
           mkdir -p "$YUM_REPOS_D_FETCHED"
-          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+            cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          fi
         fi
       fi
 

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -447,7 +447,9 @@ spec:
           if [ -f "$prefetched_repo_for_my_arch" ]; then
             echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
             mkdir -p "$YUM_REPOS_D_FETCHED"
-            cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+            if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+              cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+            fi
           fi
         fi
 

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -479,7 +479,9 @@ spec:
         if [ -f "$prefetched_repo_for_my_arch" ]; then
           echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
           mkdir -p "$YUM_REPOS_D_FETCHED"
-          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+            cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          fi
         fi
       fi
 

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -447,7 +447,9 @@ spec:
         if [ -f "$prefetched_repo_for_my_arch" ]; then
           echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
           mkdir -p "$YUM_REPOS_D_FETCHED"
-          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+            cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          fi
         fi
       fi
 

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -367,7 +367,9 @@ spec:
         if [ -f "$prefetched_repo_for_my_arch" ]; then
           echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
           mkdir -p "$YUM_REPOS_D_FETCHED"
-          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+            cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          fi
         fi
       fi
 

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -599,7 +599,9 @@ spec:
           if [ -f "$prefetched_repo_for_my_arch" ]; then
             echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
             mkdir -p "$YUM_REPOS_D_FETCHED"
-            cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+            if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+              cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+            fi
           fi
         fi
 

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -527,7 +527,9 @@ spec:
         if [ -f "$prefetched_repo_for_my_arch" ]; then
           echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
           mkdir -p "$YUM_REPOS_D_FETCHED"
-          cp --no-clobber "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          if [ ! -f "${YUM_REPOS_D_FETCHED}/cachi2.repo" ]; then
+            cp "$prefetched_repo_for_my_arch" "$YUM_REPOS_D_FETCHED"
+          fi
         fi
       fi
 


### PR DESCRIPTION
This fixes a bug in the coverity-check task. When builds are run with prefetched rpms, the cachi2.repo file is first copied by the original buildah task. Later when coverity-check repeats the build, the cachi2.repo file is already there, so `cp --no-clobber` exits with an error.

Fix tested here: https://github.com/openshift-kni/dpdk-base/pull/17
