### PR TITLE
chore(KFLUXVNGD-315): external-tasks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,30 @@ make sure to run the `hack/generate-ta-tasks.sh` script to update the
 `${task_name}-oci-ta` Task definition. Not doing so will fail the
 [`.github/workflows/check-ta.yaml`](.github/workflows/check-ta.yaml) workflow.
 
+### External tasks
+
+External tasks are tasks that were built outside of build definitions.
+The option to add them to our pipelines is now available by adding them to the 
+external-task folder in the structure of a catalog including the name and version
+of the task, for example:
+
+```
+external-task/
+└── rpms-signature-scan
+    └── 0.2
+        └── rpms-signature-scan.yaml
+```
+
+The task definition yaml only includes the reference to the task bundle in the repository:
+```yaml
+task_bundle: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:ea256cb37e60e49bc03b9639054e696a3ddffb97a24b3c3dda64b40986fd6d01
+```
+
+A renovate rule should be added in order to update the reference of the task's bundle, [example](https://github.com/konflux-ci/build-definitions/blob/79a84deef2d95c51520dba233228517a5864926f/renovate.json#L249-L259)
+
+Once the build-definitions CI will run and build all the tasks and pipelines it will first iterate over the external-task folder and will add these tasks to the pipelines, then, it will iterate over the internal tasks.
+To avoid duplications, the external task will get prioritize over the internal one. So if a task is found both in external-task and in task, the external-task will be in use.
+
 ### StepActions
 
 Take a look at the [Tekton documentation](https://tekton.dev/docs/pipelines/stepactions/) for more information about StepActions.

--- a/external-task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
+++ b/external-task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7d1c087d7d33dd97effb3b4c9f3788e4c3138da2032040d69da6929e9a3aaceb

--- a/renovate.json
+++ b/renovate.json
@@ -251,6 +251,17 @@
     {
       "customType": "regex",
       "fileMatch": [
+        "^external-task/.*/.*/.*\\.yaml$"
+      ],
+      "matchStrings": [
+        "task_bundle: (?<depName>quay\\.io/konflux-ci/konflux-vanguard/[^:]+):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "autoReplaceStringTemplate": "task_bundle: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
         ".github/workflows/run-task-tests.yaml"
       ],
       "matchStrings": [


### PR DESCRIPTION
This is a POC for running build-definitions' CI with tasks that are built externally (in other repositories).
Using an external-task folder with the format of `task` folder (task-name -> task-version -> definition file).

`The build-and-push.sh` script will first inject the tasks in the `external-task` folder by getting their structure and fetching the task_bundle from its definition file.

After injecting all the external tasks, the script will proceed to the task folder and inject only the tasks that has no definition in the external tasks folder, so that the priority will be for external tasks in case of duplication.

The external task definition will contain a single yaml file (it can be other format) which will hold the url of the task_bundle (this task was built externally to build- definitions)
This file will be updated by renovate.

For example: https://github.com/konflux-ci/build-definitions/pull/2309/files#diff-c08821a42bbb13d6aa2e8ef7994c02164773cf9473f2285a82db1e87e4610450 
