### PR TITLE
[ISV-5704] Used parent image and runtime arch is identified.

### DIFF
--- a/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.2/buildah-oci-ta.yaml
@@ -394,7 +394,43 @@ spec:
 
         if [ -n "${TARGET_STAGE}" ]; then
           BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+          # Search for parent image
+
+          # step 1: try to find the build step with the target as an alias
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json |
+              tr -d '"' |
+              tr -d "'"
+          )
+
+          # step 2a: If not found, then it is not an alias, but an image spec
+          if [ -z "$LAST_IMAGE_REF" ]; then
+            PARENT_IMAGE="$TARGET_STAGE"
+          fi
+
+          # step 2b: If found, repeat with the new reference until a spec is found
+          while [ -n "$LAST_IMAGE_REF" ]; do
+            # The last image ref in the chain is the parent image
+            PARENT_IMAGE="$LAST_IMAGE_REF"
+            LAST_IMAGE_REF=$(
+              jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+                select(.As==$alias) | .BaseName |
+                select(test("^oci-archive:") | not)' \
+                /shared/parsed_dockerfile.json | tr -d '"' |
+                tr -d "'"
+            )
+          done
+        else
+          PARENT_IMAGE=$(tail -1 <<<"${BASE_IMAGES}")
         fi
+
+        ARCH_USED=$(uname -m)
+        echo "PARENT_IMAGE: $PARENT_IMAGE"
+        echo "ARCH_USED: $ARCH_USED"
 
         BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
@@ -430,7 +466,7 @@ spec:
             "$dockerfile_copy"
           echo "Prefetched content will be made available"
 
-          prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+          prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/${ARCH_USED}/repos.d/cachi2.repo"
           if [ -f "$prefetched_repo_for_my_arch" ]; then
             echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
             mkdir -p "$YUM_REPOS_D_FETCHED"
@@ -453,7 +489,7 @@ spec:
 
         DEFAULT_LABELS=(
           "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
-          "--label" "architecture=$(uname -m)"
+          "--label" "architecture=${ARCH_USED}"
           "--label" "vcs-type=git"
         )
         [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")

--- a/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.3/buildah-oci-ta.yaml
@@ -391,7 +391,43 @@ spec:
 
         if [ -n "${TARGET_STAGE}" ]; then
           BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+          # Search for parent image
+
+          # step 1: try to find the build step with the target as an alias
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json |
+              tr -d '"' |
+              tr -d "'"
+          )
+
+          # step 2a: If not found, then it is not an alias, but an image spec
+          if [ -z "$LAST_IMAGE_REF" ]; then
+            PARENT_IMAGE="$TARGET_STAGE"
+          fi
+
+          # step 2b: If found, repeat with the new reference until a spec is found
+          while [ -n "$LAST_IMAGE_REF" ]; do
+            # The last image ref in the chain is the parent image
+            PARENT_IMAGE="$LAST_IMAGE_REF"
+            LAST_IMAGE_REF=$(
+              jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+                select(.As==$alias) | .BaseName |
+                select(test("^oci-archive:") | not)' \
+                /shared/parsed_dockerfile.json | tr -d '"' |
+                tr -d "'"
+            )
+          done
+        else
+          PARENT_IMAGE=$(tail -1 <<<"${BASE_IMAGES}")
         fi
+
+        ARCH_USED=$(uname -m)
+        echo "PARENT_IMAGE: $PARENT_IMAGE"
+        echo "ARCH_USED: $ARCH_USED"
 
         BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -443,7 +443,43 @@ spec:
 
         if [ -n "${TARGET_STAGE}" ]; then
           BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+          # Search for parent image
+
+          # step 1: try to find the build step with the target as an alias
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json |
+              tr -d '"' |
+              tr -d "'"
+          )
+
+          # step 2a: If not found, then it is not an alias, but an image spec
+          if [ -z "$LAST_IMAGE_REF" ]; then
+            PARENT_IMAGE="$TARGET_STAGE"
+          fi
+
+          # step 2b: If found, repeat with the new reference until a spec is found
+          while [ -n "$LAST_IMAGE_REF" ]; do
+            # The last image ref in the chain is the parent image
+            PARENT_IMAGE="$LAST_IMAGE_REF"
+            LAST_IMAGE_REF=$(
+              jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+                select(.As==$alias) | .BaseName |
+                select(test("^oci-archive:") | not)' \
+                /shared/parsed_dockerfile.json | tr -d '"' |
+                tr -d "'"
+            )
+          done
+        else
+          PARENT_IMAGE=$(tail -1 <<<"${BASE_IMAGES}")
         fi
+
+        ARCH_USED=$(uname -m)
+        echo "PARENT_IMAGE: $PARENT_IMAGE"
+        echo "ARCH_USED: $ARCH_USED"
 
         BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 

--- a/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.2/buildah-remote-oci-ta.yaml
@@ -435,7 +435,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+        done
+      else
+        PARENT_IMAGE=$(tail -1 <<<"${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
@@ -471,7 +507,7 @@ spec:
           "$dockerfile_copy"
         echo "Prefetched content will be made available"
 
-        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/${ARCH_USED}/repos.d/cachi2.repo"
         if [ -f "$prefetched_repo_for_my_arch" ]; then
           echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
           mkdir -p "$YUM_REPOS_D_FETCHED"
@@ -494,7 +530,7 @@ spec:
 
       DEFAULT_LABELS=(
         "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
-        "--label" "architecture=$(uname -m)"
+        "--label" "architecture=${ARCH_USED}"
         "--label" "vcs-type=git"
       )
       [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")

--- a/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.3/buildah-remote-oci-ta.yaml
@@ -431,7 +431,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+        done
+      else
+        PARENT_IMAGE=$(tail -1 <<<"${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -482,7 +482,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+        done
+      else
+        PARENT_IMAGE=$(tail -1 <<<"${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 

--- a/task/buildah-remote/0.2/buildah-remote.yaml
+++ b/task/buildah-remote/0.2/buildah-remote.yaml
@@ -406,7 +406,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+          done
+      else
+        PARENT_IMAGE=$(tail -1 <<< "${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
@@ -442,7 +478,7 @@ spec:
             "$dockerfile_copy"
         echo "Prefetched content will be made available"
 
-        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/${ARCH_USED}/repos.d/cachi2.repo"
         if [ -f "$prefetched_repo_for_my_arch" ]; then
           echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
           mkdir -p "$YUM_REPOS_D_FETCHED"
@@ -465,7 +501,7 @@ spec:
 
       DEFAULT_LABELS=(
         "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
-        "--label" "architecture=$(uname -m)"
+        "--label" "architecture=${ARCH_USED}"
         "--label" "vcs-type=git"
       )
       [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")

--- a/task/buildah-remote/0.3/buildah-remote.yaml
+++ b/task/buildah-remote/0.3/buildah-remote.yaml
@@ -402,7 +402,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+          done
+      else
+        PARENT_IMAGE=$(tail -1 <<< "${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -450,7 +450,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+          done
+      else
+        PARENT_IMAGE=$(tail -1 <<< "${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 

--- a/task/buildah/0.2/buildah.yaml
+++ b/task/buildah/0.2/buildah.yaml
@@ -318,7 +318,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+          done
+      else
+        PARENT_IMAGE=$(tail -1 <<< "${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
@@ -354,7 +390,7 @@ spec:
             "$dockerfile_copy"
         echo "Prefetched content will be made available"
 
-        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/$(uname -m)/repos.d/cachi2.repo"
+        prefetched_repo_for_my_arch="/tmp/cachi2/output/deps/rpm/${ARCH_USED}/repos.d/cachi2.repo"
         if [ -f "$prefetched_repo_for_my_arch" ]; then
           echo "Adding $prefetched_repo_for_my_arch to $YUM_REPOS_D_FETCHED"
           mkdir -p "$YUM_REPOS_D_FETCHED"
@@ -377,7 +413,7 @@ spec:
 
       DEFAULT_LABELS=(
         "--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%S')"
-        "--label" "architecture=$(uname -m)"
+        "--label" "architecture=${ARCH_USED}"
         "--label" "vcs-type=git"
       )
       [ -n "$COMMIT_SHA" ] && DEFAULT_LABELS+=("--label" "vcs-ref=$COMMIT_SHA")

--- a/task/buildah/0.3/buildah.yaml
+++ b/task/buildah/0.3/buildah.yaml
@@ -315,7 +315,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+          done
+      else
+        PARENT_IMAGE=$(tail -1 <<< "${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -361,7 +361,43 @@ spec:
 
       if [ -n "${TARGET_STAGE}" ]; then
         BUILDAH_ARGS+=("--target=${TARGET_STAGE}")
+
+        # Search for parent image
+
+        # step 1: try to find the build step with the target as an alias
+        LAST_IMAGE_REF=$(
+          jq --arg alias "${TARGET_STAGE}" '.Stages[] |
+            select(.As==$alias) | .BaseName |
+            select(test("^oci-archive:") | not)' \
+            /shared/parsed_dockerfile.json |
+            tr -d '"' |
+            tr -d "'"
+        )
+
+        # step 2a: If not found, then it is not an alias, but an image spec
+        if [ -z "$LAST_IMAGE_REF" ]; then
+          PARENT_IMAGE="$TARGET_STAGE"
+        fi
+
+        # step 2b: If found, repeat with the new reference until a spec is found
+        while [ -n "$LAST_IMAGE_REF" ]; do
+          # The last image ref in the chain is the parent image
+          PARENT_IMAGE="$LAST_IMAGE_REF"
+          LAST_IMAGE_REF=$(
+            jq --arg alias "${PARENT_IMAGE}" '.Stages[] |
+              select(.As==$alias) | .BaseName |
+              select(test("^oci-archive:") | not)' \
+              /shared/parsed_dockerfile.json | tr -d '"' |
+              tr -d "'"
+          )
+          done
+      else
+        PARENT_IMAGE=$(tail -1 <<< "${BASE_IMAGES}")
       fi
+
+      ARCH_USED=$(uname -m)
+      echo "PARENT_IMAGE: $PARENT_IMAGE"
+      echo "ARCH_USED: $ARCH_USED"
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 


### PR DESCRIPTION
# Identify parent image

This PR adds variables to the `buildah` task identifying the parent image and arch used at runtime.

To do this, PR simply stores the last value of the `BASE_IMAGES` array if no `TARGET_STAGE` is specified.

If this argument is specified, then it looks for an image alias (attribute `As` in the `dockerfile-json` output) with value of `$TARGET_STAGE`. If not found, the target must be a pullspec.

If the image alias is found, the script tries to look for an image which has the alias set to the `BaseName` of the previous image. This way even transitive references are resolved (example [here](https://github.com/keilerkonzept/dockerfile-json?tab=readme-ov-file#json-output)).

The `buildah-oci-ta` and `buildah-remote` tasks have been updated by the scripts in the `hack` directory, I have skipped Buildah 0.1 as there is no parsed Dockerfile there.

This has been tested on [this repository](https://github.com/BorekZnovustvoritel/Konflux-testrepo/pull/2) and a private Konflux app.

Ticket for tracking: [ISV-5704](https://issues.redhat.com//browse/ISV-5704)