### PR TITLE
chore: add HOME var to appstudio-utils

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -28,3 +28,6 @@ RUN dnf -y --setopt=tsflags=nodocs install \
 
 COPY util-scripts /appstudio-utils/util-scripts
 COPY util-scripts/select-oci-auth.sh /usr/local/bin/select-oci-auth
+
+# Set HOME variable to something else than `/` to avoid 'permission denied' problems when writing files.
+ENV HOME=/tekton/home


### PR DESCRIPTION
Add `HOME` environment variable to appstudio-utils

When using appstudio-utils to run `ec track` command it fails for authorization.
The solution is to add HOME environment variable to the task that uses this image.

We can simply add `HOME` to the dockerfile and avoid updating the tasks that uses it.

Example taken from release service:
https://github.com/konflux-ci/release-service-utils/blob/main/Dockerfile#L97


