### PR TITLE
feat(STONEINTG-1195): add retry to command meeting intermittent issue

### DIFF
--- a/task/clair-scan/0.1/clair-scan.yaml
+++ b/task/clair-scan/0.1/clair-scan.yaml
@@ -63,6 +63,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+        # shellcheck source=/dev/null
         . /utils.sh
 
         imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
@@ -71,11 +72,17 @@ spec:
         echo "Inspecting raw image manifest $imageanddigest."
 
         # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
-        image_manifests=$(get_image_manifests -i ${imageanddigest})
+        image_manifests=$(get_image_manifests -i "${imageanddigest}")
         if [ -n "$image_manifests" ]; then
           echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"' | while read -r arch arch_sha; do
             echo "$arch_sha" > /tekton/home/image-manifest-$arch.sha
           done
+        else
+          echo "Failed to get image manifests from image \"$imageanddigest\""
+          note="Task $(context.task.name) failed: Failed to get image manifests from image \"$imageanddigest\". For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
         fi
     - name: get-vulnerabilities
       image: quay.io/konflux-ci/clair-in-ci:v1  # explicit floating tag, daily updates, per arch call this is exempt for now for use of image digest
@@ -94,6 +101,9 @@ spec:
           value: $(params.image-digest)
       script: |
         #!/usr/bin/env bash
+        set -euo pipefail
+        # shellcheck source=/utils.sh
+        . /utils.sh
 
         imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
         images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
@@ -107,7 +117,7 @@ spec:
 
             echo "Running clair-action on $arch image manifest."
             # run the scan for each image manifest in the image index
-            clair-action report --image-ref=$arch_specific_digest --db-path=/tmp/matcher.db --format=quay | tee /tekton/home/clair-result-$arch.json || true
+            retry clair-action report --image-ref="$arch_specific_digest" --db-path=/tmp/matcher.db --format=quay | tee /tekton/home/clair-result-"$arch".json || true
 
             digests_processed+=("\"$arch_sha\"")
           fi

--- a/task/clair-scan/0.2/clair-scan.yaml
+++ b/task/clair-scan/0.2/clair-scan.yaml
@@ -64,6 +64,7 @@ spec:
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
+        # shellcheck source=/dev/null
         . /utils.sh
 
         imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
@@ -72,11 +73,17 @@ spec:
         echo "Inspecting raw image manifest $imageanddigest."
 
         # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
-        image_manifests=$(get_image_manifests -i ${imageanddigest})
+        image_manifests=$(get_image_manifests -i "${imageanddigest}")
         if [ -n "$image_manifests" ]; then
           echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"' | while read -r arch arch_sha; do
             echo "$arch_sha" > /tekton/home/image-manifest-$arch.sha
           done
+        else
+          echo "Failed to get image manifests from image \"$imageanddigest\""
+          note="Task $(context.task.name) failed: Failed to get image manifests from image \"$imageanddigest\". For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
         fi
     - name: get-vulnerabilities
       image: quay.io/konflux-ci/clair-in-ci:v1  # explicit floating tag, daily updates, per arch call this is exempt for now for use of image digest
@@ -99,6 +106,8 @@ spec:
         set -o errexit
         set -o nounset
         set -o pipefail
+        # shellcheck source=/utils.sh
+        . /utils.sh
 
         imagewithouttag=$(echo -n $IMAGE_URL | sed "s/\(.*\):.*/\1/")
         images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
@@ -109,8 +118,8 @@ spec:
         # we require in the policy rules, so we resort to running clair-action
         # twice to produce both quay and clair formatted output
         clair_report() {
-          { clair-action report --image-ref="$1" --db-path=/tmp/matcher.db --format=quay | tee "clair-result-$2.json"; } && \
-          { clair-action report --image-ref="$1" --db-path=/tmp/matcher.db --format=clair > "clair-report-$2.json"; }
+          { retry clair-action report --image-ref="$1" --db-path=/tmp/matcher.db --format=quay | tee "clair-result-$2.json"; } && \
+          { retry clair-action report --image-ref="$1" --db-path=/tmp/matcher.db --format=clair > "clair-report-$2.json"; }
         }
 
         for sha_file in image-manifest-*.sha; do

--- a/task/clamav-scan/0.1/clamav-scan.yaml
+++ b/task/clamav-scan/0.1/clamav-scan.yaml
@@ -82,7 +82,7 @@ spec:
         echo "Extracting image(s)."
 
         # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
-        image_manifests=$(get_image_manifests -i ${imageanddigest})
+        image_manifests=$(get_image_manifests -i "${imageanddigest}")
         if [ -n "$image_manifests" ]; then
           while read -r arch arch_sha; do
             destination=$(echo content-$arch)
@@ -151,6 +151,12 @@ spec:
               cat /work/logs/clamscan-ec-test-$arch.json
             fi
           done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+        else
+          echo "Failed to get image manifests from image \"$imageanddigest\""
+          note="Task $(context.task.name) failed: Failed to get image manifests from image \"$imageanddigest\". For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
         fi
 
         jq -s -rce '

--- a/task/clamav-scan/0.2/clamav-scan.yaml
+++ b/task/clamav-scan/0.2/clamav-scan.yaml
@@ -83,7 +83,7 @@ spec:
         echo "Extracting image(s)."
 
         # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
-        image_manifests=$(get_image_manifests -i ${imageanddigest})
+        image_manifests=$(get_image_manifests -i "${imageanddigest}")
         if [ -n "$image_manifests" ]; then
           while read -r arch arch_sha; do
             destination=$(echo content-$arch)
@@ -134,6 +134,12 @@ spec:
               cat /work/logs/clamscan-ec-test-$arch.json
             fi
           done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+        else
+          echo "Failed to get image manifests from image \"$imageanddigest\""
+          note="Task $(context.task.name) failed: Failed to get image manifests from image \"$imageanddigest\". For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
         fi
 
         jq -s -rce '

--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -78,7 +78,7 @@ spec:
         imageanddigest=$(echo -n $imagewithouttag@$IMAGE_DIGEST)
 
         # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
-        image_manifests=$(get_image_manifests -i ${imageanddigest})
+        image_manifests=$(get_image_manifests -i "${imageanddigest}")
         if [ -n "$image_manifests" ]; then
           while read -r arch arch_sha; do
             SBOM_FILE_PATH=$(echo "/tmp/sbom-$arch.json")
@@ -109,6 +109,12 @@ spec:
 
             digests_processed+=("\"$arch_sha\"")
           done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+        else
+          echo "Failed to get image manifests from image \"$imageanddigest\""
+          note="Task $(context.task.name) failed: Failed to get image manifests from image \"$imageanddigest\". For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
         fi
 
         # If the image is an Image Index, also add the Image Index digest to the list.

--- a/task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -78,7 +78,7 @@ spec:
         imageanddigest=$(echo -n $imagewithouttag@$IMAGE_DIGEST)
 
         # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
-        image_manifests=$(get_image_manifests -i ${imageanddigest})
+        image_manifests=$(get_image_manifests -i "${imageanddigest}")
         if [ -n "$image_manifests" ]; then
           while read -r arch arch_sha; do
             SBOM_FILE_PATH=$(echo "/tmp/sbom-$arch.json")
@@ -109,6 +109,12 @@ spec:
 
             digests_processed+=("\"$arch_sha\"")
           done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+        else
+          echo "Failed to get image manifests from image \"$imageanddigest\""
+          note="Task $(context.task.name) failed: Failed to get image manifests from image \"$imageanddigest\". For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
         fi
 
         # If the image is an Image Index, also add the Image Index digest to the list.

--- a/task/sbom-json-check/0.1/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.1/sbom-json-check.yaml
@@ -64,7 +64,7 @@ spec:
       image_with_digest=$(echo $imagewithouttag@$IMAGE_DIGEST)
       digests_processed=()
 
-      image_manifests=$(get_image_manifests -i ${image_with_digest})
+      image_manifests=$(get_image_manifests -i "${image_with_digest}")
       echo "$image_manifests"
       if [ -n "$image_manifests" ]; then
         while read -r arch arch_sha; do

--- a/task/sbom-json-check/0.2/sbom-json-check.yaml
+++ b/task/sbom-json-check/0.2/sbom-json-check.yaml
@@ -64,7 +64,7 @@ spec:
       image_with_digest=$(echo $imagewithouttag@$IMAGE_DIGEST)
       digests_processed=()
 
-      image_manifests=$(get_image_manifests -i ${image_with_digest})
+      image_manifests=$(get_image_manifests -i "${image_with_digest}")
       echo "$image_manifests"
       if [ -n "$image_manifests" ]; then
         while read -r arch arch_sha; do


### PR DESCRIPTION
* retry command which meet integmittent issue as below get_image_manifests, clair-action, c image extract
* echo message to TEST_OUTPUT and mark result as ERROR when command fails


igned-off-by: Hongwei Liu <hongliu@redhat.com>
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
