### PR TITLE
feat: Add support for ANNOTATIONS_FILE

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -51,6 +51,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
@@ -189,6 +190,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -50,6 +50,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
@@ -186,6 +187,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -50,6 +50,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
@@ -181,6 +182,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -50,6 +50,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -83,6 +83,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | |

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -80,6 +80,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | |

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -122,6 +122,11 @@ spec:
     description: Additional key=value annotations that should be applied to the image
     name: ANNOTATIONS
     type: array
+  - default: ""
+    description: Path to a file with additional key=value annotations that should
+      be applied to the image
+    name: ANNOTATIONS_FILE
+    type: string
   - default: "false"
     description: Whether to enable privileged mode, should be used only with remote
       VMs
@@ -209,6 +214,8 @@ spec:
       value: $(params.SKIP_SBOM_GENERATION)
     - name: SBOM_TYPE
       value: $(params.SBOM_TYPE)
+    - name: ANNOTATIONS_FILE
+      value: $(params.ANNOTATIONS_FILE)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -305,6 +312,17 @@ spec:
 
       LABELS=()
       ANNOTATIONS=()
+      # Append any annotations from the specified file
+      if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+        echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          # Skip empty lines and comments
+          if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+            ANNOTATIONS+=("--annotation" "$line")
+          fi
+        done < "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+      fi
+
       # Split `args` into two sets of arguments.
       while [[ $# -gt 0 ]]; do
           case $1 in

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -12,6 +12,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
+|ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -39,6 +39,11 @@ spec:
         to the image
       type: array
       default: []
+    - name: ANNOTATIONS_FILE
+      description: Path to a file with additional key=value annotations that
+        should be applied to the image
+      type: string
+      default: ""
     - name: BUILDAH_FORMAT
       description: The format for the resulting image's mediaType. Valid values
         are oci (default) or docker.
@@ -212,6 +217,8 @@ spec:
         value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
         value: $(params.ADD_CAPABILITIES)
+      - name: ANNOTATIONS_FILE
+        value: $(params.ANNOTATIONS_FILE)
       - name: BUILD_ARGS_FILE
         value: $(params.BUILD_ARGS_FILE)
       - name: CONTEXT
@@ -364,6 +371,17 @@ spec:
 
         LABELS=()
         ANNOTATIONS=()
+        # Append any annotations from the specified file
+        if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+          echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            # Skip empty lines and comments
+            if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+              ANNOTATIONS+=("--annotation" "$line")
+            fi
+          done <"${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        fi
+
         # Split `args` into two sets of arguments.
         while [[ $# -gt 0 ]]; do
           case $1 in

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -38,6 +38,11 @@ spec:
     description: Additional key=value annotations that should be applied to the image
     name: ANNOTATIONS
     type: array
+  - default: ""
+    description: Path to a file with additional key=value annotations that should
+      be applied to the image
+    name: ANNOTATIONS_FILE
+    type: string
   - default: oci
     description: The format for the resulting image's mediaType. Valid values are
       oci (default) or docker.
@@ -190,6 +195,8 @@ spec:
       value: $(params.ADDITIONAL_SECRET)
     - name: ADD_CAPABILITIES
       value: $(params.ADD_CAPABILITIES)
+    - name: ANNOTATIONS_FILE
+      value: $(params.ANNOTATIONS_FILE)
     - name: BUILD_ARGS_FILE
       value: $(params.BUILD_ARGS_FILE)
     - name: CONTEXT
@@ -403,6 +410,17 @@ spec:
 
       LABELS=()
       ANNOTATIONS=()
+      # Append any annotations from the specified file
+      if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+        echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          # Skip empty lines and comments
+          if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+            ANNOTATIONS+=("--annotation" "$line")
+          fi
+        done <"${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+      fi
+
       # Split `args` into two sets of arguments.
       while [[ $# -gt 0 ]]; do
         case $1 in
@@ -686,6 +704,7 @@ spec:
           -e ACTIVATION_KEY="${ACTIVATION_KEY@Q}" \
           -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
           -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e ANNOTATIONS_FILE="${ANNOTATIONS_FILE@Q}" \
           -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
           -e CONTEXT="${CONTEXT@Q}" \
           -e ENTITLEMENT_SECRET="${ENTITLEMENT_SECRET@Q}" \

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -122,6 +122,11 @@ spec:
     description: Additional key=value annotations that should be applied to the image
     name: ANNOTATIONS
     type: array
+  - default: ""
+    description: Path to a file with additional key=value annotations that should
+      be applied to the image
+    name: ANNOTATIONS_FILE
+    type: string
   - default: "false"
     description: Whether to enable privileged mode, should be used only with remote
       VMs
@@ -217,6 +222,8 @@ spec:
       value: $(params.SKIP_SBOM_GENERATION)
     - name: SBOM_TYPE
       value: $(params.SBOM_TYPE)
+    - name: ANNOTATIONS_FILE
+      value: $(params.ANNOTATIONS_FILE)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah-task:latest@sha256:4d8273444b0f2781264c232e12e88449bbf078c99e3da2a7f6dcaaf27bc53712
     - name: PLATFORM
@@ -380,6 +387,17 @@ spec:
 
       LABELS=()
       ANNOTATIONS=()
+      # Append any annotations from the specified file
+      if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+        echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          # Skip empty lines and comments
+          if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+            ANNOTATIONS+=("--annotation" "$line")
+          fi
+        done < "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+      fi
+
       # Split `args` into two sets of arguments.
       while [[ $# -gt 0 ]]; do
           case $1 in
@@ -672,6 +690,7 @@ spec:
           -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
           -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
           -e SBOM_TYPE="${SBOM_TYPE@Q}" \
+          -e ANNOTATIONS_FILE="${ANNOTATIONS_FILE@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e DOCKERFILE="${DOCKERFILE@Q}" \
           -v "${BUILD_DIR@Q}/workspaces/source:$(workspaces.source.path):Z" \

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -110,6 +110,10 @@ spec:
     description: Additional key=value annotations that should be applied to the image
     type: array
     default: []
+  - name: ANNOTATIONS_FILE
+    description: Path to a file with additional key=value annotations that should be applied to the image
+    type: string
+    default: ""
   - name: PRIVILEGED_NESTED
     description: Whether to enable privileged mode, should be used only with remote VMs
     type: string
@@ -197,6 +201,8 @@ spec:
       value: $(params.SKIP_SBOM_GENERATION)
     - name: SBOM_TYPE
       value: $(params.SBOM_TYPE)
+    - name: ANNOTATIONS_FILE
+      value: $(params.ANNOTATIONS_FILE)
 
   steps:
   - image: quay.io/konflux-ci/buildah-task:latest@sha256:4d8273444b0f2781264c232e12e88449bbf078c99e3da2a7f6dcaaf27bc53712
@@ -292,6 +298,17 @@ spec:
 
       LABELS=()
       ANNOTATIONS=()
+      # Append any annotations from the specified file
+      if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+        echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          # Skip empty lines and comments
+          if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+            ANNOTATIONS+=("--annotation" "$line")
+          fi
+        done < "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+      fi
+
       # Split `args` into two sets of arguments.
       while [[ $# -gt 0 ]]; do
           case $1 in

--- a/task/sast-coverity-check-oci-ta/0.2/README.md
+++ b/task/sast-coverity-check-oci-ta/0.2/README.md
@@ -10,6 +10,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
+|ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -38,6 +38,11 @@ spec:
         to the image
       type: array
       default: []
+    - name: ANNOTATIONS_FILE
+      description: Path to a file with additional key=value annotations that
+        should be applied to the image
+      type: string
+      default: ""
     - name: BUILDAH_FORMAT
       description: The format for the resulting image's mediaType. Valid values
         are oci (default) or docker.
@@ -236,6 +241,8 @@ spec:
         value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
         value: $(params.ADD_CAPABILITIES)
+      - name: ANNOTATIONS_FILE
+        value: $(params.ANNOTATIONS_FILE)
       - name: BUILD_ARGS_FILE
         value: $(params.BUILD_ARGS_FILE)
       - name: CONTEXT
@@ -524,6 +531,17 @@ spec:
 
         LABELS=()
         ANNOTATIONS=()
+        # Append any annotations from the specified file
+        if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+          echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            # Skip empty lines and comments
+            if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+              ANNOTATIONS+=("--annotation" "$line")
+            fi
+          done <"${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        fi
+
         # Split `args` into two sets of arguments.
         while [[ $# -gt 0 ]]; do
           case $1 in

--- a/task/sast-coverity-check-oci-ta/0.3/README.md
+++ b/task/sast-coverity-check-oci-ta/0.3/README.md
@@ -10,6 +10,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
+|ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -38,6 +38,11 @@ spec:
         to the image
       type: array
       default: []
+    - name: ANNOTATIONS_FILE
+      description: Path to a file with additional key=value annotations that
+        should be applied to the image
+      type: string
+      default: ""
     - name: BUILDAH_FORMAT
       description: The format for the resulting image's mediaType. Valid values
         are oci (default) or docker.
@@ -241,6 +246,8 @@ spec:
         value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
         value: $(params.ADD_CAPABILITIES)
+      - name: ANNOTATIONS_FILE
+        value: $(params.ANNOTATIONS_FILE)
       - name: BUILD_ARGS_FILE
         value: $(params.BUILD_ARGS_FILE)
       - name: CONTEXT
@@ -529,6 +536,17 @@ spec:
 
         LABELS=()
         ANNOTATIONS=()
+        # Append any annotations from the specified file
+        if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+          echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+          while IFS= read -r line || [[ -n "$line" ]]; do
+            # Skip empty lines and comments
+            if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+              ANNOTATIONS+=("--annotation" "$line")
+            fi
+          done <"${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        fi
+
         # Split `args` into two sets of arguments.
         while [[ $# -gt 0 ]]; do
           case $1 in

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -121,6 +121,11 @@ spec:
     description: Additional key=value annotations that should be applied to the image
     name: ANNOTATIONS
     type: array
+  - default: ""
+    description: Path to a file with additional key=value annotations that should
+      be applied to the image
+    name: ANNOTATIONS_FILE
+    type: string
   - default: "false"
     description: Whether to enable privileged mode, should be used only with remote
       VMs
@@ -229,6 +234,8 @@ spec:
       value: $(params.SKIP_SBOM_GENERATION)
     - name: SBOM_TYPE
       value: $(params.SBOM_TYPE)
+    - name: ANNOTATIONS_FILE
+      value: $(params.ANNOTATIONS_FILE)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -461,6 +468,17 @@ spec:
 
       LABELS=()
       ANNOTATIONS=()
+      # Append any annotations from the specified file
+      if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+        echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          # Skip empty lines and comments
+          if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+            ANNOTATIONS+=("--annotation" "$line")
+          fi
+        done < "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+      fi
+
       # Split `args` into two sets of arguments.
       while [[ $# -gt 0 ]]; do
           case $1 in

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -121,6 +121,11 @@ spec:
     description: Additional key=value annotations that should be applied to the image
     name: ANNOTATIONS
     type: array
+  - default: ""
+    description: Path to a file with additional key=value annotations that should
+      be applied to the image
+    name: ANNOTATIONS_FILE
+    type: string
   - default: "false"
     description: Whether to enable privileged mode, should be used only with remote
       VMs
@@ -233,6 +238,8 @@ spec:
       value: $(params.SKIP_SBOM_GENERATION)
     - name: SBOM_TYPE
       value: $(params.SBOM_TYPE)
+    - name: ANNOTATIONS_FILE
+      value: $(params.ANNOTATIONS_FILE)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -465,6 +472,17 @@ spec:
 
       LABELS=()
       ANNOTATIONS=()
+      # Append any annotations from the specified file
+      if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
+        echo "Reading annotations from file: ${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+        while IFS= read -r line || [[ -n "$line" ]]; do
+          # Skip empty lines and comments
+          if [[ -n "$line" && ! "$line" =~ ^[[:space:]]*# ]]; then
+            ANNOTATIONS+=("--annotation" "$line")
+          fi
+        done < "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}"
+      fi
+
       # Split `args` into two sets of arguments.
       while [[ $# -gt 0 ]]; do
           case $1 in


### PR DESCRIPTION
# Feature

This change will allow users of this task to specify a path to a file
containing annotations for their build.

This is especially useful in scenarios where the annotation value is dynamically generated by another task and the resulting value exceeds the limit set by Tekton task results.

## Usage:
Users can have a basic `annotations.txt` file in their repo with contents such as the following:
```
test.annotation.a=abc123
test.annotation.b=def456
```

And specify the param in the following format:
```
- name: ANNOTATIONS_FILE
  value: "annotations.txt"
```

Or dynamically generate and export the annotation file in a script using the `run-script-oci-ta` task.