### PR TITLE
Use new Konflux-built Conforma/EC images

### DIFF
--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -37,7 +37,7 @@ spec:
       stepactions_dir stepactions-ec
   - name: validate-all-tasks
     workingDir: "$(workspaces.source.path)/source"
-    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:57e14c2ae9591a5bb1e2638ed4c657876ad1889016e8a1a430fd59cb3735da38
+    image: quay.io/enterprise-contract/cli:latest@sha256:966e786a3d8606f4e44de775e3d8e9a679e66c47d35db8f84df02430df921b3e
     script: |
       set -euo pipefail
 
@@ -51,7 +51,7 @@ spec:
       ec validate input --policy "${policy}" --output yaml --strict=true ${args[*]}
   - name: validate-build-tasks
     workingDir: "$(workspaces.source.path)/source"
-    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:57e14c2ae9591a5bb1e2638ed4c657876ad1889016e8a1a430fd59cb3735da38
+    image: quay.io/enterprise-contract/cli:latest@sha256:966e786a3d8606f4e44de775e3d8e9a679e66c47d35db8f84df02430df921b3e
     script: |
       set -euo pipefail
 
@@ -65,7 +65,7 @@ spec:
       ec validate input --policy "${policy}" --output yaml --strict=true ${args[*]}
   - name: validate-step-actions
     workingDir: "$(workspaces.source.path)/source"
-    image: quay.io/enterprise-contract/ec-cli:snapshot@sha256:57e14c2ae9591a5bb1e2638ed4c657876ad1889016e8a1a430fd59cb3735da38
+    image: quay.io/enterprise-contract/cli:latest@sha256:966e786a3d8606f4e44de775e3d8e9a679e66c47d35db8f84df02430df921b3e
     script: |
       #!/bin/bash
       set -euo pipefail

--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/enterprise-contract/ec-cli:snapshot AS ec-image
+FROM quay.io/enterprise-contract/cli:latest AS ec-image
 FROM registry.access.redhat.com/ubi9/ubi
 
 COPY --from=ec-image /usr/local/bin/ec_linux_amd64.gz /usr/bin/ec.gz

--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -120,7 +120,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: quay.io/enterprise-contract/ec-task-bundle:snapshot@sha256:3a77cc4a82e45bc9ddbbef622c5d272c1d3ec91c9e1452a739dd94e1d6418974
+            value: quay.io/enterprise-contract/tekton-task:latest@sha256:b0f8910248d3b3a1e213221f0ac91a0c79d8cf5438ff72e9e072f405f86f6af9
           - name: name
             value: verify-enterprise-contract
           - name: kind


### PR DESCRIPTION
We're now building a main branch Conforma image and related Tekton task bundle in Konflux. These new Konflux-built images are pushed to a different repo than the equivalent GitHub built images.

The goal is to use the Konflux builds instead of the GitHub builds. In this PR the image refs are updated in a few different places.

(See commit messages for further details.)

Ref: https://issues.redhat.com/browse/EC-913