### PR TITLE
Bump Mobster image to 0.2.1

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -192,7 +192,7 @@ spec:
         add:
           - SETFCAP
 
-  - image: quay.io/konflux-ci/mobster@sha256:9b7bf71d09771065432bef7c6ed13193a3ac4e2c41895c6197e4b09e1c0ee905
+  - image: quay.io/konflux-ci/mobster@sha256:1b53ca81dc7427e6362b311180532cfbc431f83fa11e7e1154df1c26e3a46a0b
     name: create-sbom
     computeResources:
       limits:

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -201,7 +201,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster@sha256:9b7bf71d09771065432bef7c6ed13193a3ac4e2c41895c6197e4b09e1c0ee905
+    image: quay.io/konflux-ci/mobster@sha256:1b53ca81dc7427e6362b311180532cfbc431f83fa11e7e1154df1c26e3a46a0b
     name: create-sbom
     script: |
       #!/bin/bash

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -167,7 +167,7 @@ spec:
         echo -n "${IMAGE}@${RESULTING_DIGEST}" > "$(results.IMAGE_REF.path)"
 
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster@sha256:78cabbe1b40a5ddbb4773e451f88272a840036a434495ce0a99c88679fc90f6f
+      image: quay.io/konflux-ci/mobster@sha256:1b53ca81dc7427e6362b311180532cfbc431f83fa11e7e1154df1c26e3a46a0b
       workingDir: /var/workdir
       script: |
         #!/bin/bash


### PR DESCRIPTION
The new version contains fixes in SBOM generation that influences a quality of documents for incident response.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
