### PR TITLE
Add missing task version labels

### DIFF
--- a/task/acs-deploy-check/0.1/acs-deploy-check.yaml
+++ b/task/acs-deploy-check/0.1/acs-deploy-check.yaml
@@ -7,6 +7,8 @@ metadata:
     task.results.type: roxctl-deployment-check
     task.results.container: step-report
     task.output.location: logs
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: >-
     Policy check a deployment with StackRox/RHACS This tasks allows you to check

--- a/task/acs-image-check/0.1/acs-image-check.yaml
+++ b/task/acs-image-check/0.1/acs-image-check.yaml
@@ -7,6 +7,8 @@ metadata:
     task.results.type: roxctl-image-check
     task.results.container: step-report
     task.output.location: logs
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Policy check an image with StackRox/RHACS This tasks allows you to
     check an image against build-time policies and apply enforcement to fail builds.

--- a/task/acs-image-scan/0.1/acs-image-scan.yaml
+++ b/task/acs-image-scan/0.1/acs-image-scan.yaml
@@ -8,6 +8,8 @@ metadata:
     task.results.key: SCAN_OUTPUT
     task.results.container: step-report
     task.output.location: logs
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Policy check an image with StackRox/RHACS This tasks allows you to
     check an image against build-time policies and apply enforcement to fail builds.

--- a/task/build-helm-chart-oci-ta/0.1/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.1/build-helm-chart-oci-ta.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: build-helm-chart-oci-ta
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: |-
     The task packages and pushes a Helm chart to an OCI repository.

--- a/task/build-helm-chart/0.1/build-helm-chart.yaml
+++ b/task/build-helm-chart/0.1/build-helm-chart.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: build-helm-chart
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: |-
     The task packages and pushes a Helm chart to an OCI repository.

--- a/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
+++ b/task/download-sbom-from-url-in-attestation/0.1/download-sbom-from-url-in-attestation.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     tekton.dev/tags: "sbom, attestation, cosign"
   name: download-sbom-from-url-in-attestation
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: |-
     Get the SBOM for an image by downloading the OCI blob referenced in the image attestation.

--- a/task/eaas-provision-space/0.1/eaas-provision-space.yaml
+++ b/task/eaas-provision-space/0.1/eaas-provision-space.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: eaas-provision-space
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: >-
     Provisions an ephemeral namespace on an EaaS cluster using a crossplane namespace claim.

--- a/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.1/ecosystem-cert-preflight-checks.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: ecosystem-cert-preflight-checks
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: >-
     Scans container images for certification readiness

--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: ecosystem-cert-preflight-checks
+  labels:
+    app.kubernetes.io/version: "0.2"
 spec:
   description: >-
     Scans container images for certification readiness. Note that running this

--- a/task/gather-deploy-images/0.1/gather-deploy-images.yaml
+++ b/task/gather-deploy-images/0.1/gather-deploy-images.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: gather-deploy-images
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Extract images from deployment YAML to pass to EC for validation
   workspaces:

--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: operator-sdk-generate-bundle
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Generate an OLM bundle using the operator-sdk
   params:

--- a/task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
+++ b/task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: opm-get-bundle-version
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Fetch the current version of the provided OLM bundle image
   params:

--- a/task/opm-render-bundles/0.1/opm-render-bundles.yaml
+++ b/task/opm-render-bundles/0.1/opm-render-bundles.yaml
@@ -3,6 +3,8 @@ apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
   name: opm-render-bundles
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Create a catalog index and render the provided bundles into it
   params:

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -5,6 +5,8 @@ metadata:
   name: sbom-json-check
   annotations:
     build.appstudio.redhat.com/expires-on: 2025-09-30T00:00:00Z
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: >-
     Verifies the integrity and security of the Software Bill of Materials (SBOM) file in JSON format using CyloneDX tool.

--- a/task/sbom-json-check/0.2/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.2/sbom-json-check.yaml
@@ -5,6 +5,8 @@ metadata:
   name: sbom-json-check
   annotations:
     build.appstudio.redhat.com/expires-on: 2025-09-30T00:00:00Z
+  labels:
+    app.kubernetes.io/version: "0.2"
 spec:
   description: >-
     Verifies the integrity and security of the Software Bill of Materials (SBOM) file in JSON format using CyloneDX tool.

--- a/task/update-deployment/0.1/update-deployment.yaml
+++ b/task/update-deployment/0.1/update-deployment.yaml
@@ -2,6 +2,8 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: update-deployment
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: Task to update deployment with newly built image in gitops repository.
   params:

--- a/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
+++ b/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
@@ -4,6 +4,8 @@ metadata:
   annotations:
     tekton.dev/tags: "sbom, trustification"
   name: upload-sbom-to-trustification
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   description: |-
     Upload an SBOM file to [Trustification] using the [BOMbastic] API.

--- a/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
+++ b/task/verify-signed-rpms/0.1/verify-signed-rpms.yaml
@@ -8,6 +8,8 @@ metadata:
     build.appstudio.redhat.com/expiry-message: 'Instead of using this task, switch
       to task rpms-signature-scan
       (https://quay.io/repository/konflux-ci/tekton-catalog/task-rpms-signature-scan)'
+  labels:
+    app.kubernetes.io/version: "0.1"
 spec:
   params:
     - name: INPUT


### PR DESCRIPTION
With the help of `hack/check-task-version-labels.sh` from #2127 I added an `app.kubernetes.io/version` label to all the tasks that don't have it.

(This one should be low risk, and hence easy to merge.)
