### PR TITLE
fix(KFLUXVNGD-212): update reference to FILES array

### DIFF
--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -199,7 +199,9 @@ spec:
         task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
         ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
 
-        task_dir=$(echo "${FILES[@]}" | awk -F'/' '{NF--; print $0}' OFS='/')
+        # task_dir is where all the tasks definitions resides
+        # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
+        task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
         if [ -f "${task_dir}/README.md" ]; then
           ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")
         fi

--- a/task/tkn-bundle/0.2/README.md
+++ b/task/tkn-bundle/0.2/README.md
@@ -7,6 +7,8 @@ Task finds all `*.yaml` or `*.yml` files within `CONTEXT`, packages and pushes
 them as a Tekton Bundle to the image repository, name and tag specified by the
 `IMAGE` parameter.
 
+The task also adds annotations to the Tekton bundle. 
+
 ## Input Parameters
 
 The task supports the following input parameters.

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -181,7 +181,9 @@ spec:
         task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
         ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
 
-        task_dir=$(echo "${FILES[@]}" | awk -F'/' '{NF--; print $0}' OFS='/')
+        # task_dir is where all the tasks definitions resides
+        # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
+        task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
         if [ -f "${task_dir}/README.md" ]; then
           ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")
         fi


### PR DESCRIPTION
Updating FILES[@] to FILES[0] to only pick the first element. 
All elements are referencing to the same task dir.


