### PR TITLE
feat(KONFLUX-7331): Setup limits and resource for sast-snyk-check

### DIFF
--- a/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.1/sast-snyk-check-oci-ta.yaml
@@ -112,6 +112,12 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
     - name: upload
       image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
       workingDir: /var/workdir/source
@@ -142,3 +148,9 @@ spec:
         oras attach --no-tty --registry-config "$HOME/auth.json" --distribution-spec v1.1-referrers-api --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         echo "Attaching to ${IMAGE_URL} via the OCI 1.1 Referrers Tag"
         oras attach --no-tty --registry-config "$HOME/auth.json" --distribution-spec v1.1-referrers-tag --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/task/sast-snyk-check-oci-ta/0.2/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.2/sast-snyk-check-oci-ta.yaml
@@ -120,6 +120,12 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
     - name: upload
       image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
       workingDir: /var/workdir/source
@@ -148,3 +154,9 @@ spec:
         select-oci-auth $IMAGE_URL >$HOME/auth.json
         echo "Attaching to ${IMAGE_URL}"
         oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.3/sast-snyk-check-oci-ta.yaml
@@ -293,6 +293,12 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
     - name: upload
       image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
       workingDir: /var/workdir/source
@@ -328,3 +334,9 @@ spec:
           echo "Attaching to ${IMAGE_URL}"
           oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -290,6 +290,12 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
     - name: upload
       image: quay.io/konflux-ci/oras:latest@sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
       workingDir: /var/workdir/source
@@ -327,3 +333,9 @@ spec:
           echo "Attaching to ${IMAGE_URL}"
           oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/task/sast-snyk-check/0.1/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.1/sast-snyk-check.yaml
@@ -38,6 +38,12 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
       image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
@@ -95,6 +101,12 @@ spec:
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
     - name: upload
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       env:

--- a/task/sast-snyk-check/0.2/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.2/sast-snyk-check.yaml
@@ -38,6 +38,12 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
       image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
@@ -97,6 +103,12 @@ spec:
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee $(results.TEST_OUTPUT.path)
     - name: upload
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       env:

--- a/task/sast-snyk-check/0.3/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.3/sast-snyk-check.yaml
@@ -74,6 +74,12 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
       image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
@@ -261,6 +267,12 @@ spec:
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
     - name: upload
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/oras:latest@sha256:8d756a91aae1fa5186efafee056446bb5e77228cf5ad9a7ae0e3f8d727da50cd
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       volumeMounts:

--- a/task/sast-snyk-check/0.3/tests/pre-apply-task-hook.sh
+++ b/task/sast-snyk-check/0.3/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Removing computeResources for task: $1"
+yq -i eval '.spec.steps[0].computeResources = {}' $1
+yq -i eval '.spec.steps[1].computeResources = {}' $1

--- a/task/sast-snyk-check/0.4/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.4/sast-snyk-check.yaml
@@ -80,6 +80,12 @@ spec:
         optional: true
   steps:
     - name: sast-snyk-check
+      computeResources:
+        limits:
+          memory: 6Gi
+        requests:
+          cpu: "1"
+          memory: 6Gi
       image: quay.io/konflux-ci/konflux-test:v1.4.23@sha256:e451a01a24824fbac8c3a667924337f67153a5bdaa68001410183bbac37e000f
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
@@ -267,6 +273,12 @@ spec:
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
     - name: upload
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi
       image: quay.io/konflux-ci/oras:latest@sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       volumeMounts:

--- a/task/sast-snyk-check/0.4/tests/pre-apply-task-hook.sh
+++ b/task/sast-snyk-check/0.4/tests/pre-apply-task-hook.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Removing computeResources for task: $1"
+yq -i eval '.spec.steps[0].computeResources = {}' $1
+yq -i eval '.spec.steps[1].computeResources = {}' $1


### PR DESCRIPTION
### Description

This PR updates resource limits and requests for the task **sast-snyk-check** as part of this effort - [KONFLUX-7331](https://issues.redhat.com/browse/KONFLUX-7331). 

The new request/limit values have been defined taking into account usages observed historically (tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?gid=1735880927#gid=1735880927)) in the **stone-prd-rh01** cluster. 

The memory usage is increased to 6Gi for sast-snyk-check task based on the discussion in this PR: https://www.google.com/url?q=https://github.com/konflux-ci/build-definitions/pull/2051%23discussion_r1992927271&sa=D&source=editors&ust=1744272213794567&usg=AOvVaw0au9JdXyoKZfsQ7o3oXeAq

## step sast-snyk-check
#### CPU Usage for step sast-snyk-check (max & 95%)
![image](https://github.com/user-attachments/assets/e9f5953c-98b2-43e3-842e-318caad7c944)


#### Memory Usage for step sast-snyk-check (max & 95%)

![image](https://github.com/user-attachments/assets/996a39ca-9bbb-403e-bcbc-e69c691247e6)

## step upload

#### CPU Usage for step-upload (max & 95%)
![image](https://github.com/user-attachments/assets/66ae5bb1-e3ad-429a-90ef-eea999528b08)

#### Memory Usage for step-upload (max & 95%)
![image](https://github.com/user-attachments/assets/c08a6d79-1ad9-44d7-af70-518b1d074735)


