### PR TITLE
Fix mismatched task version labels

### DIFF
--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: 0.3.1
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: 0.3.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.2.1
+    app.kubernetes.io/version: 0.3.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     build.appstudio.redhat.com/expires-on: "2025-03-01T00:00:00Z"

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: 0.3.1
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     build.appstudio.redhat.com/expires-on: "2025-03-31T00:00:00Z"

--- a/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
+++ b/task/coverity-availability-check-oci-ta/0.2/coverity-availability-check-oci-ta.yaml
@@ -9,7 +9,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   name: coverity-availability-check-oci-ta
 spec:
   description: This task performs needed checks in order to use Coverity image in

--- a/task/coverity-availability-check/0.2/coverity-availability-check.yaml
+++ b/task/coverity-availability-check/0.2/coverity-availability-check.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -3,7 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
+++ b/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: rpm-ostree
     build.appstudio.redhat.com/multi-platform-required: "true"
 spec:

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.2"
     build.appstudio.redhat.com/build_type: rpm-ostree
     build.appstudio.redhat.com/multi-platform-required: "true"
   name: rpm-ostree


### PR DESCRIPTION
With the help of the `hack/check-task-version-labels.sh` script from PR #2127 , I updated the version labels that seem incorrect.

I'm not 100% what impact this will have in the hack/build-and-push.sh, so please consider that when reviewing.

For the 0.2.1 -> 0.3.1 changes, there's an argument for changing them to just "0.3", but I'm not sure what the pros and cons are, or if it would make any difference to anything.

See also #2128.