### PR TITLE
feat(ISV-5862): Generate OCI copy SBOMs using Mobster

### DIFF
--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -301,7 +301,7 @@ spec:
           add:
             - SETFCAP
     - name: sbom-generate
-      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+      image: quay.io/konflux-ci/mobster@sha256:1b53ca81dc7427e6362b311180532cfbc431f83fa11e7e1154df1c26e3a46a0b
       workingDir: /var/workdir
       script: |
         #!/bin/bash
@@ -309,19 +309,15 @@ spec:
 
         IMAGE_URL=$(cat "$(results.IMAGE_URL.path)")
         IMAGE_DIGEST=$(cat "$(results.IMAGE_DIGEST.path)")
-        oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
+        OCI_COPY_FILE_PATH="$(pwd)/source/$OCI_COPY_FILE"
 
-        python3 /scripts/sbom_for_oci_copy_task.py "$oci_copy_file_path" \
-          --sbom-type "$SBOM_TYPE" \
-          -o sbom.json
-
-        python3 /scripts/add_image_reference.py \
-          --image-url "$IMAGE_URL" \
+        mobster generate \
+          --output sbom.json \
+          oci-artifact \
+          --oci-copy-yaml "$OCI_COPY_FILE_PATH" \
+          --image-pullspec "$IMAGE_URL" \
           --image-digest "$IMAGE_DIGEST" \
-          --input-file sbom.json \
-          --output-file /tmp/sbom.tmp.json
-
-        mv /tmp/sbom.tmp.json sbom.json
+          --sbom-type "$SBOM_TYPE"
     - name: upload-sbom
       image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df
       workingDir: /var/workdir

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -281,26 +281,23 @@ spec:
           name: varlibcontainers
       workingDir: $(workspaces.source.path)
     - name: sbom-generate
-      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1939901046f2ec0afda6d48f32dc82f991d9a4e2b4b4513635b9c79e3d4c2872
+      image: quay.io/konflux-ci/mobster@sha256:1b53ca81dc7427e6362b311180532cfbc431f83fa11e7e1154df1c26e3a46a0b
       script: |
         #!/bin/bash
         set -euo pipefail
 
         IMAGE_URL=$(cat "$(results.IMAGE_URL.path)")
         IMAGE_DIGEST=$(cat "$(results.IMAGE_DIGEST.path)")
-        oci_copy_file_path="$(pwd)/source/$OCI_COPY_FILE"
+        OCI_COPY_FILE_PATH="$(pwd)/source/$OCI_COPY_FILE"
 
-        python3 /scripts/sbom_for_oci_copy_task.py "$oci_copy_file_path" \
-          --sbom-type "$SBOM_TYPE" \
-          -o sbom.json
-
-        python3 /scripts/add_image_reference.py \
-          --image-url "$IMAGE_URL" \
+        mobster generate \
+          --output sbom.json \
+          oci-artifact \
+          --oci-copy-yaml "$OCI_COPY_FILE_PATH" \
+          --image-pullspec "$IMAGE_URL" \
           --image-digest "$IMAGE_DIGEST" \
-          --input-file sbom.json \
-          --output-file /tmp/sbom.tmp.json
+          --sbom-type "$SBOM_TYPE"
 
-        mv /tmp/sbom.tmp.json sbom.json
       workingDir: $(workspaces.source.path)
     - name: upload-sbom
       image: quay.io/konflux-ci/appstudio-utils:8f9f933d7b0b57e37b96fd34698c92c785cfeadc@sha256:924eb1680b6cda674e902579135a06b2c6683c3cc1082bbdc159a4ce5ea9f4df


### PR DESCRIPTION
The Mobster is a tool for generating SBOMs for Konflux content. The tool ported existing code and aligned it with the existing SBOM format standards.

In terms of SBOM content the output SBOMs still produces same data based on the provided oci-copy file in SPDX or CycloneDX format.

The Mobster code with a doc is available at:
https://github.com/konflux-ci/mobster/blob/main/docs/sboms/oci_image_sbom.md

JIRA: [ISV-5864](https://issues.redhat.com//browse/ISV-5864)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
