### PR TITLE
Several fixes & improvements for hack/trusted-tasks-update

### DIFF
--- a/hack/trusted-tasks-update.sh
+++ b/hack/trusted-tasks-update.sh
@@ -101,4 +101,5 @@ ec track bundle \
   --input "oci:${INPUT_IMAGE}" \
   --output "oci:${OUTPUT_IMAGE}" \
   "${git_params[@]}" \
-  "${oci_params[@]}"
+  "${oci_params[@]}" \
+  --timeout 0

--- a/hack/trusted-tasks-update.sh
+++ b/hack/trusted-tasks-update.sh
@@ -25,7 +25,7 @@ set -o pipefail
 
 mapfile -td ' ' COLLECT < <(echo -n "${COLLECT:-git oci}")
 mapfile -td ' ' QUAY_NAMESPACES < <(
-    echo -n "${QUAY_NAMESPACES:-'redhat-appstudio-tekton-catalog konflux-ci/tekton-catalog'}"
+    echo -n "${QUAY_NAMESPACES:-"redhat-appstudio-tekton-catalog konflux-ci/tekton-catalog"}"
 )
 
 INPUT_IMAGE=${INPUT_IMAGE:-quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest}


### PR DESCRIPTION
* Fix a bug related to default env var quoting
* Remove possibility of ec track bundle timing out
* Support specifying just the task that needs to update, since updating them all takes a really long time.

All these changes were either necessary or useful for [EC-1199](https://issues.redhat.com/browse/EC-1199) where I needed to get one missing task added to the acceptable bundles data.