### PR TITLE
buildah: prevent upload-sbom failing silently

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -810,6 +810,7 @@ spec:
     name: upload-sbom
     script: |
       #!/bin/bash
+      set -euo pipefail
 
       echo "[$(date --utc -Ins)] Upload SBOM"
 

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -869,6 +869,7 @@ spec:
           readOnly: true
       script: |
         #!/bin/bash
+        set -euo pipefail
 
         echo "[$(date --utc -Ins)] Upload SBOM"
 

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -1013,11 +1013,12 @@ spec:
     name: upload-sbom
     script: |
       #!/bin/bash
-
+      set -euo pipefail
       if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+
       echo "[$(date --utc -Ins)] Upload SBOM"
 
       if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -982,11 +982,12 @@ spec:
     name: upload-sbom
     script: |
       #!/bin/bash
-
+      set -euo pipefail
       if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
         IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         export IMAGE
       fi
+
       echo "[$(date --utc -Ins)] Upload SBOM"
 
       if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -798,6 +798,7 @@ spec:
     image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
     script: |
       #!/bin/bash
+      set -euo pipefail
 
       echo "[$(date --utc -Ins)] Upload SBOM"
 


### PR DESCRIPTION
The script was missing 'set -e', so the cosign attach command could fail and the script would still succeed.

Other tasks should not be affected, since buildah was the only one that declared an explicit shebang AND didn't have 'set -e'

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
