### PR TITLE
feat(KONFLUX-7127): Set limits/resources for task init

### DIFF
--- a/task/init/0.1/init.yaml
+++ b/task/init/0.1/init.yaml
@@ -39,6 +39,12 @@ spec:
       image: registry.redhat.io/openshift4/ose-cli:4.13@sha256:73df37794ffff7de1101016c23dc623e4990810390ebdabcbbfa065214352c7c
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
       env:
         - name: IMAGE_URL
           value: $(params.image-url)

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -26,6 +26,12 @@ spec:
   steps:
     - name: init
       image: registry.access.redhat.com/ubi9/skopeo:9.5-1744118252@sha256:e68e3e3cb40e03d9df197b6c496e75847c40b7e76c1a2a376cc179b4d5f5907d
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
       env:
         - name: IMAGE_URL
           value: $(params.image-url)

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:


### PR DESCRIPTION
This PR updates resource limits and requests for the task init as part of this effort - [KONFLUX-7127](https://issues.redhat.com/browse/KONFLUX-7127).

The new request/limit values have been defined taking into account usages observed historically (tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?gid=1735880927#gid=1735880927)) in the stone-prd-rh01 cluster.