### PR TITLE
Set limits/resources for task inspect-image

### DIFF
--- a/task/inspect-image/0.1/inspect-image.yaml
+++ b/task/inspect-image/0.1/inspect-image.yaml
@@ -37,6 +37,12 @@ spec:
     image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
+    computeResources:
+      limits:
+        memory: 256Mi
+      requests:
+        memory: 256Mi
+        cpu: 100m
     workingDir: $(workspaces.source.path)/hacbs/$(context.task.name)
     securityContext:
       runAsUser: 0

--- a/task/inspect-image/0.1/inspect-image.yaml
+++ b/task/inspect-image/0.1/inspect-image.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:

--- a/task/inspect-image/0.2/inspect-image.yaml
+++ b/task/inspect-image/0.2/inspect-image.yaml
@@ -1,5 +1,5 @@
 # WARNING: This is an auto generated file, do not modify this file directly
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:

--- a/task/inspect-image/0.2/inspect-image.yaml
+++ b/task/inspect-image/0.2/inspect-image.yaml
@@ -32,7 +32,13 @@ spec:
   - description: Tekton task test output.
     name: TEST_OUTPUT
   steps:
-  - env:
+  - computeResources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    env:
     - name: IMAGE_URL
       value: $(params.IMAGE_URL)
     - name: IMAGE_DIGEST


### PR DESCRIPTION
This PR updates resource limits and requests for the task inspect-image as part of this effort - [KONFLUX-7127](https://issues.redhat.com/browse/KONFLUX-7127).

The new request/limit values have been defined taking into account usages observed historically (tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?gid=1735880927#gid=1735880927)) in the stone-prd-rh01 cluster.