### PR TITLE
buildah etc.: run syft on oci-dir, not oci-archive

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -580,8 +580,8 @@ spec:
       done
 
       image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-      echo "/shared/$image_name.tar" > /shared/container_path
+      buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+      echo "/shared/$image_name.oci" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
     securityContext:
@@ -705,7 +705,7 @@ spec:
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image"
-      syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
+      syft oci-dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -648,8 +648,8 @@ spec:
         done
 
         image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-        buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-        echo "/shared/$image_name.tar" >/shared/container_path
+        buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+        echo "/shared/$image_name.oci" >/shared/container_path
 
         echo "[$(date --utc -Ins)] End build"
       computeResources:
@@ -776,7 +776,7 @@ spec:
         echo "Running syft on the source directory"
         syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="/var/workdir/sbom-source.json"
         echo "Running syft on the image"
-        syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
+        syft oci-dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
 
         echo "[$(date --utc -Ins)] End sbom-syft-generate"
     - name: prepare-sboms

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -687,8 +687,8 @@ spec:
       done
 
       image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-      echo "/shared/$image_name.tar" >/shared/container_path
+      buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+      echo "/shared/$image_name.oci" >/shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
 
@@ -905,7 +905,7 @@ spec:
       echo "Running syft on the source directory"
       syft dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="/var/workdir/sbom-source.json"
       echo "Running syft on the image"
-      syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
+      syft oci-dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="/var/workdir/sbom-image.json"
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -655,8 +655,8 @@ spec:
       done
 
       image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-      echo "/shared/$image_name.tar" > /shared/container_path
+      buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+      echo "/shared/$image_name.oci" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
 
@@ -873,7 +873,7 @@ spec:
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image"
-      syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
+      syft oci-dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -567,8 +567,8 @@ spec:
       done
 
       image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-      echo "/shared/$image_name.tar" > /shared/container_path
+      buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+      echo "/shared/$image_name.oci" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
 
@@ -698,7 +698,7 @@ spec:
       echo "Running syft on the source directory"
       syft dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-source.json"
       echo "Running syft on the image"
-      syft oci-archive:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
+      syft oci-dir:"$(cat /shared/container_path)" --output "$syft_sbom_type"="$(workspaces.source.path)/sbom-image.json"
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -808,8 +808,8 @@ spec:
         done
 
         image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-        buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-        echo "/shared/$image_name.tar" >/shared/container_path
+        buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+        echo "/shared/$image_name.oci" >/shared/container_path
 
         echo "[$(date --utc -Ins)] End build"
       computeResources:

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -813,8 +813,8 @@ spec:
         done
 
         image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-        buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-        echo "/shared/$image_name.tar" >/shared/container_path
+        buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+        echo "/shared/$image_name.oci" >/shared/container_path
 
         echo "[$(date --utc -Ins)] End build"
       computeResources:

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -736,8 +736,8 @@ spec:
       done
 
       image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-      echo "/shared/$image_name.tar" > /shared/container_path
+      buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+      echo "/shared/$image_name.oci" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
     securityContext:

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -740,8 +740,8 @@ spec:
       done
 
       image_name=$(echo "${IMAGE##*/}" | tr ':' '-')
-      buildah push "$IMAGE" oci-archive:"/shared/$image_name.tar"
-      echo "/shared/$image_name.tar" > /shared/container_path
+      buildah push "$IMAGE" oci:"/shared/$image_name.oci"
+      echo "/shared/$image_name.oci" > /shared/container_path
 
       echo "[$(date --utc -Ins)] End build"
     securityContext:


### PR DESCRIPTION
Syft refuses to extract a large blob from an oci-archive. It fails with:

    [0001] ERROR could not determine source:
    an error occurred attempting to resolve 'big-image.tar':
    oci-archive: failed to visit tar entry="blobs/sha256/..." :
    zip read limit hit (potential decompression bomb attack):
    copied 2147483648, limit 2147483648

Syft has no such reservations about processing an equally large blob in an oci-dir.
