### PR TITLE
generate-readme: work around bug in yq v4.45.2

### DIFF
--- a/hack/generate-readme.sh
+++ b/hack/generate-readme.sh
@@ -9,17 +9,19 @@ echo "# $(yq '.metadata.name' $RESOURCE) $(yq '.kind | downcase' $RESOURCE)"
 echo
 yq '.spec.description' $RESOURCE
 echo
-PARAMS=$(yq '
-    .spec.params.[] |
-    with(select(.default | type == "!!seq"); .default = (.default | tojson(0))) |
-    (
-        "|" + .name +
-        "|" + (.description // "" | sub("\n", " ")) +
-        "|" + (.default // (.default != "*" | "")) +
-        "|" + (.default != "*") + "|"
-    )' $RESOURCE
-)
-if [ -n "$PARAMS" ]; then
+
+if [[ $(yq '.spec.params | length' "$RESOURCE") -gt 0 ]]; then
+  PARAMS=$(yq '
+      .spec.params.[] |
+      with(select(.default | type == "!!seq"); .default = (.default | tojson(0))) |
+      (
+          "|" + .name +
+          "|" + (.description // "" | sub("\n", " ")) +
+          "|" + (.default // (.default != "*" | "")) +
+          "|" + (.default != "*") + "|"
+      )' $RESOURCE
+  )
+
   echo "## Parameters"
   echo "|name|description|default value|required|"
   echo "|---|---|---|---|"
@@ -27,8 +29,9 @@ if [ -n "$PARAMS" ]; then
   echo
 fi
 
-RESULTS=$(yq '.spec.results.[] | ("|" + .name + "|" + (.description // "" | sub("\n", " ")) + "|")' $RESOURCE)
-if [ -n "$RESULTS" ]; then
+if [[ $(yq '.spec.results | length' "$RESOURCE") -gt 0 ]]; then
+  RESULTS=$(yq '.spec.results.[] | ("|" + .name + "|" + (.description // "" | sub("\n", " ")) + "|")' $RESOURCE)
+
   echo "## Results"
   echo "|name|description|"
   echo "|---|---|"
@@ -36,8 +39,9 @@ if [ -n "$RESULTS" ]; then
   echo
 fi
 
-WORKSPACES=$(yq '.spec.workspaces.[] | ("|" + .name + "|" + (.description // "" | sub("\n", " ")) + "|" + (.optional // "false") + "|")' $RESOURCE)
-if [ -n "$WORKSPACES" ]; then
+if [[ $(yq '.spec.workspaces | length' "$RESOURCE") -gt 0 ]]; then
+  WORKSPACES=$(yq '.spec.workspaces.[] | ("|" + .name + "|" + (.description // "" | sub("\n", " ")) + "|" + (.optional // "false") + "|")' $RESOURCE)
+
   echo "## Workspaces"
   echo "|name|description|optional|"
   echo "|---|---|---|"


### PR DESCRIPTION
The behavior of empty array streaming changed in v4.45.2 [1]

Before:

    $ echo '[]' | yq.4.45.1 '.[] | .a + "hi"'
    <no output>

After:

    $ echo '[]' | yq.4.45.2 '.[] | .a + "hi"'
    hi

This broke the logic in the README generator script. It is now trying to add sections that have no content, e.g. a Workspaces section for tasks that have no workspaces.

Refactor to work with the new yq version.

[1]: https://github.com/mikefarah/yq/issues/2325#issuecomment-2851357108
