### PR TITLE
Improve log-based buildah debugging

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -281,7 +281,7 @@ spec:
       # instruction to the Containerfile.
       inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
-      echo "[$(date --utc -Ins)] Prepare system"
+      echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -518,6 +518,7 @@ spec:
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
       echo "[$(date --utc -Ins)] Run buildah build"
+      echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -340,7 +340,7 @@ spec:
         # instruction to the Containerfile.
         inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
-        echo "[$(date --utc -Ins)] Prepare system"
+        echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
         # Fixing group permission on /var/lib/containers
         chown root:root /var/lib/containers
@@ -586,6 +586,7 @@ spec:
         find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
         echo "[$(date --utc -Ins)] Run buildah build"
+        echo "[$(date --utc -Ins)] ${command}"
 
         unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -379,7 +379,7 @@ spec:
       # instruction to the Containerfile.
       inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
-      echo "[$(date --utc -Ins)] Prepare system"
+      echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -625,6 +625,7 @@ spec:
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
       echo "[$(date --utc -Ins)] Run buildah build"
+      echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -356,7 +356,7 @@ spec:
       # instruction to the Containerfile.
       inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
-      echo "[$(date --utc -Ins)] Prepare system"
+      echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -593,6 +593,7 @@ spec:
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
       echo "[$(date --utc -Ins)] Run buildah build"
+      echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -268,7 +268,7 @@ spec:
       # instruction to the Containerfile.
       inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
-      echo "[$(date --utc -Ins)] Prepare system"
+      echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -505,6 +505,7 @@ spec:
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
       echo "[$(date --utc -Ins)] Run buildah build"
+      echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -500,7 +500,7 @@ spec:
         # instruction to the Containerfile.
         inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
-        echo "[$(date --utc -Ins)] Prepare system"
+        echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
         # Fixing group permission on /var/lib/containers
         chown root:root /var/lib/containers
@@ -746,6 +746,7 @@ spec:
         find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
         echo "[$(date --utc -Ins)] Run buildah build"
+        echo "[$(date --utc -Ins)] ${command}"
 
         unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -437,7 +437,7 @@ spec:
       # instruction to the Containerfile.
       inject-icm-to-containerfile "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
 
-      echo "[$(date --utc -Ins)] Prepare system"
+      echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
       # Fixing group permission on /var/lib/containers
       chown root:root /var/lib/containers
@@ -674,6 +674,7 @@ spec:
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
       echo "[$(date --utc -Ins)] Run buildah build"
+      echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" -- sh -c "$command"
 


### PR DESCRIPTION
As a user, I have often wanted to know what architecture a build is running on at the start as well as what the actual buildah command used was. We can easily output both of these to the log.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
