### PR TITLE
feat(CLOUDDST-27468): set limits/resources for task sast-unicode-check

### DIFF
--- a/task/sast-unicode-check-oci-ta/0.2/sast-unicode-check-oci-ta.yaml
+++ b/task/sast-unicode-check-oci-ta/0.2/sast-unicode-check-oci-ta.yaml
@@ -283,6 +283,12 @@ spec:
           ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
         fi
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 4Gi
     - name: upload
       image: quay.io/konflux-ci/oras:latest@sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
       workingDir: /var/workdir/source
@@ -322,3 +328,9 @@ spec:
           echo "Attaching to ${IMAGE_URL}"
           oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
         done
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/task/sast-unicode-check/0.2/sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.2/sast-unicode-check.yaml
@@ -67,6 +67,12 @@ spec:
   steps:
     - name: sast-unicode-check
       image: quay.io/konflux-ci/konflux-test:v1.4.20@sha256:f9db697d8a45870b862252de61b3c29d9d6f79272ef8bf61ecb645f8bca27705
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
+          cpu: 100m
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
@@ -258,6 +264,12 @@ spec:
         echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
     - name: upload
       image: quay.io/konflux-ci/oras:latest@sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
       workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
       volumeMounts:
         - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt


### PR DESCRIPTION
This PR updates resource limits and requests for the task sast-unicode-check as part of this effort - KONFLUX-7127.

The new request/limit values have been defined taking into account usages observed historically (tracked in this [spreadsheet](https://docs.google.com/spreadsheets/d/1d4Tn7PYkY2EVgpNyT29xL7y62akZNPIjy18VTzw54iQ/edit?gid=1735880927#gid=1735880927)) in the stone-prd-rh01 cluster.