### PR TITLE
Force fetching git tags on some projects with go submodule

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -372,6 +372,13 @@ spec:
 
         INPUT=$(inject_rpm_summary_flag "$INPUT")
 
+        # Some repos with go submodules would fail during prefetch dependencies task
+        # Forcing fetching tags serves as a workaround
+        if [[ "$(cd "/var/workdir/source" && ! git fetch --tags)" ]]; then
+          echo "Retrying fetch command..."
+          "$(cd "/var/workdir/source" && git fetch --tags)"
+        fi
+
         cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
           $dev_pacman_flag \
           --source=/var/workdir/source \

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -302,6 +302,13 @@ spec:
 
       INPUT=$(inject_rpm_summary_flag "$INPUT")
 
+      # Some repos with go submodules would fail during prefetch dependencies task
+      # Forcing fetching tags serves as a workaround
+      if [[ "$(cd "$(workspaces.source.path)/source" && ! git fetch --tags)" ]]; then
+        echo "Retrying fetch command..."
+        "$(cd "$(workspaces.source.path)/source" && git fetch --tags)"
+      fi
+
       cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
       $dev_pacman_flag \
       --source=$(workspaces.source.path)/source \


### PR DESCRIPTION
Some repos with go submodules would fail during prefetch dependencies task. 
Cachi2 would fail and this serves as a workaround, since we didn't find the root cause.
