### PR TITLE
fix: check cachi2 dir existence/PREFETCH_ARTIFACT being non-empty

### DIFF
--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -167,11 +167,14 @@ spec:
         echo 'root:1:4294967294' | tee -a /etc/subuid >>/etc/subgid
 
         UNSHARE_ARGS=()
-        HERMETO_MOUNT=""
-        HERMETO_SOURCE=""
         if [ "${HERMETIC}" == "true" ]; then
           echo "The script will be executed with network isolation"
           UNSHARE_ARGS+=("--net")
+        fi
+
+        HERMETO_MOUNT=""
+        HERMETO_SOURCE=""
+        if [ -d "/var/workdir/cachi2" ]; then
           HERMETO_MOUNT="--volume /var/workdir/cachi2:/cachi2"
           HERMETO_SOURCE=". /cachi2/cachi2.env &&"
         fi


### PR DESCRIPTION
some build would fail, because cachi2 directory doesn't exist in the image


