### PR TITLE
Rename the oci-copy build type

### DIFF
--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: "0.2"
-    build.appstudio.redhat.com/build_type: oci-artifact
+    build.appstudio.redhat.com/build_type: oci-copy
 spec:
   description: Given a file in the user's source directory, copy content from
     arbitrary urls into the OCI registry.

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: "0.2"
-    build.appstudio.redhat.com/build_type: oci-artifact
+    build.appstudio.redhat.com/build_type: oci-copy
   name: oci-copy
 spec:
   description: Given a file in the user's source directory, copy content from arbitrary urls into the OCI registry.


### PR DESCRIPTION
We can only declare one list of required tasks per "build_type" in the conforma rule data and "oci-artifact" was a little too generic.

By making this more specific, we can create a list of tasks required for "oci-copy" build pipelines that includes the oci-copy task.

Related:

* https://github.com/konflux-ci/build-definitions/pull/2170
* https://github.com/release-engineering/rhtap-ec-policy/pull/138