### PR TITLE
Retry push for appstudio-utils image

### DIFF
--- a/hack/build-and-push.sh
+++ b/hack/build-and-push.sh
@@ -196,14 +196,14 @@ rm -f "${OUTPUT_TASK_BUNDLE_LIST}" "${OUTPUT_PIPELINE_BUNDLE_LIST}"
 if [ "$SKIP_BUILD" == "" ]; then
     echo "Using $QUAY_NAMESPACE to push results "
     docker build -t "$APPSTUDIO_UTILS_IMG" "appstudio-utils/"
-    docker push "$APPSTUDIO_UTILS_IMG"
+    retry docker push "$APPSTUDIO_UTILS_IMG"
 
     # This isn't needed during PR testing
     if [[ "$BUILD_TAG" != "latest" && -z "$TEST_REPO_NAME" ]]; then
         # tag with latest
         IMAGE_NAME="${APPSTUDIO_UTILS_IMG%:*}:latest"
         docker tag "$APPSTUDIO_UTILS_IMG" "$IMAGE_NAME"
-        docker push "$IMAGE_NAME"
+        retry docker push "$IMAGE_NAME"
     fi
 
 fi


### PR DESCRIPTION
The push failed due to Bad Gateway:

```
Copying blob sha256:6f0a4413f0e0eac0199d0ccade8d781a577fb7d6c43619a9b21a0549c3809374
error pushing image "quay.io/konflux-ci/pull-request-builds:appstudio-utils-b4525f6fcf9bfdf026717af3f868bcc83a0462db" to "docker://quay.io/konflux-ci/pull-request-builds:appstudio-utils-b4525f6fcf9bfdf026717af3f868bcc83a0462db": writing blob: initiating layer upload to /v2/konflux-ci/pull-request-builds/blobs/uploads/ in quay.io: received unexpected HTTP status: 502 Bad Gateway
time="2025-03-21T08:36:37Z" level=error msg="exit status 125"
```

Re-ran passed.