### PR TITLE
Update stepaction ref in FIPS tasks

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -212,7 +212,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 37abe79dc07c00ea4aac25753a964a35d91b84db
+            value: d01f85b9c0caade637da2c92f8a5d81e0f7ef067
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -198,7 +198,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 37abe79dc07c00ea4aac25753a964a35d91b84db
+            value: d01f85b9c0caade637da2c92f8a5d81e0f7ef067
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -160,7 +160,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 37abe79dc07c00ea4aac25753a964a35d91b84db
+            value: d01f85b9c0caade637da2c92f8a5d81e0f7ef067
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -134,7 +134,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 37abe79dc07c00ea4aac25753a964a35d91b84db
+            value: d01f85b9c0caade637da2c92f8a5d81e0f7ef067
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 


### PR DESCRIPTION
Updating stepaction ref in FIPS task to account for this fix: https://github.com/konflux-ci/build-definitions/pull/2333