### PR TITLE
fix(KFLUXVNGD-267): tkn-bundle task fails when the context is a file

### DIFF
--- a/task/tkn-bundle-oci-ta/0.1/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.1/tkn-bundle-oci-ta.yaml
@@ -97,7 +97,7 @@ spec:
             )
           else
             # for files add the file to the collected paths
-            paths+=("${path}")
+            paths+=("/var/workdir/${SOURCE_CODE_DIR}/${path}")
           fi
           if [[ $neg == 0 ]]; then
             # collect current paths to FILES

--- a/task/tkn-bundle/0.1/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.1/tkn-bundle.yaml
@@ -79,7 +79,7 @@ spec:
           )
         else
           # for files add the file to the collected paths
-          paths+=("${path}")
+          paths+=("$(workspaces.source.path)/${SOURCE_CODE_DIR}/${path}")
         fi
         if [[ $neg == 0 ]]; then
           # collect current paths to FILES


### PR DESCRIPTION
When using a file as CONTEXT in the task, the task fails for not finding the file.
It happens because in the task's script we are adding only the file without the workspace and source.

Update the task to add the workspace and source dir to the file