### PR TITLE
build-maven-zip: work around broken cosign auth

### DIFF
--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -197,7 +197,9 @@ spec:
           sbom_type=spdx
         fi
 
-        cosign attach sbom --sbom sbom.json --type "$sbom_type" "$IMAGE"
+        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+        mkdir -p /tmp/auth && select-oci-auth "$IMAGE" >/tmp/auth/config.json
+        DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom.json --type "$sbom_type" "$IMAGE"
 
         # Remove tag from IMAGE while allowing registry to contain a port number.
         sbom_repo="${IMAGE%:*}"

--- a/task/build-maven-zip/0.1/build-maven-zip.yaml
+++ b/task/build-maven-zip/0.1/build-maven-zip.yaml
@@ -163,7 +163,9 @@ spec:
         sbom_type=spdx
       fi
 
-      cosign attach sbom --sbom sbom.json --type "$sbom_type" "$IMAGE"
+      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+      mkdir -p /tmp/auth && select-oci-auth "$IMAGE" >/tmp/auth/config.json
+      DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom.json --type "$sbom_type" "$IMAGE"
 
       # Remove tag from IMAGE while allowing registry to contain a port number.
       sbom_repo="${IMAGE%:*}"


### PR DESCRIPTION
Cosign uses the go-containerregistry module for authentication. This
module doesn't implement containers-auth.json handling properly [1].
In particular, the keys in the auth file must either be full image
names or just hostnames:

    quay.io/my-org/my-image
    quay.io

Partial paths are not supported:

    quay.io/my-org

Use the select-oci-auth script [1] as a workaround to make cosign work
for partial paths in the auth file.

[1]: https://github.com/konflux-ci/build-definitions/blob/main/appstudio-utils/util-scripts/select-oci-auth.sh

Signed-off-by: Adam Cmiel <acmiel@redhat.com>