### PR TITLE
feat(CLOUDDST-27064): Allow pruning in specific channels

### DIFF
--- a/task/fbc-target-index-pruning-check/0.1/README.md
+++ b/task/fbc-target-index-pruning-check/0.1/README.md
@@ -2,11 +2,13 @@
 
 ## Description:
 This task ensures file-based catalog (FBC) components do not remove previously released versions of operators from a target catalog, specified in the `TARGET_INDEX` parameter, which by default points to the Red Hat production Index Image `registry.redhat.io/redhat/redhat-operator-index`. Image pull credentials are required for `registry.redhat.io` or the registry you specify in `TARGET_INDEX`.
+Pruning is allowed only in channels that contain dev-preview, pre-ga, or candidate in their names.
 
 ### What this check does:
 - Runs `opm render` on both FBC fragment and TARGET_INDEX:OCP_VERSION images.
 - Compares the channel data of the FBC fragment and target index.
 - Checks if the FBC fragment will remove channels or channel entries previously added to the target index.
+- Allows pruning only in channels that contain dev-preview, pre-ga, or candidate in their names.
 
 
 ## Params:

--- a/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
+++ b/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   description: >-
     Ensures file-based catalog (FBC) components do not remove versions of operators already added to a released catalog.
+    Pruning is allowed only in channels that contain dev-preview, pre-ga, or candidate in their names.
   params:
     - name: IMAGE_URL
       description: Fully qualified image name.
@@ -128,6 +129,8 @@ spec:
 
         failure_num=0
         TESTPASSED=true
+        # Allowed pruned channels are those that contain dev-preview, pre-ga, or candidate anywhere in their names
+        fbc_allowed_pruned_channels=".*(dev-preview|pre-ga|candidate).*"
 
         fbc_channels=/tmp/olm-channels-fbc-image.json
         ndx_channels=/tmp/olm-channels-target-index.json
@@ -180,9 +183,13 @@ spec:
               if echo "${fbc_channel_names[@]}" | grep -Fwq "${chan}"; then
                 channels_to_test+=("${chan}")
               else
-                echo "!FAILURE! - FBC fragment prunes entire ${pkg}.${chan} channel."
-                TESTPASSED=false
-                failure_num=$((failure_num + 1))
+                if [[ ! "${chan}" =~ ${fbc_allowed_pruned_channels} ]]; then
+                  echo "!FAILURE! - FBC fragment prunes entire ${pkg}.${chan} channel."
+                  TESTPASSED=false
+                  failure_num=$((failure_num + 1))
+                else
+                  echo "FBC fragment prunes entire ${pkg}.${chan} channel. Pruning in ${chan} channel is allowed."
+                fi
               fi
             done
 
@@ -198,9 +205,13 @@ spec:
 
                 for entry in "${ndx_entries[@]}"; do
                   if ! echo "${fbc_entries[@]}" | grep -Fwq "${entry}"; then
-                    echo "!FAILURE! - FBC fragment prunes ${entry} from ${pkg}.${chan} channel."
-                    failure_num=$((failure_num + 1))
-                    TESTPASSED=false
+                    if [[ ! "${chan}" =~ ${fbc_allowed_pruned_channels} ]]; then
+                      echo "!FAILURE! - FBC fragment prunes ${entry} from ${pkg}.${chan} channel."
+                      failure_num=$((failure_num + 1))
+                      TESTPASSED=false
+                    else
+                      echo "FBC fragment prunes ${entry} from ${pkg}.${chan} channel. Pruning in ${chan} channel is allowed."
+                    fi
                   fi
                 done
               done


### PR DESCRIPTION
This PR modifies the fbc-target-index-pruning-check Tekton task to allow pruning in channels that start with dev-preview, pre-ga, or candidate.