### PR TITLE
Generate renovate.json via update_renovate_json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -243,7 +243,7 @@
         "^task/.+/patch\\.yaml$"
       ],
       "matchStrings": [
-        "(?:image: |tooling-image=)(?:['\"])?(?<depName>[0-9a-z.\/-]+)(?::(?<currentValue>[0-9a-z.-]+))?@(?<currentDigest>sha256:[a-f0-9]{64})(?:['\"])?"
+        "(?:image: |tooling-image=)(?:['\"])?(?<depName>[0-9a-z./-]+)(?::(?<currentValue>[0-9a-z.-]+))?@(?<currentDigest>sha256:[a-f0-9]{64})(?:['\"])?"
       ],
       "datasourceTemplate": "docker"
     },


### PR DESCRIPTION
There is a discrepancy between the output renovate.json that is generated by running update_renovate_json_based_on_codeowners.py and the current renovate.json.
Run the update_renovate_json script and commit the generated file so that the expected and actual renovate.json are the same