### PR TITLE
Adding request and limits for CPU and Memory for push-dockerfile task

### DIFF
--- a/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
+++ b/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
@@ -135,7 +135,7 @@ spec:
           yq '.reference' | tr -d '\r\n' >"$IMAGE_REF_RESULT"
       computeResources:
         limits:
-          memory: 1Gi
+          memory: 256Mi
         requests:
           cpu: 100m
-          memory: 1Gi
+          memory: 256Mi

--- a/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
+++ b/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
@@ -133,3 +133,9 @@ spec:
           --artifact-type "$ARTIFACT_TYPE" \
           "$dockerfile_image" "$(basename $dockerfile_for_upload_path)" |
           yq '.reference' | tr -d '\r\n' >"$IMAGE_REF_RESULT"
+      computeResources:
+        limits:
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 1Gi

--- a/task/push-dockerfile/0.1/push-dockerfile.yaml
+++ b/task/push-dockerfile/0.1/push-dockerfile.yaml
@@ -70,6 +70,12 @@ spec:
       value: $(params.ARTIFACT_TYPE)
     - name: IMAGE_REF_RESULT
       value: $(results.IMAGE_REF.path)
+    computeResources:
+      limits:
+        memory: 1Gi
+      requests:
+        cpu: 100m
+        memory: 1Gi
     script: |
       set -eu
       set -o pipefail

--- a/task/push-dockerfile/0.1/push-dockerfile.yaml
+++ b/task/push-dockerfile/0.1/push-dockerfile.yaml
@@ -72,10 +72,10 @@ spec:
       value: $(results.IMAGE_REF.path)
     computeResources:
       limits:
-        memory: 1Gi
+        memory: 256Mi
       requests:
         cpu: 100m
-        memory: 1Gi
+        memory: 256Mi
     script: |
       set -eu
       set -o pipefail


### PR DESCRIPTION
We conducted a CPU and memory resource usage analysis for the push-dockerfile task to determine appropriate Kubernetes resource requests and limits. The following PromQL queries were executed against 3 weeks of metrics data. 

PEAK MEMORY
![image](https://github.com/user-attachments/assets/426459fb-0a61-40bd-8b5b-1516c5fd0742)

95 PERCENTILE MEMORY

![image](https://github.com/user-attachments/assets/20117851-0c49-422a-9c0c-5152715a02a9)


PEAK CPU

![image](https://github.com/user-attachments/assets/ce23a04d-a42f-4306-b92b-9cdaa32cd294)



95 PERCENTILE CPU

![image](https://github.com/user-attachments/assets/474f1344-f8c0-440f-8f62-04d70cc121b9)



The spreadsheet has been updated with the resulting values to guide tuning of resource requests and limits

https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?pli=1&gid=1735880927#gid=1735880927




