### PR TITLE
Extend conforma acceptable-bundles time period to 60 days

### DIFF
--- a/.tekton/scripts/build-acceptable-bundles.sh
+++ b/.tekton/scripts/build-acceptable-bundles.sh
@@ -55,6 +55,7 @@ mapfile -t -d ' ' BUNDLES_PARAM < <(printf -- '--bundle=%s ' "${BUNDLES[@]}")
 PARAMS=("${TASK_PARAM[@]}" "${BUNDLES_PARAM[@]}")
 
 ec track bundle --debug \
+    --in-effect-days 60 \
     --input "oci:${DATA_BUNDLE_REPO}:latest" \
     --output "oci:${DATA_BUNDLE_REPO}:${DATA_BUNDLE_TAG}" \
     --timeout "15m0s" \

--- a/hack/trusted-tasks-update.sh
+++ b/hack/trusted-tasks-update.sh
@@ -101,6 +101,7 @@ PS4=''
 set -x
 ec track bundle \
   --freshen \
+  --in-effect-days 60 \
   --input "oci:${INPUT_IMAGE}" \
   --output "oci:${OUTPUT_IMAGE}" \
   "${git_params[@]}" \


### PR DESCRIPTION
The default is 30.

In practice, I find that 30 days is too short. For various complicated reasons, some of our users find themselves ready to release one day, only to find that their build suddenly fails policy the next day.

Doubling the period like this should help take the pressure off.
