### PR TITLE
feat: bump API version for TPA 2.x

### DIFF
--- a/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
+++ b/task/upload-sbom-to-trustification/0.1/upload-sbom-to-trustification.yaml
@@ -262,7 +262,7 @@ spec:
           -H "transfer-encoding: chunked" \
           -H "content-type: application/json" \
           --data "@$supported_version_of_sbom" \
-          "$bombastic_api_url/api/v1/sbom?id=$sbom_id"
+          "$bombastic_api_url/api/v2/sbom?id=$sbom_id"
       done
 
   - name: report


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED