### PR TITLE
Add note to sast tasks about KFP directory names

### DIFF
--- a/task/sast-coverity-check/0.3/README.md
+++ b/task/sast-coverity-check/0.3/README.md
@@ -4,7 +4,7 @@
 
 The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST).
 
-The documentation for this mode can be found here: https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
+The documentation for this mode can be found here: <https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html>
 
 The characteristics of these tasks are:
 
@@ -17,7 +17,7 @@ The characteristics of these tasks are:
 
 ## Params:
 
-| name                      | description                                                                                                                           | default value             | required |                                                                                                                   
+| name                      | description                                                                                                                           | default value             | required |
 |---------------------------|---------------------------------------------------------------------------------------------------------------------------------------|---------------------------|----------|
 | COV_ANALYZE_ARGS          | Append arguments to the cov-analyze CLI command                                                                                       | ""                        | no       |
 | COV_LICENSE               | Name of secret which contains the Coverity license                                                                                    | cov-license               | no       |
@@ -28,6 +28,9 @@ The characteristics of these tasks are:
 | RECORD_EXCLUDED           | If set to `true`, excluded findings will be written to a file named `excluded-findings.json` for auditing purposes.                   | false                     | no       |
 |image-digest|Digest of the image to which the scan results should be associated.||true|
 |image-url|URL of the image to which the scan results should be associated.||true|
+
+For path exclusions defined in the known-false-positives (KFP) repo to be applied to scan results, the component name should match the respective directory in KFP. By default this is sourced from the `"appstudio.openshift.io/component"` label, but the `PROJECT_NAME` parameter can be used to override this.
+
 ## Results:
 
 | name              | description              |
@@ -38,8 +41,7 @@ The characteristics of these tasks are:
 
 // TODO: Add reference to private repo for the container image once the task is migrated to repo
 
-
 ## Additional links:
 
-* https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html
-* https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/cli/topics/options_reference.html
+* <https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html>
+* <https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/cli/topics/options_reference.html>

--- a/task/sast-shell-check/0.1/README.md
+++ b/task/sast-shell-check/0.1/README.md
@@ -15,6 +15,8 @@ ShellCheck is a static analysis tool, gives warnings and suggestions for bash/sh
 | RECORD_EXCLUDED   | Whether to record the excluded findings to file, Useful for auditing.<br/>If "true", the excluded findings will be stored in `excluded-findings.json`. | "false"       | No       |
 | IMP_FINDINGS_ONLY | Whether to report only important findings. To report all findings, specify "false".                                                                    | "true"        | No       |
 
+For path exclusions defined in the known-false-positives (KFP) repo to be applied to scan results, the component name should match the respective directory in KFP. By default this is sourced from the `"appstudio.openshift.io/component"` label, but the `PROJECT_NAME` parameter can be used to override this.
+
 ## Results:
 
 | name        | description              |
@@ -23,10 +25,10 @@ ShellCheck is a static analysis tool, gives warnings and suggestions for bash/sh
 
 ## Source repository for image:
 
-https://github.com/konflux-ci/konflux-test
+<https://github.com/konflux-ci/konflux-test>
 
 ## Additional links:
 
-* https://www.shellcheck.net/wiki/Home
-* https://github.com/koalaman/shellcheck
-* https://github.com/csutils/csmock
+* <https://www.shellcheck.net/wiki/Home>
+* <https://github.com/koalaman/shellcheck>
+* <https://github.com/csutils/csmock>

--- a/task/sast-snyk-check/0.4/README.md
+++ b/task/sast-snyk-check/0.4/README.md
@@ -22,6 +22,8 @@ Snyk's SAST tool uses a combination of static analysis and machine learning tech
 |image-digest|Digest of the image to scan.||true|
 |image-url|Image URL.||true|
 
+For path exclusions defined in the known-false-positives (KFP) repo to be applied to scan results, the component name should match the respective directory in KFP. By default this is sourced from the `"appstudio.openshift.io/component"` label, but the `PROJECT_NAME` parameter can be used to override this.
+
 ## How to obtain a snyk-token and enable snyk task on the pipeline:
 
 Follow the steps given [here](https://konflux-ci.dev/docs/testing/build/snyk/)
@@ -34,9 +36,9 @@ Follow the steps given [here](https://konflux-ci.dev/docs/testing/build/snyk/)
 
 ## Source repository for image:
 
-https://github.com/konflux-ci/konflux-test
+<https://github.com/konflux-ci/konflux-test>
 
 ## Additional links:
 
-* https://snyk.io/product/snyk-code/
-* https://snyk.io/
+* <https://snyk.io/product/snyk-code/>
+* <https://snyk.io/>

--- a/task/sast-unicode-check/0.2/README.md
+++ b/task/sast-unicode-check/0.2/README.md
@@ -15,6 +15,7 @@ The sast-unicode-check task uses [find-unicode-control](https://github.com/siddh
 | RECORD_EXCLUDED              | Whether to record the excluded findings (defaults to false). If `true`, the the excluded findings will be stored in `excluded-findings.json`. | "false"                                                                                         | No       |
 | image-digest | Image digest that will be uploaded with ORAS control.                                                                                                  | | YES                                                                                          | true       |
 
+For path exclusions defined in the known-false-positives (KFP) repo to be applied to scan results, the component name should match the respective directory in KFP. By default this is sourced from the `"appstudio.openshift.io/component"` label, but the `PROJECT_NAME` parameter can be used to override this.
 
 ## Results:
 
@@ -24,8 +25,8 @@ The sast-unicode-check task uses [find-unicode-control](https://github.com/siddh
 
 ## Source repository for image:
 
-https://github.com/konflux-ci/konflux-test
+<https://github.com/konflux-ci/konflux-test>
 
 ## Additional links:
 
-* https://github.com/siddhesh/find-unicode-control.git
+* <https://github.com/siddhesh/find-unicode-control.git>


### PR DESCRIPTION
Supports https://issues.redhat.com/browse/PSSECAUT-1147 but I also intend to update other docs.

Note sure if I missed something, but I assumed that if I just updated the sast non-trusted-artifact tasks the `hack/generate-everything.sh` script would update the -oci-ta tasks for me. That didn't seem to occur, so I updated the -oci-ta tasks manually.

I also did some light markdown linting, like wrapping bare URLs in `<>` and whitespace tidy.