### PR TITLE
chore(KFLUXVNGD-283): use scoped auth for helm push

### DIFF
--- a/task/build-helm-chart-oci-ta/0.1/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.1/build-helm-chart-oci-ta.yaml
@@ -134,8 +134,18 @@ spec:
         chart_version="$chart_version$VERSION_SUFFIX"
         helm package . --version "$chart_version" --app-version "$COMMIT_SHA"
 
+        # Helm (ORAS) doesn't do a good job with selecting the correct auth, so
+        # need to provide it with just one option
+        jq --arg registry "$REPO" '.auths[$registry]' ~/.docker/config.json |
+          jq -n --arg registry "$REPO" '{auths:{($registry):inputs}}' \
+            >scoped_authfile.json
+
         dest="oci://${REPO%/*}"
-        output=$(helm push "$chart_name"-"$chart_version".tgz "$dest" 2>&1)
+
+        output=$(
+          helm push "$chart_name"-"$chart_version".tgz "$dest" \
+            --registry-config ./scoped_authfile.json 2>&1
+        )
         pushed=$(echo "$output" | grep "Pushed" | awk '{print $2}')
         digest=$(echo "$output" | grep "Digest" | awk '{print $2}')
 

--- a/task/build-helm-chart/0.1/build-helm-chart.yaml
+++ b/task/build-helm-chart/0.1/build-helm-chart.yaml
@@ -104,8 +104,18 @@ spec:
       chart_version="$chart_version$VERSION_SUFFIX"
       helm package . --version "$chart_version" --app-version "$COMMIT_SHA"
 
+      # Helm (ORAS) doesn't do a good job with selecting the correct auth, so
+      # need to provide it with just one option
+      jq --arg registry "$REPO" '.auths[$registry]' ~/.docker/config.json \
+        | jq -n --arg registry "$REPO" '{auths:{($registry):inputs}}' \
+        > scoped_authfile.json
+
       dest="oci://${REPO%/*}"
-      output=$(helm push "$chart_name"-"$chart_version".tgz "$dest" 2>&1)
+
+      output=$(
+        helm push "$chart_name"-"$chart_version".tgz "$dest" \
+        --registry-config ./scoped_authfile.json 2>&1
+      )
       pushed=$(echo "$output" | grep "Pushed" | awk '{print $2}')
       digest=$(echo "$output" | grep "Digest" | awk '{print $2}')
 


### PR DESCRIPTION
Helm is unable to select the correct auth when pushing to OCI registries, so need to help it select the right one.