### PR TITLE
Cachi2 -> Hermeto rebranding [vol.1]

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -130,7 +130,7 @@ spec:
     name: hermetic
     type: string
   - default: ""
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -18,7 +18,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-images:0.4:IMAGE ; build-image-index:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.4:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-images:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
+|prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.2:input ; build-images:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-images:0.4:PRIVILEGED_NESTED|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
@@ -167,10 +167,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
+|config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
-|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|log-level| Set prefetch tool log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
@@ -420,5 +420,5 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
-|netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -48,7 +48,7 @@ spec:
     name: hermetic
     type: string
   - default: ""
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -17,7 +17,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-container:0.4:IMAGE ; build-image-index:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.4:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
+|prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.4:PRIVILEGED_NESTED|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
@@ -164,10 +164,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
+|config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
-|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|log-level| Set prefetch tool log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
@@ -417,5 +417,5 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
-|netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -48,7 +48,7 @@ spec:
     name: hermetic
     type: string
   - default: ""
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -17,7 +17,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.4:IMAGE ; build-image-index:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.4:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.1:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
+|prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.2:input ; build-container:0.4:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.4:PRIVILEGED_NESTED|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
@@ -162,10 +162,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
+|config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
-|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|log-level| Set prefetch tool log level (debug, info, warning, error)| info| |
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### push-dockerfile:0.1 task parameters
 |name|description|default value|already set by|
@@ -409,9 +409,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
-|netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
-|source| Workspace with the source code, cachi2 artifacts will be stored on the workspace as well| False| workspace|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|
+|source| Workspace with the source code, prefetch artifacts will be stored on the workspace as well| False| workspace|
 ### push-dockerfile:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -64,7 +64,7 @@ spec:
     name: hermetic
     type: string
   - default: ""
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -18,7 +18,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; run-opm-command:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.4:IMAGE_EXPIRES_AFTER ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; run-opm-command:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-images:0.4:IMAGE ; build-image-index:0.1:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.4:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input ; build-images:0.4:PREFETCH_INPUT|
+|prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.2:input ; build-images:0.4:PREFETCH_INPUT|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -148,10 +148,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.run-opm-command.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
+|config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
-|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|log-level| Set prefetch tool log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
@@ -257,5 +257,5 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
-|netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -48,7 +48,7 @@ spec:
     name: hermetic
     type: string
   - default: ""
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -10,7 +10,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-oci-artifact:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| generic| prefetch-dependencies:0.2:input|
+|prefetch-input| Build dependencies to be prefetched| generic| prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -68,10 +68,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
+|config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
-|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|log-level| Set prefetch tool log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
@@ -244,5 +244,5 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
-|netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -34,7 +34,7 @@ spec:
     name: skip-checks
     type: string
   - default: generic
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -10,7 +10,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-oci-artifact:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| generic| prefetch-dependencies:0.2:input|
+|prefetch-input| Build dependencies to be prefetched| generic| prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -67,10 +67,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
+|config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
-|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|log-level| Set prefetch tool log level (debug, info, warning, error)| info| |
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### sast-coverity-check:0.3 task parameters
 |name|description|default value|already set by|
@@ -239,9 +239,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### prefetch-dependencies:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
-|netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
-|source| Workspace with the source code, cachi2 artifacts will be stored on the workspace as well| False| workspace|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|
+|source| Workspace with the source code, prefetch artifacts will be stored on the workspace as well| False| workspace|
 ### sast-coverity-check:0.3 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -50,7 +50,7 @@ spec:
     name: skip-checks
     type: string
   - default: generic
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -11,7 +11,7 @@
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-image-index:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-container:0.2:IMAGE ; build-image-index:0.1:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input|
+|prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -73,10 +73,10 @@
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
+|config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
-|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|log-level| Set prefetch tool log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).prefetch'|
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
@@ -191,8 +191,8 @@
 ### prefetch-dependencies-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
-|netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|
 ### summary:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -57,7 +57,7 @@ spec:
     name: hermetic
     type: string
   - default: ""
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -11,7 +11,7 @@
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-image-index:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| show-summary:0.2:image-url ; init:0.2:image-url ; build-container:0.2:IMAGE ; build-image-index:0.1:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
-|prefetch-input| Build dependencies to be prefetched by Cachi2| | prefetch-dependencies:0.2:input|
+|prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.2:input|
 |rebuild| Force rebuild image| false| init:0.2:rebuild|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
 |skip-checks| Skip checks against built image| false| init:0.2:skip-checks|
@@ -73,10 +73,10 @@
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
+|config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
 |dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
-|log-level| Set cachi2 log level (debug, info, warning, error)| info| |
+|log-level| Set prefetch tool log level (debug, info, warning, error)| info| |
 |sbom-type| Select the SBOM format to generate. Valid values: spdx, cyclonedx.| spdx| |
 ### sast-shell-check:0.1 task parameters
 |name|description|default value|already set by|
@@ -180,9 +180,9 @@
 ### prefetch-dependencies:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
-|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
-|netrc| Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. | True| netrc|
-|source| Workspace with the source code, cachi2 artifacts will be stored on the workspace as well| False| workspace|
+|git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
+|netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|
+|source| Workspace with the source code, prefetch artifacts will be stored on the workspace as well| False| workspace|
 ### sast-shell-check:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -59,7 +59,7 @@ spec:
     name: hermetic
     type: string
   - default: ""
-    description: Build dependencies to be prefetched by Cachi2
+    description: Build dependencies to be prefetched
     name: prefetch-input
     type: string
   - default: ""

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -41,7 +41,7 @@ spec:
       name: hermetic
       type: string
       default: "false"
-    - description: Build dependencies to be prefetched by Cachi2
+    - description: Build dependencies to be prefetched
       name: prefetch-input
       type: string
       default: ""

--- a/task-generator/trusted-artifacts/README.md
+++ b/task-generator/trusted-artifacts/README.md
@@ -26,8 +26,8 @@ to a Trusted Artifacts Tekton Task definition.
 
 Basic recipe consists of providing a base path to the non-Trusted Artifacts Task
 and declaring that the Task will either create or use Trusted Artifacts by
-setting the add to `create-source`, `create-cachi2`, `use-source` and/or
-`use-cachi2`.
+setting the add to `create-source`, `create-prefetch`, `use-source` and/or
+`use-prefetch`.
 
 For example:
 
@@ -48,7 +48,7 @@ The following is the list of supported options:
 
 | Option               | Type                                             | Description |
 |----------------------|--------------------------------------------------|-------------|
-| `add`                | sequence of strings                              | Task Steps to add, can be one or more of `create-source`, `create-cachi2`, `use-source` or `use-cachi2` |
+| `add`                | sequence of strings                              | Task Steps to add, can be one or more of `create-source`, `create-prefetch`, `use-source` or `use-prefetch` |
 | `addEnvironment`     | sequence of [EnvVar]                             | Additional environment variables to add to all existing Task Steps in the non-Trusted Artifact Task |
 | `additionalSteps`    | sequence of [AdditionalSteps](#additional-steps) | Additional Tekton Steps to add |
 | `addParams`          | sequence of Tekton [ParamSpec]s                  | Additional Tekton Task parameters to add to the Task |

--- a/task-generator/trusted-artifacts/golden/buildah/base.yaml
+++ b/task-generator/trusted-artifacts/golden/buildah/base.yaml
@@ -351,7 +351,7 @@ spec:
       runAsUser: 0
 
   - name: merge-cachi2-sbom
-    image: quay.io/konflux-ci/cachi2:0.17.0@sha256:963870f04aeb4a207e79b8eacb47e16c8faa7451f52e92959e0e16cdbd258fb3
+    image: quay.io/konflux-ci/hermeto:0.29.0@sha256:f577e0399953471df7a9826c1550aef83d28e8b35f76dd65a193441822b629ee
     script: |
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
         echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"

--- a/task-generator/trusted-artifacts/golden/buildah/base.yaml
+++ b/task-generator/trusted-artifacts/golden/buildah/base.yaml
@@ -260,9 +260,9 @@ spec:
       buildah mount $container | tee /workspace/container_path
       echo $container > /workspace/container_name
 
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
       fi
 
       # Expose base image digests
@@ -350,15 +350,15 @@ spec:
     securityContext:
       runAsUser: 0
 
-  - name: merge-cachi2-sbom
+  - name: merge-prefetch-sbom
     image: quay.io/konflux-ci/hermeto:0.29.0@sha256:f577e0399953471df7a9826c1550aef83d28e8b35f76dd65a193441822b629ee
     script: |
       if [ -d "$(workspaces.source.path)/cachi2" ]; then
-        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
-        /src/utils/merge_syft_sbom.py sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        echo "Merging contents of sbom-prefetch.json into sbom-cyclonedx.json"
+        /src/utils/merge_syft_sbom.py sbom-prefetch.json sbom-cyclonedx.json > sbom-temp.json
         mv sbom-temp.json sbom-cyclonedx.json
       else
-        echo "Skipping step since no Cachi2 SBOM was produced"
+        echo "Skipping step since no source SBOM was produced"
       fi
     workingDir: $(workspaces.source.path)
     securityContext:

--- a/task-generator/trusted-artifacts/golden/buildah/recipe.yaml
+++ b/task-generator/trusted-artifacts/golden/buildah/recipe.yaml
@@ -3,7 +3,7 @@ removeParams:
   - BUILDER_IMAGE
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 removeWorkspaces:
   - source
 replacements:

--- a/task-generator/trusted-artifacts/golden/buildah/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/buildah/ta.yaml
@@ -266,9 +266,9 @@ spec:
       buildah mount $container | tee /var/workdir/container_path
       echo $container > /var/workdir/container_name
 
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
       if [ -d "/var/workdir/cachi2" ]; then
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
       fi
 
       # Expose base image digests
@@ -354,15 +354,15 @@ spec:
     securityContext:
       runAsUser: 0
 
-  - name: merge-cachi2-sbom
+  - name: merge-prefetch-sbom
     image: quay.io/konflux-ci/hermeto:0.29.0@sha256:f577e0399953471df7a9826c1550aef83d28e8b35f76dd65a193441822b629ee
     script: |
       if [ -d "/var/workdir/cachi2" ]; then
-        echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"
-        /src/utils/merge_syft_sbom.py sbom-cachi2.json sbom-cyclonedx.json > sbom-temp.json
+        echo "Merging contents of sbom-prefetch.json into sbom-cyclonedx.json"
+        /src/utils/merge_syft_sbom.py sbom-prefetch.json sbom-cyclonedx.json > sbom-temp.json
         mv sbom-temp.json sbom-cyclonedx.json
       else
-        echo "Skipping step since no Cachi2 SBOM was produced"
+        echo "Skipping step since no source SBOM was produced"
       fi
     workingDir: /var/workdir
     securityContext:

--- a/task-generator/trusted-artifacts/golden/buildah/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/buildah/ta.yaml
@@ -355,7 +355,7 @@ spec:
       runAsUser: 0
 
   - name: merge-cachi2-sbom
-    image: quay.io/konflux-ci/cachi2:0.17.0@sha256:963870f04aeb4a207e79b8eacb47e16c8faa7451f52e92959e0e16cdbd258fb3
+    image: quay.io/konflux-ci/hermeto:0.29.0@sha256:f577e0399953471df7a9826c1550aef83d28e8b35f76dd65a193441822b629ee
     script: |
       if [ -d "/var/workdir/cachi2" ]; then
         echo "Merging contents of sbom-cachi2.json into sbom-cyclonedx.json"

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/base.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/base.yaml
@@ -102,6 +102,14 @@ spec:
 
       hermeto --log-level="$LOG_LEVEL" inject-files $(workspaces.source.path)/cachi2/output \
       --for-output-dir=/cachi2/output
+
+      # NOTE: Compatibility hack, hermeto will create a hermeto.repo when processing RPMs (1 for
+      # each architecture) which may break users expecting cachi2.repo
+      find /var/workdir/cachi2/output \
+        -type f \
+        -name hermeto.repo \
+        -execdir mv {} cachi2.repo \;
+
   workspaces:
   - name: source
     description: Workspace with the source code, prefetch artifacts will be stored on the workspace as well

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/base.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/base.yaml
@@ -89,18 +89,18 @@ spec:
         update-ca-trust
       fi
 
-      cachi2 --log-level="$LOG_LEVEL" fetch-deps \
+      hermeto --log-level="$LOG_LEVEL" fetch-deps \
       $dev_pacman_flag \
       --source=$(workspaces.source.path)/source \
       --output=$(workspaces.source.path)/cachi2/output \
       "${INPUT}"
 
-      cachi2 --log-level="$LOG_LEVEL" generate-env $(workspaces.source.path)/cachi2/output \
+      hermeto --log-level="$LOG_LEVEL" generate-env $(workspaces.source.path)/cachi2/output \
       --format env \
       --for-output-dir=/cachi2/output \
       --output $(workspaces.source.path)/cachi2/cachi2.env
 
-      cachi2 --log-level="$LOG_LEVEL" inject-files $(workspaces.source.path)/cachi2/output \
+      hermeto --log-level="$LOG_LEVEL" inject-files $(workspaces.source.path)/cachi2/output \
       --for-output-dir=/cachi2/output
   workspaces:
   - name: source

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/base.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/base.yaml
@@ -31,7 +31,7 @@ spec:
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
   steps:
-  - image: quay.io/konflux-ci/cachi2:0.17.0@sha256:963870f04aeb4a207e79b8eacb47e16c8faa7451f52e92959e0e16cdbd258fb3
+  - image: quay.io/konflux-ci/hermeto:0.29.0@sha256:f577e0399953471df7a9826c1550aef83d28e8b35f76dd65a193441822b629ee
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: prefetch-dependencies

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/base.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/base.yaml
@@ -9,8 +9,8 @@ metadata:
   name: prefetch-dependencies
 spec:
   description: |-
-    Task that uses Cachi2 to prefetch build dependencies.
-    See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+    Task that uses Hermeto to prefetch build dependencies.
+    See docs at https://hermetoproject.github.io/hermeto/#basic-usage
   params:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
@@ -19,7 +19,7 @@ spec:
       notice. Use at your own risk.
     name: dev-package-managers
     default: "false"
-  - description: Set cachi2 log level (debug, info, warning, error)
+  - description: Set prefetch tool log level (debug, info, warning, error)
     name: log-level
     default: "info"
   - name: caTrustConfigMapName
@@ -54,7 +54,7 @@ spec:
       if [ -z "${INPUT}" ]
       then
         # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
-        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+        echo "No prefetch will be performed because no input was provided for hermeto fetch-deps"
         exit 0
       fi
 
@@ -104,11 +104,11 @@ spec:
       --for-output-dir=/cachi2/output
   workspaces:
   - name: source
-    description: Workspace with the source code, cachi2 artifacts will be stored on the workspace as well
+    description: Workspace with the source code, prefetch artifacts will be stored on the workspace as well
   - name: git-basic-auth
     description: |
       A Workspace containing a .gitconfig and .git-credentials file or username and password.
-      These will be copied to the user's home before any cachi2 commands are run. Any
+      These will be copied to the user's home before prefetch is run. Any
       other files in this Workspace are ignored. It is strongly recommended
       to bind a Secret to this Workspace over other volume types.
     optional: true

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/recipe.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/recipe.yaml
@@ -2,7 +2,7 @@
 add:
   - use-source
   - create-source
-  - create-cachi2
+  - create-prefetch
 additionalSteps:
   - at: 0
     name: skip-ta

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/recipe.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/recipe.yaml
@@ -22,10 +22,10 @@ additionalSteps:
         echo -n "" > $(results.CACHI2_ARTIFACT.path)
       fi
 description: |-
-    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    Task that uses Hermeto to prefetch build dependencies. The fetched dependencies and the
     application source code are stored as a trusted artifact in the provided OCI repository.
-    For additional info on Cachi2, see docs at
-    https://github.com/containerbuildsystem/cachi2#basic-usage.
+    For additional info on Hermeto, see docs at
+    https://hermetoproject.github.io/hermeto/#basic-usage
 preferStepTemplate: true
 removeWorkspaces:
   - source

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -134,18 +134,18 @@ spec:
         update-ca-trust
       fi
 
-      cachi2 --log-level="$LOG_LEVEL" fetch-deps \
+      hermeto --log-level="$LOG_LEVEL" fetch-deps \
       $dev_pacman_flag \
       --source=/var/workdir/source \
       --output=/var/workdir/cachi2/output \
       "${INPUT}"
 
-      cachi2 --log-level="$LOG_LEVEL" generate-env /var/workdir/cachi2/output \
+      hermeto --log-level="$LOG_LEVEL" generate-env /var/workdir/cachi2/output \
       --format env \
       --for-output-dir=/cachi2/output \
       --output /var/workdir/cachi2/cachi2.env
 
-      cachi2 --log-level="$LOG_LEVEL" inject-files /var/workdir/cachi2/output \
+      hermeto --log-level="$LOG_LEVEL" inject-files /var/workdir/cachi2/output \
       --for-output-dir=/cachi2/output
   - image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved
     name: create-trusted-artifact

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -78,7 +78,7 @@ spec:
     args:
       - use
       - $(params.SOURCE_ARTIFACT)=/var/workdir/source
-  - image: quay.io/konflux-ci/cachi2:0.17.0@sha256:963870f04aeb4a207e79b8eacb47e16c8faa7451f52e92959e0e16cdbd258fb3
+  - image: quay.io/konflux-ci/hermeto:0.29.0@sha256:f577e0399953471df7a9826c1550aef83d28e8b35f76dd65a193441822b629ee
     name: prefetch-dependencies
     env:
     - name: INPUT

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -147,6 +147,14 @@ spec:
 
       hermeto --log-level="$LOG_LEVEL" inject-files /var/workdir/cachi2/output \
       --for-output-dir=/cachi2/output
+
+      # NOTE: Compatibility hack, hermeto will create a hermeto.repo when processing RPMs (1 for
+      # each architecture) which may break users expecting cachi2.repo
+      find /var/workdir/cachi2/output \
+        -type f \
+        -name hermeto.repo \
+        -execdir mv {} cachi2.repo \;
+
   - image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved
     name: create-trusted-artifact
     env:

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -10,10 +10,10 @@ metadata:
   name: prefetch-dependencies-oci-ta
 spec:
   description: |-
-    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    Task that uses Hermeto to prefetch build dependencies. The fetched dependencies and the
     application source code are stored as a trusted artifact in the provided OCI repository.
-    For additional info on Cachi2, see docs at
-    https://github.com/containerbuildsystem/cachi2#basic-usage.
+    For additional info on Hermeto, see docs at
+    https://hermetoproject.github.io/hermeto/#basic-usage
   params:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
@@ -34,7 +34,7 @@ spec:
       notice. Use at your own risk.
     name: dev-package-managers
     default: "false"
-  - description: Set cachi2 log level (debug, info, warning, error)
+  - description: Set prefetch tool log level (debug, info, warning, error)
     name: log-level
     default: "info"
   - name: caTrustConfigMapName
@@ -99,7 +99,7 @@ spec:
       if [ -z "${INPUT}" ]
       then
         # Confirm input was provided though it's likely the whole task would be skipped if it wasn't
-        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+        echo "No prefetch will be performed because no input was provided for hermeto fetch-deps"
         exit 0
       fi
 
@@ -168,7 +168,7 @@ spec:
   - name: git-basic-auth
     description: |
       A Workspace containing a .gitconfig and .git-credentials file or username and password.
-      These will be copied to the user's home before any cachi2 commands are run. Any
+      These will be copied to the user's home before prefetch is run. Any
       other files in this Workspace are ignored. It is strongly recommended
       to bind a Secret to this Workspace over other volume types.
     optional: true

--- a/task-generator/trusted-artifacts/golden/sast-snyk-check/recipe.yaml
+++ b/task-generator/trusted-artifacts/golden/sast-snyk-check/recipe.yaml
@@ -1,7 +1,7 @@
 ---
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 description: >-
   Scans source code for security vulnerabilities, including common issues such as SQL injection,
   cross-site scripting (XSS), and code injection attacks using Snyk Code, a Static Application

--- a/task-generator/trusted-artifacts/golden/source-build/base.yaml
+++ b/task-generator/trusted-artifacts/golden/source-build/base.yaml
@@ -152,7 +152,7 @@ spec:
           --source-dir "$SOURCE_DIR" \
           --base-images "$base_images" \
           --write-result-to "$RESULT_FILE" \
-          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
+          --prefetch-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
           --registry-allowlist="$registry_allowlist"
 
         cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"

--- a/task-generator/trusted-artifacts/golden/source-build/recipe.yaml
+++ b/task-generator/trusted-artifacts/golden/source-build/recipe.yaml
@@ -1,7 +1,7 @@
 ---
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 removeWorkspaces:
   - workspace
 removeVolumes:

--- a/task-generator/trusted-artifacts/golden/source-build/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/source-build/ta.yaml
@@ -151,7 +151,7 @@ spec:
           --source-dir "$SOURCE_DIR" \
           --base-images "$base_images" \
           --write-result-to "$RESULT_FILE" \
-          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
+          --prefetch-artifacts-dir "$CACHI2_ARTIFACTS_DIR" \
           --registry-allowlist="$registry_allowlist"
 
         cat "$RESULT_FILE" | jq -j ".image_url" >"$RESULT_SOURCE_IMAGE_URL"

--- a/task-generator/trusted-artifacts/recipe.go
+++ b/task-generator/trusted-artifacts/recipe.go
@@ -36,9 +36,9 @@ type Recipe struct {
 	RemoveWorkspaces   []string              `json:"removeWorkspaces"`
 	Replacements       map[string]string     `json:"replacements"`
 	Suffix             string                `json:"suffix"`
-	createCachi2       bool
+	createPrefetch     bool
 	createSource       bool
-	useCachi2          bool
+	usePrefetch        bool
 	useSource          bool
 }
 
@@ -56,9 +56,9 @@ func readRecipe(path string) (*Recipe, error) {
 	}
 
 	sort.Strings(recipe.Add)
-	_, recipe.createCachi2 = slices.BinarySearch(recipe.Add, "create-cachi2")
+	_, recipe.createPrefetch = slices.BinarySearch(recipe.Add, "create-prefetch")
 	_, recipe.createSource = slices.BinarySearch(recipe.Add, "create-source")
-	_, recipe.useCachi2 = slices.BinarySearch(recipe.Add, "use-cachi2")
+	_, recipe.usePrefetch = slices.BinarySearch(recipe.Add, "use-prefetch")
 	_, recipe.useSource = slices.BinarySearch(recipe.Add, "use-source")
 
 	if !filepath.IsAbs(recipe.Base) {

--- a/task-generator/trusted-artifacts/ta.go
+++ b/task-generator/trusted-artifacts/ta.go
@@ -47,7 +47,7 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		Type:        pipeline.ResultsTypeString,
 	}
 
-	cachi2Result := pipeline.TaskResult{
+	prefetchResult := pipeline.TaskResult{
 		Name:        "CACHI2_ARTIFACT",
 		Description: "The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.",
 		Type:        pipeline.ResultsTypeString,
@@ -59,7 +59,7 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		Description: "The Trusted Artifact URI pointing to the artifact with the application source code.",
 	}
 
-	useCachi2Param := pipeline.ParamSpec{
+	usePrefetchParam := pipeline.ParamSpec{
 		Name:        "CACHI2_ARTIFACT",
 		Type:        pipeline.ParamTypeString,
 		Description: "The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.",
@@ -127,11 +127,11 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		task.Spec.Params = append(task.Spec.Params, useSourceParam)
 	}
 
-	if recipe.useCachi2 {
-		task.Spec.Params = append(task.Spec.Params, useCachi2Param)
+	if recipe.usePrefetch {
+		task.Spec.Params = append(task.Spec.Params, usePrefetchParam)
 	}
 
-	if recipe.createSource || recipe.createCachi2 {
+	if recipe.createSource || recipe.createPrefetch {
 		task.Spec.Params = append(task.Spec.Params, createParams...)
 	}
 
@@ -139,8 +139,8 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		if recipe.createSource {
 			recipe.AddResult = append(recipe.AddResult, sourceResult)
 		}
-		if recipe.createCachi2 {
-			recipe.AddResult = append(recipe.AddResult, cachi2Result)
+		if recipe.createPrefetch {
+			recipe.AddResult = append(recipe.AddResult, prefetchResult)
 		}
 	}
 	task.Spec.Results = append(task.Spec.Results, recipe.AddResult...)
@@ -306,14 +306,14 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		task.Spec.Steps[i].Script = buf.String()
 	}
 
-	if recipe.useSource || recipe.useCachi2 {
+	if recipe.useSource || recipe.usePrefetch {
 		args := []string{"use"}
 
 		if recipe.useSource {
 			args = append(args, fmt.Sprintf("$(params.SOURCE_ARTIFACT)=/var/workdir/%s", "source"))
 		}
 
-		if recipe.useCachi2 {
+		if recipe.usePrefetch {
 			args = append(args, fmt.Sprintf("$(params.CACHI2_ARTIFACT)=/var/workdir/%s", "cachi2"))
 		}
 
@@ -324,7 +324,7 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 			VolumeMounts: recipe.AddTAVolumeMount,
 		}}, task.Spec.Steps...)
 	}
-	if recipe.createSource || recipe.createCachi2 {
+	if recipe.createSource || recipe.createPrefetch {
 		args := []string{
 			"create",
 			"--store",
@@ -335,7 +335,7 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 			args = append(args, "$(results.SOURCE_ARTIFACT.path)=/var/workdir/source")
 		}
 
-		if recipe.createCachi2 {
+		if recipe.createPrefetch {
 			args = append(args, "$(results.CACHI2_ARTIFACT.path)=/var/workdir/cachi2")
 		}
 

--- a/task/build-maven-zip-oci-ta/0.1/recipe.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/recipe.yaml
@@ -1,7 +1,7 @@
 ---
 base: ../../build-maven-zip/0.1/build-maven-zip.yaml
 add:
-  - use-cachi2
+  - use-prefetch
 removeWorkspaces:
   - source
 replacements:

--- a/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
+++ b/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
@@ -430,8 +430,8 @@ spec:
 
         sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
 
-        if [ -f "sbom-cachi2.json" ]; then
-          sboms_to_merge+=(cachi2:sbom-cachi2.json)
+        if [ -f "sbom-prefetch.json" ]; then
+          sboms_to_merge+=(hermeto:sbom-prefetch.json)
         fi
 
         echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -705,10 +705,10 @@ spec:
 
       echo "[$(date --utc -Ins)] Add metadata"
 
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        echo "Making copy of sbom-cachi2.json"
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        echo "Making copy of sbom-prefetch.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
       fi
 
       touch /shared/base_images_digests

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -783,10 +783,10 @@ spec:
 
         echo "[$(date --utc -Ins)] Add metadata"
 
-        # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+        # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
         if [ -f "/tmp/cachi2/output/bom.json" ]; then
-          echo "Making copy of sbom-cachi2.json"
-          cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+          echo "Making copy of sbom-prefetch.json"
+          cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
         fi
 
         touch /shared/base_images_digests

--- a/task/buildah-oci-ta/0.4/recipe.yaml
+++ b/task/buildah-oci-ta/0.4/recipe.yaml
@@ -4,7 +4,7 @@ removeParams:
   - BUILDER_IMAGE
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 removeWorkspaces:
   - source
 useTAVolumeMount: true

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -812,10 +812,10 @@ spec:
 
       echo "[$(date --utc -Ins)] Add metadata"
 
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        echo "Making copy of sbom-cachi2.json"
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        echo "Making copy of sbom-prefetch.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
       fi
 
       touch /shared/base_images_digests

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -782,10 +782,10 @@ spec:
 
       echo "[$(date --utc -Ins)] Add metadata"
 
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        echo "Making copy of sbom-cachi2.json"
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        echo "Making copy of sbom-prefetch.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
       fi
 
       touch /shared/base_images_digests

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -692,10 +692,10 @@ spec:
 
       echo "[$(date --utc -Ins)] Add metadata"
 
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        echo "Making copy of sbom-cachi2.json"
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        echo "Making copy of sbom-prefetch.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
       fi
 
       touch /shared/base_images_digests

--- a/task/prefetch-dependencies-oci-ta/0.2/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.2/README.md
@@ -1,9 +1,9 @@
 # prefetch-dependencies-oci-ta task
 
-Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+Task that uses Hermeto to prefetch build dependencies. The fetched dependencies and the
 application source code are stored as a trusted artifact in the provided OCI repository.
-For additional info on Cachi2, see docs at
-https://github.com/containerbuildsystem/cachi2#basic-usage.
+For additional info on Hermeto, see docs at
+https://hermetoproject.github.io/hermeto/#basic-usage
 
 ## Configuration
 
@@ -21,7 +21,7 @@ params:
       subprocess_timeout: 3600
 ```
 
-[available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+[available configuration parameters]: https://hermetoproject.github.io/hermeto/#available-configuration-parameters
 
 ## Parameters
 |name|description|default value|required|
@@ -30,10 +30,10 @@ params:
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
-|config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|config-file-content|Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
 |dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
 |input|Configures project packages that will have their dependencies prefetched.||true|
-|log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
+|log-level|Set prefetch tool log level (debug, info, warning, error)|info|false|
 |ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
 |ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
 |sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|spdx|false|
@@ -47,5 +47,5 @@ params:
 ## Workspaces
 |name|description|optional|
 |---|---|---|
-|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
-|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|
+|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -10,10 +10,10 @@ metadata:
     app.kubernetes.io/version: "0.2"
 spec:
   description: |-
-    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    Task that uses Hermeto to prefetch build dependencies. The fetched dependencies and the
     application source code are stored as a trusted artifact in the provided OCI repository.
-    For additional info on Cachi2, see docs at
-    https://github.com/containerbuildsystem/cachi2#basic-usage.
+    For additional info on Hermeto, see docs at
+    https://hermetoproject.github.io/hermeto/#basic-usage
 
     ## Configuration
 
@@ -31,7 +31,7 @@ spec:
           subprocess_timeout: 3600
     ```
 
-    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+    [available configuration parameters]: https://hermetoproject.github.io/hermeto/#available-configuration-parameters
   params:
     - name: ACTIVATION_KEY
       description: Name of secret which contains subscription activation key
@@ -52,7 +52,7 @@ spec:
       default: trusted-ca
     - name: config-file-content
       description: |
-        Pass configuration to cachi2.
+        Pass configuration to the prefetch tool.
         Note this needs to be passed as a YAML-formatted config dump, not as a file path!
       default: ""
     - name: dev-package-managers
@@ -63,7 +63,7 @@ spec:
       description: Configures project packages that will have their dependencies
         prefetched.
     - name: log-level
-      description: Set cachi2 log level (debug, info, warning, error)
+      description: Set prefetch tool log level (debug, info, warning, error)
       default: info
     - name: ociArtifactExpiresAfter
       description: Expiration date for the trusted artifacts created in the
@@ -110,13 +110,13 @@ spec:
     - name: git-basic-auth
       description: |
         A Workspace containing a .gitconfig and .git-credentials file or username and password.
-        These will be copied to the user's home before any cachi2 commands are run. Any
+        These will be copied to the user's home before prefetch is run. Any
         other files in this Workspace are ignored. It is strongly recommended
         to bind a Secret to this Workspace over other volume types.
       optional: true
     - name: netrc
       description: |
-        Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+        Workspace containing a .netrc file. Prefetch will use the credentials in this file when
         performing http(s) requests.
       optional: true
   stepTemplate:
@@ -152,13 +152,13 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
-    - name: sanitize-cachi2-config-file-with-yq
+    - name: sanitize-config-file-with-yq
       image: quay.io/konflux-ci/yq:latest@sha256:15d0238843d954ee78c9c190705eb8b36f6e52c31434183c37d99a80841a635a
       script: |
         if [ -n "${CONFIG_FILE_CONTENT}" ]; then
-          # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM
-          # impact of this configuration option will be:
-          # https://github.com/containerbuildsystem/cachi2/issues/577
+          # we need to drop 'goproxy_url' for safety reasons until the CLI prefetch tool upstream
+          # decides what the SBOM impact of this configuration option will be:
+          # https://github.com/containerbuildsystem/hermeto/issues/577
           yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}" >/mnt/config/config.yaml
         fi
     - name: prefetch-dependencies
@@ -326,7 +326,7 @@ spec:
 
         if [ -z "${INPUT}" ]; then
           # Confirm input was provided
-          echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+          echo "No prefetch will be performed because no input was provided"
           exit 0
         fi
 
@@ -371,7 +371,7 @@ spec:
           update-ca-trust
         fi
 
-        # RHSM HANDLING: REGISTER RHSM & CACHI2 CONFIGURATION
+        # RHSM HANDLING: REGISTER RHSM & PREFETCH CLI CONFIGURATION
         if [ -e /activation-key/org ]; then
           RHSM_ORG=$(cat /activation-key/org)
           RHSM_ACT_KEY=$(cat /activation-key/activationkey)
@@ -391,7 +391,7 @@ spec:
           ENTITLEMENT_CERT_PATH="$(grep -v -e '-key.pem$' <<<"$entitlement_files")"
           CA_BUNDLE_PATH="/etc/rhsm/ca/redhat-uep.pem"
 
-          CACHI2_SSL_OPTS="$(
+          PREFETCH_SSL_OPTS="$(
             jq -n \
               --arg key "$ENTITLEMENT_CERT_KEY_PATH" \
               --arg cert "$ENTITLEMENT_CERT_PATH" \
@@ -399,8 +399,8 @@ spec:
               '{client_key: $key, client_cert: $cert, ca_bundle: $ca_bundle}'
           )"
 
-          # We need to modify the cachi2 params in place if we're processing RPMs
-          INPUT=$(inject_ssl_opts "$INPUT" "$CACHI2_SSL_OPTS")
+          # We need to modify the CLI params in place if we're processing RPMs
+          INPUT=$(inject_ssl_opts "$INPUT" "$PREFETCH_SSL_OPTS")
         fi
 
         INPUT=$(inject_rpm_summary_flag "$INPUT")

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -414,19 +414,19 @@ spec:
         fi
         unset RETRY_MAX_TRIES
 
-        cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+        hermeto --log-level="$LOG_LEVEL" $config_flag fetch-deps \
           $dev_pacman_flag \
           --source="/var/workdir/source" \
           --output="/var/workdir/cachi2/output" \
           --sbom-output-type="$SBOM_TYPE" \
           "${INPUT}"
 
-        cachi2 --log-level="$LOG_LEVEL" generate-env "/var/workdir/cachi2/output" \
+        hermeto --log-level="$LOG_LEVEL" generate-env "/var/workdir/cachi2/output" \
           --format env \
           --for-output-dir=/cachi2/output \
           --output "/var/workdir/cachi2/cachi2.env"
 
-        cachi2 --log-level="$LOG_LEVEL" inject-files "/var/workdir/cachi2/output" \
+        hermeto --log-level="$LOG_LEVEL" inject-files "/var/workdir/cachi2/output" \
           --for-output-dir=/cachi2/output
 
         # hack: the OCI generator would delete the function since it doesn't consider trap a "usage"

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -429,6 +429,13 @@ spec:
         hermeto --log-level="$LOG_LEVEL" inject-files "/var/workdir/cachi2/output" \
           --for-output-dir=/cachi2/output
 
+        # NOTE: Compatibility hack, hermeto will create a hermeto.repo when processing RPMs (1 for
+        # each architecture) which may break users expecting cachi2.repo
+        find "/var/workdir/cachi2/output" \
+          -type f \
+          -name hermeto.repo \
+          -execdir mv {} cachi2.repo \;
+
         # hack: the OCI generator would delete the function since it doesn't consider trap a "usage"
         if false; then
           rhsm_unregister

--- a/task/prefetch-dependencies-oci-ta/0.2/recipe.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/recipe.yaml
@@ -23,10 +23,10 @@ additionalSteps:
         echo -n "" > $(results.CACHI2_ARTIFACT.path)
       fi
 description: |-
-    Task that uses Cachi2 to prefetch build dependencies. The fetched dependencies and the
+    Task that uses Hermeto to prefetch build dependencies. The fetched dependencies and the
     application source code are stored as a trusted artifact in the provided OCI repository.
-    For additional info on Cachi2, see docs at
-    https://github.com/containerbuildsystem/cachi2#basic-usage.
+    For additional info on Hermeto, see docs at
+    https://hermetoproject.github.io/hermeto/#basic-usage
 
     ## Configuration
 
@@ -44,7 +44,7 @@ description: |-
           subprocess_timeout: 3600
     ```
 
-    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+    [available configuration parameters]: https://hermetoproject.github.io/hermeto/#available-configuration-parameters
 preferStepTemplate: true
 removeWorkspaces:
   - source

--- a/task/prefetch-dependencies-oci-ta/0.2/recipe.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/recipe.yaml
@@ -3,7 +3,7 @@ base: ../../prefetch-dependencies/0.2/prefetch-dependencies.yaml
 add:
   - use-source
   - create-source
-  - create-cachi2
+  - create-prefetch
 additionalSteps:
   - at: 0
     name: skip-ta

--- a/task/prefetch-dependencies/0.2/README.md
+++ b/task/prefetch-dependencies/0.2/README.md
@@ -1,6 +1,6 @@
 # prefetch-dependencies task
 
-Task that uses Cachi2 to prefetch build dependencies.
+Task that uses a prefetch CLI tool to prefetch build dependencies.
 See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
 
 ## Configuration
@@ -26,8 +26,8 @@ params:
 |---|---|---|---|
 |input|Configures project packages that will have their dependencies prefetched.||true|
 |dev-package-managers|Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. |false|false|
-|log-level|Set cachi2 log level (debug, info, warning, error)|info|false|
-|config-file-content|Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|log-level|Set prefetch tool log level (debug, info, warning, error)|info|false|
+|config-file-content|Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
 |sbom-type|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|spdx|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
@@ -36,6 +36,6 @@ params:
 ## Workspaces
 |name|description|optional|
 |---|---|---|
-|source|Workspace with the source code, cachi2 artifacts will be stored on the workspace as well|false|
-|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any cachi2 commands are run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
-|netrc|Workspace containing a .netrc file. Cachi2 will use the credentials in this file when performing http(s) requests. |true|
+|source|Workspace with the source code, prefetch artifacts will be stored on the workspace as well|false|
+|git-basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. |true|
+|netrc|Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. |true|

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -359,6 +359,13 @@ spec:
       hermeto --log-level="$LOG_LEVEL" inject-files "$(workspaces.source.path)/cachi2/output" \
       --for-output-dir=/cachi2/output
 
+      # NOTE: Compatibility hack, hermeto will create a hermeto.repo when processing RPMs (1 for
+      # each architecture) which may break users expecting cachi2.repo
+      find "$(workspaces.source.path)/cachi2/output" \
+        -type f \
+        -name hermeto.repo \
+        -execdir mv {} cachi2.repo \;
+
       # hack: the OCI generator would delete the function since it doesn't consider trap a "usage"
       if false; then
         rhsm_unregister

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -344,19 +344,19 @@ spec:
       fi
       unset RETRY_MAX_TRIES
 
-      cachi2 --log-level="$LOG_LEVEL" $config_flag fetch-deps \
+      hermeto --log-level="$LOG_LEVEL" $config_flag fetch-deps \
       $dev_pacman_flag \
       --source="$(workspaces.source.path)/source" \
       --output="$(workspaces.source.path)/cachi2/output" \
       --sbom-output-type="$SBOM_TYPE" \
       "${INPUT}"
 
-      cachi2 --log-level="$LOG_LEVEL" generate-env "$(workspaces.source.path)/cachi2/output" \
+      hermeto --log-level="$LOG_LEVEL" generate-env "$(workspaces.source.path)/cachi2/output" \
       --format env \
       --for-output-dir=/cachi2/output \
       --output "$(workspaces.source.path)/cachi2/cachi2.env"
 
-      cachi2 --log-level="$LOG_LEVEL" inject-files "$(workspaces.source.path)/cachi2/output" \
+      hermeto --log-level="$LOG_LEVEL" inject-files "$(workspaces.source.path)/cachi2/output" \
       --for-output-dir=/cachi2/output
 
       # hack: the OCI generator would delete the function since it doesn't consider trap a "usage"

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -9,8 +9,8 @@ metadata:
   name: prefetch-dependencies
 spec:
   description: |-
-    Task that uses Cachi2 to prefetch build dependencies.
-    See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+    Task that uses a prefetch CLI tool to prefetch build dependencies.
+    See docs at https://github.com/containerbuildsystem/hermeto#basic-usage.
 
     ## Configuration
 
@@ -28,7 +28,7 @@ spec:
           subprocess_timeout: 3600
     ```
 
-    [available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+    [available configuration parameters]: https://github.com/containerbuildsystem/hermeto?tab=readme-ov-file#available-configuration-parameters
   params:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
@@ -37,11 +37,11 @@ spec:
       notice. Use at your own risk.
     name: dev-package-managers
     default: "false"
-  - description: Set cachi2 log level (debug, info, warning, error)
+  - description: Set prefetch tool log level (debug, info, warning, error)
     name: log-level
     default: "info"
   - description: |
-      Pass configuration to cachi2.
+      Pass configuration to the prefetch tool.
       Note this needs to be passed as a YAML-formatted config dump, not as a file path!
     name: config-file-content
     default: ""
@@ -71,14 +71,14 @@ spec:
       - mountPath: /shared
         name: shared
   steps:
-  - name: sanitize-cachi2-config-file-with-yq
+  - name: sanitize-config-file-with-yq
     image: quay.io/konflux-ci/yq:latest@sha256:15d0238843d954ee78c9c190705eb8b36f6e52c31434183c37d99a80841a635a
     script: |
       if [ -n "${CONFIG_FILE_CONTENT}" ]
       then
-        # we need to drop 'goproxy_url' for safety reasons until cachi2 decides what the SBOM
-        # impact of this configuration option will be:
-        # https://github.com/containerbuildsystem/cachi2/issues/577
+        # we need to drop 'goproxy_url' for safety reasons until the CLI prefetch tool upstream
+        # decides what the SBOM impact of this configuration option will be:
+        # https://github.com/containerbuildsystem/hermeto/issues/577
         yq 'del(.goproxy_url)' <<< "${CONFIG_FILE_CONTENT}" > /mnt/config/config.yaml
       fi
 
@@ -257,7 +257,7 @@ spec:
 
       if [ -z "${INPUT}" ]; then
         # Confirm input was provided
-        echo "No prefetch will be performed because no input was provided for cachi2 fetch-deps"
+        echo "No prefetch will be performed because no input was provided"
         exit 0
       fi
 
@@ -302,7 +302,7 @@ spec:
         update-ca-trust
       fi
 
-      # RHSM HANDLING: REGISTER RHSM & CACHI2 CONFIGURATION
+      # RHSM HANDLING: REGISTER RHSM & PREFETCH CLI CONFIGURATION
       if [ -e /activation-key/org ]; then
         RHSM_ORG=$(cat /activation-key/org)
         RHSM_ACT_KEY=$(cat /activation-key/activationkey)
@@ -322,15 +322,15 @@ spec:
         ENTITLEMENT_CERT_PATH="$(grep -v -e '-key.pem$' <<< "$entitlement_files")"
         CA_BUNDLE_PATH="/etc/rhsm/ca/redhat-uep.pem"
 
-        CACHI2_SSL_OPTS="$(jq -n \
+        PREFETCH_SSL_OPTS="$(jq -n \
                               --arg key "$ENTITLEMENT_CERT_KEY_PATH" \
                               --arg cert "$ENTITLEMENT_CERT_PATH" \
                               --arg ca_bundle "$CA_BUNDLE_PATH" \
                               '{client_key: $key, client_cert: $cert, ca_bundle: $ca_bundle}'
                           )"
 
-        # We need to modify the cachi2 params in place if we're processing RPMs
-        INPUT=$(inject_ssl_opts "$INPUT" "$CACHI2_SSL_OPTS")
+        # We need to modify the CLI params in place if we're processing RPMs
+        INPUT=$(inject_ssl_opts "$INPUT" "$PREFETCH_SSL_OPTS")
       fi
 
       INPUT=$(inject_rpm_summary_flag "$INPUT")
@@ -366,17 +366,17 @@ spec:
 
   workspaces:
   - name: source
-    description: Workspace with the source code, cachi2 artifacts will be stored on the workspace as well
+    description: Workspace with the source code, prefetch artifacts will be stored on the workspace as well
   - name: git-basic-auth
     description: |
       A Workspace containing a .gitconfig and .git-credentials file or username and password.
-      These will be copied to the user's home before any cachi2 commands are run. Any
+      These will be copied to the user's home before prefetch is run. Any
       other files in this Workspace are ignored. It is strongly recommended
       to bind a Secret to this Workspace over other volume types.
     optional: true
   - name: netrc
     description: |
-      Workspace containing a .netrc file. Cachi2 will use the credentials in this file when
+      Workspace containing a .netrc file. Prefetch will use the credentials in this file when
       performing http(s) requests.
     optional: true
   volumes:

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -172,11 +172,11 @@ spec:
           UNSHARE_ARGS+=("--net")
         fi
 
-        HERMETO_MOUNT=""
-        HERMETO_SOURCE=""
+        PREFETCH_MOUNT=""
+        PREFETCH_SOURCE=""
         if [ -d "/var/workdir/cachi2" ]; then
-          HERMETO_MOUNT="--volume /var/workdir/cachi2:/cachi2"
-          HERMETO_SOURCE=". /cachi2/cachi2.env &&"
+          PREFETCH_MOUNT="--volume /var/workdir/cachi2:/cachi2"
+          PREFETCH_SOURCE=". /cachi2/cachi2.env &&"
         fi
 
         # Create the script file
@@ -185,7 +185,7 @@ spec:
 
         mkdir /var/workdir/output
         buildah from --name script-container "$SCRIPT_RUNNER_IMAGE"
-        BUILDAH_CMD="buildah run ${HERMETO_MOUNT} --volume /tmp/script.sh:/tmp/script.sh --volume /var/workdir/source:/var/workdir/source --volume /var/workdir/output:/var/workdir/output --workingdir ${SCRIPT_WORKDIR} --user root:root -- script-container /bin/sh -c '${HERMETO_SOURCE} SCRIPT_OUTPUT=/var/workdir/output/output SCRIPT_OUTPUT_ARRAY=/var/workdir/output/array exec /tmp/script.sh'"
+        BUILDAH_CMD="buildah run ${PREFETCH_MOUNT} --volume /tmp/script.sh:/tmp/script.sh --volume /var/workdir/source:/var/workdir/source --volume /var/workdir/output:/var/workdir/output --workingdir ${SCRIPT_WORKDIR} --user root:root -- script-container /bin/sh -c '${PREFETCH_SOURCE} SCRIPT_OUTPUT=/var/workdir/output/output SCRIPT_OUTPUT_ARRAY=/var/workdir/output/array exec /tmp/script.sh'"
         unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w /var/workdir sh -c "${BUILDAH_CMD}"
 
         IMAGE_REFERENCE=$(buildah inspect script-container | jq -r '.FromImage')

--- a/task/sast-coverity-check-oci-ta/0.3/recipe.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/recipe.yaml
@@ -4,7 +4,7 @@ removeParams:
   - BUILDER_IMAGE
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 removeWorkspaces:
   - source
 replacements:

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -977,10 +977,10 @@ spec:
 
         echo "[$(date --utc -Ins)] Add metadata"
 
-        # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
+        # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
         if [ -f "/tmp/cachi2/output/bom.json" ]; then
-          echo "Making copy of sbom-prefetch.json"
-          cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
+          echo "Making copy of sbom-cachi2.json"
+          cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
         fi
 
         touch /shared/base_images_digests

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -977,10 +977,10 @@ spec:
 
         echo "[$(date --utc -Ins)] Add metadata"
 
-        # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+        # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
         if [ -f "/tmp/cachi2/output/bom.json" ]; then
-          echo "Making copy of sbom-cachi2.json"
-          cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+          echo "Making copy of sbom-prefetch.json"
+          cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
         fi
 
         touch /shared/base_images_digests

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -892,10 +892,10 @@ spec:
 
       echo "[$(date --utc -Ins)] Add metadata"
 
-      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
+      # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        echo "Making copy of sbom-cachi2.json"
-        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
+        echo "Making copy of sbom-prefetch.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
       fi
 
       touch /shared/base_images_digests

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -892,10 +892,10 @@ spec:
 
       echo "[$(date --utc -Ins)] Add metadata"
 
-      # Save the SBOM produced in prefetch so it can be merged into the final SBOM later
+      # Save the SBOM produced by Cachi2 so it can be merged into the final SBOM later
       if [ -f "/tmp/cachi2/output/bom.json" ]; then
-        echo "Making copy of sbom-prefetch.json"
-        cp /tmp/cachi2/output/bom.json ./sbom-prefetch.json
+        echo "Making copy of sbom-cachi2.json"
+        cp /tmp/cachi2/output/bom.json ./sbom-cachi2.json
       fi
 
       touch /shared/base_images_digests

--- a/task/sast-shell-check-oci-ta/0.1/recipe.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/recipe.yaml
@@ -2,7 +2,7 @@
 base: ../../sast-shell-check/0.1/sast-shell-check.yaml
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 preferStepTemplate: true
 removeWorkspaces:
   - workspace

--- a/task/sast-snyk-check-oci-ta/0.4/recipe.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/recipe.yaml
@@ -2,7 +2,7 @@
 base: ../../sast-snyk-check/0.4/sast-snyk-check.yaml
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 preferStepTemplate: true
 removeWorkspaces:
   - workspace

--- a/task/sast-unicode-check-oci-ta/0.2/recipe.yaml
+++ b/task/sast-unicode-check-oci-ta/0.2/recipe.yaml
@@ -2,7 +2,7 @@
 base: ../../sast-unicode-check/0.2/sast-unicode-check.yaml
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 preferStepTemplate: true
 removeWorkspaces:
   - workspace

--- a/task/sast-unicode-check-oci-ta/0.3/recipe.yaml
+++ b/task/sast-unicode-check-oci-ta/0.3/recipe.yaml
@@ -2,7 +2,7 @@
 base: ../../sast-unicode-check/0.3/sast-unicode-check.yaml
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 preferStepTemplate: true
 removeWorkspaces:
   - workspace

--- a/task/source-build-oci-ta/0.3/recipe.yaml
+++ b/task/source-build-oci-ta/0.3/recipe.yaml
@@ -2,7 +2,7 @@
 base: ../../source-build/0.3/source-build.yaml
 add:
   - use-source
-  - use-cachi2
+  - use-prefetch
 removeWorkspaces:
   - workspace
 removeVolumes:

--- a/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
@@ -216,7 +216,7 @@ spec:
           --source-dir "$SOURCE_DIR"
           --base-images "$base_images"
           --write-result-to "$RESULT_FILE"
-          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR"
+          --prefetch-artifacts-dir "$CACHI2_ARTIFACTS_DIR"
           --registry-allowlist="$registry_allowlist"
         )
         if [ "$IGNORE_UNSIGNED_IMAGE" == "true" ]; then

--- a/task/source-build/0.3/source-build.yaml
+++ b/task/source-build/0.3/source-build.yaml
@@ -219,7 +219,7 @@ spec:
           --source-dir "$SOURCE_DIR"
           --base-images "$base_images"
           --write-result-to "$RESULT_FILE"
-          --cachi2-artifacts-dir "$CACHI2_ARTIFACTS_DIR"
+          --prefetch-artifacts-dir "$CACHI2_ARTIFACTS_DIR"
           --registry-allowlist="$registry_allowlist"
         )
         if [ "$IGNORE_UNSIGNED_IMAGE" == "true" ]; then


### PR DESCRIPTION
This an initial RFC for the cachi2 -> hermeto rebranding work. The prefetching tool, formerly known as cachi2, rebranded in upstream a couple of months ago to Hermeto and to ensure backwards compatibility with existing deployments and Conforma, it maintains a legacy CLI entrypoint called cachi2. The time has come and we should rename cachi2 to hermeto in Konflux tasks as well. See individual commits for the exact details.

Note that there's going to be at least 1 known CI failure with this PR since the circular dependency that exists between this repo and https://github.com/konflux-ci/build-tasks-dockerfiles.

**Depends on:**  https://github.com/konflux-ci/build-definitions/pull/2344, https://github.com/konflux-ci/build-tasks-dockerfiles/pull/298