### PR TITLE
New task: run-opm-command-oci-ta

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -55,6 +55,7 @@
 /task/fbc-fips-check                            @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/fbc-fips-check-oci-ta                     @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/fbc-target-index-pruning-check            @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
+/task/run-opm-command-oci-ta                    @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/sbom-json-check                           @konflux-ci/integration-service-maintainers @Allda @jedinym
 /task/validate-fbc                              @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/fips-operator-bundle-check                @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -129,18 +129,37 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
+  - name: run-opm-command
+    params:
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).opm
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    - name: OPM_ARGS
+      value: []
+    - name: OPM_OUTPUT_PATH
+      value: ""
+    - name: IDMS_PATH
+      value: ""
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: run-opm-command-oci-ta
+      version: "0.1"
   - name: prefetch-dependencies
     params:
     - name: input
       value: $(params.prefetch-input)
     - name: SOURCE_ARTIFACT
-      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      value: $(tasks.run-opm-command.results.SOURCE_ARTIFACT)
     - name: ociStorage
       value: $(params.output-image).prefetch
     - name: ociArtifactExpiresAfter
       value: $(params.image-expires-after)
     runAfter:
-    - clone-repository
+    - run-opm-command
     taskRef:
       name: prefetch-dependencies-oci-ta
       version: "0.2"

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -38,28 +38,36 @@
 - op: replace
   path: /spec/params/7/default
   value: "true"
-# Remove tasks
-# $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.[].name" | nl -v 0
-#      0  init
-#      1  clone-repository
-#      2  prefetch-dependencies
-#      3  build-images
-#      4  build-image-index
-#      5  build-source-image
-#      6  deprecated-base-image-check
-#      7  clair-scan
-#      8  ecosystem-cert-preflight-checks
-#      9  sast-snyk-check
-#     10  clamav-scan
-#     11  sast-coverity-check
-#     12  coverity-availability-check
-#     13  sast-shell-check
-#     14  sast-unicode-check
-#     15  apply-tags
-#     16  push-dockerfile
-#     17  rpms-signature-scan
+- op: add
+  path: /spec/tasks/2
+  value:
+    name: run-opm-command
+    runAfter:
+      - clone-repository
+    taskRef:
+      name: run-opm-command-oci-ta
+      version: "0.1"
+    params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).opm
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: OPM_ARGS
+        value: []
+      - name: OPM_OUTPUT_PATH
+        value: ""
+      - name: IDMS_PATH
+        value: ""
 - op: replace
   path: /spec/tasks/3/runAfter/0
+  value: run-opm-command
+- op: replace
+  path: /spec/tasks/3/params/1/value
+  value: $(tasks.run-opm-command.results.SOURCE_ARTIFACT)
+- op: replace
+  path: /spec/tasks/4/runAfter/0
   value: clone-repository
 # Remove params
 # $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.3.params.[].name" | nl -v 0
@@ -77,29 +85,29 @@
 #     11	CACHI2_ARTIFACT
 #     12	IMAGE_APPEND_PLATFORM
 - op: remove
-  path: /spec/tasks/17  # rpms-signature-scan
+  path: /spec/tasks/4/params/9
 - op: remove
-  path: /spec/tasks/16  # push-dockerfile
+  path: /spec/tasks/18  # rpms-signature-scan
 - op: remove
-  path: /spec/tasks/14  # sast-unicode-scan
+  path: /spec/tasks/17  # push-dockerfile
 - op: remove
-  path: /spec/tasks/13  # sast-shell-scan
+  path: /spec/tasks/15  # sast-unicode-scan
 - op: remove
-  path: /spec/tasks/12  # coverity-availability-check
+  path: /spec/tasks/14  # sast-shell-scan
 - op: remove
-  path: /spec/tasks/11  # sast-coverity-check
+  path: /spec/tasks/13  # coverity-availability-check
 - op: remove
-  path: /spec/tasks/10  # clamav-scan
+  path: /spec/tasks/12  # sast-coverity-check
 - op: remove
-  path: /spec/tasks/9  # sast-snyk-check
+  path: /spec/tasks/11  # clamav-scan
 - op: remove
-  path: /spec/tasks/8  # ecosystem-cert-preflight-checks
+  path: /spec/tasks/10  # sast-snyk-check
 - op: remove
-  path: /spec/tasks/7  # clair-scan
+  path: /spec/tasks/9  # ecosystem-cert-preflight-checks
 - op: remove
-  path: /spec/tasks/5  # build-source-image
-- op: remove           # build-images -> PRIVILEGED_NESTED
-  path: /spec/tasks/3/params/9
+  path: /spec/tasks/8  # clair-scan
+- op: remove
+  path: /spec/tasks/6  # build-source-image
 - op: add
   path: /spec/tasks/-
   value:

--- a/renovate.json
+++ b/renovate.json
@@ -98,6 +98,7 @@
         "task/fbc-target-index-pruning-check/**",
         "task/fips-operator-bundle-check-oci-ta/**",
         "task/fips-operator-bundle-check/**",
+        "task/run-opm-command-oci-ta/**",
         "task/sast-coverity-check-oci-ta/**",
         "task/sast-coverity-check/**",
         "task/sast-shell-check-oci-ta/**",

--- a/task/run-opm-command-oci-ta/0.1/README.md
+++ b/task/run-opm-command-oci-ta/0.1/README.md
@@ -1,0 +1,46 @@
+# run-opm-command-oci-ta task
+
+This Task allows you to execute `opm` (Operator Package Manager) commands 
+within a Tekton Pipeline. It's designed to work with **Trusted Artifacts** 
+and helps in automating the process of generating and validating OPM-related outputs, such as file-based catalogs.
+
+---
+
+## Table of Contents
+
+* [Overview](#overview)
+* [Parameters](#parameters)
+* [Results](#results)
+
+---
+
+## Overview
+
+The `run-opm-command-oci-ta` Task performs the following key steps:
+
+1.  **Retrieves Source Artifacts**: Downloads your application's source code, which should contain any necessary `opm` inputs (e.g., catalog templates).
+2.  **Executes OPM Command**: Runs the `opm` command with user-defined arguments and redirects the output to a specified file within the source directory. This step is configured to fail if the output path is not provided or is absolute.
+3.  **Applies ImageDigestMirrorSet (Optional)**: If an `ImageDigestMirrorSet` (IDMS) file is provided, this step replaces image pull specifications in the generated OPM output (e.g., in a catalog) based on the mirror definitions in the IDMS file. This is crucial for environments where images need to be pulled from internal registries.
+4.  **Validates Catalog**: Runs `opm validate` on the generated output to ensure its correctness.
+5.  **Creates Trusted Artifact**: Uploads the modified source directory (including the `opm` command's output) as a new Trusted Artifact.
+
+---
+
+## Parameters
+
+| Parameter           | Description                                                                                                                                                       | Type    | Required | Default               |
+| :------------------ |:------------------------------------------------------------------------------------------------------------------------------------------------------------------| :------ | :------- | :-------------------- |
+| `SOURCE_ARTIFACT`   | The Trusted Artifact URI pointing to the artifact with the application source code.                                                                               | `string`| Yes      |                       |
+| `ociStorage`        | The OCI repository where the Trusted Artifacts are stored.                                                                                                        | `string`| Yes      |                       |
+| `OPM_ARGS`          | An array of arguments to pass directly to the `opm` command (e.g., `['alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']`).                       | `array` | Yes      |                       |
+| `OPM_OUTPUT_PATH`   | The relative path for the `opm` command's output file (e.g., `'v4.18/catalog/example-operator/catalog.json'`). Relative to the root directory of the source code. | `string`| Yes      |                       |
+| `IDMS_PATH`         | Path to an `ImageDigestMirrorSet` file (e.g., `.tekton/images-mirror-set.yaml`). Used to replace related image pullspecs in the catalog.                          | `string`| No       | `""` (empty string) |
+
+---
+
+## Results
+
+| Result            | Description                                                                                                 |
+| :---------------- | :---------------------------------------------------------------------------------------------------------- |
+| `SOURCE_ARTIFACT` | The Trusted Artifact URI pointing to the artifact with the application source code, now including the generated file-based catalog. |
+

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -1,0 +1,221 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: run-opm-command-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: This task runs an OPM command with user-specified arguments, passed as an array.
+  params:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      type: string
+      description: >-
+        Expiration date for the trusted artifacts created in the OCI repository. An empty string means
+        the artifacts do not expire.
+    - name: OPM_ARGS
+      description: The array of arguments to pass to the 'opm' command
+        (e.g., [ 'alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']).
+      type: array
+    - name: OPM_OUTPUT_PATH
+      description: Relative path for the opm command's output file (e.g. 'v4.18/catalog/example-operator/catalog.json').
+        Relative to the root directory of given source code (Git repository).
+      type: string
+    - name: IDMS_PATH
+      description: Optional, path for ImageDigestMirrorSet file. It defaults to .tekton/images-mirror-set.yaml`
+      type: string
+      default: ".tekton/images-mirror-set.yaml"
+  results:
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code with generated file-based catalog from catalog-template.yml.
+  volumes:
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: check-and-skip-if-needed
+      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+      results:
+        - name: valid_params
+          description: True or False depending if all required parameters were set.
+      env:
+        - name: OPM_OUTPUT_PATH_PARAM
+          value: $(params.OPM_OUTPUT_PATH)
+        - name: SOURCE_ARTIFACT_PARAM
+          value: $(params.SOURCE_ARTIFACT)
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          #!/bin/bash
+          # shellcheck source=/dev/null
+          set -e
+
+          if [[ $# -eq 0 || -z "${OPM_OUTPUT_PATH_PARAM}" ]]; then
+            if [[ $# -eq 0 ]]; then
+              echo "Parameter 'OPM_ARGS' is empty. Skipping OPM execution."
+            else
+              echo "Parameter 'OPM_OUTPUT_PATH' is empty. Skipping OPM execution."
+            fi
+
+            echo "Returning SOURCE_ARTIFACT from previous task."
+            echo -n "${SOURCE_ARTIFACT_PARAM}" | tee "$(results.SOURCE_ARTIFACT.path)"
+
+            echo -n "false" > "$(step.results.valid_params.path)"
+            exit 0
+          fi
+
+          echo -n "true" > "$(step.results.valid_params.path)"
+        - "bash"
+        - $(params.OPM_ARGS[*])
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:635a890e9f0211b4eb5b8c811d6f06b3ed9ff7da952ebad236fbfe52ba36dbf7
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      when:
+        - input: "$(steps.check-and-skip-if-needed.results.valid_params)"
+          operator: in
+          values: ["true"]
+    - name: run-opm-with-user-args
+      image: quay.io/konflux-ci/operator-sdk-builder:latest@sha256:e7cfe742ef5be036478408e98094f49109474418521970f739a6c1ff6faa4267
+      workingDir: /var/workdir/source
+      when:
+        - input: "$(steps.check-and-skip-if-needed.results.valid_params)"
+          operator: in
+          values: ["true"]
+      results:
+        - name: skip_replace
+          description: "True if the IDMS file does not exist, false otherwise."
+      env:
+        - name: OPM_OUTPUT_PATH_PARAM
+          value: $(params.OPM_OUTPUT_PATH)
+        - name: IDMS_PATH_PARAM
+          value: $(params.IDMS_PATH)
+      securityContext:
+        runAsUser: 0
+      command:
+        - "/bin/bash"
+        - "-c"
+      args:
+        - |
+          #!/bin/bash
+          set -euo pipefail
+
+          echo "Running OPM command in working directory: $(pwd)"
+          printf "OPM Argument received: '%s'\n" "$@"
+
+          # Ensure OPM_OUTPUT_PATH_PARAM is provided
+          if [[ -z "${OPM_OUTPUT_PATH_PARAM}" ]]; then
+            echo "Error: OPM_OUTPUT_PATH is a mandatory parameter and cannot be empty."
+            exit 1
+          fi
+
+          # Validate that the path is not absolute
+          if [[ "${OPM_OUTPUT_PATH_PARAM}" == /* ]]; then
+            echo "Error: OPM_OUTPUT_PATH must be a relative path, but got '${OPM_OUTPUT_PATH_PARAM}'."
+            exit 1
+          fi
+
+          # Get the directory part of the path
+          OUTPUT_DIR=$(dirname "${OPM_OUTPUT_PATH_PARAM}")
+
+          # Create the directory if it's not the current directory '.'
+          if [[ "${OUTPUT_DIR}" != "." ]]; then
+            echo "Ensuring directory '${OUTPUT_DIR}' exists."
+            mkdir -p "${OUTPUT_DIR}"
+          fi
+
+          echo "Running OPM command and writing the output to file: $(pwd)/${OPM_OUTPUT_PATH_PARAM}"
+
+          # Execute the opm command and redirect its output
+          opm "$@" > "${OPM_OUTPUT_PATH_PARAM}"
+
+          echo "OPM command finished"
+
+          # Check for IDMS file existence
+          # this check need to be here since this is the first step with access to the source code
+          if [[ -n "${IDMS_PATH_PARAM}" && -f "${IDMS_PATH_PARAM}" ]]; then
+              echo -n "false" > "$(step.results.skip_replace.path)"
+          else
+              if [[ -n "${IDMS_PATH_PARAM}" ]]; then
+                echo "IDMS file '${IDMS_PATH_PARAM}' not found."
+              fi
+              echo "Step replace-related-images-pullspec-in-catalog will be skipped."
+
+              echo -n "true" > "$(step.results.skip_replace.path)"
+          fi
+        - "bash"
+        - $(params.OPM_ARGS[*])
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 1
+          memory: 4Gi
+    - name: replace-related-images-pullspec-in-catalog
+      image: quay.io/konflux-ci/konflux-test:v1.4.33@sha256:f1e256d52ec62f8927106659d65fc842e330d3cfed791775c1ef4fedf270dbc8
+      workingDir: /var/workdir/source
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: IDMS_PATH
+          value: $(params.IDMS_PATH)
+        - name: OPM_OUTPUT_PATH
+          value: $(params.OPM_OUTPUT_PATH)
+      when:
+        - input: "$(steps.run-opm-with-user-args.results.skip_replace)"
+          operator: in
+          values: ["false"]
+        - input: "$(steps.check-and-skip-if-needed.results.valid_params)"
+          operator: in
+          values: ["true"]
+        - input: "$(params.IDMS_PATH)"
+          operator: notin
+          values: ["", "null"]
+      script: |
+          #!/bin/bash
+          set -euo pipefail
+
+          # shellcheck source=/dev/null
+          source /utils.sh
+
+          replace_mirror_pullspec_with_source "${IDMS_PATH}" "${OPM_OUTPUT_PATH}"
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: 1
+          memory: 2Gi
+    - name: create-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:edd8e3affc389320b15b9de8a5aedbf7b0463211b77c981563a2cfa20076b0c0
+      env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.ociArtifactExpiresAfter)
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+      when:
+        - input: "$(steps.check-and-skip-if-needed.results.valid_params)"
+          operator: in
+          values: ["true"]
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi


### PR DESCRIPTION
Adding non mandatory task for running `opm` command which can be used to render catalog from catalog template. Pullspecs of related images can be replaced when ImageDigestMirrorSet file is provided. 

[KONFLUX-5311]
[CLOUDDST-26462]

