### PR TITLE
oci-copy: work around broken cosign auth

### DIFF
--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -326,7 +326,9 @@ spec:
       image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
       workingDir: /var/workdir
       script: |
-        cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+        mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" >/tmp/auth/config.json
+        DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
     - name: report-sbom-url
       image: quay.io/konflux-ci/yq:latest@sha256:93bb15cff64b708263055a5814b24a0b450d8724b86a7e5206396f25d81fcc21
       workingDir: /var/workdir

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -323,7 +323,7 @@ spec:
 
         mv /tmp/sbom.tmp.json sbom.json
     - name: upload-sbom
-      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
       workingDir: /var/workdir
       script: |
         cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -303,7 +303,7 @@ spec:
         mv /tmp/sbom.tmp.json sbom.json
       workingDir: $(workspaces.source.path)
     - name: upload-sbom
-      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
       workingDir: $(workspaces.source.path)
       script: |
         cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -306,7 +306,9 @@ spec:
       image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
       workingDir: $(workspaces.source.path)
       script: |
-        cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+        mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" > /tmp/auth/config.json
+        DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
     - name: report-sbom-url
       image: quay.io/konflux-ci/yq:latest@sha256:93bb15cff64b708263055a5814b24a0b450d8724b86a7e5206396f25d81fcc21
       script: |


### PR DESCRIPTION
Cosign uses the go-containerregistry module for authentication. This
module doesn't implement containers-auth.json handling properly [1].
In particular, the keys in the auth file must either be full image
names or just hostnames:

    quay.io/my-org/my-image
    quay.io

Partial paths are not supported:

    quay.io/my-org

Use the select-oci-auth script [1] as a workaround to make cosign work
for partial paths in the auth file.

[1]: https://github.com/konflux-ci/build-definitions/blob/main/appstudio-utils/util-scripts/select-oci-auth.sh

Signed-off-by: Adam Cmiel <acmiel@redhat.com>