### PR TITLE
Remove workspace from show-summary task

### DIFF
--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -188,4 +188,4 @@
 ### summary:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|workspace| The workspace where source code is included.| True| workspace|
+|workspace| The workspace where source code is included.| True| |

--- a/pipelines/tekton-bundle-builder-oci-ta/patch.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/patch.yaml
@@ -91,3 +91,7 @@
     value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
 - op: remove
   path: /spec/tasks/6/workspaces/0
+
+# summary
+- op: remove
+  path: /spec/finally/0/workspaces/0

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -22,9 +22,7 @@ spec:
     taskRef:
       name: summary
       version: "0.2"
-    workspaces:
-    - name: workspace
-      workspace: workspace
+    workspaces: []
   params:
   - description: Source Repository URL
     name: git-url


### PR DESCRIPTION
workspace was removed from the pipeline when creating tekton-bundle-builder-oci-ta pipeline.

workspace is optional for task summary, so this removal just works.

This issue is found during review on #2018. That makes migration validation fails.