### PR TITLE
deprecate old tasks owned by the build team

### DIFF
--- a/task/init/0.1/init.yaml
+++ b/task/init/0.1/init.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-05-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"
   name: init

--- a/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.1/prefetch-dependencies-oci-ta.yaml
@@ -4,6 +4,7 @@ kind: Task
 metadata:
   name: prefetch-dependencies-oci-ta
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-05-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:

--- a/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.1/prefetch-dependencies.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-05-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, konflux"
   name: prefetch-dependencies

--- a/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.1/source-build-oci-ta.yaml
@@ -4,6 +4,7 @@ kind: Task
 metadata:
   name: source-build-oci-ta
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-05-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: konflux
   labels:

--- a/task/source-build/0.1/source-build.yaml
+++ b/task/source-build/0.1/source-build.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-05-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"
 spec:

--- a/task/summary/0.1/summary.yaml
+++ b/task/summary/0.1/summary.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-05-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"
   name: summary


### PR DESCRIPTION
Expiry date is set to the 31st of May.
After the deprecation period, they should be removed.

