### PR TITLE
fix(KONFLUX-7507): inject image content manifests via Containerfile

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -231,7 +231,7 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:97cba9cc7929c948bccf7bf8ce9aec9a039cfbb9a11ecf47fa9d25d8daf2356b
     name: build
     script: |
       #!/bin/bash
@@ -275,6 +275,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      # Inject the image content manifest into the container we are producing.
+      # This will generate the content-sets.json file and copy it by appending a COPY
+      # instruction to the Containerfile.
+      inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
       echo "[$(date --utc -Ins)] Prepare system"
 
@@ -559,20 +564,6 @@ spec:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
-    workingDir: $(workspaces.source.path)
-  - image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:f7a57ec2435029b2bed6866b3dddb97027f22bb81b2648bb450c9073e4c4f65e
-    name: icm
-    script: |
-      #!/bin/bash
-      set -euo pipefail
-      /scripts/inject-icm.sh "$IMAGE"
-    securityContext:
-      capabilities:
-        add:
-        - SETFCAP
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
     workingDir: $(workspaces.source.path)
   - env:
     - name: BUILDAH_FORMAT

--- a/task/buildah-min/0.4/patch.yaml
+++ b/task/buildah-min/0.4/patch.yaml
@@ -11,7 +11,7 @@
 - op: replace
   path: /spec/steps/0/computeResources/requests/cpu
   value: 100m
-# icm, push, and sbom-syft-generate steps
+# push, and sbom-syft-generate steps
 - op: replace
   path: /spec/stepTemplate/computeResources/limits/memory
   value: 2Gi
@@ -23,21 +23,21 @@
   value: 100m
 # prepare-sboms step
 - op: replace
-  path: /spec/steps/4/computeResources/limits/memory
+  path: /spec/steps/3/computeResources/limits/memory
   value: 256Mi
 - op: replace
-  path: /spec/steps/4/computeResources/requests/memory
+  path: /spec/steps/3/computeResources/requests/memory
   value: 128Mi
 - op: replace
-  path: /spec/steps/4/computeResources/requests/cpu
+  path: /spec/steps/3/computeResources/requests/cpu
   value: 10m
 # upload-sbom step
 - op: replace
-  path: /spec/steps/5/computeResources/limits/memory
+  path: /spec/steps/4/computeResources/limits/memory
   value: 2Gi
 - op: replace
-  path: /spec/steps/5/computeResources/requests/memory
+  path: /spec/steps/4/computeResources/requests/memory
   value: 512Mi
 - op: replace
-  path: /spec/steps/5/computeResources/requests/cpu
+  path: /spec/steps/4/computeResources/requests/cpu
   value: 100m

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -266,7 +266,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:97cba9cc7929c948bccf7bf8ce9aec9a039cfbb9a11ecf47fa9d25d8daf2356b
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -334,6 +334,11 @@ spec:
 
         dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
         cp "$dockerfile_path" "$dockerfile_copy"
+
+        # Inject the image content manifest into the container we are producing.
+        # This will generate the content-sets.json file and copy it by appending a COPY
+        # instruction to the Containerfile.
+        inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
         echo "[$(date --utc -Ins)] Prepare system"
 
@@ -617,20 +622,6 @@ spec:
         requests:
           cpu: "1"
           memory: 2Gi
-      securityContext:
-        capabilities:
-          add:
-            - SETFCAP
-    - name: icm
-      image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:f7a57ec2435029b2bed6866b3dddb97027f22bb81b2648bb450c9073e4c4f65e
-      workingDir: /var/workdir
-      volumeMounts:
-        - mountPath: /var/lib/containers
-          name: varlibcontainers
-      script: |
-        #!/bin/bash
-        set -euo pipefail
-        /scripts/inject-icm.sh "$IMAGE"
       securityContext:
         capabilities:
           add:

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -227,7 +227,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:97cba9cc7929c948bccf7bf8ce9aec9a039cfbb9a11ecf47fa9d25d8daf2356b
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -268,7 +268,7 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:97cba9cc7929c948bccf7bf8ce9aec9a039cfbb9a11ecf47fa9d25d8daf2356b
     name: build
     script: |-
       #!/bin/bash
@@ -373,6 +373,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      # Inject the image content manifest into the container we are producing.
+      # This will generate the content-sets.json file and copy it by appending a COPY
+      # instruction to the Containerfile.
+      inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
       echo "[$(date --utc -Ins)] Prepare system"
 
@@ -748,25 +753,6 @@ spec:
     - mountPath: /ssh
       name: ssh
       readOnly: true
-    workingDir: /var/workdir
-  - computeResources: {}
-    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:f7a57ec2435029b2bed6866b3dddb97027f22bb81b2648bb450c9073e4c4f65e
-    name: icm
-    script: |
-      #!/bin/bash
-      set -euo pipefail
-      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
-        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
-        export IMAGE
-      fi
-      /scripts/inject-icm.sh "$IMAGE"
-    securityContext:
-      capabilities:
-        add:
-        - SETFCAP
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
     workingDir: /var/workdir
   - computeResources: {}
     env:

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -218,7 +218,7 @@ spec:
     - name: SBOM_TYPE
       value: $(params.SBOM_TYPE)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:97cba9cc7929c948bccf7bf8ce9aec9a039cfbb9a11ecf47fa9d25d8daf2356b
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -245,7 +245,7 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:97cba9cc7929c948bccf7bf8ce9aec9a039cfbb9a11ecf47fa9d25d8daf2356b
     name: build
     script: |-
       #!/bin/bash
@@ -350,6 +350,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      # Inject the image content manifest into the container we are producing.
+      # This will generate the content-sets.json file and copy it by appending a COPY
+      # instruction to the Containerfile.
+      inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
       echo "[$(date --utc -Ins)] Prepare system"
 
@@ -716,25 +721,6 @@ spec:
     - mountPath: /ssh
       name: ssh
       readOnly: true
-    workingDir: $(workspaces.source.path)
-  - computeResources: {}
-    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:f7a57ec2435029b2bed6866b3dddb97027f22bb81b2648bb450c9073e4c4f65e
-    name: icm
-    script: |
-      #!/bin/bash
-      set -euo pipefail
-      if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
-        IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
-        export IMAGE
-      fi
-      /scripts/inject-icm.sh "$IMAGE"
-    securityContext:
-      capabilities:
-        add:
-        - SETFCAP
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
     workingDir: $(workspaces.source.path)
   - computeResources: {}
     env:

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -199,7 +199,7 @@ spec:
       value: $(params.SBOM_TYPE)
 
   steps:
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:97cba9cc7929c948bccf7bf8ce9aec9a039cfbb9a11ecf47fa9d25d8daf2356b
     name: build
     computeResources:
       limits:
@@ -262,6 +262,11 @@ spec:
 
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
+
+      # Inject the image content manifest into the container we are producing.
+      # This will generate the content-sets.json file and copy it by appending a COPY
+      # instruction to the Containerfile.
+      inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
       echo "[$(date --utc -Ins)] Prepare system"
 
@@ -548,20 +553,6 @@ spec:
       mountPath: /mnt/trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - name: icm
-    image: quay.io/konflux-ci/icm-injection-scripts:latest@sha256:f7a57ec2435029b2bed6866b3dddb97027f22bb81b2648bb450c9073e4c4f65e
-    securityContext:
-      capabilities:
-        add:
-          - SETFCAP
-    volumeMounts:
-    - mountPath: /var/lib/containers
-      name: varlibcontainers
-    workingDir: $(workspaces.source.path)
-    script: |
-      #!/bin/bash
-      set -euo pipefail
-      /scripts/inject-icm.sh "$IMAGE"
   - name: push
     image: quay.io/konflux-ci/buildah-task:latest@sha256:ab0ba3b70f99faa74d2dd737422a965197af4922dec0109113bc535a94db0dfd
     env:

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -495,6 +495,11 @@ spec:
         dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
         cp "$dockerfile_path" "$dockerfile_copy"
 
+        # Inject the image content manifest into the container we are producing.
+        # This will generate the content-sets.json file and copy it by appending a COPY
+        # instruction to the Containerfile.
+        inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+
         echo "[$(date --utc -Ins)] Prepare system"
 
         # Fixing group permission on /var/lib/containers

--- a/task/sast-coverity-check/0.2/patch.yaml
+++ b/task/sast-coverity-check/0.2/patch.yaml
@@ -29,36 +29,29 @@
 
 # upload-sbom
 - op: test
-  path: /spec/steps/5/name
-  value: upload-sbom
-- op: remove
-  path: /spec/steps/5
-
-# prepare-sboms
-- op: test
   path: /spec/steps/4/name
-  value: prepare-sboms
+  value: upload-sbom
 - op: remove
   path: /spec/steps/4
 
-# sbom-syft-generate
+# prepare-sboms
 - op: test
   path: /spec/steps/3/name
-  value: sbom-syft-generate
+  value: prepare-sboms
 - op: remove
   path: /spec/steps/3
 
-# push
+# sbom-syft-generate
 - op: test
   path: /spec/steps/2/name
-  value: push
+  value: sbom-syft-generate
 - op: remove
   path: /spec/steps/2
 
-# icm
+# push
 - op: test
   path: /spec/steps/1/name
-  value: icm
+  value: push
 - op: remove
   path: /spec/steps/1
 

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -432,6 +432,11 @@ spec:
       dockerfile_copy=$(mktemp --tmpdir "$(basename "$dockerfile_path").XXXXXX")
       cp "$dockerfile_path" "$dockerfile_copy"
 
+      # Inject the image content manifest into the container we are producing.
+      # This will generate the content-sets.json file and copy it by appending a COPY
+      # instruction to the Containerfile.
+      inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+
       echo "[$(date --utc -Ins)] Prepare system"
 
       # Fixing group permission on /var/lib/containers


### PR DESCRIPTION
When we were injecting the image content manifests after the image build, we were adding a new layer since it is not possible to just ammend the previously added layer locally. We have moved the script into the buildah-task image and modified it to COPY the `content-sets.json` into the container. This allows buildah's default behavior of only creating _one_ new layer to be respected.

resolves: [KONFLUX-7507](https://issues.redhat.com//browse/KONFLUX-7507)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
