### PR TITLE
Expose the link to an uploaded SBOM in TPA

### DIFF
--- a/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
+++ b/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
@@ -58,6 +58,10 @@ spec:
     secret:
       secretName: $(params.TRUSTIFICATION_SECRET_NAME)
       optional: true
+  - name: shared-folder
+    emptyDir:
+      medium: Memory
+      sizeLimit: 50Mi
   stepTemplate:
     env:
     - name: SBOMS_DIR
@@ -163,6 +167,9 @@ spec:
 
   - name: upload-sboms
     image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
+    volumeMounts:
+      - name: shared-folder
+        mountPath: /steps-shared-folder
     script: |
       #!/usr/bin/env bash
       set -o errexit -o nounset -o pipefail
@@ -239,6 +246,14 @@ spec:
         sbom_id="$(basename -s .json "$sbom_path")"
         supported_version_of_sbom="${sbom_path}.supported_version"
 
+        # Generate URL to the SBOM in TPA and write it to a JSON file to use for eyecatcher
+        tpa_url=${bombastic_api_url//sbom/console}
+        tpa_sbom_id="${sbom_id//sha256:/sha256%3A}"
+        jq -n \
+          --arg url "$tpa_url/sbom/content/$tpa_sbom_id" \
+          '{"TPA_SBOM_URL": $url}' \
+            > /steps-shared-folder/tpa-sbom-url.json
+
         echo "Uploading SBOM to $bombastic_api_url (with id=$sbom_id)"
         # https://docs.trustification.dev/trustification/user/bombastic.html#publishing-an-sbom-doc
         curl "${curl_opts[@]}" \
@@ -249,3 +264,13 @@ spec:
           --data "@$supported_version_of_sbom" \
           "$bombastic_api_url/api/v1/sbom?id=$sbom_id"
       done
+
+  - name: report
+    image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
+    volumeMounts:
+      - name: shared-folder
+        mountPath: /steps-shared-folder
+    script: |
+      echo "TPA_SBOM_URL_EYECATCHER_BEGIN"
+      cat /steps-shared-folder/tpa-sbom-url.json
+      echo "TPA_SBOM_URL_EYECATCHER_END"


### PR DESCRIPTION
SBOMs are getting uploaded to Red Hat Trusted Profile Analyzer in the GitOps pipeline.
Expose the link to the uploaded SBOM and wrap it around `TPA_SBOM_EYECATCHER` so that it can be used in UI.

Example output:
```
TPA_SBOM_URL_EYECATCHER_BEGIN
{
  "TPA_SBOM_URL": "<url>"
}
```