### PR TITLE
sast-coverity: skip analysis on empty project dirs

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -415,6 +415,11 @@ spec:
           /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
             | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
             > "\${json_file}"
+        elif [ -z "\$(ls -A \${proj_dir})" ]; then
+          # empty project dir indicates that instrumented command didn't do anything worth analyzing
+          # so let's create an empty scan report to allow later coverity commands to succeed
+          json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+          echo '{}' | /usr/libexec/csgrep-static --mode=json > "\${json_file}"
         fi
 
         # propagate the original exit code of the wrapped command

--- a/task/sast-coverity-check/0.3/patch.yaml
+++ b/task/sast-coverity-check/0.3/patch.yaml
@@ -268,6 +268,11 @@
         /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
           | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
           > "\${json_file}"
+      elif [ -z "\$(ls -A \${proj_dir})" ]; then
+        # empty project dir indicates that instrumented command didn't do anything worth analyzing
+        # so let's create an empty scan report to allow later coverity commands to succeed
+        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+        echo '{}' | /usr/libexec/csgrep-static --mode=json > "\${json_file}"
       fi
 
       # propagate the original exit code of the wrapped command

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -352,6 +352,11 @@ spec:
         /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
           | /usr/libexec/csgrep-static --mode=json --embed-context=3 \
           > "\${json_file}"
+      elif [ -z "\$(ls -A \${proj_dir})" ]; then
+        # empty project dir indicates that instrumented command didn't do anything worth analyzing
+        # so let's create an empty scan report to allow later coverity commands to succeed
+        json_file="\$(mktemp /shared/sast-results/\$\$-XXXX.json)"
+        echo '{}' | /usr/libexec/csgrep-static --mode=json > "\${json_file}"
       fi
 
       # propagate the original exit code of the wrapped command


### PR DESCRIPTION
[PSSECAUT-1198](https://issues.redhat.com/browse/PSSECAUT-1198)

Not 100% sure on this change, though it is intended to help with container bundle builds. An empty scan report present in `/shared/sast-results` will prevent a later attempt to run `coverity capture` on the entire source code.

Tested privately here: 

https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/sfowler-tenant/pipelinerun/snr-bundle-0-9-on-pull-request-969pt
