### PR TITLE
Automerge GitHub Actions updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -131,12 +131,13 @@
     },
     {
       "groupName": "github-actions",
-      "matchFileNames": [
-        ".github/**"
+      "matchManagers": [
+        "github-actions"
       ],
       "schedule": [
         "on sunday"
-      ]
+      ],
+      "automerge": true
     },
     {
       "matchPackageNames": [


### PR DESCRIPTION
build-definitions receive a lot of Renovate pull requests which then need to be reviewed.
Automerging GitHub Actions updates is unlikely to cause issues.

Changed `matchFileNames` to `matchManagers` because the logic for matching GH Actions is more robust than matching based on filenames, but it shouldn't have a large effect