### PR TITLE
fix: remove new lines from local storage dir names

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -97,9 +97,9 @@ spec:
         error_counter=$((error_counter + 1))
         continue
       fi
-      component_label=$(echo "${image_labels}" | grep 'com.redhat.component=' | cut -d= -f2 || true)
-      version_label=$(echo "${image_labels}" | grep 'version=' | cut -d= -f2 || true)
-      release_label=$(echo "${image_labels}" | grep 'release=' | cut -d= -f2 || true)
+      component_label=$(echo "${image_labels}" | grep 'com.redhat.component=' | cut -d= -f2 | tr -d '\n\r' | xargs || true)
+      version_label=$(echo "${image_labels}" | grep '^version=' | cut -d= -f2 | tr -d '\n\r' | xargs || true)
+      release_label=$(echo "${image_labels}" | grep 'release=' | cut -d= -f2 | tr -d '\n\r' | xargs || true)
       echo "Component label is ${component_label}"
       echo "Version label is ${version_label}"
       echo "Release label is ${release_label}"


### PR DESCRIPTION
1. Fix retrieval of the version label to extract only the label that starts with the word version. Currently, it matches multiple labels that contain the word version:
* io.buildah.version
* upstream-version
* version

2. Sanitize the component, version, and release labels by removing newlines and whitespace.