### PR TITLE
git-clone: Fix error when merging target branch and there is no diff

### DIFF
--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -290,16 +290,22 @@ spec:
             echo "------------------"
             exit "${MERGE_CHECK_EXIT_CODE}"
           else
-            echo "Merge successful (no conflicts found), committing..."
-            git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
-            COMMIT_EXIT_CODE="$?"
-            if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
-              echo "ERROR: Failed to commit merge." >&2
-              exit "${COMMIT_EXIT_CODE}"
+            git diff --staged --quiet
+            GIT_DIFF_EXIT_CODE="$?"
+            if [ "${GIT_DIFF_EXIT_CODE}" = "0" ]; then
+              echo "No diff was found, skipping merge..." >&2
+            else
+              echo "Merge successful (no conflicts found), committing..."
+              git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+              COMMIT_EXIT_CODE="$?"
+              if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
+                echo "ERROR: Failed to commit merge." >&2
+                exit "${COMMIT_EXIT_CODE}"
+              fi
+              MERGED_SHA=$(git rev-parse HEAD)
+              echo "New HEAD after merge: ${MERGED_SHA}"
+              echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
             fi
-            MERGED_SHA=$(git rev-parse HEAD)
-            echo "New HEAD after merge: ${MERGED_SHA}"
-            echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
           fi
         else
           echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -282,16 +282,22 @@ spec:
           echo "------------------"
           exit "${MERGE_CHECK_EXIT_CODE}"
         else
-          echo "Merge successful (no conflicts found), committing..."
-          git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
-          COMMIT_EXIT_CODE="$?"
-          if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
-            echo "ERROR: Failed to commit merge." >&2
-            exit "${COMMIT_EXIT_CODE}"
+          git diff --staged --quiet
+          GIT_DIFF_EXIT_CODE="$?"
+          if [ "${GIT_DIFF_EXIT_CODE}" = "0" ]; then
+            echo "No diff was found, skipping merge..." >&2
+          else
+            echo "Merge successful (no conflicts found), committing..."
+            git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+            COMMIT_EXIT_CODE="$?"
+            if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
+              echo "ERROR: Failed to commit merge." >&2
+              exit "${COMMIT_EXIT_CODE}"
+            fi
+            MERGED_SHA=$(git rev-parse HEAD)
+            echo "New HEAD after merge: ${MERGED_SHA}"
+            echo "${MERGED_SHA}" > "$(results.merged_sha.path)"
           fi
-          MERGED_SHA=$(git rev-parse HEAD)
-          echo "New HEAD after merge: ${MERGED_SHA}"
-          echo "${MERGED_SHA}" > "$(results.merged_sha.path)"
         fi
       else
         echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -274,16 +274,22 @@ spec:
           echo "------------------"
           exit "${MERGE_CHECK_EXIT_CODE}"
         else
-          echo "Merge successful (no conflicts found), committing..."
-          git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
-          COMMIT_EXIT_CODE="$?"
-          if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
-            echo "ERROR: Failed to commit merge." >&2
-            exit "${COMMIT_EXIT_CODE}"
+          git diff --staged --quiet
+          GIT_DIFF_EXIT_CODE="$?"
+          if [ "${GIT_DIFF_EXIT_CODE}" = "0" ]; then
+            echo "No diff was found, skipping merge..." >&2
+          else
+            echo "Merge successful (no conflicts found), committing..."
+            git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+            COMMIT_EXIT_CODE="$?"
+            if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
+              echo "ERROR: Failed to commit merge." >&2
+              exit "${COMMIT_EXIT_CODE}"
+            fi
+            MERGED_SHA=$(git rev-parse HEAD)
+            echo "New HEAD after merge: ${MERGED_SHA}"
+            echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
           fi
-          MERGED_SHA=$(git rev-parse HEAD)
-          echo "New HEAD after merge: ${MERGED_SHA}"
-          echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
         fi
       else
         echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."


### PR DESCRIPTION
When attempting to merge a target branch by using the 'mergeTargetBranch' and 'targetBranch' params, the git-clone tasks would sometimes fail even if no merge conflict happened. This is because when trying to commit without any diff in the staging area, the 'git commit' commands exits with a code 1, which makes the whole task fail.

This patches changes this behavior to only commit if a diff is found.
