### PR TITLE
downgrade runner for check-ta

### DIFF
--- a/.github/workflows/check-ta.yaml
+++ b/.github/workflows/check-ta.yaml
@@ -7,7 +7,7 @@ name: Validate PR - Trusted Artifact variants
 jobs:
   go:
     name: Check Trusted Artifact variants
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
Recent update of the runner to [ubuntu-24.04 ](https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250504.1) introduced the new verion of yq-4.45.2, which broke check-ta job. Downgrading to ubuntu-22.04 serves as a workaround, since it contains yq-4.45.1, until the issue is resolved in the yq.

GitHub also doesn't support using minor version of a runner.