### PR TITLE
git-clone: Fix merge target branch workflow

### DIFF
--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -290,9 +290,8 @@ spec:
             echo "------------------"
             exit "${MERGE_CHECK_EXIT_CODE}"
           else
-            git diff --staged --quiet
-            GIT_DIFF_EXIT_CODE="$?"
-            if [ "${GIT_DIFF_EXIT_CODE}" = "0" ]; then
+            # Check if there are changes that need to be merged, and if so, create a merge commit.
+            if git diff --staged --quiet; then
               echo "No diff was found, skipping merge..." >&2
             else
               echo "Merge successful (no conflicts found), committing..."

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -282,9 +282,8 @@ spec:
           echo "------------------"
           exit "${MERGE_CHECK_EXIT_CODE}"
         else
-          git diff --staged --quiet
-          GIT_DIFF_EXIT_CODE="$?"
-          if [ "${GIT_DIFF_EXIT_CODE}" = "0" ]; then
+          # Check if there are changes that need to be merged, and if so, create a merge commit.
+          if git diff --staged --quiet; then
             echo "No diff was found, skipping merge..." >&2
           else
             echo "Merge successful (no conflicts found), committing..."

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -274,9 +274,8 @@ spec:
           echo "------------------"
           exit "${MERGE_CHECK_EXIT_CODE}"
         else
-          git diff --staged --quiet
-          GIT_DIFF_EXIT_CODE="$?"
-          if [ "${GIT_DIFF_EXIT_CODE}" = "0" ]; then
+          # Check if there are changes that need to be merged, and if so, create a merge commit.
+          if git diff --staged --quiet; then
             echo "No diff was found, skipping merge..." >&2
           else
             echo "Merge successful (no conflicts found), committing..."


### PR DESCRIPTION
When the user sets the mergeTargetBranch param to true, this task will fetch the branch and perform a git merge that ultimately skips the commit part. It also leaves any change that will be commited in Git's staging area.

A previous commit (3f84d17) included a check that would only apply a git merge command if any diff was found in the staging area. Unfortunately, the command used to check if there's any staged changes returns an exit code 1, which makes the whole task fail. This patch changes the way the check is made to avoid the issue.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
