### PR TITLE
increase mem limit in clair-scan

### DIFF
--- a/task/clair-scan/0.2/clair-scan.yaml
+++ b/task/clair-scan/0.2/clair-scan.yaml
@@ -82,7 +82,7 @@ spec:
       image: quay.io/konflux-ci/clair-in-ci:v1  # explicit floating tag, daily updates, per arch call this is exempt for now for use of image digest
       computeResources:
         limits:
-          memory: 6Gi
+          memory: 8Gi
         requests:
           memory: 2Gi
           cpu: 500m


### PR DESCRIPTION
* increase mem limit in clair-scan since [rhoai](https://console.redhat.com/application-pipeline/workspaces/rhoai/applications/notebooks/activity/pipelineruns) tenant meet OOMKilled frequently such as https://console.redhat.com/application-pipeline/workspaces/rhoai/applications/notebooks/pipelineruns/notebooks-rocm-tensorflow-poc-on-push-zdnv5

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
