### PR TITLE
Update Conforma policy git urls

### DIFF
--- a/policies/step-actions.yaml
+++ b/policies/step-actions.yaml
@@ -2,8 +2,8 @@
 # These policies are meant to be applied to all of the Tasks in this repo.
 sources:
   - policy:
-      - github.com/enterprise-contract/ec-policies//policy/lib
-      - github.com/enterprise-contract/ec-policies//policy/stepaction
+      - github.com/conforma/policy//policy/lib
+      - github.com/conforma/policy//policy/stepaction
     data:
       - oci::quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles:latest
       - github.com/release-engineering/rhtap-ec-policy//data

--- a/task/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+++ b/task/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
@@ -2,10 +2,10 @@
 # IMPORTANT: This Task definition exists in this repository as a means to facilitate integration
 # with RHTAP. It is NOT meant to be used in Konflux. If you are debugging EC failures in Konflux,
 # this is NOT the file you are looking for. Do NOT directly modify this file. Any change should
-# first be done in the https://github.com/enterprise-contract/ec-cli repository then synced to this
+# first be done in the https://github.com/conforma/cli repository then synced to this
 # repository. Any pull request that modifies anything other than this comment in this file and is
 # not a sync from the ec-cli repository will be immediately closed. See
-# https://github.com/enterprise-contract/ec-cli/blob/main/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
+# https://github.com/conforma/cli/blob/main/tasks/verify-enterprise-contract/0.1/verify-enterprise-contract.yaml
 apiVersion: tekton.dev/v1
 kind: Task
 metadata:


### PR DESCRIPTION
Conforma policies were moved to a new location, so let's update the urls accordlingly.

Ref: https://issues.redhat.com/browse/EC-1113
