### PR TITLE
docker-build: add dev-package-manager globally

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -12,6 +12,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
+|dev-package-managers| Enable in-development package managers| false| prefetch-dependencies:0.2:dev-package-managers|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.4:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
@@ -159,7 +160,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
-|dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
+|dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| '$(params.dev-package-managers)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -83,6 +83,10 @@ spec:
       VMs
     name: privileged-nested
     type: string
+  - default: "false"
+    description: Enable in-development package managers
+    name: dev-package-managers
+    type: string
   - default:
     - linux/x86_64
     description: List of platforms to build the container images on. The available
@@ -143,6 +147,8 @@ spec:
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
+    - name: dev-package-managers
+      value: $(params.dev-package-managers)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -11,6 +11,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.3:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
+|dev-package-managers| Enable in-development package managers| false| prefetch-dependencies:0.2:dev-package-managers|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
@@ -156,7 +157,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to cachi2. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | | |
-|dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| |
+|dev-package-managers| Enable in-development package managers. WARNING: the behavior may change at any time without notice. Use at your own risk. | false| '$(params.dev-package-managers)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set cachi2 log level (debug, info, warning, error)| info| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| | '$(params.image-expires-after)'|

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -83,6 +83,10 @@ spec:
       VMs
     name: privileged-nested
     type: string
+  - default: "false"
+    description: Enable in-development package managers
+    name: dev-package-managers
+    type: string
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -137,6 +141,8 @@ spec:
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
+    - name: dev-package-managers
+      value: $(params.dev-package-managers)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/docker-build-oci-ta/patch.yaml
+++ b/pipelines/docker-build-oci-ta/patch.yaml
@@ -15,6 +15,15 @@
     "pipelines.openshift.io/used-by": "build-cloud"
     "pipelines.openshift.io/runtime": "generic"
     "pipelines.openshift.io/strategy": "docker"
+
+- op: add
+  path: /spec/params/-
+  value:
+    name: dev-package-managers
+    description: Enable in-development package managers
+    type: string
+    default: "false"
+
 - op: remove
   path: /spec/workspaces/0
 # Order of Tasks from the base docker-build Pipeline:
@@ -73,6 +82,11 @@
   value:
     name: ociArtifactExpiresAfter
     value: $(params.image-expires-after)
+- op: add
+  path: /spec/tasks/2/params/-
+  value:
+    name: dev-package-managers
+    value: $(params.dev-package-managers)
 - op: remove
   path: /spec/tasks/2/workspaces/0
 

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -32,7 +32,10 @@
 #     12  build-args
 #     13  build-args-file
 #     14  privileged-nested
-#     15  build-platforms
+#     15  dev-package-managers
+#     16  build-platforms
+- op: remove
+  path: /spec/params/15
 - op: remove
   path: /spec/params/14
 - op: replace
@@ -100,6 +103,8 @@
   path: /spec/tasks/5  # build-source-image
 - op: remove           # build-images -> PRIVILEGED_NESTED
   path: /spec/tasks/3/params/9
+- op: remove           # prefetch-dependencies -> dev-package-managers
+  path: /spec/tasks/2/params/4
 - op: add
   path: /spec/tasks/-
   value:


### PR DESCRIPTION
We add the `dev-package-manager` parameter as 'global' parameter in order to be able to customize the `docker-build` (and `-multi-platform`) pipeline when pulling it with `pipelineRef` and bundle.

This change should not break backward compatibility as it's still setting an env var with same default value.