### PR TITLE
feat(KONFLUX-7334): Setup limits and resource for task validate-fbc

### DIFF
--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -63,6 +63,12 @@ spec:
         name: workdir
   steps:
     - name: inspect-image
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
@@ -216,10 +222,10 @@ spec:
             - SETFCAP
       computeResources:
         limits:
-          memory: 6Gi
+          memory: 8Gi
         requests:
-          memory: 6Gi
-          cpu: 10m
+          memory: 8Gi
+          cpu: "8"
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -466,6 +472,12 @@ spec:
         fi
         popd
     - name: save-related-images
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
       script: |
         #!/usr/bin/env bash
@@ -477,6 +489,12 @@ spec:
         attach-helper --subject "${IMAGE_URL}@${IMAGE_DIGEST}" --media-type-name "related-images+json" --digestfile "$(results.RELATED_IMAGES_DIGEST.path)" \
           /shared/related-images.json
     - name: save-rendered-catalog
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
       script: |
         #!/usr/bin/env bash


### PR DESCRIPTION
### Description

This PR updates resource limits and requests for the task **validate-fbc** as part of this effort - [KONFLUX-7334](https://issues.redhat.com/browse/KONFLUX-7334). 

The new request/limit values have been defined taking into account usages observed historically (tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?gid=1735880927#gid=1735880927)) in the **stone-prd-rh01** cluster. 

## step inspect-image

#### CPU Usage (max & 95%)
- New CPU Request: 100m

![image](https://github.com/user-attachments/assets/84670612-4cde-4022-9abf-57297e1c9bb0)

#### Memory Usage (max & 95%)
- New Memory Request: 256Mi

![image](https://github.com/user-attachments/assets/fbdc98f8-e95f-4fb9-bcae-85129035a8dd)


## step extract-and-validate
#### CPU Usage (max & 95%)

- Increased the CPU request from 1 to 6, considering the 95% overall utilization.

![image](https://github.com/user-attachments/assets/42da01f4-c88b-4f37-bdd5-e41842fba8c1)

#### Memory Usage (max & 95%)

- Increased the memory request from 6Gi to 8Gi, which should provide enough buffer.

![image](https://github.com/user-attachments/assets/cacf2e1b-4073-444f-bea9-968cb0a9d09f)

## step save-related-images

#### CPU Usage (max & 95%)
- New CPU Request: 100m

![image](https://github.com/user-attachments/assets/a03fb0bc-566c-4a0c-a6e4-378f4b179e01)

#### Memory Usage (max & 95%)
- New Memory Request: 256Mi

![image](https://github.com/user-attachments/assets/b894459f-e25f-4eaa-b99d-b0b9e5e37df2)


## step save-rendered-catalog

#### CPU Usage (max & 95%)
- New CPU Request: 100m

![image](https://github.com/user-attachments/assets/f9822e75-84d2-4ab6-b402-1665bcc2d234)


#### Memory Usage (max & 95%)
- New Memory Request: 256Mi

![image](https://github.com/user-attachments/assets/b6e1df1b-400b-45b4-83c7-f68bb6f93596)

