### PR TITLE
buildah-remote-oci-ta: pass a HERMETIC build-arg

### DIFF
--- a/task/buildah-remote-oci-ta/0.4/README.md
+++ b/task/buildah-remote-oci-ta/0.4/README.md
@@ -2,7 +2,8 @@
 
 Buildah task builds source code into a container image and pushes the image into container registry using buildah tool.
 In addition, it generates a SBOM file, injects the SBOM file into final container image and pushes the SBOM file as separate image using cosign tool.
-When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment.
+When prefetch-dependencies task is activated it is using its artifacts to run build in hermetic environment, passing a HERMETIC=true build-arg to the
+container build.
 
 ## Parameters
 |name|description|default value|required|

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -468,6 +468,10 @@ spec:
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
+      if [ "${HERMETIC}" == "true" ]; then
+        BUILD_ARG_FLAGS+=("--build-arg=HERMETIC=true")
+      fi
+
       dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
       BASE_IMAGES=$(
         jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |


### PR DESCRIPTION
Being aware in the Container build that the hermetic mode is active is useful in some scenarios when we try to use already existing resources that point to remotes.

For ex in rpm-ostree the repo files are defined alongside the manifests and rpm-ostree use those to compose the rootfs. Having the HERMETIC value set here allow to fetch the repo files made available by hermeto under /etc/yum.repos.d instead.


