### PR TITLE
fix: infra-depoyment update not needed

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -205,20 +205,6 @@ spec:
           - name: source
             workspace: workspace
 
-      - name: update-infra-repo
-        runAfter:
-          - build-bundles
-        params:
-          - name: ORIGIN_REPO
-            value: $(params.git-url)
-          - name: REVISION
-            value: $(params.revision)
-          - name: SCRIPT
-            value: |
-              sed -i -E 's/[0-9a-f]{40}/$(params.revision)/g' components/build-service/base/build-pipeline-config/build-pipeline-config.yaml
-        taskRef:
-          name: update-infra-deployments
-
     workspaces:
       - name: workspace
         description: Workspace containing arbitrary artifacts used during the pipeline run.


### PR DESCRIPTION
Since we are moving to use `devel` tag instead of `commit_id` tag, no need to update the `build-pipeline-config` configMap.
This is part of the story: https://issues.redhat.com/browse/KONFLUX-7680

Related [change](https://github.com/redhat-appstudio/infra-deployments/pull/6288) in the infra-deployment side.
