### PR TITLE
feat: git-clone: Add optional targetBranch merging

### DIFF
--- a/hack/generate-everything.sh
+++ b/hack/generate-everything.sh
@@ -1,8 +1,14 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail -o xtrace
 
 SCRIPTDIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 cd "$SCRIPTDIR/.."
+
+yq --version | grep -q mikefarah/yq || {
+  echo "You need the yq tool from mikefarah/yq to run this script."
+  echo "your version is probably the python version that is not compatible"
+  exit 1
+}
 
 # These 3 need to run in this order. Not for any logical reasons, but simply
 # because of the current state of dependence between the generated tasks

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -127,6 +127,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).git'|
@@ -136,6 +137,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -334,6 +336,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-images:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
 ### init:0.2 task results

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -124,6 +124,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).git'|
@@ -133,6 +134,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -331,6 +333,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
 ### init:0.2 task results

--- a/pipelines/docker-build-rhtap/README.md
+++ b/pipelines/docker-build-rhtap/README.md
@@ -61,6 +61,7 @@
 |gitInitImage| Deprecated. Has no effect. Will be removed in the future.| | |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
@@ -69,6 +70,7 @@
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -124,6 +126,7 @@
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -124,6 +124,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |gitInitImage| Deprecated. Has no effect. Will be removed in the future.| | |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
@@ -132,6 +133,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -322,6 +324,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| build-container:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA ; sast-coverity-check:0.2:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -112,6 +112,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).git'|
@@ -121,6 +122,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -203,6 +205,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-images:0.4:COMMIT_SHA ; build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
 ### init:0.2 task results

--- a/pipelines/gitops-pull-request-rhtap/README.md
+++ b/pipelines/gitops-pull-request-rhtap/README.md
@@ -47,6 +47,7 @@
 |gitInitImage| Deprecated. Has no effect. Will be removed in the future.| | |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
@@ -55,6 +56,7 @@
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -107,6 +109,7 @@
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| |
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
 ### verify-enterprise-contract:0.1 task results

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -41,6 +41,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).git'|
@@ -50,6 +51,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -192,6 +194,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| |
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| |
 ### init:0.2 task results

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -42,6 +42,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |gitInitImage| Deprecated. Has no effect. Will be removed in the future.| | |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
@@ -50,6 +51,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -187,6 +189,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| |
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -45,6 +45,7 @@
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).git'|
@@ -54,6 +55,7 @@
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -143,6 +145,7 @@
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| prefetch-dependencies:0.2:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -47,6 +47,7 @@
 |gitInitImage| Deprecated. Has no effect. Will be removed in the future.| | |
 |httpProxy| HTTP proxy server for non-SSL requests.| | |
 |httpsProxy| HTTPS proxy server for SSL requests.| | |
+|mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| | |
 |refspec| Refspec to fetch before checking out revision.| | |
 |revision| Revision to checkout. (branch, tag, sha, ref, etc...)| | '$(params.revision)'|
@@ -55,6 +56,7 @@
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
 |submodules| Initialize and fetch git submodules.| true| |
+|targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
 |userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
 |verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
@@ -135,6 +137,7 @@
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |commit| The precise commit SHA that was fetched by this Task.| build-image-index:0.1:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
+|merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
 |short-commit| The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters| |
 |url| The precise URL that was fetched by this Task.| show-summary:0.2:git-url|
 ### init:0.2 task results

--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -12,6 +12,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |fetchTags|Fetch all tags for the repo.|false|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
 |noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
 |ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
 |ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
@@ -21,6 +22,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
 |sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
 |submodules|Initialize and fetch git submodules.|true|false|
+|targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
 |url|Repository URL to clone from.||true|
 |userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
 |verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
@@ -33,6 +35,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
 |commit|The precise commit SHA that was fetched by this Task.|
 |commit-timestamp|The commit timestamp of the checkout|
+|merged_sha|The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).|
 |short-commit|The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters|
 |url|The precise URL that was fetched by this Task.|
 

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -46,6 +46,11 @@ spec:
       description: HTTPS proxy server for SSL requests.
       type: string
       default: ""
+    - name: mergeTargetBranch
+      description: Set to "true" to merge the targetBranch into the checked-out
+        revision.
+      type: string
+      default: "false"
     - name: noProxy
       description: Opt out of proxying HTTP/HTTPS requests.
       type: string
@@ -85,6 +90,11 @@ spec:
       description: Initialize and fetch git submodules.
       type: string
       default: "true"
+    - name: targetBranch
+      description: The target branch to merge into the revision (if mergeTargetBranch
+        is true).
+      type: string
+      default: main
     - name: url
       description: Repository URL to clone from.
       type: string
@@ -113,6 +123,9 @@ spec:
       description: The precise commit SHA that was fetched by this Task.
     - name: commit-timestamp
       description: The commit timestamp of the checkout
+    - name: merged_sha
+      description: The SHA of the commit after merging the target branch (if
+        the param mergeTargetBranch is true).
     - name: short-commit
       description: The commit SHA that was fetched by this Task limited to
         params.shortCommitLength number of characters
@@ -184,6 +197,10 @@ spec:
           value: $(params.userHome)
         - name: PARAM_FETCH_TAGS
           value: $(params.fetchTags)
+        - name: PARAM_MERGE_TARGET_BRANCH
+          value: $(params.mergeTargetBranch)
+        - name: PARAM_TARGET_BRANCH
+          value: $(params.targetBranch)
         - name: WORKSPACE_SSH_DIRECTORY_BOUND
           value: $(workspaces.ssh-directory.bound)
         - name: WORKSPACE_SSH_DIRECTORY_PATH
@@ -251,6 +268,41 @@ spec:
         EXIT_CODE="$?"
         if [ "${EXIT_CODE}" != 0 ]; then
           exit "${EXIT_CODE}"
+        fi
+        if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
+          echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+          echo "Fetching target branch '${PARAM_TARGET_BRANCH}'..."
+          git fetch origin "${PARAM_TARGET_BRANCH}"
+          FETCH_EXIT_CODE="$?"
+          if [ "${FETCH_EXIT_CODE}" != "0" ]; then
+            echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}'." >&2
+            exit "${FETCH_EXIT_CODE}"
+          fi
+          echo "Merging origin/${PARAM_TARGET_BRANCH} into current HEAD..."
+          git config --global user.email "tekton-git-clone@tekton.dev"
+          git config --global user.name "Tekton Git Clone Task"
+          git merge "origin/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
+          MERGE_CHECK_EXIT_CODE="$?"
+          if [ "${MERGE_CHECK_EXIT_CODE}" != "0" ]; then
+            echo "ERROR: Merge conflict detected or merge failed before commit." >&2
+            echo "--- Git Status ---"
+            git status
+            echo "------------------"
+            exit "${MERGE_CHECK_EXIT_CODE}"
+          else
+            echo "Merge successful (no conflicts found), committing..."
+            git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+            COMMIT_EXIT_CODE="$?"
+            if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
+              echo "ERROR: Failed to commit merge." >&2
+              exit "${COMMIT_EXIT_CODE}"
+            fi
+            MERGED_SHA=$(git rev-parse HEAD)
+            echo "New HEAD after merge: ${MERGED_SHA}"
+            echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
+          fi
+        else
+          echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
         fi
         printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
         printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -25,6 +25,8 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |fetchTags|Fetch all tags for the repo.|false|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|mergeTargetBranch|Whether to merge the target branch into the revision after checkout.|false|false|
+|targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|"main"|false|
 
 ## Results
 |name|description|
@@ -32,6 +34,7 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |commit|The precise commit SHA that was fetched by this Task.|
 |short-commit|The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters|
 |url|The precise URL that was fetched by this Task.|
+|merged_sha|The SHA of the commit after merging the target branch (if mergeTargetBranch is true) |
 |commit-timestamp|The commit timestamp of the checkout|
 |CHAINS-GIT_URL|The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
 |CHAINS-GIT_COMMIT|The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -72,7 +72,6 @@ spec:
   - default: ""
     description: Deprecated. Has no effect. Will be removed in the future.
     name: gitInitImage
-    type: string
   - default: /tekton/home
     description: |
       Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
@@ -95,6 +94,14 @@ spec:
     type: string
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
+  - name: mergeTargetBranch
+    description: Set to "true" to merge the targetBranch into the checked-out revision.
+    type: string
+    default: "false"
+  - name: targetBranch
+    description: The target branch to merge into the revision (if mergeTargetBranch is true).
+    type: string
+    default: "main"
   results:
   - description: The precise commit SHA that was fetched by this Task.
     name: commit
@@ -108,6 +115,8 @@ spec:
     name: CHAINS-GIT_URL
   - description: The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.
     name: CHAINS-GIT_COMMIT
+  - name: merged_sha
+    description: The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).
   steps:
   - name: clone
     env:
@@ -147,6 +156,10 @@ spec:
       value: $(params.fetchTags)
     - name: PARAM_GIT_INIT_IMAGE
       value: $(params.gitInitImage)
+    - name: PARAM_MERGE_TARGET_BRANCH
+      value: $(params.mergeTargetBranch)
+    - name: PARAM_TARGET_BRANCH
+      value: $(params.targetBranch)
     - name: WORKSPACE_OUTPUT_PATH
       value: $(workspaces.output.path)
     - name: WORKSPACE_SSH_DIRECTORY_BOUND
@@ -247,6 +260,41 @@ spec:
       EXIT_CODE="$?"
       if [ "${EXIT_CODE}" != 0 ] ; then
         exit "${EXIT_CODE}"
+      fi
+      if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
+        echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+        echo "Fetching target branch '${PARAM_TARGET_BRANCH}'..."
+        git fetch origin "${PARAM_TARGET_BRANCH}"
+        FETCH_EXIT_CODE="$?"
+        if [ "${FETCH_EXIT_CODE}" != "0" ]; then
+          echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}'." >&2
+          exit "${FETCH_EXIT_CODE}"
+        fi
+        echo "Merging origin/${PARAM_TARGET_BRANCH} into current HEAD..."
+        git config --global user.email "tekton-git-clone@tekton.dev"
+        git config --global user.name "Tekton Git Clone Task"
+        git merge "origin/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
+        MERGE_CHECK_EXIT_CODE="$?"
+        if [ "${MERGE_CHECK_EXIT_CODE}" != "0" ] ; then
+          echo "ERROR: Merge conflict detected or merge failed before commit." >&2
+          echo "--- Git Status ---"
+          git status
+          echo "------------------"
+          exit "${MERGE_CHECK_EXIT_CODE}"
+        else
+          echo "Merge successful (no conflicts found), committing..."
+          git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+          COMMIT_EXIT_CODE="$?"
+          if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
+            echo "ERROR: Failed to commit merge." >&2
+            exit "${COMMIT_EXIT_CODE}"
+          fi
+          MERGED_SHA=$(git rev-parse HEAD)
+          echo "New HEAD after merge: ${MERGED_SHA}"
+          echo "${MERGED_SHA}" > "$(results.merged_sha.path)"
+        fi
+      else
+        echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
       fi
       printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
       printf "%s" "${RESULT_SHA}" > "$(results.CHAINS-GIT_COMMIT.path)"

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -49,6 +49,10 @@ spec:
     description: HTTPS proxy server for SSL requests.
     name: httpsProxy
     type: string
+  - default: "false"
+    description: Set to "true" to merge the targetBranch into the checked-out revision.
+    name: mergeTargetBranch
+    type: string
   - default: ""
     description: Opt out of proxying HTTP/HTTPS requests.
     name: noProxy
@@ -86,6 +90,11 @@ spec:
   - default: "true"
     description: Initialize and fetch git submodules.
     name: submodules
+    type: string
+  - default: main
+    description: The target branch to merge into the revision (if mergeTargetBranch
+      is true).
+    name: targetBranch
     type: string
   - description: Repository URL to clone from.
     name: url
@@ -130,6 +139,9 @@ spec:
     name: commit
   - description: The commit timestamp of the checkout
     name: commit-timestamp
+  - description: The SHA of the commit after merging the target branch (if the param
+      mergeTargetBranch is true).
+    name: merged_sha
   - description: The commit SHA that was fetched by this Task limited to params.shortCommitLength
       number of characters
     name: short-commit
@@ -167,6 +179,10 @@ spec:
       value: $(params.userHome)
     - name: PARAM_FETCH_TAGS
       value: $(params.fetchTags)
+    - name: PARAM_MERGE_TARGET_BRANCH
+      value: $(params.mergeTargetBranch)
+    - name: PARAM_TARGET_BRANCH
+      value: $(params.targetBranch)
     - name: WORKSPACE_SSH_DIRECTORY_BOUND
       value: $(workspaces.ssh-directory.bound)
     - name: WORKSPACE_SSH_DIRECTORY_PATH
@@ -236,6 +252,41 @@ spec:
       EXIT_CODE="$?"
       if [ "${EXIT_CODE}" != 0 ]; then
         exit "${EXIT_CODE}"
+      fi
+      if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
+        echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+        echo "Fetching target branch '${PARAM_TARGET_BRANCH}'..."
+        git fetch origin "${PARAM_TARGET_BRANCH}"
+        FETCH_EXIT_CODE="$?"
+        if [ "${FETCH_EXIT_CODE}" != "0" ]; then
+          echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}'." >&2
+          exit "${FETCH_EXIT_CODE}"
+        fi
+        echo "Merging origin/${PARAM_TARGET_BRANCH} into current HEAD..."
+        git config --global user.email "tekton-git-clone@tekton.dev"
+        git config --global user.name "Tekton Git Clone Task"
+        git merge "origin/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
+        MERGE_CHECK_EXIT_CODE="$?"
+        if [ "${MERGE_CHECK_EXIT_CODE}" != "0" ]; then
+          echo "ERROR: Merge conflict detected or merge failed before commit." >&2
+          echo "--- Git Status ---"
+          git status
+          echo "------------------"
+          exit "${MERGE_CHECK_EXIT_CODE}"
+        else
+          echo "Merge successful (no conflicts found), committing..."
+          git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+          COMMIT_EXIT_CODE="$?"
+          if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
+            echo "ERROR: Failed to commit merge." >&2
+            exit "${COMMIT_EXIT_CODE}"
+          fi
+          MERGED_SHA=$(git rev-parse HEAD)
+          echo "New HEAD after merge: ${MERGED_SHA}"
+          echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
+        fi
+      else
+        echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
       fi
       printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
       printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"


### PR DESCRIPTION
This pull request introduces new functionality to the `git-clone` task to optionally merge a target branch into the checked-out revision. The changes
include:

- **Introduced `mergeTargetBranch` parameter:** Allows enabling the merge of a target branch.
- **Added `targetBranch` parameter:** Specifies the branch to be merged (defaults to `main`).
- **Included new result `merged_sha`:** Outputs the commit SHA after a successful merge.
- **Updated `spec` and `steps` sections:** Added parameters and logic to handle the merge process.

### Changes Made:
1. **Added `mergeTargetBranch` parameter:** This parameter, when set to `"true"`, enables the merge of the specified target branch.
2. **Added `targetBranch` parameter:** Specifies the branch to be merged (defaults to `main`).
3. **Added `merged_sha` result:** This result provides the commit SHA after a successful merge.
4. **Updated `spec` and `steps` sections:** Added parameters and logic to handle the merge process.

### Example

See this example pull request here: https://raw.githubusercontent.com/chmouel/scratchmyback/c660385d14021a16ede96780e5019ab56d5008ad/.tekton/pull-request.yaml


https://issues.redhat.com/browse/SRVKP-7450