### PR TITLE
buildah-remote: fix ssh shell quoting

### DIFF
--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -268,7 +268,7 @@ if ! [[ $IS_LOCALHOST ]]; then
 		ret += "\n  echo \"[$(date --utc -Ins)] Build via ssh\""
 		podmanArgs += "    -v \"$BUILD_DIR/scripts:/scripts:Z\" \\\n"
 		podmanArgs += "    \"${PRIVILEGED_NESTED_FLAGS[@]}\" \\\n"
-		ret += "\n  # shellcheck disable=SC2086\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run " + env + "" + podmanArgs + "    --user=0 \"${PODMAN_NVIDIA_ARGS[@]}\" --rm \"$BUILDER_IMAGE\" /" + containerScript + ` "$@"`
+		ret += "\n  # shellcheck disable=SC2086\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run " + env + "" + podmanArgs + "    --user=0 \"${PODMAN_NVIDIA_ARGS[@]}\" --rm \"$BUILDER_IMAGE\" /" + containerScript + ` "${@@Q}"`
 
 		// Sync the contents of the workspaces back so subsequent tasks can use them
 		ret += "\n  echo \"[$(date --utc -Ins)] Rsync back\""

--- a/task-generator/remote/main.go
+++ b/task-generator/remote/main.go
@@ -268,7 +268,10 @@ if ! [[ $IS_LOCALHOST ]]; then
 		ret += "\n  echo \"[$(date --utc -Ins)] Build via ssh\""
 		podmanArgs += "    -v \"${BUILD_DIR@Q}/scripts:/scripts:Z\" \\\n"
 		podmanArgs += "    \"${PRIVILEGED_NESTED_FLAGS[@]@Q}\" \\\n"
-		ret += "\n  # shellcheck disable=SC2086\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run " + env + "" + podmanArgs + "    --user=0 \"${PODMAN_NVIDIA_ARGS[@]@Q}\" --rm \"${BUILDER_IMAGE@Q}\" /" + containerScript + ` "${@@Q}"`
+		ret += "\n  # shellcheck disable=SC2086"
+		ret += "\n  # Please note: all variables below the first ssh line must be quoted with ${var@Q}!"
+		ret += "\n  # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters"
+		ret += "\n  ssh $SSH_ARGS \"$SSH_HOST\" $PORT_FORWARD podman  run " + env + "" + podmanArgs + "    --user=0 \"${PODMAN_NVIDIA_ARGS[@]@Q}\" --rm \"${BUILDER_IMAGE@Q}\" /" + containerScript + ` "${@@Q}"`
 
 		// Sync the contents of the workspaces back so subsequent tasks can use them
 		ret += "\n  echo \"[$(date --utc -Ins)] Rsync back\""

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -502,7 +502,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -471,6 +471,8 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         echo "[$(date --utc -Ins)] Build via ssh"
         # shellcheck disable=SC2086
+        # Please note: all variables below the first ssh line must be quoted with ${var@Q}!
+        # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
           -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \

--- a/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.1/buildah-remote-oci-ta.yaml
@@ -247,7 +247,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         echo "$BUILD_DIR"
         # shellcheck disable=SC2086
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/workspaces" "${BUILD_DIR@Q}/scripts" "${BUILD_DIR@Q}/volumes"
 
         PORT_FORWARD=""
         PODMAN_PORT_FORWARD=""
@@ -465,7 +465,7 @@ spec:
           # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
           # https://github.com/coreos/rpm-ostree/discussions/4648
           # shellcheck disable=SC2086
-          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/var/tmp"
           PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
         fi
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
@@ -473,36 +473,36 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-          -e CONTEXT="$CONTEXT" \
-          -e DOCKERFILE="$DOCKERFILE" \
-          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-          -e HERMETIC="$HERMETIC" \
-          -e IMAGE="$IMAGE" \
-          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-          -e SQUASH="$SQUASH" \
-          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-          -e TARGET_STAGE="$TARGET_STAGE" \
-          -e TLSVERIFY="$TLSVERIFY" \
-          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-          -e COMMIT_SHA="$COMMIT_SHA" \
-          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-          -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
-          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-          -v "$BUILD_DIR/results/:/tekton/results:Z" \
-          -v "$BUILD_DIR/scripts:/scripts:Z" \
-          "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
+          -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
+          -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \
+          -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
+          -e CONTEXT="${CONTEXT@Q}" \
+          -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \
+          -e HERMETIC="${HERMETIC@Q}" \
+          -e IMAGE="${IMAGE@Q}" \
+          -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
+          -e SQUASH="${SQUASH@Q}" \
+          -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
+          -e TARGET_STAGE="${TARGET_STAGE@Q}" \
+          -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
+          -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
+          -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
+          -e COMMIT_SHA="${COMMIT_SHA@Q}" \
+          -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
+          -v "${BUILD_DIR@Q}/volumes/workdir:/var/workdir:Z" \
+          -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
+          -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
+          -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
+          -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
+          -v "${BUILD_DIR@Q}/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]@Q}" \
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]@Q}" --rm "${BUILDER_IMAGE@Q}" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -669,7 +669,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -634,6 +634,8 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         echo "[$(date --utc -Ins)] Build via ssh"
         # shellcheck disable=SC2086
+        # Please note: all variables below the first ssh line must be quoted with ${var@Q}!
+        # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
           -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -293,7 +293,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         echo "$BUILD_DIR"
         # shellcheck disable=SC2086
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/workspaces" "${BUILD_DIR@Q}/scripts" "${BUILD_DIR@Q}/volumes"
 
         PORT_FORWARD=""
         PODMAN_PORT_FORWARD=""
@@ -628,7 +628,7 @@ spec:
           # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
           # https://github.com/coreos/rpm-ostree/discussions/4648
           # shellcheck disable=SC2086
-          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/var/tmp"
           PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
         fi
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
@@ -636,40 +636,40 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
-          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-          -e CONTEXT="$CONTEXT" \
-          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-          -e HERMETIC="$HERMETIC" \
-          -e IMAGE="$IMAGE" \
-          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-          -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
-          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
-          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
-          -e SQUASH="$SQUASH" \
-          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-          -e TARGET_STAGE="$TARGET_STAGE" \
-          -e TLSVERIFY="$TLSVERIFY" \
-          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-          -e COMMIT_SHA="$COMMIT_SHA" \
-          -e DOCKERFILE="$DOCKERFILE" \
-          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-          -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
-          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-          -v "$BUILD_DIR/results/:/tekton/results:Z" \
-          -v "$BUILD_DIR/scripts:/scripts:Z" \
-          "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
+          -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \
+          -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
+          -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \
+          -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
+          -e CONTEXT="${CONTEXT@Q}" \
+          -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \
+          -e HERMETIC="${HERMETIC@Q}" \
+          -e IMAGE="${IMAGE@Q}" \
+          -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
+          -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
+          -e SOURCE_CODE_DIR="${SOURCE_CODE_DIR@Q}" \
+          -e SQUASH="${SQUASH@Q}" \
+          -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
+          -e TARGET_STAGE="${TARGET_STAGE@Q}" \
+          -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
+          -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
+          -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
+          -e COMMIT_SHA="${COMMIT_SHA@Q}" \
+          -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
+          -v "${BUILD_DIR@Q}/volumes/workdir:/var/workdir:Z" \
+          -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
+          -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
+          -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
+          -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
+          -v "${BUILD_DIR@Q}/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]@Q}" \
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]@Q}" --rm "${BUILDER_IMAGE@Q}" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -666,7 +666,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -292,7 +292,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         echo "$BUILD_DIR"
         # shellcheck disable=SC2086
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/workspaces" "${BUILD_DIR@Q}/scripts" "${BUILD_DIR@Q}/volumes"
 
         PORT_FORWARD=""
         PODMAN_PORT_FORWARD=""
@@ -624,7 +624,7 @@ spec:
           # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
           # https://github.com/coreos/rpm-ostree/discussions/4648
           # shellcheck disable=SC2086
-          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/var/tmp"
           PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
         fi
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
@@ -632,41 +632,41 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
-          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-          -e CONTEXT="$CONTEXT" \
-          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-          -e HERMETIC="$HERMETIC" \
-          -e IMAGE="$IMAGE" \
-          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-          -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
-          -e SBOM_TYPE="$SBOM_TYPE" \
-          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
-          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
-          -e SQUASH="$SQUASH" \
-          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-          -e TARGET_STAGE="$TARGET_STAGE" \
-          -e TLSVERIFY="$TLSVERIFY" \
-          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-          -e COMMIT_SHA="$COMMIT_SHA" \
-          -e DOCKERFILE="$DOCKERFILE" \
-          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-          -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
-          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-          -v "$BUILD_DIR/results/:/tekton/results:Z" \
-          -v "$BUILD_DIR/scripts:/scripts:Z" \
-          "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
+          -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \
+          -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
+          -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \
+          -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
+          -e CONTEXT="${CONTEXT@Q}" \
+          -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \
+          -e HERMETIC="${HERMETIC@Q}" \
+          -e IMAGE="${IMAGE@Q}" \
+          -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e SBOM_TYPE="${SBOM_TYPE@Q}" \
+          -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
+          -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
+          -e SOURCE_CODE_DIR="${SOURCE_CODE_DIR@Q}" \
+          -e SQUASH="${SQUASH@Q}" \
+          -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
+          -e TARGET_STAGE="${TARGET_STAGE@Q}" \
+          -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
+          -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
+          -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
+          -e COMMIT_SHA="${COMMIT_SHA@Q}" \
+          -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
+          -v "${BUILD_DIR@Q}/volumes/workdir:/var/workdir:Z" \
+          -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
+          -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
+          -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
+          -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
+          -v "${BUILD_DIR@Q}/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]@Q}" \
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]@Q}" --rm "${BUILDER_IMAGE@Q}" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -630,6 +630,8 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         echo "[$(date --utc -Ins)] Build via ssh"
         # shellcheck disable=SC2086
+        # Please note: all variables below the first ssh line must be quoted with ${var@Q}!
+        # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
           -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -305,7 +305,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         echo "$BUILD_DIR"
         # shellcheck disable=SC2086
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/workspaces" "${BUILD_DIR@Q}/scripts" "${BUILD_DIR@Q}/volumes"
 
         PORT_FORWARD=""
         PODMAN_PORT_FORWARD=""
@@ -667,7 +667,7 @@ spec:
           # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
           # https://github.com/coreos/rpm-ostree/discussions/4648
           # shellcheck disable=SC2086
-          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/var/tmp"
           PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
         fi
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
@@ -675,40 +675,40 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
-          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-          -e CONTEXT="$CONTEXT" \
-          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-          -e HERMETIC="$HERMETIC" \
-          -e IMAGE="$IMAGE" \
-          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-          -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
-          -e SBOM_TYPE="$SBOM_TYPE" \
-          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
-          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
-          -e SQUASH="$SQUASH" \
-          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-          -e TARGET_STAGE="$TARGET_STAGE" \
-          -e TLSVERIFY="$TLSVERIFY" \
-          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-          -e COMMIT_SHA="$COMMIT_SHA" \
-          -e DOCKERFILE="$DOCKERFILE" \
-          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-          -v "$BUILD_DIR/volumes/workdir:/var/workdir:Z" \
-          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-          -v "$BUILD_DIR/results/:/tekton/results:Z" \
-          -v "$BUILD_DIR/scripts:/scripts:Z" \
-          "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
+          -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \
+          -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
+          -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
+          -e CONTEXT="${CONTEXT@Q}" \
+          -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \
+          -e HERMETIC="${HERMETIC@Q}" \
+          -e IMAGE="${IMAGE@Q}" \
+          -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e SBOM_TYPE="${SBOM_TYPE@Q}" \
+          -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
+          -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
+          -e SOURCE_CODE_DIR="${SOURCE_CODE_DIR@Q}" \
+          -e SQUASH="${SQUASH@Q}" \
+          -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
+          -e TARGET_STAGE="${TARGET_STAGE@Q}" \
+          -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
+          -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
+          -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
+          -e COMMIT_SHA="${COMMIT_SHA@Q}" \
+          -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
+          -v "${BUILD_DIR@Q}/volumes/workdir:/var/workdir:Z" \
+          -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
+          -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
+          -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
+          -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
+          -v "${BUILD_DIR@Q}/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]@Q}" \
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]@Q}" --rm "${BUILDER_IMAGE@Q}" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -708,7 +708,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/workdir/" /var/workdir/

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -673,6 +673,8 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         echo "[$(date --utc -Ins)] Build via ssh"
         # shellcheck disable=SC2086
+        # Please note: all variables below the first ssh line must be quoted with ${var@Q}!
+        # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
           -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -235,7 +235,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         echo "$BUILD_DIR"
         # shellcheck disable=SC2086
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/workspaces" "${BUILD_DIR@Q}/scripts" "${BUILD_DIR@Q}/volumes"
 
         PORT_FORWARD=""
         PODMAN_PORT_FORWARD=""
@@ -457,7 +457,7 @@ spec:
           # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
           # https://github.com/coreos/rpm-ostree/discussions/4648
           # shellcheck disable=SC2086
-          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/var/tmp"
           PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
         fi
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
@@ -465,37 +465,37 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-          -e HERMETIC="$HERMETIC" \
-          -e CONTEXT="$CONTEXT" \
-          -e DOCKERFILE="$DOCKERFILE" \
-          -e IMAGE="$IMAGE" \
-          -e TLSVERIFY="$TLSVERIFY" \
-          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-          -e TARGET_STAGE="$TARGET_STAGE" \
-          -e PARAM_BUILDER_IMAGE="$PARAM_BUILDER_IMAGE" \
-          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e SQUASH="$SQUASH" \
-          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-          -e COMMIT_SHA="$COMMIT_SHA" \
-          -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
-          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-          -v "$BUILD_DIR/results/:/tekton/results:Z" \
-          -v "$BUILD_DIR/scripts:/scripts:Z" \
-          "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
+          -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \
+          -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
+          -e HERMETIC="${HERMETIC@Q}" \
+          -e CONTEXT="${CONTEXT@Q}" \
+          -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -e IMAGE="${IMAGE@Q}" \
+          -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
+          -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
+          -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
+          -e TARGET_STAGE="${TARGET_STAGE@Q}" \
+          -e PARAM_BUILDER_IMAGE="${PARAM_BUILDER_IMAGE@Q}" \
+          -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \
+          -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
+          -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
+          -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e SQUASH="${SQUASH@Q}" \
+          -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
+          -e COMMIT_SHA="${COMMIT_SHA@Q}" \
+          -v "${BUILD_DIR@Q}/workspaces/source:$(workspaces.source.path):Z" \
+          -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
+          -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
+          -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
+          -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
+          -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
+          -v "${BUILD_DIR@Q}/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]@Q}" \
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]@Q}" --rm "${BUILDER_IMAGE@Q}" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -495,7 +495,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/

--- a/task/buildah-remote/0.1/buildah-remote.yaml
+++ b/task/buildah-remote/0.1/buildah-remote.yaml
@@ -463,6 +463,8 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         echo "[$(date --utc -Ins)] Build via ssh"
         # shellcheck disable=SC2086
+        # Please note: all variables below the first ssh line must be quoted with ${var@Q}!
+        # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
           -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -640,7 +640,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -270,7 +270,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         echo "$BUILD_DIR"
         # shellcheck disable=SC2086
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/workspaces" "${BUILD_DIR@Q}/scripts" "${BUILD_DIR@Q}/volumes"
 
         PORT_FORWARD=""
         PODMAN_PORT_FORWARD=""
@@ -599,7 +599,7 @@ spec:
           # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
           # https://github.com/coreos/rpm-ostree/discussions/4648
           # shellcheck disable=SC2086
-          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/var/tmp"
           PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
         fi
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
@@ -607,40 +607,40 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-          -e HERMETIC="$HERMETIC" \
-          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
-          -e CONTEXT="$CONTEXT" \
-          -e IMAGE="$IMAGE" \
-          -e TLSVERIFY="$TLSVERIFY" \
-          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-          -e TARGET_STAGE="$TARGET_STAGE" \
-          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
-          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e SQUASH="$SQUASH" \
-          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-          -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
-          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
-          -e COMMIT_SHA="$COMMIT_SHA" \
-          -e DOCKERFILE="$DOCKERFILE" \
-          -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
-          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-          -v "$BUILD_DIR/results/:/tekton/results:Z" \
-          -v "$BUILD_DIR/scripts:/scripts:Z" \
-          "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
+          -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \
+          -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
+          -e HERMETIC="${HERMETIC@Q}" \
+          -e SOURCE_CODE_DIR="${SOURCE_CODE_DIR@Q}" \
+          -e CONTEXT="${CONTEXT@Q}" \
+          -e IMAGE="${IMAGE@Q}" \
+          -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
+          -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
+          -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
+          -e TARGET_STAGE="${TARGET_STAGE@Q}" \
+          -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \
+          -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \
+          -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
+          -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
+          -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e SQUASH="${SQUASH@Q}" \
+          -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
+          -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
+          -e COMMIT_SHA="${COMMIT_SHA@Q}" \
+          -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -v "${BUILD_DIR@Q}/workspaces/source:$(workspaces.source.path):Z" \
+          -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
+          -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
+          -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
+          -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
+          -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
+          -v "${BUILD_DIR@Q}/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]@Q}" \
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]@Q}" --rm "${BUILDER_IMAGE@Q}" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -605,6 +605,8 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         echo "[$(date --utc -Ins)] Build via ssh"
         # shellcheck disable=SC2086
+        # Please note: all variables below the first ssh line must be quoted with ${var@Q}!
+        # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
           -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -637,7 +637,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -601,6 +601,8 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         echo "[$(date --utc -Ins)] Build via ssh"
         # shellcheck disable=SC2086
+        # Please note: all variables below the first ssh line must be quoted with ${var@Q}!
+        # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
           -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -269,7 +269,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         echo "$BUILD_DIR"
         # shellcheck disable=SC2086
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/workspaces" "${BUILD_DIR@Q}/scripts" "${BUILD_DIR@Q}/volumes"
 
         PORT_FORWARD=""
         PODMAN_PORT_FORWARD=""
@@ -595,7 +595,7 @@ spec:
           # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
           # https://github.com/coreos/rpm-ostree/discussions/4648
           # shellcheck disable=SC2086
-          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/var/tmp"
           PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
         fi
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
@@ -603,41 +603,41 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e BUILDAH_FORMAT="$BUILDAH_FORMAT" \
-          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-          -e HERMETIC="$HERMETIC" \
-          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
-          -e CONTEXT="$CONTEXT" \
-          -e IMAGE="$IMAGE" \
-          -e TLSVERIFY="$TLSVERIFY" \
-          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-          -e TARGET_STAGE="$TARGET_STAGE" \
-          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
-          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e SQUASH="$SQUASH" \
-          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-          -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
-          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
-          -e SBOM_TYPE="$SBOM_TYPE" \
-          -e COMMIT_SHA="$COMMIT_SHA" \
-          -e DOCKERFILE="$DOCKERFILE" \
-          -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
-          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-          -v "$BUILD_DIR/results/:/tekton/results:Z" \
-          -v "$BUILD_DIR/scripts:/scripts:Z" \
-          "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
+          -e BUILDAH_FORMAT="${BUILDAH_FORMAT@Q}" \
+          -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
+          -e HERMETIC="${HERMETIC@Q}" \
+          -e SOURCE_CODE_DIR="${SOURCE_CODE_DIR@Q}" \
+          -e CONTEXT="${CONTEXT@Q}" \
+          -e IMAGE="${IMAGE@Q}" \
+          -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
+          -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
+          -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
+          -e TARGET_STAGE="${TARGET_STAGE@Q}" \
+          -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \
+          -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \
+          -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
+          -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
+          -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e SQUASH="${SQUASH@Q}" \
+          -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
+          -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
+          -e SBOM_TYPE="${SBOM_TYPE@Q}" \
+          -e COMMIT_SHA="${COMMIT_SHA@Q}" \
+          -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -v "${BUILD_DIR@Q}/workspaces/source:$(workspaces.source.path):Z" \
+          -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
+          -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
+          -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
+          -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
+          -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
+          -v "${BUILD_DIR@Q}/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]@Q}" \
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]@Q}" --rm "${BUILDER_IMAGE@Q}" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -282,7 +282,7 @@ spec:
         export SSH_ARGS="-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -o ServerAliveCountMax=10"
         echo "$BUILD_DIR"
         # shellcheck disable=SC2086
-        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/volumes"
+        ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/workspaces" "${BUILD_DIR@Q}/scripts" "${BUILD_DIR@Q}/volumes"
 
         PORT_FORWARD=""
         PODMAN_PORT_FORWARD=""
@@ -635,7 +635,7 @@ spec:
           # This is a workaround for building bootc images because the cache filesystem (/var/tmp/ on the host) must be a real filesystem that supports setting SELinux security attributes.
           # https://github.com/coreos/rpm-ostree/discussions/4648
           # shellcheck disable=SC2086
-          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "$BUILD_DIR/var/tmp"
+          ssh $SSH_ARGS "$SSH_HOST"  mkdir -p "${BUILD_DIR@Q}/var/tmp"
           PRIVILEGED_NESTED_FLAGS=(--privileged --mount "type=bind,source=$BUILD_DIR/var/tmp,target=/var/tmp,relabel=shared")
         fi
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
@@ -643,40 +643,40 @@ spec:
         # shellcheck disable=SC2086
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
-          -e STORAGE_DRIVER="$STORAGE_DRIVER" \
-          -e HERMETIC="$HERMETIC" \
-          -e SOURCE_CODE_DIR="$SOURCE_CODE_DIR" \
-          -e CONTEXT="$CONTEXT" \
-          -e IMAGE="$IMAGE" \
-          -e TLSVERIFY="$TLSVERIFY" \
-          -e IMAGE_EXPIRES_AFTER="$IMAGE_EXPIRES_AFTER" \
-          -e YUM_REPOS_D_SRC="$YUM_REPOS_D_SRC" \
-          -e YUM_REPOS_D_FETCHED="$YUM_REPOS_D_FETCHED" \
-          -e YUM_REPOS_D_TARGET="$YUM_REPOS_D_TARGET" \
-          -e TARGET_STAGE="$TARGET_STAGE" \
-          -e ENTITLEMENT_SECRET="$ENTITLEMENT_SECRET" \
-          -e ACTIVATION_KEY="$ACTIVATION_KEY" \
-          -e ADDITIONAL_SECRET="$ADDITIONAL_SECRET" \
-          -e BUILD_ARGS_FILE="$BUILD_ARGS_FILE" \
-          -e ADD_CAPABILITIES="$ADD_CAPABILITIES" \
-          -e SQUASH="$SQUASH" \
-          -e SKIP_UNUSED_STAGES="$SKIP_UNUSED_STAGES" \
-          -e PRIVILEGED_NESTED="$PRIVILEGED_NESTED" \
-          -e SKIP_SBOM_GENERATION="$SKIP_SBOM_GENERATION" \
-          -e SBOM_TYPE="$SBOM_TYPE" \
-          -e COMMIT_SHA="$COMMIT_SHA" \
-          -e DOCKERFILE="$DOCKERFILE" \
-          -v "$BUILD_DIR/workspaces/source:$(workspaces.source.path):Z" \
-          -v "$BUILD_DIR/volumes/shared:/shared:Z" \
-          -v "$BUILD_DIR/volumes/etc-pki-entitlement:/entitlement:Z" \
-          -v "$BUILD_DIR/volumes/activation-key:/activation-key:Z" \
-          -v "$BUILD_DIR/volumes/additional-secret:/additional-secret:Z" \
-          -v "$BUILD_DIR/volumes/trusted-ca:/mnt/trusted-ca:Z" \
-          -v "$BUILD_DIR/.docker/:/root/.docker:Z" \
-          -v "$BUILD_DIR/results/:/tekton/results:Z" \
-          -v "$BUILD_DIR/scripts:/scripts:Z" \
-          "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
+          -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
+          -e HERMETIC="${HERMETIC@Q}" \
+          -e SOURCE_CODE_DIR="${SOURCE_CODE_DIR@Q}" \
+          -e CONTEXT="${CONTEXT@Q}" \
+          -e IMAGE="${IMAGE@Q}" \
+          -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
+          -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
+          -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
+          -e TARGET_STAGE="${TARGET_STAGE@Q}" \
+          -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \
+          -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \
+          -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
+          -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
+          -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e SQUASH="${SQUASH@Q}" \
+          -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
+          -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
+          -e SBOM_TYPE="${SBOM_TYPE@Q}" \
+          -e COMMIT_SHA="${COMMIT_SHA@Q}" \
+          -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -v "${BUILD_DIR@Q}/workspaces/source:$(workspaces.source.path):Z" \
+          -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
+          -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
+          -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
+          -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
+          -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
+          -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
+          -v "${BUILD_DIR@Q}/scripts:/scripts:Z" \
+          "${PRIVILEGED_NESTED_FLAGS[@]@Q}" \
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]@Q}" --rm "${BUILDER_IMAGE@Q}" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -641,6 +641,8 @@ spec:
         rsync -ra scripts "$SSH_HOST:$BUILD_DIR"
         echo "[$(date --utc -Ins)] Build via ssh"
         # shellcheck disable=SC2086
+        # Please note: all variables below the first ssh line must be quoted with ${var@Q}!
+        # See https://stackoverflow.com/questions/6592376/prevent-ssh-from-breaking-up-shell-script-parameters
         ssh $SSH_ARGS "$SSH_HOST" $PORT_FORWARD podman  run $PODMAN_PORT_FORWARD \
           --tmpfs /run/secrets \
           -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -676,7 +676,7 @@ spec:
           -v "$BUILD_DIR/results/:/tekton/results:Z" \
           -v "$BUILD_DIR/scripts:/scripts:Z" \
           "${PRIVILEGED_NESTED_FLAGS[@]}" \
-          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "$@"
+          --user=0 "${PODMAN_NVIDIA_ARGS[@]}" --rm "$BUILDER_IMAGE" /scripts/script-build.sh "${@@Q}"
         echo "[$(date --utc -Ins)] Rsync back"
         rsync -ra "$SSH_HOST:$BUILD_DIR/workspaces/source/" "$(workspaces.source.path)/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/" /shared/


### PR DESCRIPTION
When passing a variable to SSH, it gets evaluated by two shells: the shell that's currently running and the shell on the remote server. What does this mean?

If you run this example locally:

    message='hello there'
    printf '%s.' $message

    # result: hello.there.

The message breaks into two arguments, because it's not properly quoted. Fix by adding quotes:

    message='hello there'
    printf '%s.' "$message"

    # result: hello there.

But then, when you add ssh into the mix:

    message='hello there'
    ssh "$some_host" printf '%s.' "$message"

    # result: hello.there.

The message broke again. That's because ssh received a list of arguments already expanded by your shell and concatenated them together, resulting in a command that may look something like this:

    printf %s. hello there

When passing arbitrary strings to ssh, they need two layers of quoting. The result of variable expansion on the client side must be a string that, when evaluated by a shell again, expands to the original value of the variable. In bash, this is achieved with the ${var@Q} operator; see the Bash manual [1] (refer to the "parameter@operator" section).

Apply the `@Q` operator when passing the $@ argument array to ssh, as well as other variables.

[1]: https://www.gnu.org/software/bash/manual/html_node/Shell-Parameter-Expansion.html

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
