### PR TITLE
feat(ISV-5868): Use Mobster to generate index image sboms

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -192,7 +192,7 @@ spec:
         add:
           - SETFCAP
 
-  - image: quay.io/konflux-ci/sbom-utility-scripts@sha256:5e0c5996f77b877c4d6027b64bb0217f85716408a59821c3e48ba49e2556440d
+  - image: quay.io/konflux-ci/mobster@sha256:9b7bf71d09771065432bef7c6ed13193a3ac4e2c41895c6197e4b09e1c0ee905
     name: create-sbom
     computeResources:
       limits:
@@ -213,11 +213,12 @@ spec:
       IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
       IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
       echo "Creating SBOM result file..."
-      python3 index_image_sbom_script.py \
-        --image-index-url "$IMAGE_URL" \
-        --image-index-digest "$IMAGE_DIGEST" \
-        --inspect-input-file "$MANIFEST_DATA_FILE" \
-        --output-path /index-build-data/sbom-results.json
+      mobster generate \
+        --output /index-build-data/index.spdx.json \
+        oci-index \
+        --index-image-pullspec "$IMAGE_URL" \
+        --index-image-digest "$IMAGE_DIGEST" \
+        --index-manifest-path "$MANIFEST_DATA_FILE" \
 
   - name: upload-sbom
     image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
@@ -225,9 +226,9 @@ spec:
       #!/bin/bash
       set -e
 
-      SBOM_RESULT_FILE="/index-build-data/sbom-results.json"
+      SBOM_RESULT_FILE="/index-build-data/index.spdx.json"
       if [ ! -f "$SBOM_RESULT_FILE" ]; then
-        echo "The sbom_results.json file does not exists. Skipping the SBOM upload..."
+        echo "The index.spdx.json file does not exists. Skipping the SBOM upload..."
         exit 0
       fi
 

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -201,7 +201,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:5e0c5996f77b877c4d6027b64bb0217f85716408a59821c3e48ba49e2556440d
+    image: quay.io/konflux-ci/mobster@sha256:9b7bf71d09771065432bef7c6ed13193a3ac4e2c41895c6197e4b09e1c0ee905
     name: create-sbom
     script: |
       #!/bin/bash
@@ -216,11 +216,12 @@ spec:
       IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
       IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
       echo "Creating SBOM result file..."
-      python3 index_image_sbom_script.py \
-        --image-index-url "$IMAGE_URL" \
-        --image-index-digest "$IMAGE_DIGEST" \
-        --inspect-input-file "$MANIFEST_DATA_FILE" \
-        --output-path /index-build-data/sbom-results.json
+      mobster generate \
+        --output /index-build-data/index.spdx.json \
+        oci-index \
+        --index-image-pullspec "$IMAGE_URL" \
+        --index-image-digest "$IMAGE_DIGEST" \
+        --index-manifest-path "$MANIFEST_DATA_FILE" \
   - computeResources:
       limits:
         memory: 512Mi
@@ -233,9 +234,9 @@ spec:
       #!/bin/bash
       set -e
 
-      SBOM_RESULT_FILE="/index-build-data/sbom-results.json"
+      SBOM_RESULT_FILE="/index-build-data/index.spdx.json"
       if [ ! -f "$SBOM_RESULT_FILE" ]; then
-        echo "The sbom_results.json file does not exists. Skipping the SBOM upload..."
+        echo "The index.spdx.json file does not exists. Skipping the SBOM upload..."
         exit 0
       fi
 


### PR DESCRIPTION
The Mobster tool is generic SBOM content generate that will be used to generate Konflux SBOMs. This commit is one of the first that switches SBOM generation to use Mobster. Index image SBOMs are now fully handled by the tool.

Mobster source code is available here: https://github.com/konflux-ci/mobster

JIRA: [ISV-5868](https://issues.redhat.com//browse/ISV-5868)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
