### PR TITLE
fix(STONEINTG-1192): add migration script to sast-coverity-check-oci-ta

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.3/MIGRATION.md
+++ b/task/sast-coverity-check-oci-ta/0.3/MIGRATION.md
@@ -1,8 +1,4 @@
 # Migration from 0.2 to 0.3
 
-- The `image-digest` parameter has been added.
-
-## Action from users
-
-- All resources used task `sast-coverity-check-oci-ta` should be directed to use new `0.3` version.
-- The `image-digest` parameter definition is required to be added for this task in the build pipeline.
+- All resources using task `sast-coverity-check-oci-ta` should be directed to use new `0.3` version.
+- The `image-digest` parameter is required to be added for this task in the build pipeline. It will be added to build pipeline definition file automatically by script migrations/0.3.sh when MintMaker runs [pipeline-migration-tool](https://github.com/konflux-ci/pipeline-migration-tool).

--- a/task/sast-coverity-check-oci-ta/0.3/migrations/0.3.sh
+++ b/task/sast-coverity-check-oci-ta/0.3/migrations/0.3.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: sast-coverity-check@0.3
+# Creation time: 2025-03-28T10:28:54Z
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# Determine the correct image-digest and image-url values based on task presence
+if yq -e '.spec.tasks[] | select(.name == "build-oci-artifact")' "$pipeline_file" >/dev/null; then
+    image_digest_value="\$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
+    image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+elif yq -e '.spec.tasks[] | select(.name == "build-image-index")' "$pipeline_file" >/dev/null; then
+    image_digest_value="\$(tasks.build-image-index.results.IMAGE_DIGEST)"
+    image_url_value="\$(tasks.build-image-index.results.IMAGE_URL)"
+else
+    echo "Neither build-oci-artifact nor build-image-index tasks found."
+    exit 0
+fi
+
+# Check if image-digest parameter already exists using precise path
+if yq -e '.spec.tasks[] | select(.name == "sast-coverity-check")' "$pipeline_file" >/dev/null && ! yq -e '.spec.tasks[] | select(.name == "sast-coverity-check").params[] | select(.name == "image-digest")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-digest parameter to sast-coverity-check task"
+    yq -i "(.spec.tasks[] | select(.name == \"sast-coverity-check\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+elif yq -e '.spec.tasks[] | select(.name == "sast-coverity-check-oci-ta")' "$pipeline_file" >/dev/null && ! yq -e '.spec.tasks[] | select(.name == "sast-coverity-check-oci-ta").params[] | select(.name == "image-digest")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-digest parameter to sast-coverity-check-oci-ta task"
+    yq -i "(.spec.tasks[] | select(.name == \"sast-coverity-check-oci-ta\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+else
+    echo "image-digest parameter already exists in sast-coverity-check(-oci-ta) task or task doesn't exist. No changes needed."
+fi
+
+# Check if image-url parameter already exists using precise path
+if yq -e '.spec.tasks[] | select(.name == "sast-coverity-check")' "$pipeline_file" >/dev/null && ! yq -e '.spec.tasks[] | select(.name == "sast-coverity-check").params[] | select(.name == "image-url")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-url parameter to sast-coverity-check task"
+    yq -i "(.spec.tasks[] | select(.name == \"sast-coverity-check\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+elif yq -e '.spec.tasks[] | select(.name == "sast-coverity-check-oci-ta")' "$pipeline_file" >/dev/null && ! yq -e '.spec.tasks[] | select(.name == "sast-coverity-check-oci-ta").params[] | select(.name == "image-url")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-url parameter to sast-coverity-check-oci-ta task"
+    yq -i "(.spec.tasks[] | select(.name == \"sast-coverity-check-oci-ta\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+else
+    echo "image-url parameter already exists in sast-coverity-check(-oci-ta) task or task doesn't exist. No changes needed."
+fi

--- a/task/sast-coverity-check/0.3/MIGRATION.md
+++ b/task/sast-coverity-check/0.3/MIGRATION.md
@@ -1,9 +1,4 @@
 # Migration from 0.2 to 0.3
 
-- The required `image-digest` parameter has been added back.
-
-## Action from users
-
-- All resources used task `sast-coverity-check` should be directed to use new `0.3` version.
-- The `image-digest` parameter definition is required to be added for this task in the build pipeline.
-
+- All resources using task `sast-coverity-check` should be directed to use new `0.3` version.
+- The `image-digest` parameter is required to be added for this task in the build pipeline. It will be added to build pipeline definition file automatically by script migrations/0.3.sh when MintMaker runs [pipeline-migration-tool](https://github.com/konflux-ci/pipeline-migration-tool).


### PR DESCRIPTION
* add 0.3 migration script to sast-coverity-check-oci-ta folder since they need to run in pipeline-migration-tool separately.

Refer to [slack thread](https://redhat-internal.slack.com/archives/C02CTEB3MMF/p1745996501575899) for details

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
