### PR TITLE
updating preflight task to use PFLT_KONFLUX env

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -152,7 +152,7 @@ spec:
           mountPath: /bundle
 
     - name: app-check
-      image: quay.io/opdev/preflight:stable@sha256:3f5b988200a3fd490e0a102a4851e0a81f2f41e724e7482a726b79b9d5ccd3b6
+      image: quay.io/opdev/preflight:stable@sha256:8f88ee1e9aca6d966ee3ca51fffeb9e25bc6e885ef7a330efbffdcb5d18a5a15
       args: ["check", "container", "$(params.image-url)"]
       resources:
         limits:
@@ -163,6 +163,8 @@ spec:
       env:
         - name: PFLT_DOCKERCONFIG
           value: "$(steps.generate-container-auth.results.auth-json-path)"
+        - name: PFLT_KONFLUX
+          value: "true"
       volumeMounts:
         - name: pfltoutputdir
           mountPath: /artifacts


### PR DESCRIPTION
## Motivation
When `preflight` added the Red Hat Trademark tests, we were unable to update the `preflight` check in konflux, otherwise all Red Hat pipelines would fail the check. We then introduced the `PFLT_KONFLUX` in `preflight` which when enabled runs a konflux specific policy, with the Trademark tests removed. The below linked PR has those related changes.

- Relates: redhat-openshift-ecosystem/openshift-preflight#1247

## Changes
Enable the flag in the latest `preflight` task and update to the `stable` release tag for the container image.

## Testing
Using the test cluster, I built a new `tkn` bundle and created a `PipelineRun` to run against the `simple-demo-operator` container. The output below shows that the all checks passed, and the Trademark tests never ran.

```
[test-preflight : app-check] time="2025-04-18T21:14:54Z" level=info msg="certification library version" version="1.13.0 <commit: 39da695c5e9af533b994b24a680ec7ff5a6f1b7d>"
[test-preflight : app-check] time="2025-04-18T21:14:55Z" level=info msg="running checks for quay.io/opdev/simple-demo-operator:latest for platform amd64"
[test-preflight : app-check] time="2025-04-18T21:14:55Z" level=info msg="target image" image="quay.io/opdev/simple-demo-operator:latest"
[test-preflight : app-check] time="2025-04-18T21:15:01Z" level=info msg="check completed" check=HasLicense result=PASSED
[test-preflight : app-check] time="2025-04-18T21:15:01Z" level=info msg="check completed" check=HasUniqueTag result=PASSED
[test-preflight : app-check] time="2025-04-18T21:15:01Z" level=info msg="check completed" check=LayerCountAcceptable result=PASSED
[test-preflight : app-check] time="2025-04-18T21:15:01Z" level=info msg="check completed" check=HasNoProhibitedPackages result=PASSED
[test-preflight : app-check] time="2025-04-18T21:15:01Z" level=info msg="check completed" check=HasRequiredLabel result=PASSED
[test-preflight : app-check] time="2025-04-18T21:15:01Z" level=info msg="USER 65532:65532 specified that is non-root" check=RunAsNonRoot
[test-preflight : app-check] time="2025-04-18T21:15:01Z" level=info msg="check completed" check=RunAsNonRoot result=PASSED
[test-preflight : app-check] time="2025-04-18T21:15:03Z" level=info msg="check completed" check=HasModifiedFiles result=PASSED
[test-preflight : app-check] time="2025-04-18T21:15:03Z" level=info msg="check completed" check=BasedOnUbi result=PASSED
[test-preflight : app-check] time="2025-04-18T21:15:03Z" level=info msg="This image's tag latest will be paired with digest sha256:0a54f05b93489ffbef0f98882fce71d4c8a88dc2637616efb8e4076049e0d389 once this image has been published in accordance with Red Hat Certification policy. You may then add or remove any supplemental tags through your Red Hat Connect portal as you see fit."
[test-preflight : app-check] {
[test-preflight : app-check]     "image": "quay.io/opdev/simple-demo-operator:latest",
[test-preflight : app-check]     "passed": true,
[test-preflight : app-check]     "test_library": {
[test-preflight : app-check]         "name": "github.com/redhat-openshift-ecosystem/openshift-preflight",
[test-preflight : app-check]         "version": "1.13.0",
[test-preflight : app-check]         "commit": "39da695c5e9af533b994b24a680ec7ff5a6f1b7d"
[test-preflight : app-check]     },
[test-preflight : app-check]     "results": {
[test-preflight : app-check]         "passed": [
[test-preflight : app-check]             {
[test-preflight : app-check]                 "name": "HasLicense",
[test-preflight : app-check]                 "elapsed_time": 0,
[test-preflight : app-check]                 "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses"
[test-preflight : app-check]             },
[test-preflight : app-check]             {
[test-preflight : app-check]                 "name": "HasUniqueTag",
[test-preflight : app-check]                 "elapsed_time": 384,
[test-preflight : app-check]                 "description": "Checking if container has a tag other than 'latest', so that the image can be uniquely identified."
[test-preflight : app-check]             },
[test-preflight : app-check]             {
[test-preflight : app-check]                 "name": "LayerCountAcceptable",
[test-preflight : app-check]                 "elapsed_time": 0,
[test-preflight : app-check]                 "description": "Checking if container has less than 40 layers.  Too many layers within the container images can degrade container performance."
[test-preflight : app-check]             },
[test-preflight : app-check]             {
[test-preflight : app-check]                 "name": "HasNoProhibitedPackages",
[test-preflight : app-check]                 "elapsed_time": 16,
[test-preflight : app-check]                 "description": "Checks to ensure that the image in use does not include prohibited packages, such as Red Hat Enterprise Linux (RHEL) kernel packages."
[test-preflight : app-check]             },
[test-preflight : app-check]             {
[test-preflight : app-check]                 "name": "HasRequiredLabel",
[test-preflight : app-check]                 "elapsed_time": 0,
[test-preflight : app-check]                 "description": "Checking if the required labels (name, vendor, version, release, summary, description, maintainer) are present in the container metadata"
[test-preflight : app-check]             },
[test-preflight : app-check]             {
[test-preflight : app-check]                 "name": "RunAsNonRoot",
[test-preflight : app-check]                 "elapsed_time": 0,
[test-preflight : app-check]                 "description": "Checking if container runs as the root user because a container that does not specify a non-root user will fail the automatic certification, and will be subject to a manual review before the container can be approved for publication"
[test-preflight : app-check]             },
[test-preflight : app-check]             {
[test-preflight : app-check]                 "name": "HasModifiedFiles",
[test-preflight : app-check]                 "elapsed_time": 1615,
[test-preflight : app-check]                 "description": "Checks that no files installed via RPM in the base Red Hat layer have been modified"
[test-preflight : app-check]             },
[test-preflight : app-check]             {
[test-preflight : app-check]                 "name": "BasedOnUbi",
[test-preflight : app-check]                 "elapsed_time": 590,
[test-preflight : app-check]                 "description": "Checking if the container's base image is based upon the Red Hat Universal Base Image (UBI)"
[test-preflight : app-check]             }
[test-preflight : app-check]         ],
[test-preflight : app-check]         "failed": [],
[test-preflight : app-check]         "errors": []
[test-preflight : app-check]     }
[test-preflight : app-check] }
[test-preflight : app-check] time="2025-04-18T21:15:04Z" level=info msg="Preflight result: PASSED"
```
