### PR TITLE
Disable verbose output during migration validation

### DIFF
--- a/.github/workflows/check-task-migration.yaml
+++ b/.github/workflows/check-task-migration.yaml
@@ -31,4 +31,4 @@ jobs:
           # Make `git branch --show-current` works.
           git checkout -b pr-verify
           export IN_CLUSTER=1
-          bash -x ./hack/validate-migration.sh
+          bash ./hack/validate-migration.sh


### PR DESCRIPTION
The current output is informative enough. When check CI job logs from GitHub, verbose mode makes the logs too long to focus on the necessary messages output from the script itself.
