### PR TITLE
rpm-ostree: work around broken cosign auth

### DIFF
--- a/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
+++ b/task/rpm-ostree-oci-ta/0.2/rpm-ostree-oci-ta.yaml
@@ -306,4 +306,6 @@ spec:
       image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
       workingDir: /var/workdir
       script: |
-        cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
+        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+        mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" >/tmp/auth/config.json
+        DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"

--- a/task/rpm-ostree/0.2/rpm-ostree.yaml
+++ b/task/rpm-ostree/0.2/rpm-ostree.yaml
@@ -290,7 +290,9 @@ spec:
     image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
     workingDir: $(workspaces.source.path)
     script: |
-      cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
+      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+      mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" > /tmp/auth/config.json
+      DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom-cyclonedx.json --type cyclonedx "$(cat "$(results.IMAGE_REF.path)")"
   volumes:
   - emptyDir: {}
     name: varlibcontainers


### PR DESCRIPTION
Cosign uses the go-containerregistry module for authentication. This
module doesn't implement containers-auth.json handling properly [1].
In particular, the keys in the auth file must either be full image
names or just hostnames:

    quay.io/my-org/my-image
    quay.io

Partial paths are not supported:

    quay.io/my-org

Use the select-oci-auth script [1] as a workaround to make cosign work
for partial paths in the auth file.

[1]: https://github.com/konflux-ci/build-definitions/blob/main/appstudio-utils/util-scripts/select-oci-auth.sh

Signed-off-by: Adam Cmiel <acmiel@redhat.com>