### PR TITLE
.tekton/push: fix docker auth mount path

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -138,7 +138,7 @@ spec:
                 - name: OUTPUT_PIPELINE_BUNDLE_LIST
                   value: $(workspaces.source.path)/pipeline-bundle-list-appstudio
               volumeMounts:
-                - mountPath: /root/.docker/config.json
+                - mountPath: /tekton/home/.docker/config.json
                   subPath: .dockerconfigjson
                   name: quay-secret
             - name: update-acceptable-bundles


### PR DESCRIPTION
In 0e7654818966eb2f929ccdcc0cf9f81a1ae17597, the HOME in the appstudio-utils image changed to /tekton/home. Update the mount path of the redhat-appstudio-tekton-catalog secret accordingly.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
