### PR TITLE
Set preflight to SUCCESS for operator bundles

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -144,7 +144,9 @@ spec:
         . /utils.sh # gives us the make_result_json helper used below.
 
         # Generate TEST_OUTPUT
-        TEST_OUTPUT=$(make_result_json -r "SKIPPED" -t "${NOTE}")
+        # We're skipping the test, but don't use status "SKIPPED" because
+        # it produces unwanted Conforma violations
+        TEST_OUTPUT=$(make_result_json -r "SUCCESS" -t "${NOTE}")
 
         printf "%s" "${TEST_OUTPUT}" | tee "$(step.results.test-output.path)" /bundle/konflux.results.json
       volumeMounts:


### PR DESCRIPTION
`ecosystem-cert-preflight-checks` is skipped for operator bundles. However, conforma checks fail if the result of it is not `SUCCESS`. This commit changes the task code to return `SUCCESS` when skipping due to the image under test being an operator bundle.

Originally-implemented-by: Dale Haiducek <19750917+dhaiducek@users.noreply.github.com>

Fixes #1931 