### PR TITLE
pipelines: pass correct image url to source task

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -286,7 +286,7 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(params.output-image)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     runAfter:
     - build-image-index
     taskRef:

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -224,7 +224,7 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(params.output-image)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -211,7 +211,7 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(params.output-image)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -219,7 +219,7 @@ spec:
   - name: build-source-image
     params:
     - name: BINARY_IMAGE
-      value: $(params.output-image)
+      value: $(tasks.build-image-index.results.IMAGE_URL)
     runAfter:
     - build-image-index
     taskRef:

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -154,7 +154,7 @@ spec:
         version: "0.2"
       params:
         - name: BINARY_IMAGE
-          value: "$(params.output-image)"
+          value: "$(tasks.build-image-index.results.IMAGE_URL)"
       workspaces:
         - name: workspace
           workspace: workspace


### PR DESCRIPTION
Previously, it was possible to set parameters in such a way that the image url passed to the build-source-image task wouldn't exist.

In particular:

- IMAGE_APPEND_PLATFORM=true for the buildah-remote task; this causes the output image to become {output-image}-{platform}
- ALWAYS_BUILD_INDEX=false for the build-index-image task; this causes the build-index-image task to skip index image generation if there is only a single image.
- build-plaforms=[only one platform]

This combination of parameters causes the pipeline to not push the {output-image} at all, there's only {output-image}-{platform}. That's likely not what the user intended, but nevertheless, there's no reason the build-source-image task should fail because of it.

Pass the IMAGE_URL result from the build-index-image task instead of passing the output-image param. When building the index is disabled, the build-index-image task just forwards the result of the per-platform build task. That ensures the image passed to the source-build task exists, regardless of the parameter combination.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
