### PR TITLE
buildah: add WORKINGDIR_MOUNT parameter

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -76,6 +76,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
@@ -220,6 +221,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -73,6 +73,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
@@ -217,6 +218,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -71,6 +71,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
@@ -210,6 +211,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -75,6 +75,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -112,6 +112,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -107,6 +107,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |
 |YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
 |YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -153,6 +153,12 @@ spec:
       image_reference_with_digest strings
     name: ADDITIONAL_BASE_IMAGES
     type: array
+  - default: ""
+    description: Mount the current working directory into the build using --volume
+      $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for
+      the build (see the CONTEXT param).
+    name: WORKINGDIR_MOUNT
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -216,6 +222,8 @@ spec:
       value: $(params.SBOM_TYPE)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
+    - name: WORKINGDIR_MOUNT
+      value: $(params.WORKINGDIR_MOUNT)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -488,6 +496,18 @@ spec:
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
         echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "$WORKINGDIR_MOUNT" ]; then
+        if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+          echo "WORKINGDIR_MOUNT contains ':'" >&2
+          echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+          exit 1
+        fi
+        # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+        # (we set the workdir using 'unshare -w')
+        context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+        VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
       fi
 
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -35,6 +35,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
 |YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -145,6 +145,12 @@ spec:
         to a non-TLS registry)
       type: string
       default: "true"
+    - name: WORKINGDIR_MOUNT
+      description: Mount the current working directory into the build using
+        --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context
+        directory for the build (see the CONTEXT param).
+      type: string
+      default: ""
     - name: YUM_REPOS_D_FETCHED
       description: Path in source workspace where dynamically-fetched repos
         are present
@@ -249,6 +255,8 @@ spec:
         value: $(params.TARGET_STAGE)
       - name: TLSVERIFY
         value: $(params.TLSVERIFY)
+      - name: WORKINGDIR_MOUNT
+        value: $(params.WORKINGDIR_MOUNT)
       - name: YUM_REPOS_D_FETCHED
         value: $(params.YUM_REPOS_D_FETCHED)
       - name: YUM_REPOS_D_SRC
@@ -556,6 +564,18 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
           echo "Adding the entitlement to the build"
+        fi
+
+        if [ -n "$WORKINGDIR_MOUNT" ]; then
+          if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+            echo "WORKINGDIR_MOUNT contains ':'" >&2
+            echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+            exit 1
+          fi
+          # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+          # (we set the workdir using 'unshare -w')
+          context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+          VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
         fi
 
         if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -143,6 +143,12 @@ spec:
       registry)
     name: TLSVERIFY
     type: string
+  - default: ""
+    description: Mount the current working directory into the build using --volume
+      $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for
+      the build (see the CONTEXT param).
+    name: WORKINGDIR_MOUNT
+    type: string
   - default: fetched.repos.d
     description: Path in source workspace where dynamically-fetched repos are present
     name: YUM_REPOS_D_FETCHED
@@ -227,6 +233,8 @@ spec:
       value: $(params.TARGET_STAGE)
     - name: TLSVERIFY
       value: $(params.TLSVERIFY)
+    - name: WORKINGDIR_MOUNT
+      value: $(params.WORKINGDIR_MOUNT)
     - name: YUM_REPOS_D_FETCHED
       value: $(params.YUM_REPOS_D_FETCHED)
     - name: YUM_REPOS_D_SRC
@@ -597,6 +605,18 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      if [ -n "$WORKINGDIR_MOUNT" ]; then
+        if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+          echo "WORKINGDIR_MOUNT contains ':'" >&2
+          echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+          exit 1
+        fi
+        # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+        # (we set the workdir using 'unshare -w')
+        context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+        VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
+      fi
+
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
         # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
         # Instrumented builds (SAST) use this step as their base and add some other tools.
@@ -717,6 +737,7 @@ spec:
           -e STORAGE_DRIVER="${STORAGE_DRIVER@Q}" \
           -e TARGET_STAGE="${TARGET_STAGE@Q}" \
           -e TLSVERIFY="${TLSVERIFY@Q}" \
+          -e WORKINGDIR_MOUNT="${WORKINGDIR_MOUNT@Q}" \
           -e YUM_REPOS_D_FETCHED="${YUM_REPOS_D_FETCHED@Q}" \
           -e YUM_REPOS_D_SRC="${YUM_REPOS_D_SRC@Q}" \
           -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -153,6 +153,12 @@ spec:
       image_reference_with_digest strings
     name: ADDITIONAL_BASE_IMAGES
     type: array
+  - default: ""
+    description: Mount the current working directory into the build using --volume
+      $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for
+      the build (see the CONTEXT param).
+    name: WORKINGDIR_MOUNT
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -224,6 +230,8 @@ spec:
       value: $(params.SBOM_TYPE)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
+    - name: WORKINGDIR_MOUNT
+      value: $(params.WORKINGDIR_MOUNT)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah-task:latest@sha256:4d8273444b0f2781264c232e12e88449bbf078c99e3da2a7f6dcaaf27bc53712
     - name: PLATFORM
@@ -565,6 +573,18 @@ spec:
         echo "Adding the entitlement to the build"
       fi
 
+      if [ -n "$WORKINGDIR_MOUNT" ]; then
+        if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+          echo "WORKINGDIR_MOUNT contains ':'" >&2
+          echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+          exit 1
+        fi
+        # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+        # (we set the workdir using 'unshare -w')
+        context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+        VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
+      fi
+
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then
         # ADDITIONAL_VOLUME_MOUNTS allows to specify more volumes for the build.
         # Instrumented builds (SAST) use this step as their base and add some other tools.
@@ -688,6 +708,7 @@ spec:
           -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
           -e SBOM_TYPE="${SBOM_TYPE@Q}" \
           -e ANNOTATIONS_FILE="${ANNOTATIONS_FILE@Q}" \
+          -e WORKINGDIR_MOUNT="${WORKINGDIR_MOUNT@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e DOCKERFILE="${DOCKERFILE@Q}" \
           -v "${BUILD_DIR@Q}/workspaces/source:$(workspaces.source.path):Z" \

--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -38,6 +38,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
+|WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -28,14 +28,16 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
-|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
+|ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
+|ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -137,6 +137,13 @@ spec:
       Additional base image references to include to the SBOM. Array of image_reference_with_digest strings
     type: array
     default: []
+  - name: WORKINGDIR_MOUNT
+    description: >-
+      Mount the current working directory into the build using
+      --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the
+      context directory for the build (see the CONTEXT param).
+    type: string
+    default: ""
 
   results:
   - description: Digest of the image just built
@@ -203,6 +210,8 @@ spec:
       value: $(params.SBOM_TYPE)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
+    - name: WORKINGDIR_MOUNT
+      value: $(params.WORKINGDIR_MOUNT)
 
   steps:
   - image: quay.io/konflux-ci/buildah-task:latest@sha256:4d8273444b0f2781264c232e12e88449bbf078c99e3da2a7f6dcaaf27bc53712
@@ -474,6 +483,18 @@ spec:
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
         echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "$WORKINGDIR_MOUNT" ]; then
+        if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+          echo "WORKINGDIR_MOUNT contains ':'" >&2
+          echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+          exit 1
+        fi
+        # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+        # (we set the workdir using 'unshare -w')
+        context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+        VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
       fi
 
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then

--- a/task/sast-coverity-check-oci-ta/0.2/README.md
+++ b/task/sast-coverity-check-oci-ta/0.2/README.md
@@ -39,6 +39,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
 |YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -171,6 +171,12 @@ spec:
         to a non-TLS registry)
       type: string
       default: "true"
+    - name: WORKINGDIR_MOUNT
+      description: Mount the current working directory into the build using
+        --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context
+        directory for the build (see the CONTEXT param).
+      type: string
+      default: ""
     - name: YUM_REPOS_D_FETCHED
       description: Path in source workspace where dynamically-fetched repos
         are present
@@ -273,6 +279,8 @@ spec:
         value: $(params.TARGET_STAGE)
       - name: TLSVERIFY
         value: $(params.TLSVERIFY)
+      - name: WORKINGDIR_MOUNT
+        value: $(params.WORKINGDIR_MOUNT)
       - name: YUM_REPOS_D_FETCHED
         value: $(params.YUM_REPOS_D_FETCHED)
       - name: YUM_REPOS_D_SRC
@@ -716,6 +724,18 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
           echo "Adding the entitlement to the build"
+        fi
+
+        if [ -n "$WORKINGDIR_MOUNT" ]; then
+          if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+            echo "WORKINGDIR_MOUNT contains ':'" >&2
+            echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+            exit 1
+          fi
+          # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+          # (we set the workdir using 'unshare -w')
+          context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+          VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
         fi
 
         if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then

--- a/task/sast-coverity-check-oci-ta/0.3/README.md
+++ b/task/sast-coverity-check-oci-ta/0.3/README.md
@@ -39,6 +39,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
 |YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -171,6 +171,12 @@ spec:
         to a non-TLS registry)
       type: string
       default: "true"
+    - name: WORKINGDIR_MOUNT
+      description: Mount the current working directory into the build using
+        --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context
+        directory for the build (see the CONTEXT param).
+      type: string
+      default: ""
     - name: YUM_REPOS_D_FETCHED
       description: Path in source workspace where dynamically-fetched repos
         are present
@@ -278,6 +284,8 @@ spec:
         value: $(params.TARGET_STAGE)
       - name: TLSVERIFY
         value: $(params.TLSVERIFY)
+      - name: WORKINGDIR_MOUNT
+        value: $(params.WORKINGDIR_MOUNT)
       - name: YUM_REPOS_D_FETCHED
         value: $(params.YUM_REPOS_D_FETCHED)
       - name: YUM_REPOS_D_SRC
@@ -721,6 +729,18 @@ spec:
           cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
           VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
           echo "Adding the entitlement to the build"
+        fi
+
+        if [ -n "$WORKINGDIR_MOUNT" ]; then
+          if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+            echo "WORKINGDIR_MOUNT contains ':'" >&2
+            echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+            exit 1
+          fi
+          # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+          # (we set the workdir using 'unshare -w')
+          context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+          VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
         fi
 
         if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -152,6 +152,12 @@ spec:
       image_reference_with_digest strings
     name: ADDITIONAL_BASE_IMAGES
     type: array
+  - default: ""
+    description: Mount the current working directory into the build using --volume
+      $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for
+      the build (see the CONTEXT param).
+    name: WORKINGDIR_MOUNT
+    type: string
   - name: image-url
     type: string
   - default: cov-license
@@ -236,6 +242,8 @@ spec:
       value: $(params.SBOM_TYPE)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
+    - name: WORKINGDIR_MOUNT
+      value: $(params.WORKINGDIR_MOUNT)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -644,6 +652,18 @@ spec:
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
         echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "$WORKINGDIR_MOUNT" ]; then
+        if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+          echo "WORKINGDIR_MOUNT contains ':'" >&2
+          echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+          exit 1
+        fi
+        # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+        # (we set the workdir using 'unshare -w')
+        context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+        VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
       fi
 
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -152,6 +152,12 @@ spec:
       image_reference_with_digest strings
     name: ADDITIONAL_BASE_IMAGES
     type: array
+  - default: ""
+    description: Mount the current working directory into the build using --volume
+      $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for
+      the build (see the CONTEXT param).
+    name: WORKINGDIR_MOUNT
+    type: string
   - description: Digest of the image to which the scan results should be associated.
     name: image-digest
     type: string
@@ -240,6 +246,8 @@ spec:
       value: $(params.SBOM_TYPE)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
+    - name: WORKINGDIR_MOUNT
+      value: $(params.WORKINGDIR_MOUNT)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -648,6 +656,18 @@ spec:
         cp -r --preserve=mode "$ENTITLEMENT_PATH" /tmp/entitlement
         VOLUME_MOUNTS+=(--volume /tmp/entitlement:/etc/pki/entitlement)
         echo "Adding the entitlement to the build"
+      fi
+
+      if [ -n "$WORKINGDIR_MOUNT" ]; then
+        if [[ "$WORKINGDIR_MOUNT" == *:* ]]; then
+          echo "WORKINGDIR_MOUNT contains ':'" >&2
+          echo "Refusing to proceed in case this is an attempt to set unexpected mount options." >&2
+          exit 1
+        fi
+        # ${SOURCE_CODE_DIR}/${CONTEXT} will be the $PWD when we call 'buildah build'
+        # (we set the workdir using 'unshare -w')
+        context_dir=$(realpath "${SOURCE_CODE_DIR}/${CONTEXT}")
+        VOLUME_MOUNTS+=(--volume "$context_dir:${WORKINGDIR_MOUNT}")
       fi
 
       if [ -n "${ADDITIONAL_VOLUME_MOUNTS-}" ]; then


### PR DESCRIPTION
Allows to mount the current working directory into the build using
--volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context
directory for the build, because we set the workdir to the context dir
before calling 'buildah build'.

The primary use case for this parameter is for builds that need to write
some outputs into a shared directory and reference the output in a later
FROM instruction, e.g.

    FROM oci-archive:./out.ociarchive

See https://github.com/konflux-ci/buildah-container/issues/134 for more details.
