### PR TITLE
Add SBOM_DIGEST result to build-index-image task

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -295,6 +295,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### buildah-remote-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -302,6 +303,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| Image reference of the built image| build-image-index:0.1:IMAGES|
 |IMAGE_URL| Image repository and tag where the built image was pushed| |
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### clair-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -292,6 +292,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### buildah-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -299,6 +300,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| Image reference of the built image| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### clair-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -284,6 +284,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.1:image-url ; sast-snyk-check:0.3:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.2:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### buildah:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -291,6 +292,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| Image reference of the built image| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.1:IMAGES|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### clair-scan:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -175,6 +175,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; deprecated-base-image-check:0.5:IMAGE_URL ; apply-tags:0.1:IMAGE ; validate-fbc:0.1:IMAGE_URL ; fbc-target-index-pruning-check:0.1:IMAGE_URL ; fbc-fips-check-oci-ta:0.1:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### buildah-remote-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -182,6 +183,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| Image reference of the built image| build-image-index:0.1:IMAGES|
 |IMAGE_URL| Image repository and tag where the built image was pushed| |
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### deprecated-image-check:0.5 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -137,6 +137,7 @@
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### git-clone-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -130,6 +130,7 @@
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| sast-shell-check:0.1:image-url ; sast-unicode-check:0.1:image-url ; apply-tags:0.1:IMAGE|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+|SBOM_DIGEST| A reference to the digest of the SBOM blob| |
 ### git-clone:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -54,6 +54,9 @@ spec:
   - name: SBOM_BLOB_URL
     description: Reference of SBOM blob digest to enable digest-based verification from provenance
     type: string
+  - name: SBOM_DIGEST
+    description: A reference to the digest of the SBOM blob
+    type: string
   volumes:
     - name: shared-dir
       emptyDir: {}
@@ -238,6 +241,9 @@ spec:
       sbom_digest="$(sha256sum "$SBOM_RESULT_FILE" | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+      # Expose the SBOM digest as result to find the SBOM in Atlas.
+      echo -n "${sbom_digest}" | tee "$(results.SBOM_DIGEST.path)"
     computeResources:
       limits:
         memory: 512Mi

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -63,6 +63,9 @@ spec:
       from provenance
     name: SBOM_BLOB_URL
     type: string
+  - description: A reference to the digest of the SBOM blob
+    name: SBOM_DIGEST
+    type: string
   stepTemplate:
     env:
     - name: BUILDAH_FORMAT
@@ -246,6 +249,9 @@ spec:
       sbom_digest="$(sha256sum "$SBOM_RESULT_FILE" | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+      # Expose the SBOM digest as result to find the SBOM in Atlas.
+      echo -n "${sbom_digest}" | tee "$(results.SBOM_DIGEST.path)"
   volumes:
   - emptyDir: {}
     name: shared-dir

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -159,6 +159,9 @@ spec:
       from provenance
     name: SBOM_BLOB_URL
     type: string
+  - description: A reference to the digest of the SBOM blob
+    name: SBOM_DIGEST
+    type: string
   stepTemplate:
     computeResources:
       limits:
@@ -801,6 +804,9 @@ spec:
       sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+      # Expose the SBOM digest as result to find the SBOM in Atlas.
+      echo -n "${sbom_digest}" | tee "$(results.SBOM_DIGEST.path)"
 
       echo
       echo "[$(date --utc -Ins)] End upload-sbom"

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -47,4 +47,5 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |IMAGE_REF|Image reference of the built image|
 |IMAGE_URL|Image repository and tag where the built image was pushed|
 |SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+|SBOM_DIGEST|A reference to the digest of the SBOM blob|
 

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -172,6 +172,9 @@ spec:
       description: Reference of SBOM blob digest to enable digest-based verification
         from provenance
       type: string
+    - name: SBOM_DIGEST
+      description: A reference to the digest of the SBOM blob
+      type: string
   volumes:
     - name: activation-key
       secret:
@@ -860,6 +863,9 @@ spec:
         sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
         # The SBOM_BLOB_URL is created by `cosign attach sbom`.
         echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+        # Expose the SBOM digest as result to find the SBOM in Atlas.
+        echo -n "${sbom_digest}" | tee "$(results.SBOM_DIGEST.path)"
 
         echo
         echo "[$(date --utc -Ins)] End upload-sbom"

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -176,6 +176,9 @@ spec:
       from provenance
     name: SBOM_BLOB_URL
     type: string
+  - description: A reference to the digest of the SBOM blob
+    name: SBOM_DIGEST
+    type: string
   stepTemplate:
     computeResources:
       limits:
@@ -1016,6 +1019,9 @@ spec:
       sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+      # Expose the SBOM digest as result to find the SBOM in Atlas.
+      echo -n "${sbom_digest}" | tee "$(results.SBOM_DIGEST.path)"
 
       echo
       echo "[$(date --utc -Ins)] End upload-sbom"

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -167,6 +167,9 @@ spec:
       from provenance
     name: SBOM_BLOB_URL
     type: string
+  - description: A reference to the digest of the SBOM blob
+    name: SBOM_DIGEST
+    type: string
   stepTemplate:
     computeResources:
       limits:
@@ -985,6 +988,9 @@ spec:
       sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+      # Expose the SBOM digest as result to find the SBOM in Atlas.
+      echo -n "${sbom_digest}" | tee "$(results.SBOM_DIGEST.path)"
 
       echo
       echo "[$(date --utc -Ins)] End upload-sbom"

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -144,6 +144,9 @@ spec:
   - name: SBOM_BLOB_URL
     description: Reference of SBOM blob digest to enable digest-based verification from provenance
     type: string
+  - name: SBOM_DIGEST
+    description: A reference to the digest of the SBOM blob
+    type: string
   stepTemplate:
     computeResources:
       limits:
@@ -789,6 +792,9 @@ spec:
       sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+      # Expose the SBOM digest as result to find the SBOM in Atlas.
+      echo -n "${sbom_digest}" | tee "$(results.SBOM_DIGEST.path)"
 
       echo
       echo "[$(date --utc -Ins)] End upload-sbom"


### PR DESCRIPTION
The SBOM digest is exposed in the task result to be later used by the Konflux UI to redirect user to SBOM uploaded to Atlas UI.

This is done because a new version of Atlas no longer supports URL templates based on custom fields. The SBOM digest is now used as primary identifier.

JIRA: [ISV-5734](https://issues.redhat.com//browse/ISV-5734)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
