### PR TITLE
Expose the actual time for the generate-labels task

### DIFF
--- a/task/generate-labels/0.1/README.md
+++ b/task/generate-labels/0.1/README.md
@@ -26,5 +26,7 @@ The following environment variables are defined for use in label-templates
 ## Results
 |name|description|
 |---|---|
-|labels|The rendered labels, rendered from the provided templates|
+|labels|The rendered labels, rendered from the provided templates.|
+|actual-date|The actual date identified by this task. This can be used in other tasks if trying to establish parity between labels and tags.|
+|actual-date-epoch|The epoch of the actual date. This can be used in other tasks if trying to establish parity between labels and tags.|
 

--- a/task/generate-labels/0.1/generate-labels.yaml
+++ b/task/generate-labels/0.1/generate-labels.yaml
@@ -34,8 +34,14 @@ spec:
     default: ""
   results:
     - name: labels
-      description: The rendered labels, rendered from the provided templates
+      description: The rendered labels, rendered from the provided templates.
       type: array
+    - name: actual-date
+      description: The actual date identified by this task. This can be used in other tasks if trying to establish parity between labels and tags.
+      type: string
+    - name: actual-date-epoch
+      description: The epoch of the actual date. This can be used in other tasks if trying to establish parity between labels and tags.
+      type: string
   steps:
     - name: render
       image: quay.io/konflux-ci/yq:latest@sha256:f1e9392d1d7851643e8dd05887e340025c030b449beec4bef4576de73a9a74fc
@@ -69,6 +75,9 @@ spec:
             SOURCE_DATE_EPOCH="$ACTUAL_DATE_EPOCH"
           fi
           SOURCE_DATE=$(date -u --date=@"$SOURCE_DATE_EPOCH" +'%Y-%m-%dT%H:%M:%SZ')
+
+          echo -n "$ACTUAL_DATE" > "$(results.actual-date.path)"
+          echo -n "$ACTUAL_DATE_EPOCH" > "$(results.actual-date-epoch.path)"
 
           # Export, so that these are available to the subshell below
           export ACTUAL_DATE


### PR DESCRIPTION
If we want to achieve parity between tags and labels for a monotonically increasing "release" number, the only recourse we currently have is the git commit timestamp. While this produces a reproducible integer, if the commit is rebuilt, the tag will move to a new digest. In order to improve uniqueness, users may want to base the release off of the actual timestsamp. Exposing the time of this task enables easier parity between tags and labels without having to add the desired tags as a konflux.additional-tags label.

relates to: https://github.com/konflux-ci/docs/pull/330
