### PR TITLE
fix: Make BUILDAH_IMAGE available inside remote script

### DIFF
--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -193,6 +193,7 @@ spec:
         export TAGGED_AS="$TAGGED_AS"
         export IMAGE_TYPE_ARGUMENT="$IMAGE_TYPE_ARGUMENT"
         export STORAGE_DRIVER="$STORAGE_DRIVER"
+        export BUILDAH_IMAGE="$BUILDAH_IMAGE"
 
         REMOTESSHEOF
 


### PR DESCRIPTION
Bugfix for heredoc madness.

Without this patch, when $BUILDAH_IMAGE is used inside the script, it always evaluats to the empty string. This patch exposes it from the scope outside the heredoc to the scope inside.
