### PR TITLE
feat(CLOUDDST-27284): improve scanning performance by using clamdscan

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -382,7 +382,7 @@ spec:
     - build-image-index
     taskRef:
       name: clamav-scan
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -92,15 +92,16 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |docker-auth| unused, should be removed in next task version.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### clamav-scan:0.2 task parameters
+### clamav-scan:0.3 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|clamd-max-threads| Maximum number of threads clamd runs.| 8| |
 |docker-auth| unused| | |
+|image-arch| Image arch.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|scan-threads| Number of threads to run in clamscan parallel. Should be <= 8.| 1| |
 ### coverity-availability-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -307,9 +308,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| build-source-image:0.3:BINARY_IMAGE_DIGEST ; deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; apply-tags:0.2:IMAGE_DIGEST ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| build-source-image:0.3:BINARY_IMAGE_DIGEST ; deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.3:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; apply-tags:0.2:IMAGE_DIGEST ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; build-source-image:0.3:BINARY_IMAGE ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.2:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.2:IMAGE_URL ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; build-source-image:0.3:BINARY_IMAGE ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.2:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.3:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.2:IMAGE_URL ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-remote-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -325,7 +326,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |REPORTS| Mapping of image digests to report digests| |
 |SCAN_OUTPUT| Clair scan result.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### clamav-scan:0.2 task results
+### clamav-scan:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -314,7 +314,12 @@ spec:
       values:
       - "false"
     workspaces: []
-  - name: clamav-scan
+  - matrix:
+      params:
+      - name: image-arch
+        value:
+        - $(params.build-platforms)
+    name: clamav-scan
     params:
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
@@ -324,7 +329,7 @@ spec:
     - build-image-index
     taskRef:
       name: clamav-scan
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build-multi-platform-oci-ta/patch.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/patch.yaml
@@ -85,3 +85,9 @@
     type: array
     default:
       - "linux/x86_64"
+- op: add
+  path: /spec/tasks/10/matrix
+  value:
+    params:
+      - name: image-arch
+        value: ["$(params.build-platforms)"]

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -89,15 +89,16 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |docker-auth| unused, should be removed in next task version.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### clamav-scan:0.2 task parameters
+### clamav-scan:0.3 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|clamd-max-threads| Maximum number of threads clamd runs.| 8| |
 |docker-auth| unused| | |
+|image-arch| Image arch.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|scan-threads| Number of threads to run in clamscan parallel. Should be <= 8.| 1| |
 ### coverity-availability-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -304,9 +305,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| build-source-image:0.3:BINARY_IMAGE_DIGEST ; deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; apply-tags:0.2:IMAGE_DIGEST ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| build-source-image:0.3:BINARY_IMAGE_DIGEST ; deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.3:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; apply-tags:0.2:IMAGE_DIGEST ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; build-source-image:0.3:BINARY_IMAGE ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.2:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.2:IMAGE_URL ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; build-source-image:0.3:BINARY_IMAGE ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.2:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.3:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.2:IMAGE_URL ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-oci-ta:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -322,7 +323,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |REPORTS| Mapping of image digests to report digests| |
 |SCAN_OUTPUT| Clair scan result.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### clamav-scan:0.2 task results
+### clamav-scan:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -311,7 +311,7 @@ spec:
     - build-image-index
     taskRef:
       name: clamav-scan
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -87,15 +87,16 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |docker-auth| unused, should be removed in next task version.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-### clamav-scan:0.2 task parameters
+### clamav-scan:0.3 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |ca-trust-config-map-key| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+|clamd-max-threads| Maximum number of threads clamd runs.| 8| |
 |docker-auth| unused| | |
+|image-arch| Image arch.| | |
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
-|scan-threads| Number of threads to run in clamscan parallel. Should be <= 8.| 1| |
 ### coverity-availability-check:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -296,9 +297,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| build-source-image:0.3:BINARY_IMAGE_DIGEST ; deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.2:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; apply-tags:0.2:IMAGE_DIGEST ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| build-source-image:0.3:BINARY_IMAGE_DIGEST ; deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.2:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.3:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.2:image-digest ; apply-tags:0.2:IMAGE_DIGEST ; push-dockerfile:0.1:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; build-source-image:0.3:BINARY_IMAGE ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.2:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.2:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.2:IMAGE_URL ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| show-sbom:0.1:IMAGE_URL ; build-source-image:0.3:BINARY_IMAGE ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.2:image-url ; ecosystem-cert-preflight-checks:0.2:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.3:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.2:image-url ; apply-tags:0.2:IMAGE_URL ; push-dockerfile:0.1:IMAGE ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah:0.4 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -314,7 +315,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |REPORTS| Mapping of image digests to report digests| |
 |SCAN_OUTPUT| Clair scan result.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### clamav-scan:0.2 task results
+### clamav-scan:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -315,7 +315,7 @@ spec:
     - build-image-index
     taskRef:
       name: clamav-scan
-      version: "0.2"
+      version: "0.3"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -231,7 +231,7 @@ spec:
         - build-image-index
       taskRef:
         name: clamav-scan
-        version: "0.2"
+        version: "0.3"
       params:
       - name: image-digest
         value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/task/clamav-scan/0.3/MIGRATION.md
+++ b/task/clamav-scan/0.3/MIGRATION.md
@@ -1,0 +1,17 @@
+# Migration from 0.2 to 0.3
+
+Version 0.3:
+
+On this version clamscan is replaced by clamdscan which can scan an image in parallel (8 threads by default).
+Besides that, if the pipelinerun uses a matrix configuration for the task, each arch will create a separate TaskRun, running in parallel.
+
+Changes:
+- The `image-arch` parameter definition is added and the defaul value is "".
+- The `clamd-max-threads` parameter definition is added and the default is 8.
+- For multi-architecture builds, `matrix` is added to the build pipeline definition file.
+
+## Action from users
+
+Renovate bot PR will be created with warning icon for a clamav-scan which is expected, no actions from users are required for the task.
+
+For multi-arch build, `matrix` will be added to build pipeline definition file automatically by script migrations/0.3.sh when MintMaker runs [pipeline-migration-tool](https://github.com/konflux-ci/pipeline-migration-tool).

--- a/task/clamav-scan/0.3/README.md
+++ b/task/clamav-scan/0.3/README.md
@@ -1,0 +1,42 @@
+# clamav-scan task
+
+## Description:
+The clamav-scan task scans files for viruses and other malware using the ClamAV antivirus scanner.
+ClamAV is an open-source antivirus engine that can be used to check for viruses, malware, and other malicious content.
+The task will extract compiled code to compare it against the latest virus database to identify any potential threats.
+The logs will provide both the version of ClamAV and the version of the database used in the comparison scan.
+
+## Version 0.3:
+On this version clamscan is replaced by clamdscan which can scan an image in parallel (8 threads by default).
+Besides that, if the pipeline task uses a matrix configuration for the task, each arch will create a separate TaskRun, running in parallel.
+
+## --max-filesize: 
+Is set to the same value as the default value according to the ClamAV official Documentation.
+
+https://wiki.debian.org/ClamAV
+
+https://docs.clamav.net/manual/Development/tips-and-tricks.html?highlight=max-filesize#general-debugging 
+
+## Params:
+
+| name                     | description                                                            | default       |
+|--------------------------|------------------------------------------------------------------------|---------------|
+| image-digest             | Image digest to scan.                                                  | None          |
+| image-url                | Image URL.                                                             | None          |
+| image-arch               | Image arch.                                                            | None          |
+| docker-auth              | Unused, should be removed in next task version.                        |               |
+| ca-trust-config-map-name | The name of the ConfigMap to read CA bundle data from.                 | trusted-ca    |
+| ca-trust-config-map-key  | The name of the key in the ConfigMap that contains the CA bundle data. | ca-bundle.crt |
+| clamd-max-threads        | Maximum number of threads clamd runs.                                  | 8             |
+
+## Results:
+
+| name               | description               |
+|--------------------|---------------------------|
+| TEST_OUTPUT  | Tekton task test output.  |
+
+## Source repository for image:
+https://github.com/konflux-ci/konflux-test/tree/main/clamav
+
+## Additional links:
+https://docs.clamav.net/

--- a/task/clamav-scan/0.3/clamav-scan.yaml
+++ b/task/clamav-scan/0.3/clamav-scan.yaml
@@ -1,0 +1,258 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "virus, konflux"
+  name: clamav-scan
+spec:
+  description: >-
+    Scans the content of container images for viruses, malware, and other malicious content using ClamAV antivirus scanner.
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+    - name: IMAGES_PROCESSED
+      description: Images processed in the task.
+  params:
+    - name: image-digest
+      description: Image digest to scan.
+    - name: image-url
+      description: Image URL.
+    - name: image-arch
+      description: Image arch.
+      default: ""
+    - name: docker-auth
+      description: unused
+      default: ""
+    - name: ca-trust-config-map-name
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: ca-trust-config-map-key
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+    - name: clamd-max-threads
+      description: Maximum number of threads clamd runs.
+      default: "8"
+
+  steps:
+    - name: extract-and-scan-image
+      # This image receives daily builds, ensuring we always have access to the latest virus definitions
+      image: quay.io/konflux-ci/clamav-db:latest
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      workingDir: /work
+      # need to change user since 'oc image extract' requires more privileges when running as root permissions
+      # https://bugzilla.redhat.com/show_bug.cgi?id=1969929
+      securityContext:
+        capabilities:
+          add: ["SETFCAP"]
+      env:
+        - name: HOME
+          value: /work
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+        - name: IMAGE_ARCH
+          value: $(params.image-arch)
+        - name: MAX_THREADS
+          value: $(params.clamd-max-threads)
+      computeResources:
+        limits:
+          memory: 8Gi
+        requests:
+          memory: 2Gi
+          cpu: 500m
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        # Start clamd in background
+        /start-clamd.sh
+
+        imagewithouttag=$(echo $IMAGE_URL | sed "s/\(.*\):.*/\1/" | tr -d '\n')
+
+        # strip new-line escape symbol from parameter and save it to variable
+        imageanddigest=$(echo $imagewithouttag@$IMAGE_DIGEST)
+
+        # check if image is attestation one, skip the clamav scan in such case
+        if [[ $imageanddigest == *.att ]]
+        then
+            echo "$imageanddigest is an attestation image. Skipping ClamAV scan."
+            exit 0
+        fi
+
+        images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
+        digests_processed=()
+        mkdir logs
+        mkdir content
+        cd content
+        echo "Extracting image(s)."
+
+        # Get the arch and image manifests by inspecting the image. This is mainly for identifying image indexes
+        image_manifests=$(get_image_manifests -i "${imageanddigest}")
+        # Proceed only if a specific arch is provided.
+        # This typically occurs when using Tekton Matrix to launch multiple TaskRuns to scan all architectures of a multi-arch image in parallel.
+        if [ -n "$IMAGE_ARCH" ]; then
+          arch="${IMAGE_ARCH#*/}"
+          if [ "${arch}" = "x86_64" ]; then
+            arch="amd64"
+          fi
+
+          # Check if arch is supported; if not (e.g., it's 'local', see link below), default to amd64.
+          # https://github.com/redhat-appstudio/infra-deployments/blob/main/components/multi-platform-controller/production/stone-prd-rh01/host-config.yaml#L9-L14
+          case "$arch" in
+            amd64|ppc64le|arm64|s390x)
+              ;;
+            *)
+              arch="amd64"
+              ;;
+          esac
+
+          image_manifests=$(echo "$image_manifests" | jq -c --arg arch "$arch" '{($arch): .[$arch]}')
+        fi
+
+        if [ -n "$image_manifests" ]; then
+          while read -r arch arch_sha; do
+            destination=$(echo content-$arch)
+            mkdir -p "$destination"
+            arch_imageanddigest=$(echo $imagewithouttag@$arch_sha)
+
+            echo "Running \"oc image extract\" on image of arch $arch"
+            retry oc image extract --registry-config ~/.docker/config.json "$arch_imageanddigest" --path="/:${destination}" --filter-by-os="linux/${arch}"
+            if [ $? -ne 0 ]; then
+              echo "Unable to extract image for arch $arch. Skipping ClamAV scan!"
+              exit 0
+            fi
+
+            db_version=$(clamdscan --version | sed 's|.*/\(.*\)/.*|\1|')
+
+            echo "Scanning image for arch $arch. This operation may take a while."
+            clamdscan "${destination}" -vi --multiscan --fdpass \
+              | tee /work/logs/clamscan-result-$arch.log || true
+
+            echo "Executed-on: Scan was executed on clamsdcan version - $(clamdscan --version) Database version: $db_version" | tee -a "/work/logs/clamscan-result-$arch.log"
+
+            digests_processed+=("\"$arch_sha\"")
+
+            if [[ -e "/work/logs/clamscan-result-$arch.log" ]]; then
+              # file_suffix=$(basename "$file" | sed 's/clamscan-result-//;s/.log//')
+              # OPA/EC requires structured data input, add clamAV log into json
+              jq -Rs '{ output: . }' /work/logs/clamscan-result-$arch.log > /work/logs/clamscan-result-log-$arch.json
+
+              EC_EXPERIMENTAL=1 ec test \
+                --namespace required_checks \
+                --policy /project/clamav/virus-check.rego \
+                -o json \
+                /work/logs/clamscan-result-log-$arch.json || true
+
+              # workaround: due to a bug in ec-cli, we cannot generate json and appstudio output at the same time, running it again
+              EC_EXPERIMENTAL=1 ec test \
+                --namespace required_checks \
+                --policy /project/clamav/virus-check.rego \
+                -o appstudio \
+                /work/logs/clamscan-result-log-$arch.json | tee /work/logs/clamscan-ec-test-$arch.json || true
+
+              cat /work/logs/clamscan-ec-test-$arch.json
+            fi
+          done < <(echo "$image_manifests" | jq -r 'to_entries[] | "\(.key) \(.value)"')
+        else
+          echo "Failed to get image manifests from image \"$imageanddigest\""
+          note="Task $(context.task.name) failed: Failed to get image manifests from image \"$imageanddigest\". For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r "ERROR" -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 0
+        fi
+
+        jq -s -rce '
+          reduce .[] as $item ({"timestamp":"0","namespace":"","successes":0,"failures":0,"warnings":0,"result":"","note":""};
+            {
+            "timestamp" : (if .timestamp < $item.timestamp then $item.timestamp else .timestamp end),
+            "namespace" : $item.namespace,
+            "successes" : (.successes + $item.successes),
+            "failures" : (.failures + $item.failures),
+            "warnings" : (.warnings + $item.warnings),
+            "result" : (if .result == "" or ($item.result == "SKIPPED" and .result == "SUCCESS") or ($item.result == "WARNING" and (.result == "SUCCESS" or .result == "SKIPPED")) or ($item.result == "FAILURE" and .result != "ERROR") or $item.result == "ERROR" then $item.result else .result end),
+            "note" : (if .result == "" or ($item.result == "SKIPPED" and .result == "SUCCESS") or ($item.result == "WARNING" and (.result == "SUCCESS" or .result == "SKIPPED")) or ($item.result == "FAILURE" and .result != "ERROR") or $item.result == "ERROR" then $item.note else .note end)
+            })' /work/logs/clamscan-ec-test-*.json | tee $(results.TEST_OUTPUT.path)
+
+        # If the image is an Image Index, also add the Image Index digest to the list.
+        if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
+          digests_processed+=("\"$IMAGE_DIGEST\"")
+        fi
+
+        digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
+        echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee $(results.IMAGES_PROCESSED.path)
+      volumeMounts:
+        - mountPath: /work
+          name: work
+        - name: trusted-ca
+          mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
+    - name: upload
+      image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
+      computeResources:
+        limits:
+          memory: 512Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      workingDir: /work
+      script: |
+        #!/usr/bin/env bash
+        set -e
+
+        # Don't return a glob expression when no matches are found
+        shopt -s nullglob
+
+        cd logs
+
+        for UPLOAD_FILE in clamscan-result*.log; do
+          MEDIA_TYPE=text/vnd.clamav
+          args+=("${UPLOAD_FILE}:${MEDIA_TYPE}")
+        done
+        for UPLOAD_FILE in clamscan-ec-test*.json; do
+          MEDIA_TYPE=application/vnd.konflux.test_output+json
+          args+=("${UPLOAD_FILE}:${MEDIA_TYPE}")
+        done
+
+        if [ -z "${args}" ]; then
+          echo "No files found. Skipping upload."
+          exit 0;
+        fi
+
+        echo "Selecting auth"
+        select-oci-auth $IMAGE_URL > $HOME/auth.json
+        echo "Attaching to ${IMAGE_URL}"
+         retry oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type application/vnd.clamav "${IMAGE_URL}@${IMAGE_DIGEST}" "${args[@]}"
+      volumeMounts:
+        - mountPath: /work
+          name: work
+        - name: trusted-ca
+          mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          subPath: ca-bundle.crt
+          readOnly: true
+  volumes:
+    - name: dbfolder
+      emptyDir: {}
+    - name: work
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        name: $(params.ca-trust-config-map-name)
+        items:
+          - key: $(params.ca-trust-config-map-key)
+            path: ca-bundle.crt
+        optional: true

--- a/task/clamav-scan/0.3/migrations/0.3.sh
+++ b/task/clamav-scan/0.3/migrations/0.3.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: clamav-scan@0.3
+# Creation time: 2025-07-21T01:11:59+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+TASK_NAME="clamav-scan"
+
+# Check if the pipeline has 'build-platforms' parameter
+if ! yq -e '.spec.params[] | select(.name == "build-platforms")' "$pipeline_file" >/dev/null 2>&1; then
+  echo "Matrix will not be added because the dependent parameter 'build-platforms' is not defined in the pipeline."
+  exit 0
+fi
+
+# Check if the task exists
+if ! yq -e '.spec.tasks[] | select(.name == "'"$TASK_NAME"'")' "$pipeline_file" >/dev/null 2>&1; then
+  echo "Task '$TASK_NAME' does not exist in the pipeline."
+  exit 0
+fi
+
+# Check if the task already has a matrix
+if yq -e '.spec.tasks[] | select(.name == "'"$TASK_NAME"'") | has("matrix")' "$pipeline_file" >/dev/null 2>&1; then
+  echo "Matrix already exists for task '$TASK_NAME'. No changes made."
+else
+  echo "Adding matrix for task '$TASK_NAME'..."
+  yq -i "
+  (.spec.tasks[] 
+    | select(.name == \"clamav-scan\" and .matrix == null)
+  ).matrix = {
+    \"params\": [
+      {
+        \"name\": \"image-arch\",
+        \"value\": [\"\$(params.build-platforms)\"]
+      }
+    ]
+  }
+" "$pipeline_file"
+
+  echo "Adding matrix for task '$TASK_NAME' completed!"
+fi


### PR DESCRIPTION
This change replaces clamscan with clamdscan to speed up scans on large and multi-architecture container images.

clamscan is single-threaded and cannot leverage multiple CPU cores, making it inefficient for scanning images with many files. It also requires reloading the virus database for each scan, increasing overhead. With clamdscan, scans are offloaded to the clamd daemon, which supports multi-threaded scanning and shared database access, significantly reducing scan time and memory usage.

Additionally, this update introduces Tekton's matrix feature to run clamav-scan tasks in parallel—one per image architecture—greatly improving performance for multi-arch images.

Performance tests comparing current clamscan and clamdscan.
1) Test scenario 1: scanning a single-arch image

| clamscan     | This PR - clamdscan (8 MaxThreads) |
|-----------------------------|-------------------------------------|
| 1:20:33 | 0:17:25                             |

2) Test scenario 2: scanning an multi-arch image (three arches)

| clamscan     | This PR - clamdscan (8 MaxThreads) - Tekton Metrix|
|-----------------------------|-------------------------------------|
| ~ 4:00:00  (~1:20:33 x3)  | 0:22:54                             |

**Note 1:** A previous PR https://github.com/konflux-ci/build-definitions/pull/2262 also aimed to improve the clamscan task performance but this PR is still necessary. The Konflux working group discussed both approaches and agreed to proceed with this one due to its better performance. The earlier PR https://github.com/konflux-ci/build-definitions/pull/2262 is retained since it is nearly complete.

Performance comparison between PR https://github.com/konflux-ci/build-definitions/pull/2262 and this PR (single arch image)
| PR https://github.com/konflux-ci/build-definitions/pull/2262 (Jared’s solution)  - 8threads  | This PR - clamdscan (8 MaxThreads) |
|-----------------------------|-------------------------------------|
| 0:32:02   | 0:17:25                            |

**Note 2 :** This PR depends on the PR https://github.com/konflux-ci/konflux-test/pull/433 which install clamd-server/clamdscan and some configuration file change.