### PR TITLE
Specify modelcar build_type is modelcar

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: "0.1"
-    build.appstudio.redhat.com/build_type: docker
+    build.appstudio.redhat.com/build_type: modelcar
   name: modelcar-oci-ta
 spec:
   description: |-


### PR DESCRIPTION
This is used by conforma to look up what tasks should be required for the given pipeline. The tasks required of a modelcar build will be different from those required of a normal docker build - primarily, the "buildah" task is not required.

Related:

* https://github.com/konflux-ci/build-definitions/pull/2171
* https://github.com/release-engineering/rhtap-ec-policy/pull/138