### PR TITLE
run-script-oci-ta: fix .metadata.name

### DIFF
--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -2,7 +2,7 @@
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:
-  name: run-script
+  name: run-script-oci-ta
   annotations:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux


### PR DESCRIPTION
The .metadata.name in run-script-oci-ta.yaml doesn't match the filename. Because of that, the CI gets confused:

- The create-task-pipeline-bundle-repos.sh script reads the name from the yaml, creates quay.io/konflux-ci/tekton-catalog/task-run-script
- The build-and-push.sh script takes the name from the file name, pushes to quay.io/konflux-ci/tekton-catalog/task-run-script-oci-ta. Pushing to a non-existent repo creates it as private. The script then fails to read from the private repo.

Fix the run-script-oci-ta task name in the YAML metadata, to make sure both the scripts will use the same name.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
