### PR TITLE
fix(KONFLUX-5907): make clamav work on kind cluster

### DIFF
--- a/task/clamav-scan/0.2/clamav-scan.yaml
+++ b/task/clamav-scan/0.2/clamav-scan.yaml
@@ -42,7 +42,8 @@ spec:
       # need to change user since 'oc image extract' requires more privileges when running as root permissions
       # https://bugzilla.redhat.com/show_bug.cgi?id=1969929
       securityContext:
-        runAsUser: 1000
+        capabilities:
+          add: ["SETFCAP"]
       env:
         - name: HOME
           value: /work


### PR DESCRIPTION
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.

This change makes it possible to extract image even on kind cluster, the behaviour of scan itself remains the same.
