### PR TITLE
chore(KFLUXVNGD-242): add kustomization support to tkn-bundle

### DIFF
--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -190,6 +190,37 @@ spec:
           printf '"%s"' "$escaped_arg"
         }
 
+        # Check if task is kustomized
+        # A task considered to be kustomized when a kustomization file is found in the task dir
+        is_kustomized_task() {
+          local -r task_dir=$1
+          if [[ -f "$task_dir/kustomization.yaml" || -f "$task_dir/kustomization.yml" ]]; then
+            return 0
+          fi
+          return 1
+        }
+
+        # Generate a task from the kustomization file
+        generate_kustomized_task() {
+          local -r task_dir=$1
+          local -r prepared_task_file="$task_dir/generated-kustomized-task.yaml"
+          kubectl kustomize "$task_dir" >"$prepared_task_file"
+          echo "$prepared_task_file"
+        }
+
+        # task_dir is where all the tasks definitions reside
+        # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
+        task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
+
+        # If task is kustomized, generate it and replace the FILES value with the value of the generated task
+        # All other files will be ignored.
+        if is_kustomized_task "$task_dir"; then
+          echo "Generating a kustomized task from $task_dir"
+          FILES=("$(generate_kustomized_task "$task_dir")")
+        else
+          echo "Task is not Kustomized - continue"
+        fi
+
         ANNOTATIONS=()
         ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
         ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
@@ -199,9 +230,6 @@ spec:
         task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
         ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
 
-        # task_dir is where all the tasks definitions resides
-        # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
-        task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
         if [ -f "${task_dir}/README.md" ]; then
           ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")
         fi

--- a/task/tkn-bundle/0.2/README.md
+++ b/task/tkn-bundle/0.2/README.md
@@ -7,7 +7,12 @@ Task finds all `*.yaml` or `*.yml` files within `CONTEXT`, packages and pushes
 them as a Tekton Bundle to the image repository, name and tag specified by the
 `IMAGE` parameter.
 
-The task also adds annotations to the Tekton bundle. 
+In case a `kustomization.yaml` file is located in `CONTEXT`, it will be used to
+generate the task definition and all other files in `CONTEXT` will be ignored.
+
+The task also adds annotations to the Tekton bundle.
+
+
 
 ## Input Parameters
 

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -172,6 +172,37 @@ spec:
           printf '"%s"' "$escaped_arg"
         }
 
+        # Check if task is kustomized
+        # A task considered to be kustomized when a kustomization file is found in the task dir
+        is_kustomized_task() {
+            local -r task_dir=$1
+            if [[ -f "$task_dir/kustomization.yaml" || -f "$task_dir/kustomization.yml" ]] ; then
+                return 0
+            fi
+            return 1
+        }
+
+        # Generate a task from the kustomization file
+        generate_kustomized_task() {
+            local -r task_dir=$1
+            local -r prepared_task_file="$task_dir/generated-kustomized-task.yaml"
+            kubectl kustomize "$task_dir" >"$prepared_task_file"
+            echo "$prepared_task_file"
+        }
+
+        # task_dir is where all the tasks definitions reside
+        # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
+        task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
+
+        # If task is kustomized, generate it and replace the FILES value with the value of the generated task
+        # All other files will be ignored.
+        if is_kustomized_task "$task_dir"; then
+            echo "Generating a kustomized task from $task_dir"
+            FILES=("$(generate_kustomized_task "$task_dir")")
+        else
+            echo "Task is not Kustomized - continue"
+        fi
+
         ANNOTATIONS=()
         ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
         ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
@@ -181,9 +212,6 @@ spec:
         task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
         ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
 
-        # task_dir is where all the tasks definitions resides
-        # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
-        task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
         if [ -f "${task_dir}/README.md" ]; then
           ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")
         fi


### PR DESCRIPTION
Add support to kustomization file.
In case a `kustomiztion.yaml` file is located in `CONTEXT` it will be used to generate the task definition and all other files in `CONTEXT` will be ignored


