### PR TITLE
chore: skip GHA checks on merge queue till they are fixed

### DIFF
--- a/.github/workflows/checkton.yaml
+++ b/.github/workflows/checkton.yaml
@@ -2,8 +2,9 @@ name: Checkton
 "on":
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
+  # skip running this check on merge queue until STONEBLD-3354 is fixed
+  # merge_group:
+  #   types: [checks_requested]
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -2,8 +2,9 @@ name: Validate PR - golang CI
 "on":
   pull_request:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
+  # skip running this check on merge queue until STONEBLD-3354 is fixed
+  # merge_group:
+  #   types: [checks_requested]
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -6,8 +6,9 @@ name: Run Task Tests
       - opened
       - synchronize
       - reopened
-  merge_group:
-    types: [checks_requested]
+  # skip running this check on merge queue until STONEBLD-3354 is fixed
+  # merge_group:
+  #   types: [checks_requested]
 
 jobs:
   run-task-tests:


### PR DESCRIPTION
Some GHA checks fails while running on merge queue, there is [an issue ](https://issues.redhat.com/browse/STONEBLD-3354) open for it, till that issue is fixed, skip them for now