### PR TITLE
fix: fix jq queries for FIPS annotations in the task

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -141,9 +141,9 @@ spec:
               echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
               exit 0
             fi
-            subscription_label=$(echo "${bundle_out}" | jq -r '.properties[] | select(.value.annotations["operators.openshift.io/valid-subscription"] != null) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
+            subscription_label=$(echo "${bundle_out}" | jq -r '.properties[] | select((.value | type == "object") and (.value.annotations["operators.openshift.io/valid-subscription"] != null)) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
 
-            fips_annotation=$(echo "${bundle_out}" | jq -r '.properties[] | select(.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true") | .value.annotations["features.operators.openshift.io/fips-compliant"]')
+            fips_annotation=$(echo "${bundle_out}" | jq -r '.properties[] | select((.value | type == "object") and (.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true")) | .value.annotations["features.operators.openshift.io/fips-compliant"]')
 
             if ! echo "${subscription_label}" | grep -e "OpenShift Kubernetes Engine" -e "OpenShift Container Platform" -e "OpenShift Platform Plus"; then
               echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are not present in operators.openshift.io/valid-subscription."

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -138,9 +138,9 @@ spec:
               echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
               exit 0
             fi
-            subscription_label=$(echo "${bundle_out}" | jq -r '.properties[] | select(.value.annotations["operators.openshift.io/valid-subscription"] != null) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
+            subscription_label=$(echo "${bundle_out}" | jq -r '.properties[] | select((.value | type == "object") and (.value.annotations["operators.openshift.io/valid-subscription"] != null)) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
 
-            fips_annotation=$(echo "${bundle_out}" | jq -r '.properties[] | select(.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true") | .value.annotations["features.operators.openshift.io/fips-compliant"]')
+            fips_annotation=$(echo "${bundle_out}" | jq -r '.properties[] | select((.value | type == "object") and (.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true")) | .value.annotations["features.operators.openshift.io/fips-compliant"]')
 
             if ! echo "${subscription_label}" | grep -e "OpenShift Kubernetes Engine" -e "OpenShift Container Platform" -e "OpenShift Platform Plus"; then
               echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are not present in operators.openshift.io/valid-subscription."

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -77,8 +77,8 @@ spec:
 
         # Run the FIPS check only if the bundle is part of the Openshift Subscription or has the fips label set
         image_and_digest_render_out=$(opm render "$image_and_digest")
-        subscription_label=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select(.value.annotations["operators.openshift.io/valid-subscription"] != null) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
-        fips_annotation=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select(.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true") | .value.annotations["features.operators.openshift.io/fips-compliant"]')
+        subscription_label=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select((.value | type == "object") and (.value.annotations["operators.openshift.io/valid-subscription"] != null)) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
+        fips_annotation=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select((.value | type == "object") and (.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true")) | .value.annotations["features.operators.openshift.io/fips-compliant"]')
 
         if ! echo "${subscription_label}" | grep -e "OpenShift Kubernetes Engine" -e "OpenShift Container Platform" -e "OpenShift Platform Plus"; then
           echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are not present in operators.openshift.io/valid-subscription."

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -62,8 +62,8 @@ spec:
 
         # Run the FIPS check only if the bundle is part of the Openshift Subscription or has the fips label set
         image_and_digest_render_out=$(opm render "$image_and_digest")
-        subscription_label=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select(.value.annotations["operators.openshift.io/valid-subscription"] != null) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
-        fips_annotation=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select(.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true") | .value.annotations["features.operators.openshift.io/fips-compliant"]')
+        subscription_label=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select((.value | type == "object") and (.value.annotations["operators.openshift.io/valid-subscription"] != null)) | (.value.annotations["operators.openshift.io/valid-subscription"] | fromjson)[]')
+        fips_annotation=$(echo "${image_and_digest_render_out}" | jq -r '.properties[] | select((.value | type == "object") and (.value.annotations["features.operators.openshift.io/fips-compliant"]? == "true")) | .value.annotations["features.operators.openshift.io/fips-compliant"]')
 
         if ! echo "${subscription_label}" | grep -e "OpenShift Kubernetes Engine" -e "OpenShift Container Platform" -e "OpenShift Platform Plus"; then
           echo "OpenShift Kubernetes Engine, OpenShift Platform Plus or OpenShift Container Platform are not present in operators.openshift.io/valid-subscription."


### PR DESCRIPTION
The query to get the subscription label from the bundle CSV failed if the value key was a string and not an object. This commit fixes that behavior by filtering out only objects.
