### PR TITLE
fix: update deprecated image to use new konflux-test version

### DIFF
--- a/task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -31,7 +31,7 @@ spec:
   steps:
     # Download Pyxis metadata about the image
     - name: query-pyxis
-      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      image: quay.io/konflux-ci/konflux-test:v1.4.30@sha256:e4f22a48ed1c029a3b43f81fb216b76fabb9fc5fba516f69c09553310e1bc170
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -31,7 +31,7 @@ spec:
   steps:
     # Download Pyxis metadata about the image
     - name: query-pyxis
-      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      image: quay.io/konflux-ci/konflux-test:v1.4.30@sha256:e4f22a48ed1c029a3b43f81fb216b76fabb9fc5fba516f69c09553310e1bc170
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -29,7 +29,7 @@ spec:
 
   steps:
     - name: check-images
-      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      image: quay.io/konflux-ci/konflux-test:v1.4.30@sha256:e4f22a48ed1c029a3b43f81fb216b76fabb9fc5fba516f69c09553310e1bc170
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -42,7 +42,7 @@ spec:
 
   steps:
     - name: check-images
-      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      image: quay.io/konflux-ci/konflux-test:v1.4.30@sha256:e4f22a48ed1c029a3b43f81fb216b76fabb9fc5fba516f69c09553310e1bc170
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -42,7 +42,7 @@ spec:
 
   steps:
     - name: check-images
-      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      image: quay.io/konflux-ci/konflux-test:v1.4.30@sha256:e4f22a48ed1c029a3b43f81fb216b76fabb9fc5fba516f69c09553310e1bc170
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:


### PR DESCRIPTION
This is to fix the issue with deprecated-image-check failing for the below error:
`"Unauthorized: access to the requested resource is not authorized" in latest deprecated-base-image-check`