### PR TITLE
[prefetch] Switch the cachi2 image to the new name hermeto

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -162,7 +162,7 @@ spec:
           yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}" >/mnt/config/config.yaml
         fi
     - name: prefetch-dependencies
-      image: quay.io/konflux-ci/cachi2:0.22.2@sha256:c24dbc207b0eca1fe742a53b50feca2182dc0f998e5b91af6a7c94c3132bdcd0
+      image: quay.io/konflux-ci/hermeto:0.23.0@sha256:4d21d4029266f7cda0235bdd563207ad46b4d82c27b651116c54c785f8c88bd0
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -83,7 +83,7 @@ spec:
       fi
 
   - name: prefetch-dependencies
-    image: quay.io/konflux-ci/cachi2:0.22.2@sha256:c24dbc207b0eca1fe742a53b50feca2182dc0f998e5b91af6a7c94c3132bdcd0
+    image: quay.io/konflux-ci/hermeto:0.23.0@sha256:4d21d4029266f7cda0235bdd563207ad46b4d82c27b651116c54c785f8c88bd0
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     env:


### PR DESCRIPTION
Move to quay.io/konflux-ci/hermeto since I see 0.23.0 is only pushed to the new repo instead of quay.io/konflux-ci/cachi2