### PR TITLE
feat(STONEBLD-3431): Validate tasks and pipelines YAMLs

### DIFF
--- a/.github/scripts/check_task_and_pipeline_yamls.sh
+++ b/.github/scripts/check_task_and_pipeline_yamls.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+shopt -s nullglob
+set -euo pipefail
+
+echo ">>> Apply tasks"
+for task_folder in task/*/; do
+  if [ -d "$task_folder" ]; then
+    task="$(basename "$task_folder")"
+    echo ">>> Task: $task"
+    (
+      cd "$task_folder"
+      for version in */; do
+        if [ -d "$version" ]; then
+          kubectl apply -f "$version/$task.yaml" --dry-run=server
+        fi
+      done
+    )
+  fi
+done
+
+echo ">>> Apply pipelines"
+
+cd pipelines
+
+ignored_pipelines=(
+  "template-build"
+)
+
+for pipeline in */; do
+  if [ -d "$pipeline" ]; then
+    pipeline="$(basename "$pipeline")"
+    for ignored in "${ignored_pipelines[@]}"; do
+      if [ "$ignored" == "$pipeline" ]; then
+        echo ">>> Ignoring pipeline: $pipeline"
+        continue 2
+      fi
+    done
+    echo ">>> Pipeline: $pipeline"
+    to_apply=()
+    for yaml in "$pipeline"/*.yaml; do
+      if [ -f "$yaml" ] && yq eval -e 'type == "!!map" and .kind == "Pipeline"' "$yaml" > /dev/null 2>&1; then
+        to_apply+=("$yaml")
+      fi
+    done
+    
+    for file in "${to_apply[@]}"; do
+      # Pipeline files contain a version field (that is not a part of the pipeline spec) in the taskRef
+      # that is supposed to get processed, and then removed by the hack/build-and-push.sh script. 
+      # We don't call that script and for our purposes we can just remove the version field. 
+      # Otherwise the pipeline would get rejected by kubectl as it would not be valid.
+      yq eval --inplace "del(.spec.tasks[].taskRef.version)" "$file"
+      yq eval --inplace "del(.spec.finally[].taskRef.version)" "$file"
+      kubectl apply -f "$file" --dry-run=server
+    done
+  fi
+done

--- a/.github/workflows/check-task-and-pipeline-yamls.yaml
+++ b/.github/workflows/check-task-and-pipeline-yamls.yaml
@@ -1,0 +1,32 @@
+name: Check Tasks and Pipelines YAMLs
+
+"on":
+  pull_request:
+    branches: [main]
+  merge_group:
+    types: [checks_requested]
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create k8s Kind Cluster
+        uses: helm/kind-action@v1.12.0
+        with:
+          cluster_name: kind
+
+      - name: Set up Tekton
+        uses: tektoncd/actions/setup-tektoncd@main
+        with:
+          pipeline_version: latest
+
+      - name: Apply all Task & Pipeline YAMLs
+        run: |
+          set -e
+          ./.github/scripts/check_task_and_pipeline_yamls.sh

--- a/pipelines/gitops-pull-request-rhtap/README.md
+++ b/pipelines/gitops-pull-request-rhtap/README.md
@@ -120,6 +120,8 @@
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
+|git-auth| |True| clone-repository:0.1:basic-auth|
+|workspace| |False| clone-repository:0.1:output ; get-images-to-verify:0.1:source ; get-images-to-upload-sbom:0.1:source ; download-sboms:0.1:sboms ; upload-sboms-to-trustification:0.1:sboms|
 ## Available workspaces from tasks
 ### download-sbom-from-url-in-attestation:0.1 task workspaces
 |name|description|optional|workspace from pipeline

--- a/pipelines/gitops-pull-request-rhtap/gitops-pull-request.yaml
+++ b/pipelines/gitops-pull-request-rhtap/gitops-pull-request.yaml
@@ -162,3 +162,7 @@ spec:
       taskRef:
         name: upload-sbom-to-trustification
         version: "0.1"
+  workspaces:
+    - name: workspace
+    - name: git-auth
+      optional: true

--- a/pipelines/rhtap/rhtap.yaml
+++ b/pipelines/rhtap/rhtap.yaml
@@ -387,3 +387,7 @@ spec:
     workspaces:
     - name: sboms
       workspace: workspace
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true


### PR DESCRIPTION
At the moment, errors in task and pipeline YAMLs only surface after the full CI run completes. This PR adds a GitHub Actions workflow that pre-validates task and pipeline YAMLs so that we can catch apply failures immediately.

This PR addresses [STONEBLD-3431](https://issues.redhat.com//browse/STONEBLD-3431) by adding a workflow to validate the tasks and pipelines YAMLs and whether they can be applied.

* Added a bash script to generate & apply tasks and pipelines via kubectl
* Added a GH Actions workflow to prepare a cluster via kind, and invoke the script
* Modified the gitops-pull-request.yaml so that it can be applied on its own (by defining the workspaces it uses)
