### PR TITLE
fix(KFLUXSPRT-2387) Fix mirrors array population in FIPS tasks

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -62,8 +62,9 @@ spec:
         if [ -n "${image_mirror_map}" ]; then
           reg_and_repo=$(get_image_registry_and_repository "${related_image}")
           echo "Mirror Map is $image_mirror_map"
-          mirrors=$(echo "$image_mirror_map" | jq -r --arg image "$reg_and_repo" '.[$image][]')
-          echo "Mirrors for $reg_and_repo are $mirrors"
+          mapfile -t mirrors < <(echo "${image_mirror_map}" | jq -r --arg image "${reg_and_repo}" '.[$image][]')
+          echo "Mirrors for $reg_and_repo are:"
+          printf "%s\n" "${mirrors[@]}"
 
           for mirror in "${mirrors[@]}"; do
             echo "Attempting to use mirror ${mirror}"

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -110,8 +110,9 @@ spec:
               if [ -n "${image_mirror_map}" ]; then
                 reg_and_repo=$(get_image_registry_and_repository "${bundle}")
                 echo "Mirror Map is $image_mirror_map"
-                mirrors=$(echo "$image_mirror_map" | jq -r --arg image "$reg_and_repo" '.[$image][]')
-                echo "Mirrors for $reg_and_repo are $mirrors"
+                mapfile -t mirrors < <(echo "${image_mirror_map}" | jq -r --arg image "${reg_and_repo}" '.[$image][]')
+                echo "Mirrors for $reg_and_repo are:"
+                printf "%s\n" "${mirrors[@]}"
 
                 for mirror in "${mirrors[@]}"; do
                   echo "Attempting to use mirror ${mirror}"

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -107,8 +107,9 @@ spec:
               if [ -n "${image_mirror_map}" ]; then
                 reg_and_repo=$(get_image_registry_and_repository "${bundle}")
                 echo "Mirror Map is $image_mirror_map"
-                mirrors=$(echo "$image_mirror_map" | jq -r --arg image "$reg_and_repo" '.[$image][]')
-                echo "Mirrors for $reg_and_repo are $mirrors"
+                mapfile -t mirrors < <(echo "${image_mirror_map}" | jq -r --arg image "${reg_and_repo}" '.[$image][]')
+                echo "Mirrors for $reg_and_repo are:"
+                printf "%s\n" "${mirrors[@]}"
 
                 for mirror in "${mirrors[@]}"; do
                   echo "Attempting to use mirror ${mirror}"


### PR DESCRIPTION
In FIPS tasks, fixed the way lists of IDMS mirrors are populated into bash arrays.