### PR TITLE
fix(KONFLUX-7841): Increase memory for fbc pruning check

### DIFF
--- a/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
+++ b/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
@@ -56,9 +56,9 @@ spec:
             - SETFCAP
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 2Gi
         requests:
-          memory: 256Mi
+          memory: 2Gi
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -77,9 +77,9 @@ spec:
             - SETFCAP
       computeResources:
         limits:
-          memory: 4Gi
+          memory: 6Gi
         requests:
-          memory: 2Gi
+          memory: 6Gi
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
Increased memory for fbc-target-index-pruning-check.
