### PR TITLE
fix(CLOUDDST-26534): update fips stepaction

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -14,7 +14,7 @@ spec:
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.
-  image: quay.io/redhat-appstudio/konflux-test:v1.4.18@sha256:78c76869d0b171e9bfa5e931e5e6ecbe92b32f61c6ec627c57cbb9d1aad75aab
+  image: quay.io/redhat-appstudio/konflux-test:v1.4.22@sha256:cc66bfdc4abc3eacfa74d77d2efcc2627722549bffa38d3731251631f13552bf
   securityContext:
     capabilities:
       add:


### PR DESCRIPTION
Updated the fips stepaction to use konflux-test:v1.4.22, which has check-payload 0.3.5.