### PR TITLE
paketo-builder: work around broken cosign auth

### DIFF
--- a/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
+++ b/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
@@ -525,7 +525,9 @@ spec:
           update-ca-trust
         fi
 
-        cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+        mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" >/tmp/auth/config.json
+        DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca


### PR DESCRIPTION
Cosign uses the go-containerregistry module for authentication. This
module doesn't implement containers-auth.json handling properly [1].
In particular, the keys in the auth file must either be full image
names or just hostnames:

    quay.io/my-org/my-image
    quay.io

Partial paths are not supported:

    quay.io/my-org

Use the select-oci-auth script [1] as a workaround to make cosign work
for partial paths in the auth file.

[1]: https://github.com/konflux-ci/build-definitions/blob/main/appstudio-utils/util-scripts/select-oci-auth.sh

Signed-off-by: Adam Cmiel <acmiel@redhat.com>