### PR TITLE
chore(KFLUXVNGD-212): add annotations to bundles

### DIFF
--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -6,14 +6,14 @@
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-container:0.1:IMAGE ; build-image-index:0.1:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT|
+|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-container:0.2:IMAGE ; build-image-index:0.1:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
 
 ## Available params from tasks
@@ -112,14 +112,16 @@
 |git-url| Git URL| None| '$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)'|
 |image-url| Image URL| None| '$(params.output-image)'|
 |pipelinerun-name| pipeline-run to annotate| None| '$(context.pipelineRun.name)'|
-### tkn-bundle-oci-ta:0.1 task parameters
+### tkn-bundle-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |HOME| Value for the HOME environment variable.| /tekton/home| |
 |IMAGE| Reference of the image task will produce.| None| '$(params.output-image)'|
+|REVISION| Revision| None| '$(params.revision)'|
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |STEPS_IMAGE| An optional image to configure task steps with in the bundle| | |
+|URL| Source code Git URL| None| '$(params.git-url)'|
 
 ## Results
 |name|description|value|
@@ -156,7 +158,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| sast-shell-check:0.1:CACHI2_ARTIFACT ; sast-unicode-check:0.1:CACHI2_ARTIFACT|
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.1:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| build-container:0.2:SOURCE_ARTIFACT ; sast-shell-check:0.1:SOURCE_ARTIFACT ; sast-unicode-check:0.1:SOURCE_ARTIFACT|
 ### sast-shell-check-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -165,7 +167,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### tkn-bundle-oci-ta:0.1 task results
+### tkn-bundle-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_DIGEST| Digest of the image just built| |

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -142,13 +142,17 @@ spec:
       value: $(params.output-image)
     - name: CONTEXT
       value: $(params.path-context)
+    - name: URL
+      value: $(params.git-url)
+    - name: REVISION
+      value: $(params.revision)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     runAfter:
     - prefetch-dependencies
     taskRef:
       name: tkn-bundle-oci-ta
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(tasks.init.results.build)
       operator: in

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -6,14 +6,14 @@
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-image-index:0.1:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.1:IMAGE ; build-image-index:0.1:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:CONTEXT|
+|output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.2:IMAGE ; build-image-index:0.1:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
 
 ## Available params from tasks
@@ -106,13 +106,15 @@
 |git-url| Git URL| None| '$(tasks.clone-repository.results.url)?rev=$(tasks.clone-repository.results.commit)'|
 |image-url| Image URL| None| '$(params.output-image)'|
 |pipelinerun-name| pipeline-run to annotate| None| '$(context.pipelineRun.name)'|
-### tkn-bundle:0.1 task parameters
+### tkn-bundle:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |HOME| Value for the HOME environment variable.| /tekton/home| |
 |IMAGE| Reference of the image task will produce.| None| '$(params.output-image)'|
+|REVISION| Revision| None| '$(params.revision)'|
 |STEPS_IMAGE| An optional image to configure task steps with in the bundle| | |
+|URL| Source code Git URL| None| '$(params.git-url)'|
 
 ## Results
 |name|description|value|
@@ -152,7 +154,7 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |TEST_OUTPUT| Tekton task test output.| |
-### tkn-bundle:0.1 task results
+### tkn-bundle:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGE_DIGEST| Digest of the image just built| |
@@ -164,7 +166,7 @@
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.2:netrc|
-|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.1:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
+|workspace| |False| show-summary:0.2:workspace ; clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.1:workspace|
 ## Available workspaces from tasks
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -190,7 +192,7 @@
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |workspace| The workspace where source code is included.| True| workspace|
-### tkn-bundle:0.1 task workspaces
+### tkn-bundle:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |source| | False| workspace|

--- a/pipelines/tekton-bundle-builder/patch.yaml
+++ b/pipelines/tekton-bundle-builder/patch.yaml
@@ -6,7 +6,7 @@
   path: /spec/tasks/3/taskRef
   value:
     name: tkn-bundle
-    version: "0.1"
+    version: "0.2"
 # Use the template-build as a template replacing the Pipeline name and the
 # `build-container` step's task reference
 # Order of Tasks from the base template:
@@ -40,6 +40,10 @@
     value: $(params.output-image)
   - name: CONTEXT
     value: $(params.path-context)
+  - name: URL
+    value: $(params.git-url)
+  - name: REVISION
+    value: $(params.revision)
 # Remove tasks that assume a binary image
 - op: remove
   path: /spec/tasks/17  # rpms-signature-scan

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -143,11 +143,15 @@ spec:
       value: $(params.output-image)
     - name: CONTEXT
       value: $(params.path-context)
+    - name: URL
+      value: $(params.git-url)
+    - name: REVISION
+      value: $(params.revision)
     runAfter:
     - prefetch-dependencies
     taskRef:
       name: tkn-bundle
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(tasks.init.results.build)
       operator: in

--- a/task/tkn-bundle-oci-ta/0.2/MIGRATION.md
+++ b/task/tkn-bundle-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,6 @@
+# Migration from 0.1 to 0.2
+The parameter `URL` was added to the task.
+The parameter `REVISION` was added to the task.
+
+## Action from users
+Add the `URL` and `REVISION` parameters to the `tkn-bundle-oci-ta` task.

--- a/task/tkn-bundle-oci-ta/0.2/README.md
+++ b/task/tkn-bundle-oci-ta/0.2/README.md
@@ -1,0 +1,22 @@
+# tkn-bundle-oci-ta task
+
+Creates and pushes a Tekton bundle containing the specified Tekton YAML files.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|HOME|Value for the HOME environment variable.|/tekton/home|false|
+|IMAGE|Reference of the image task will produce.||true|
+|REVISION|Revision||true|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|STEPS_IMAGE|An optional image to configure task steps with in the bundle|""|false|
+|URL|Source code Git URL||true|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_REF|Image reference of the built image|
+|IMAGE_URL|Image repository and tag where the built image was pushed with tag only|
+

--- a/task/tkn-bundle-oci-ta/0.2/recipe.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,11 @@
+---
+base: ../../tkn-bundle/0.2/tkn-bundle.yaml
+add:
+  - use-source
+removeWorkspaces:
+  - source
+preferStepTemplate: true
+replacements:
+  workspaces.source.path: /var/workdir
+regexReplacements:
+  "/workspace(/.*)": /var/workdir$1

--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -1,0 +1,236 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: tkn-bundle-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.2"
+    build.appstudio.redhat.com/build_type: tkn-bundle
+spec:
+  description: Creates and pushes a Tekton bundle containing the specified
+    Tekton YAML files.
+  params:
+    - name: CONTEXT
+      description: Path to the directory to use as context.
+      type: string
+      default: .
+    - name: HOME
+      description: Value for the HOME environment variable.
+      type: string
+      default: /tekton/home
+    - name: IMAGE
+      description: Reference of the image task will produce.
+      type: string
+    - name: REVISION
+      description: Revision
+      type: string
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: STEPS_IMAGE
+      description: An optional image to configure task steps with in the bundle
+      type: string
+      default: ""
+    - name: URL
+      description: Source code Git URL
+      type: string
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the image just built
+    - name: IMAGE_REF
+      description: Image reference of the built image
+    - name: IMAGE_URL
+      description: Image repository and tag where the built image was pushed
+        with tag only
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    env:
+      - name: HOME
+        value: $(params.HOME)
+      - name: SOURCE_CODE_DIR
+        value: source
+      - name: TASK_FILE
+        value: tekton_task_files
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:635a890e9f0211b4eb5b8c811d6f06b3ed9ff7da952ebad236fbfe52ba36dbf7
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: modify-task-files
+      image: quay.io/konflux-ci/konflux-test:latest@sha256:d596724343a31c201a5c2e79f233f9ef78ac65726ae4ed5ffa41d76b3dac630f
+      workingDir: /var/workdir
+      env:
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+        - name: STEPS_IMAGE
+          value: $(params.STEPS_IMAGE)
+      script: |
+        #!/bin/env bash
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        # expand '**', and don't return glob expression when no matches found
+        shopt -s globstar nullglob
+
+        # read \$CONTEXT as an array split by comma or space into PATHS
+        IFS=', ' read -r -a PATHS <<<"$CONTEXT"
+        FILES=()
+        for path in "${PATHS[@]}"; do
+          # keeps current path expanded
+          paths=()
+          # are we negating the current path
+          neg=0
+          if [[ "${path}" == \!* ]]; then
+            neg=1
+            path="${path#\!}"
+          fi
+          if [[ -d "/var/workdir/${SOURCE_CODE_DIR}/${path}" ]]; then
+            # for directories look for any .yaml or .yml files
+            paths+=(
+              "/var/workdir/${SOURCE_CODE_DIR}/${path}"/**/*.yaml
+              "/var/workdir/${SOURCE_CODE_DIR}/${path}"/**/*.yml
+            )
+          else
+            # for files add the file to the collected paths
+            paths+=("/var/workdir/${SOURCE_CODE_DIR}/${path}")
+          fi
+          if [[ $neg == 0 ]]; then
+            # collect current paths to FILES
+            FILES+=("${paths[@]}")
+          else
+            if [[ ${#PATHS[@]} -eq 1 ]]; then
+              # single negative path provided, first include everything then
+              # subtract the negative elements
+              FILES=(
+                "/var/workdir/${SOURCE_CODE_DIR}"/**/*.yaml
+                "/var/workdir/${SOURCE_CODE_DIR}"/**/*.yml
+              )
+            fi
+            for p in "${paths[@]}"; do
+              # remove any collected paths from FILES, leaves blank elements in place
+              FILES=("${FILES[@]/$p/}")
+            done
+            # remove blank elements
+            TMP=("${FILES[@]}")
+            FILES=()
+            for p in "${TMP[@]}"; do
+              [[ -n "${p}" ]] && FILES+=("${p}")
+            done
+          fi
+        done
+
+        if [[ -n "${STEPS_IMAGE}" ]]; then
+          for f in "${FILES[@]}"; do
+            yq --in-place --yml-output '(.spec.steps[] | select(has("image")).image) = env.STEPS_IMAGE' "$f"
+          done
+        fi
+
+        printf "%s\n" "${FILES[@]}" >"${TASK_FILE}"
+    - name: build
+      image: quay.io/konflux-ci/appstudio-utils@sha256:4dd23978070d02c567303d46bef1f03bfc16d77aef62e6899ac2ac022884b4b5
+      workingDir: /var/workdir
+      env:
+        - name: CONTEXT
+          value: $(params.CONTEXT)
+        - name: IMAGE
+          value: $(params.IMAGE)
+        - name: URL
+          value: $(params.URL)
+        - name: REVISION
+          value: $(params.REVISION)
+      script: |
+        #!/bin/env bash
+
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        mapfile -t FILES <"${TASK_FILE}"
+        [[ ${#FILES[@]} -eq 0 ]] &&
+          echo "No YAML files matched by \"$CONTEXT\" in \"/var/workdir/${SOURCE_CODE_DIR}\", aborting the build" &&
+          exit 1
+        exec 3>&1
+
+        retry() {
+          local status
+          local retry=0
+          local -r interval=${RETRY_INTERVAL:-5}
+          local -r max_retries=5
+          while true; do
+            "$@" && break
+            status=$?
+            ((retry += 1))
+            if [ $retry -gt $max_retries ]; then
+              return $status
+            fi
+            echo "info: Waiting for a while, then retry ..." 1>&2
+            sleep "$interval"
+          done
+        }
+
+        function escape_tkn_bundle_arg() {
+          # the arguments to `tkn bundle --annotate` need to be escaped in a curious way
+          # see https://github.com/tektoncd/cli/issues/2402 for details
+
+          local arg=$1
+          # replace single double-quotes with double double-quotes (this escapes the double-quotes)
+          local escaped_arg=${arg//\"/\"\"}
+          # wrap the whole thing in double-quotes (this escapes commas)
+          printf '"%s"' "$escaped_arg"
+        }
+
+        ANNOTATIONS=()
+        ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
+        ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
+        ANNOTATIONS+=("org.opencontainers.image.url=${URL}/tree/${REVISION}/${CONTEXT}")
+
+        # Ensure an empty string is output rather than string "null" if the version label is not present
+        task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
+        ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
+
+        task_dir=$(echo "${FILES[@]}" | awk -F'/' '{NF--; print $0}' OFS='/')
+        if [ -f "${task_dir}/README.md" ]; then
+          ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")
+        fi
+
+        if [ -f "${task_dir}/TROUBLESHOOTING.md" ]; then
+          ANNOTATIONS+=("dev.tekton.docs.troubleshooting=${URL}/tree/${REVISION}/${CONTEXT}/TROUBLESHOOTING.md")
+        fi
+
+        if [ -f "${task_dir}/USAGE.md" ]; then
+          ANNOTATIONS+=("dev.tekton.docs.usage=${URL}/tree/${REVISION}/${CONTEXT}/USAGE.md")
+        fi
+        description=$(yq '.spec.description' "${FILES[@]}" | sed '/null/d' | tr -d '')
+        ANNOTATIONS+=("org.opencontainers.image.description=${description}")
+
+        echo "Added annotations:"
+        ANNOTATION_FLAGS=()
+        for annotation in "${ANNOTATIONS[@]}"; do
+          ANNOTATION_FLAGS+=("--annotate" "$(escape_tkn_bundle_arg "$annotation")")
+          echo "    - $annotation"
+        done
+
+        # shellcheck disable=SC2046
+        OUT="$(retry tkn bundle push "${ANNOTATION_FLAGS[@]}" "$IMAGE" \
+          $(printf ' -f %s' "${FILES[@]}") |
+          tee /proc/self/fd/3)"
+        echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"
+        digest="${OUT#*Pushed Tekton Bundle to *@}"
+        echo -n "${digest}" >"$(results.IMAGE_DIGEST.path)"
+        echo -n "${IMAGE}@${digest}" >"$(results.IMAGE_REF.path)"
+
+        # cleanup task file
+        [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"
+      securityContext:
+        runAsUser: 0

--- a/task/tkn-bundle/0.2/MIGRATION.md
+++ b/task/tkn-bundle/0.2/MIGRATION.md
@@ -1,0 +1,6 @@
+# Migration from 0.1 to 0.2
+The parameter `URL` was added to the task.
+The parameter `REVISION` was added to the task.
+
+## Action from users
+Add the `URL` and `REVISION` parameters to the `tkn-bundle` task.

--- a/task/tkn-bundle/0.2/README.md
+++ b/task/tkn-bundle/0.2/README.md
@@ -1,0 +1,59 @@
+# tkn-bundle - Tekton Task to push a Tekton Bundle to an image registry
+
+Tekton Task to build and push Tekton Bundles (OCI images) which contain
+definitions of Tekton objects, most commonly Task and Pipeline objects.
+
+Task finds all `*.yaml` or `*.yml` files within `CONTEXT`, packages and pushes
+them as a Tekton Bundle to the image repository, name and tag specified by the
+`IMAGE` parameter.
+
+## Input Parameters
+
+The task supports the following input parameters.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE|Reference of the image task will produce.||true|
+|CONTEXT|Path to the directory to use as context.|.|false|
+|HOME|Value for the HOME environment variable.|/tekton/home|false|
+|STEPS_IMAGE|An optional image to configure task steps with in the bundle|""|false|
+|URL|Source code Git URL||true|
+|REVISION|Revision||true|
+
+
+`CONTEXT` can include multiple directories or files separated by comma or space.
+Paths can be negated with exclamation mark to prevent inclusion of certain
+directories or files. Negated paths are best placed at the end as they operate
+on collected paths preceeding them. For example if `CONTEXT` is set to
+`"0.1,!0.1/spec"` for this tree:
+
+    .
+    ├── 0.1
+    │   ├── README.md
+    │   ├── spec
+    │   │   ├── spec_helper.sh
+    │   │   ├── support
+    │   │   │   ├── jq_matcher.sh
+    │   │   │   └── task_run_subject.sh
+    │   │   ├── test1.yaml
+    │   │   ├── test2.yml
+    │   │   ├── test3.yaml
+    │   │   └── tkn-bundle_spec.sh
+    │   ├── TESTING.md
+    │   └── tkn-bundle.yaml
+    └── OWNERS
+
+Only the `0.1/tkn-bundle.yaml` file will be included in the bundle.
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the image just built|
+|IMAGE_URL|Image repository and tag where the built image was pushed with tag only|
+|IMAGE_REF|Image reference of the built image|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|source||false|

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -1,0 +1,221 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.2"
+    build.appstudio.redhat.com/build_type: "tkn-bundle"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "image-build, konflux"
+  name: tkn-bundle
+spec:
+  description: |-
+    Creates and pushes a Tekton bundle containing the specified Tekton YAML files.
+  params:
+  - description: Reference of the image task will produce.
+    name: IMAGE
+    type: string
+  - default: .
+    description: Path to the directory to use as context.
+    name: CONTEXT
+    type: string
+  - name: HOME
+    type: string
+    description: Value for the HOME environment variable.
+    default: /tekton/home
+  - name: STEPS_IMAGE
+    type: string
+    description: An optional image to configure task steps with in the bundle
+    default: ""
+  - name: URL
+    type: string
+    description: Source code Git URL
+  - name: REVISION
+    type: string
+    description: Revision
+  results:
+  - description: Digest of the image just built
+    name: IMAGE_DIGEST
+  - description: Image repository and tag where the built image was pushed with tag only
+    name: IMAGE_URL
+  - description: Image reference of the built image
+    name: IMAGE_REF
+  stepTemplate:
+    env:
+    - name: HOME
+      value: "$(params.HOME)"
+    - name: TASK_FILE
+      value: tekton_task_files
+    - name: SOURCE_CODE_DIR
+      value: source
+  steps:
+  - image: quay.io/konflux-ci/konflux-test:latest@sha256:d596724343a31c201a5c2e79f233f9ef78ac65726ae4ed5ffa41d76b3dac630f
+    name: modify-task-files
+    env:
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: STEPS_IMAGE
+      value: $(params.STEPS_IMAGE)
+    script: |
+      #!/bin/env bash
+      set -o errexit
+      set -o pipefail
+      set -o nounset
+
+      # expand '**', and don't return glob expression when no matches found
+      shopt -s globstar nullglob
+
+      # read \$CONTEXT as an array split by comma or space into PATHS
+      IFS=', ' read -r -a PATHS <<< "$CONTEXT"
+      FILES=()
+      for path in "${PATHS[@]}"; do
+        # keeps current path expanded
+        paths=()
+        # are we negating the current path
+        neg=0
+        if [[ "${path}" == \!* ]]; then
+          neg=1
+          path="${path#\!}"
+        fi
+        if [[ -d "$(workspaces.source.path)/${SOURCE_CODE_DIR}/${path}" ]]; then
+          # for directories look for any .yaml or .yml files
+          paths+=(
+            "$(workspaces.source.path)/${SOURCE_CODE_DIR}/${path}"/**/*.yaml
+            "$(workspaces.source.path)/${SOURCE_CODE_DIR}/${path}"/**/*.yml
+          )
+        else
+          # for files add the file to the collected paths
+          paths+=("$(workspaces.source.path)/${SOURCE_CODE_DIR}/${path}")
+        fi
+        if [[ $neg == 0 ]]; then
+          # collect current paths to FILES
+          FILES+=("${paths[@]}")
+        else
+          if [[ ${#PATHS[@]} -eq 1 ]]; then
+            # single negative path provided, first include everything then
+            # subtract the negative elements
+            FILES=(
+              "$(workspaces.source.path)/${SOURCE_CODE_DIR}"/**/*.yaml
+              "$(workspaces.source.path)/${SOURCE_CODE_DIR}"/**/*.yml
+            )
+          fi
+          for p in "${paths[@]}"; do
+            # remove any collected paths from FILES, leaves blank elements in place
+            FILES=("${FILES[@]/$p/}")
+          done
+          # remove blank elements
+          TMP=("${FILES[@]}")
+          FILES=()
+          for p in "${TMP[@]}"; do
+            [[ -n "${p}" ]] && FILES+=("${p}")
+          done
+        fi
+      done
+
+      if [[ -n "${STEPS_IMAGE}" ]]; then
+        for f in "${FILES[@]}"; do
+          yq --in-place --yml-output '(.spec.steps[] | select(has("image")).image) = env.STEPS_IMAGE' "$f"
+        done
+      fi
+
+      printf "%s\n" "${FILES[@]}" > "${TASK_FILE}"
+    workingDir: $(workspaces.source.path)
+  - image: quay.io/konflux-ci/appstudio-utils@sha256:4dd23978070d02c567303d46bef1f03bfc16d77aef62e6899ac2ac022884b4b5
+    name: build
+    env:
+    - name: CONTEXT
+      value: $(params.CONTEXT)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: URL
+      value: $(params.URL)
+    - name: REVISION
+      value: $(params.REVISION)
+    script: |
+        #!/bin/env bash
+
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        mapfile -t FILES <"${TASK_FILE}"
+        [[ ${#FILES[@]} -eq 0 ]] &&
+          echo "No YAML files matched by \"$CONTEXT\" in \"/var/workdir/${SOURCE_CODE_DIR}\", aborting the build" &&
+          exit 1
+        exec 3>&1
+
+        retry() {
+          local status
+          local retry=0
+          local -r interval=${RETRY_INTERVAL:-5}
+          local -r max_retries=5
+          while true; do
+            "$@" && break
+            status=$?
+            ((retry += 1))
+            if [ $retry -gt $max_retries ]; then
+              return $status
+            fi
+            echo "info: Waiting for a while, then retry ..." 1>&2
+            sleep "$interval"
+          done
+        }
+
+        function escape_tkn_bundle_arg() {
+          # the arguments to `tkn bundle --annotate` need to be escaped in a curious way
+          # see https://github.com/tektoncd/cli/issues/2402 for details
+
+          local arg=$1
+          # replace single double-quotes with double double-quotes (this escapes the double-quotes)
+          local escaped_arg=${arg//\"/\"\"}
+          # wrap the whole thing in double-quotes (this escapes commas)
+          printf '"%s"' "$escaped_arg"
+        }
+
+        ANNOTATIONS=()
+        ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
+        ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
+        ANNOTATIONS+=("org.opencontainers.image.url=${URL}/tree/${REVISION}/${CONTEXT}")
+
+        # Ensure an empty string is output rather than string "null" if the version label is not present
+        task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
+        ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
+
+        task_dir=$(echo "${FILES[@]}" | awk -F'/' '{NF--; print $0}' OFS='/')
+        if [ -f "${task_dir}/README.md" ]; then
+          ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")
+        fi
+
+        if [ -f "${task_dir}/TROUBLESHOOTING.md" ]; then
+          ANNOTATIONS+=("dev.tekton.docs.troubleshooting=${URL}/tree/${REVISION}/${CONTEXT}/TROUBLESHOOTING.md")
+        fi
+
+        if [ -f "${task_dir}/USAGE.md" ]; then
+          ANNOTATIONS+=("dev.tekton.docs.usage=${URL}/tree/${REVISION}/${CONTEXT}/USAGE.md")
+        fi
+        description=$(yq '.spec.description' "${FILES[@]}" | sed '/null/d' | tr -d '')
+        ANNOTATIONS+=("org.opencontainers.image.description=${description}")
+
+        echo "Added annotations:"
+        ANNOTATION_FLAGS=()
+        for annotation in "${ANNOTATIONS[@]}"; do
+          ANNOTATION_FLAGS+=("--annotate" "$(escape_tkn_bundle_arg "$annotation")")
+          echo "    - $annotation"
+        done
+
+        # shellcheck disable=SC2046
+        OUT="$(retry tkn bundle push "${ANNOTATION_FLAGS[@]}" "$IMAGE" \
+          $(printf ' -f %s' "${FILES[@]}") |
+          tee /proc/self/fd/3)"
+        echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"
+        digest="${OUT#*Pushed Tekton Bundle to *@}"
+        echo -n "${digest}" >"$(results.IMAGE_DIGEST.path)"
+        echo -n "${IMAGE}@${digest}" >"$(results.IMAGE_REF.path)"
+
+        # cleanup task file
+        [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"
+    securityContext:
+      runAsUser: 0
+    workingDir: $(workspaces.source.path)
+  workspaces:
+  - name: source


### PR DESCRIPTION
- Adding annotations to tasks created as bundles
- Migrating to v0.2 because of parameters addition


This PR is for adding annotations to the tasks being built as bundles using the `tkn-bundle` task.
There are 2 new parameters we need for the annotations:
URL - Source Code Git URL
REVISION - Revision of the Source Repository
And therefor a migration to v0.2 is needed.




