### PR TITLE
renovate: group .tekton/* updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,12 @@
   },
   "packageRules": [
     {
+      "groupName": "tekton-ci",
+      "matchFileNames": [
+        ".tekton/**"
+      ]
+    },
+    {
       "matchPackageNames": [
         "quay.io/konflux-ci/appstudio-utils"
       ],


### PR DESCRIPTION
Currently, we have 3 separate PRs open for `.tekton/pull-request.yaml`:
* https://github.com/konflux-ci/build-definitions/pull/2187
* https://github.com/konflux-ci/build-definitions/pull/2076
* https://github.com/konflux-ci/build-definitions/pull/2060

Let's group updates like this into a single PR