### PR TITLE
sast-unicode: add 0.3 with required image-digest

### DIFF
--- a/task/sast-unicode-check-oci-ta/0.2/sast-unicode-check-oci-ta.yaml
+++ b/task/sast-unicode-check-oci-ta/0.2/sast-unicode-check-oci-ta.yaml
@@ -317,7 +317,7 @@ spec:
             continue
           fi
 
-          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+          if [ "${UPLOAD_FILE}" == "excluded-findings.json" ]; then
             MEDIA_TYPE=application/json
           else
             MEDIA_TYPE=application/sarif+json

--- a/task/sast-unicode-check-oci-ta/0.3/MIGRATION.md
+++ b/task/sast-unicode-check-oci-ta/0.3/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.2 to 0.3
+
+Version 0.2:
+
+- The `image-digest` parameter is now required and does not have a default value (previously `""`). Task runs without this parameter will fail.
+
+## Action from users
+
+- The `image-digest` parameter is required to be added to this task in the build pipeline.

--- a/task/sast-unicode-check-oci-ta/0.3/README.md
+++ b/task/sast-unicode-check-oci-ta/0.3/README.md
@@ -1,0 +1,24 @@
+# sast-unicode-check-oci-ta task
+
+Scans source code for non-printable unicode characters in all text files.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
+|FIND_UNICODE_CONTROL_ARGS|arguments for find-unicode-control command.|-p bidi -v -d -t|false|
+|FIND_UNICODE_CONTROL_GIT_URL|URL from repository to find unicode control.|https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58|false|
+|KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
+|PROJECT_NAME|Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.|""|false|
+|RECORD_EXCLUDED|Whether to record the excluded findings (defaults to false). If `true`, the excluded findings will be stored in `excluded-findings.json`. |false|false|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|image-digest|Image digest used for ORAS upload.||true|
+|image-url|Image URL used for ORAS upload.||true|
+
+## Results
+|name|description|
+|---|---|
+|TEST_OUTPUT|Tekton task test output.|
+

--- a/task/sast-unicode-check-oci-ta/0.3/migrations/0.3.sh
+++ b/task/sast-unicode-check-oci-ta/0.3/migrations/0.3.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+tasks_root=".spec.tasks[]"
+if yq -e ".spec.pipelineSpec.tasks" "$pipeline_file" &>/dev/null; then
+  tasks_root=".spec.pipelineSpec.tasks[]"
+fi
+
+# check if image-url and image-digest is missing for sast-unicode-check-oci-ta task and early exit
+if yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | has(.name == "image-url") && has(.name == "image-digest"' "$pipeline_file" &>/dev/null; then
+  echo "image-url and image-digest already set for sast-unicode-check-oci-ta"
+  exit 0
+fi
+
+# get image-url and image-digest value from other tasks
+if yq -e "$tasks_root"' | select(.name == "build-oci-artifact")' "$pipeline_file" &>/dev/null; then
+    image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+    image_digest_value="\$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
+elif yq -e "$tasks_root"' | select(.name == "build-image-index")' "$pipeline_file" &>/dev/null; then
+    image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+    image_digest_value="\$(tasks.build-image-index.results.IMAGE_DIGEST)"
+else
+    echo "Neither build-oci-artifact nor build-image-index tasks found. Can't get image-url and image-digest."
+    exit 0
+fi
+
+# add params to sast-unicode-check-oci-ta
+if ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | select(.name == "image-url")' "$pipeline_file" &>/dev/null; then
+  yq -e -i "($tasks_root | select(.name == \"sast-unicode-check-oci-ta\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+  echo "image-url added to sast-unicode-check-oci-ta"
+fi
+if ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | select(.name == "image-digest")' "$pipeline_file" &>/dev/null; then
+  yq -e -i "($tasks_root | select(.name == \"sast-unicode-check-oci-ta\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+  echo "image-digest added to sast-unicode-check-oci-ta"
+fi

--- a/task/sast-unicode-check-oci-ta/0.3/migrations/0.3.sh
+++ b/task/sast-unicode-check-oci-ta/0.3/migrations/0.3.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+# Based on task/sast-coverity-check/0.3/migrations/0.3.sh
+
 declare -r pipeline_file=${1:?missing pipeline file}
 
 tasks_root=".spec.tasks[]"
@@ -9,30 +11,36 @@ if yq -e ".spec.pipelineSpec.tasks" "$pipeline_file" &>/dev/null; then
   tasks_root=".spec.pipelineSpec.tasks[]"
 fi
 
-# check if image-url and image-digest is missing for sast-unicode-check-oci-ta task and early exit
-if yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | has(.name == "image-url") && has(.name == "image-digest"' "$pipeline_file" &>/dev/null; then
-  echo "image-url and image-digest already set for sast-unicode-check-oci-ta"
-  exit 0
-fi
-
-# get image-url and image-digest value from other tasks
-if yq -e "$tasks_root"' | select(.name == "build-oci-artifact")' "$pipeline_file" &>/dev/null; then
-    image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+# Determine the correct image-digest and image-url values based on task presence
+if yq -e "$tasks_root"' | select(.name == "build-oci-artifact")' "$pipeline_file" >/dev/null; then
     image_digest_value="\$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
-elif yq -e "$tasks_root"' | select(.name == "build-image-index")' "$pipeline_file" &>/dev/null; then
     image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+elif yq -e "$tasks_root"' | select(.name == "build-image-index")' "$pipeline_file" >/dev/null; then
     image_digest_value="\$(tasks.build-image-index.results.IMAGE_DIGEST)"
+    image_url_value="\$(tasks.build-image-index.results.IMAGE_URL)"
 else
-    echo "Neither build-oci-artifact nor build-image-index tasks found. Can't get image-url and image-digest."
+    echo "Neither build-oci-artifact nor build-image-index tasks found."
     exit 0
 fi
 
-# add params to sast-unicode-check-oci-ta
-if ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | select(.name == "image-url")' "$pipeline_file" &>/dev/null; then
-  yq -e -i "($tasks_root | select(.name == \"sast-unicode-check-oci-ta\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
-  echo "image-url added to sast-unicode-check-oci-ta"
+# Check if image-digest parameter already exists using precise path
+if yq -e "$tasks_root"' | select(.name == "sast-unicode-check")' "$pipeline_file" >/dev/null && ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | select(.name == "image-digest")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-digest parameter to sast-unicode-check task"
+    yq -i "($tasks_root | select(.name == \"sast-unicode-check\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+elif yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta")' "$pipeline_file" >/dev/null && ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | select(.name == "image-digest")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-digest parameter to sast-unicode-check-oci-ta task"
+    yq -i "($tasks_root | select(.name == \"sast-unicode-check-oci-ta\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+else
+    echo "image-digest parameter already exists in sast-unicode-check(-oci-ta) task or task doesn't exist. No changes needed."
 fi
-if ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | select(.name == "image-digest")' "$pipeline_file" &>/dev/null; then
-  yq -e -i "($tasks_root | select(.name == \"sast-unicode-check-oci-ta\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
-  echo "image-digest added to sast-unicode-check-oci-ta"
+
+# Check if image-url parameter already exists using precise path
+if yq -e "$tasks_root"' | select(.name == "sast-unicode-check")' "$pipeline_file" >/dev/null && ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | select(.name == "image-url")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-url parameter to sast-unicode-check task"
+    yq -i "($tasks_root | select(.name == \"sast-unicode-check\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+elif yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta")' "$pipeline_file" >/dev/null && ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | select(.name == "image-url")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-url parameter to sast-unicode-check-oci-ta task"
+    yq -i "($tasks_root | select(.name == \"sast-unicode-check-oci-ta\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+else
+    echo "image-url parameter already exists in sast-unicode-check(-oci-ta) task or task doesn't exist. No changes needed."
 fi

--- a/task/sast-unicode-check-oci-ta/0.3/recipe.yaml
+++ b/task/sast-unicode-check-oci-ta/0.3/recipe.yaml
@@ -1,0 +1,13 @@
+---
+base: ../../sast-unicode-check/0.3/sast-unicode-check.yaml
+add:
+  - use-source
+  - use-cachi2
+preferStepTemplate: true
+removeWorkspaces:
+  - workspace
+replacements:
+  workspaces.workspace.path: /var/workdir
+regexReplacements:
+  hacbs/\$\(context.task.name\): source
+useTAVolumeMount: true

--- a/task/sast-unicode-check-oci-ta/0.3/sast-unicode-check-oci-ta.yaml
+++ b/task/sast-unicode-check-oci-ta/0.3/sast-unicode-check-oci-ta.yaml
@@ -1,0 +1,334 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: sast-unicode-check-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: konflux
+  labels:
+    app.kubernetes.io/version: "0.3"
+spec:
+  description: Scans source code for non-printable unicode characters in all
+    text files.
+  params:
+    - name: CACHI2_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the prefetched dependencies.
+      type: string
+      default: ""
+    - name: FIND_UNICODE_CONTROL_ARGS
+      description: arguments for find-unicode-control command.
+      type: string
+      default: -p bidi -v -d -t
+    - name: FIND_UNICODE_CONTROL_GIT_URL
+      description: URL from repository to find unicode control.
+      type: string
+      default: https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58
+    - name: KFP_GIT_URL
+      description: Known False Positives (KFP) git URL (optionally taking
+        a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+        the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        for internal Konflux instance and empty string for external Konflux
+        instance. If set to an empty string, the KFP filtering is disabled.
+      type: string
+      default: SITE_DEFAULT
+    - name: PROJECT_NAME
+      description: Name of the scanned project, used to find path exclusions.
+        By default, the Konflux component name will be used.
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      description: |
+        Whether to record the excluded findings (defaults to false).
+        If `true`, the excluded findings will be stored in `excluded-findings.json`.
+      type: string
+      default: "false"
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: image-digest
+      description: Image digest used for ORAS upload.
+      type: string
+    - name: image-url
+      description: Image URL used for ORAS upload.
+      type: string
+  results:
+    - name: TEST_OUTPUT
+      description: Tekton task test output.
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+    - name: sast-unicode-check
+      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      workingDir: /var/workdir/source
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: FIND_UNICODE_CONTROL_GIT_URL
+          value: $(params.FIND_UNICODE_CONTROL_GIT_URL)
+        - name: FIND_UNICODE_CONTROL_ARGS
+          value: $(params.FIND_UNICODE_CONTROL_ARGS)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: SOURCE_CODE_DIR
+          value: /var/workdir
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+        - name: BUILD_PLR_LOG_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+      script: |
+        #!/usr/bin/env bash
+        set -exuo pipefail
+
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        if [[ -z "${PROJECT_NAME}" ]]; then
+          PROJECT_NAME=${COMPONENT_LABEL}
+        fi
+
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        SCAN_PROP=""
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # Clone the source code from upstream repo
+        GIT_URL=$(echo "${FIND_UNICODE_CONTROL_GIT_URL}" | awk -F'#' '{print $1}')
+        REV=$(echo "${FIND_UNICODE_CONTROL_GIT_URL}" | awk -F'#' '{print $2}')
+
+        # Clone find-unicode-control repository
+        if ! git clone "${GIT_URL}" find-unicode-control; then
+          echo "Failed to clone the repository: ${GIT_URL}" >&2
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 1
+        fi
+
+        if [[ -n "${REV}" ]]; then
+          if ! git -C ./find-unicode-control/ checkout "${REV}"; then
+            echo "Failed to checkout the repository: ${GIT_URL} to ${REV}" >&2
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+          fi
+          SCAN_PROP="find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}"
+        else
+          git_url_suffix=$(git -C ./find-unicode-control/ rev-parse HEAD)
+          SCAN_PROP="find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}#${git_url_suffix}"
+        fi
+
+        # Find unicode control
+        FUC_EXIT_CODE=0
+
+        # shellcheck disable=SC2086
+        LANG=en_US.utf8 ./find-unicode-control/find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${SOURCE_CODE_DIR}/source" \
+          >raw_sast_unicode_check_out.txt \
+          2>raw_sast_unicode_check_out.log ||
+          FUC_EXIT_CODE=$?
+        if [[ "${FUC_EXIT_CODE}" -ne 0 ]] && [[ "${FUC_EXIT_CODE}" -ne 1 ]]; then
+          echo "Failed to run find-unicode-control command" >&2
+          cat raw_sast_unicode_check_out.log
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 1
+        fi
+
+        # Translate the output format
+        if ! sed -i raw_sast_unicode_check_out.txt -E -e 's|(.*:[0-9]+)(.*)|\1: warning:\2|' -e 's|^|Error: UNICONTROL_WARNING:\n|'; then
+          echo "Error: failed to translate the unicontrol output format" >&2
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 1
+        fi
+
+        # Process all results as configured with CSGERP_OPTS
+        CSGERP_OPTS=(
+          --mode=json
+          --remove-duplicates
+          --embed-context=3
+          --set-scan-prop="${SCAN_PROP}"
+          --strip-path-prefix="${SOURCE_CODE_DIR}"/source/
+        )
+        # In order to generate csdiff/v1, we need to add the whole path of the source code as
+        # sast-unicode-check only provides an URI to embed the context
+        if ! csgrep "${CSGERP_OPTS[@]}" raw_sast_unicode_check_out.txt >processed_sast_unicode_check_out.json 2>processed_sast_unicode_check_out.err; then
+          echo "Error occurred while running csgrep with CSGERP_OPTS:"
+          cat processed_sast_unicode_check_out.err
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+          echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+          exit 1
+        fi
+
+        csgrep --mode=evtstat processed_sast_unicode_check_out.json
+
+        if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+            KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
+            KFP_GIT_URL=
+          fi
+        fi
+
+        # Filter known false positives if KFP_GIT_URL is set
+        if [ -n "${KFP_GIT_URL}" ]; then
+          echo "Filtering false positives in results files using ${KFP_GIT_URL}..." >&2
+
+          # Build initial csfilter-kfp command
+          csfilter_kfp_cmd=(
+            csfilter-kfp
+            --verbose
+            --kfp-git-url="${KFP_GIT_URL}"
+          )
+
+          # Append --project-nvr option if PROJECT_NVR is set
+          if [[ -n "${PROJECT_NAME}" ]]; then
+            csfilter_kfp_cmd+=(--project-nvr="${PROJECT_NAME}")
+          fi
+
+          # Append --record-excluded option if RECORD_EXCLUDED is true
+          if [[ "${RECORD_EXCLUDED}" == "true" ]]; then
+            csfilter_kfp_cmd+=(--record-excluded="excluded-findings.json")
+          fi
+
+          if ! "${csfilter_kfp_cmd[@]}" processed_sast_unicode_check_out.json >sast_unicode_check_out.json 2>sast_unicode_check_out.error; then
+            echo "Failed to filter known false positives" >&2
+            cat sast_unicode_check_out.error
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+          fi
+        else
+          echo "KFP_GIT_URL is not set. Skipping false positive filtering." >&2
+          mv processed_sast_unicode_check_out.json sast_unicode_check_out.json
+        fi
+
+        # Generate sarif report
+        csgrep --mode=sarif sast_unicode_check_out.json >sast_unicode_check_out.sarif
+        if [[ "${FUC_EXIT_CODE}" -eq 0 ]]; then
+          note="Task $(context.task.name) success: No finding was detected"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        elif [[ "${FUC_EXIT_CODE}" -eq 1 ]] && [[ ! -s sast_unicode_check_out.sarif ]]; then
+          note="Task $(context.task.name) success: Some findings were detected, but filtered by known false positive"
+          ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        else
+          echo "sast-unicode-check test failed because of the following issues:"
+          cat sast_unicode_check_out.json
+          TEST_OUTPUT=
+          parse_test_output "$(context.task.name)" sarif sast_unicode_check_out.sarif || true
+          note="Task $(context.task.name) failed: For details, check Tekton task log."
+          ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        fi
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: 100m
+          memory: 4Gi
+    - name: upload
+      image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+      workingDir: /var/workdir/source
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      script: |
+        #!/usr/bin/env bash
+
+        if [ -z "${IMAGE_URL}" ]; then
+          echo 'No image-url param provided. Skipping upload.'
+          exit 0
+        fi
+
+        UPLOAD_FILES="sast_unicode_check_out.sarif excluded-findings.json"
+        for UPLOAD_FILE in ${UPLOAD_FILES}; do
+          if [ ! -f "${UPLOAD_FILE}" ]; then
+            echo "No ${UPLOAD_FILE} exists. Skipping upload."
+            continue
+          fi
+
+          if [ "${UPLOAD_FILE}" == "excluded-findings.json" ]; then
+            MEDIA_TYPE=application/json
+          else
+            MEDIA_TYPE=application/sarif+json
+          fi
+
+          echo "Selecting auth"
+          select-oci-auth "${IMAGE_URL}" >"${HOME}/auth.json"
+          echo "Attaching to ${IMAGE_URL}"
+          retry oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        done
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 100m
+          memory: 256Mi

--- a/task/sast-unicode-check/0.2/sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.2/sast-unicode-check.yaml
@@ -296,7 +296,7 @@ spec:
               continue
             fi
 
-            if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+            if [ "${UPLOAD_FILE}" == "excluded-findings.json" ]; then
                 MEDIA_TYPE=application/json
             else
                 MEDIA_TYPE=application/sarif+json

--- a/task/sast-unicode-check/0.3/MIGRATION.md
+++ b/task/sast-unicode-check/0.3/MIGRATION.md
@@ -1,0 +1,9 @@
+# Migration from 0.2 to 0.3
+
+Version 0.2:
+
+- The `image-digest` parameter is now required and does not have a default value (previously `""`). Task runs without this parameter will fail.
+
+## Action from users
+
+- The `image-digest` parameter is required to be added to this task in the build pipeline.

--- a/task/sast-unicode-check/0.3/README.md
+++ b/task/sast-unicode-check/0.3/README.md
@@ -1,0 +1,33 @@
+# sast-unicode-check task
+
+## Description:
+
+The sast-unicode-check task uses [find-unicode-control](https://github.com/siddhesh/find-unicode-control.git) tool to perform Static Application Security Testing (SAST) to look for non-printable unicode characters in all text files in a source tree.
+
+## Parameters:
+
+| name                         | description                                                                                                                                   | Default Value                                                                                   | Required |
+|------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------|----------|
+| FIND_UNICODE_CONTROL_GIT_URL | URL from repository to find unicode control.                                                                                                  | "https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58" | No       |
+| FIND_UNICODE_CONTROL_ARGS    | arguments for find-unicode-control command.                                                                                                   | "-p bidi -v -d -t"                                                                              | No       |
+| KFP_GIT_URL                  | Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
+| PROJECT_NAME                 | Name of the scanned project, used to find path exclusions. If set to an empty string, the Konflux component name will be used.                | ""                                                                                              | No       |
+| RECORD_EXCLUDED              | Whether to record the excluded findings (defaults to false). If `true`, the the excluded findings will be stored in `excluded-findings.json`. | "false"                                                                                         | No       |
+| image-url                    | Image URL used for ORAS upload.                                                                                                               |                                                                                                 | Yes      |
+| image-digest                 | Image digest used for ORAS upload.                                                                                                            |                                                                                                 | Yes      |
+
+For path exclusions defined in the known-false-positives (KFP) repo to be applied to scan results, the component name should match the respective directory in KFP. By default this is sourced from the `"appstudio.openshift.io/component"` label, but the `PROJECT_NAME` parameter can be used to override this.
+
+## Results:
+
+| name          | description                              |
+|---------------|------------------------------------------|
+| TEST_OUTPUT   | Tekton task test output.                 |
+
+## Source repository for image:
+
+<https://github.com/konflux-ci/konflux-test>
+
+## Additional links:
+
+* <https://github.com/siddhesh/find-unicode-control.git>

--- a/task/sast-unicode-check/0.3/migrations/0.3.sh
+++ b/task/sast-unicode-check/0.3/migrations/0.3.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+# Based on task/sast-coverity-check/0.3/migrations/0.3.sh
+
 declare -r pipeline_file=${1:?missing pipeline file}
 
 tasks_root=".spec.tasks[]"
@@ -9,30 +11,36 @@ if yq -e ".spec.pipelineSpec.tasks" "$pipeline_file" &>/dev/null; then
   tasks_root=".spec.pipelineSpec.tasks[]"
 fi
 
-# check if image-url and image-digest is missing for sast-unicode-check task and early exit
-if yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | has(.name == "image-url") && has(.name == "image-digest"' "$pipeline_file" &>/dev/null; then
-  echo "image-url and image-digest already set for sast-unicode-check"
-  exit 0
-fi
-
-# get image-url and image-digest value from other tasks
-if yq -e "$tasks_root"' | select(.name == "build-oci-artifact")' "$pipeline_file" &>/dev/null; then
-    image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+# Determine the correct image-digest and image-url values based on task presence
+if yq -e "$tasks_root"' | select(.name == "build-oci-artifact")' "$pipeline_file" >/dev/null; then
     image_digest_value="\$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
-elif yq -e "$tasks_root"' | select(.name == "build-image-index")' "$pipeline_file" &>/dev/null; then
     image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+elif yq -e "$tasks_root"' | select(.name == "build-image-index")' "$pipeline_file" >/dev/null; then
     image_digest_value="\$(tasks.build-image-index.results.IMAGE_DIGEST)"
+    image_url_value="\$(tasks.build-image-index.results.IMAGE_URL)"
 else
-    echo "Neither build-oci-artifact nor build-image-index tasks found. Can't get image-url and image-digest."
+    echo "Neither build-oci-artifact nor build-image-index tasks found."
     exit 0
 fi
 
-# add params to sast-unicode-check
-if ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | select(.name == "image-url")' "$pipeline_file" &>/dev/null; then
-  yq -e -i "($tasks_root | select(.name == \"sast-unicode-check\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
-  echo "image-url added to sast-unicode-check"
+# Check if image-digest parameter already exists using precise path
+if yq -e "$tasks_root"' | select(.name == "sast-unicode-check")' "$pipeline_file" >/dev/null && ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | select(.name == "image-digest")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-digest parameter to sast-unicode-check task"
+    yq -i "($tasks_root | select(.name == \"sast-unicode-check\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+elif yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta")' "$pipeline_file" >/dev/null && ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | select(.name == "image-digest")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-digest parameter to sast-unicode-check-oci-ta task"
+    yq -i "($tasks_root | select(.name == \"sast-unicode-check-oci-ta\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+else
+    echo "image-digest parameter already exists in sast-unicode-check(-oci-ta) task or task doesn't exist. No changes needed."
 fi
-if ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | select(.name == "image-digest")' "$pipeline_file" &>/dev/null; then
-  yq -e -i "($tasks_root | select(.name == \"sast-unicode-check\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
-  echo "image-digest added to sast-unicode-check"
+
+# Check if image-url parameter already exists using precise path
+if yq -e "$tasks_root"' | select(.name == "sast-unicode-check")' "$pipeline_file" >/dev/null && ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | select(.name == "image-url")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-url parameter to sast-unicode-check task"
+    yq -i "($tasks_root | select(.name == \"sast-unicode-check\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+elif yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta")' "$pipeline_file" >/dev/null && ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check-oci-ta").params[] | select(.name == "image-url")' "$pipeline_file" >/dev/null; then
+    echo "Adding image-url parameter to sast-unicode-check-oci-ta task"
+    yq -i "($tasks_root | select(.name == \"sast-unicode-check-oci-ta\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+else
+    echo "image-url parameter already exists in sast-unicode-check(-oci-ta) task or task doesn't exist. No changes needed."
 fi

--- a/task/sast-unicode-check/0.3/migrations/0.3.sh
+++ b/task/sast-unicode-check/0.3/migrations/0.3.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+tasks_root=".spec.tasks[]"
+if yq -e ".spec.pipelineSpec.tasks" "$pipeline_file" &>/dev/null; then
+  tasks_root=".spec.pipelineSpec.tasks[]"
+fi
+
+# check if image-url and image-digest is missing for sast-unicode-check task and early exit
+if yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | has(.name == "image-url") && has(.name == "image-digest"' "$pipeline_file" &>/dev/null; then
+  echo "image-url and image-digest already set for sast-unicode-check"
+  exit 0
+fi
+
+# get image-url and image-digest value from other tasks
+if yq -e "$tasks_root"' | select(.name == "build-oci-artifact")' "$pipeline_file" &>/dev/null; then
+    image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+    image_digest_value="\$(tasks.build-oci-artifact.results.IMAGE_DIGEST)"
+elif yq -e "$tasks_root"' | select(.name == "build-image-index")' "$pipeline_file" &>/dev/null; then
+    image_url_value="\$(tasks.build-oci-artifact.results.IMAGE_URL)"
+    image_digest_value="\$(tasks.build-image-index.results.IMAGE_DIGEST)"
+else
+    echo "Neither build-oci-artifact nor build-image-index tasks found. Can't get image-url and image-digest."
+    exit 0
+fi
+
+# add params to sast-unicode-check
+if ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | select(.name == "image-url")' "$pipeline_file" &>/dev/null; then
+  yq -e -i "($tasks_root | select(.name == \"sast-unicode-check\")).params += [{\"name\": \"image-url\", \"value\": \"$image_url_value\"}]" "$pipeline_file"
+  echo "image-url added to sast-unicode-check"
+fi
+if ! yq -e "$tasks_root"' | select(.name == "sast-unicode-check").params[] | select(.name == "image-digest")' "$pipeline_file" &>/dev/null; then
+  yq -e -i "($tasks_root | select(.name == \"sast-unicode-check\")).params += [{\"name\": \"image-digest\", \"value\": \"$image_digest_value\"}]" "$pipeline_file"
+  echo "image-digest added to sast-unicode-check"
+fi

--- a/task/sast-unicode-check/0.3/sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.3/sast-unicode-check.yaml
@@ -1,0 +1,309 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+  name: sast-unicode-check
+spec:
+  description: >-
+    Scans source code for non-printable unicode characters in all text files.
+  results:
+    - description: Tekton task test output.
+      name: TEST_OUTPUT
+  params:
+    - name: image-digest
+      description: Image digest used for ORAS upload.
+      type: string
+    - name: image-url
+      type: string
+      description: Image URL used for ORAS upload.
+    - name: FIND_UNICODE_CONTROL_GIT_URL
+      type: string
+      description: URL from repository to find unicode control.
+      default: "https://github.com/siddhesh/find-unicode-control.git#c2accbfbba7553a8bc1ebd97089ae08ad8347e58"
+    - name: FIND_UNICODE_CONTROL_ARGS
+      type: string
+      description: arguments for find-unicode-control command.
+      default: "-p bidi -v -d -t"
+    - name: KFP_GIT_URL
+      type: string
+      description: Known False Positives (KFP) git URL (optionally taking
+        a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
+        the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux
+        instance and empty string for external Konflux instance.
+        If set to an empty string, the KFP filtering is disabled.
+      default: "SITE_DEFAULT"
+    - name: PROJECT_NAME
+      description: Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.
+      type: string
+      default: ""
+    - name: RECORD_EXCLUDED
+      type: string
+      description: |
+        Whether to record the excluded findings (defaults to false).
+        If `true`, the excluded findings will be stored in `excluded-findings.json`.
+      default: "false"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+  steps:
+    - name: sast-unicode-check
+      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
+          cpu: 100m
+      # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+      # the cluster will set imagePullPolicy to IfNotPresent
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+      env:
+        - name: KFP_GIT_URL
+          value: $(params.KFP_GIT_URL)
+        - name: PROJECT_NAME
+          value: $(params.PROJECT_NAME)
+        - name: FIND_UNICODE_CONTROL_GIT_URL
+          value: $(params.FIND_UNICODE_CONTROL_GIT_URL)
+        - name: FIND_UNICODE_CONTROL_ARGS
+          value: $(params.FIND_UNICODE_CONTROL_ARGS)
+        - name: RECORD_EXCLUDED
+          value: $(params.RECORD_EXCLUDED)
+        - name: SOURCE_CODE_DIR
+          value: $(workspaces.workspace.path)
+        - name: COMPONENT_LABEL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['appstudio.openshift.io/component']
+        - name: BUILD_PLR_LOG_URL
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
+      script: |
+        #!/usr/bin/env bash
+        set -exuo pipefail
+
+        # shellcheck source=/dev/null
+        . /utils.sh
+        trap 'handle_error $(results.TEST_OUTPUT.path)' EXIT
+
+        if [[ -z "${PROJECT_NAME}" ]]; then
+            PROJECT_NAME=${COMPONENT_LABEL}
+        fi
+
+        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+
+        SCAN_PROP=""
+
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          update-ca-trust
+        fi
+
+        # Clone the source code from upstream repo
+        GIT_URL=$(echo "${FIND_UNICODE_CONTROL_GIT_URL}" | awk -F'#' '{print $1}')
+        REV=$(echo "${FIND_UNICODE_CONTROL_GIT_URL}" | awk -F'#' '{print $2}')
+
+        # Clone find-unicode-control repository
+        if ! git clone "${GIT_URL}" find-unicode-control; then
+            echo "Failed to clone the repository: ${GIT_URL}" >&2
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+        fi
+
+        if [[ -n "${REV}" ]]; then
+            if ! git -C ./find-unicode-control/ checkout "${REV}"; then
+                echo "Failed to checkout the repository: ${GIT_URL} to ${REV}" >&2
+                note="Task $(context.task.name) failed: For details, check Tekton task log."
+                ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+                echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+                exit 1
+            fi
+            SCAN_PROP="find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}"
+        else
+            git_url_suffix=$(git -C ./find-unicode-control/ rev-parse HEAD)
+            SCAN_PROP="find-unicode-control-git-url:${FIND_UNICODE_CONTROL_GIT_URL}#${git_url_suffix}"
+        fi
+
+        # Find unicode control
+        FUC_EXIT_CODE=0
+
+        # shellcheck disable=SC2086
+        LANG=en_US.utf8 ./find-unicode-control/find_unicode_control.py ${FIND_UNICODE_CONTROL_ARGS} "${SOURCE_CODE_DIR}/source" \
+            >raw_sast_unicode_check_out.txt \
+            2>raw_sast_unicode_check_out.log \
+            || FUC_EXIT_CODE=$?
+        if [[ "${FUC_EXIT_CODE}" -ne 0 ]] && [[ "${FUC_EXIT_CODE}" -ne 1 ]]; then
+            echo "Failed to run find-unicode-control command" >&2
+            cat raw_sast_unicode_check_out.log
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+        fi
+
+        # Translate the output format
+        if ! sed -i raw_sast_unicode_check_out.txt -E -e 's|(.*:[0-9]+)(.*)|\1: warning:\2|' -e 's|^|Error: UNICONTROL_WARNING:\n|'; then
+            echo "Error: failed to translate the unicontrol output format" >&2
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+        fi
+
+        # Process all results as configured with CSGERP_OPTS
+        CSGERP_OPTS=(
+            --mode=json
+            --remove-duplicates
+            --embed-context=3
+            --set-scan-prop="${SCAN_PROP}"
+            --strip-path-prefix="${SOURCE_CODE_DIR}"/source/
+        )
+        # In order to generate csdiff/v1, we need to add the whole path of the source code as
+        # sast-unicode-check only provides an URI to embed the context
+        if ! csgrep "${CSGERP_OPTS[@]}" raw_sast_unicode_check_out.txt > processed_sast_unicode_check_out.json 2> processed_sast_unicode_check_out.err; then
+            echo "Error occurred while running csgrep with CSGERP_OPTS:"
+            cat processed_sast_unicode_check_out.err
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+            exit 1
+        fi
+
+        csgrep --mode=evtstat processed_sast_unicode_check_out.json
+
+        if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
+          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
+          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
+          echo -n "Probing ${PROBE_URL}... "
+          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+            KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+          else
+            echo "Setting KFP_GIT_URL to empty string"
+            KFP_GIT_URL=
+          fi
+        fi
+
+        # Filter known false positives if KFP_GIT_URL is set
+        if [ -n "${KFP_GIT_URL}" ]; then
+            echo "Filtering false positives in results files using ${KFP_GIT_URL}..." >&2
+
+            # Build initial csfilter-kfp command
+            csfilter_kfp_cmd=(
+                csfilter-kfp
+                --verbose
+                --kfp-git-url="${KFP_GIT_URL}"
+            )
+
+            # Append --project-nvr option if PROJECT_NVR is set
+            if [[ -n "${PROJECT_NAME}" ]]; then
+                csfilter_kfp_cmd+=(--project-nvr="${PROJECT_NAME}")
+            fi
+
+            # Append --record-excluded option if RECORD_EXCLUDED is true
+            if [[ "${RECORD_EXCLUDED}" == "true" ]]; then
+                csfilter_kfp_cmd+=(--record-excluded="excluded-findings.json")
+            fi
+
+            if ! "${csfilter_kfp_cmd[@]}" processed_sast_unicode_check_out.json > sast_unicode_check_out.json 2> sast_unicode_check_out.error; then
+                echo "Failed to filter known false positives" >&2
+                cat sast_unicode_check_out.error
+                note="Task $(context.task.name) failed: For details, check Tekton task log."
+                ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+                echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
+                exit 1
+            fi
+        else
+            echo "KFP_GIT_URL is not set. Skipping false positive filtering." >&2
+            mv processed_sast_unicode_check_out.json sast_unicode_check_out.json
+        fi
+
+        # Generate sarif report
+        csgrep --mode=sarif sast_unicode_check_out.json > sast_unicode_check_out.sarif
+        if [[ "${FUC_EXIT_CODE}" -eq 0 ]]; then
+            note="Task $(context.task.name) success: No finding was detected"
+            ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        elif [[ "${FUC_EXIT_CODE}" -eq 1 ]] && [[ ! -s  sast_unicode_check_out.sarif ]]; then
+            note="Task $(context.task.name) success: Some findings were detected, but filtered by known false positive"
+            ERROR_OUTPUT=$(make_result_json -r SUCCESS -t "$note")
+        else
+            echo "sast-unicode-check test failed because of the following issues:"
+            cat sast_unicode_check_out.json
+            TEST_OUTPUT=
+            parse_test_output "$(context.task.name)" sarif sast_unicode_check_out.sarif  || true
+            note="Task $(context.task.name) failed: For details, check Tekton task log."
+            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
+        fi
+        echo "${TEST_OUTPUT:-${ERROR_OUTPUT}}" | tee "$(results.TEST_OUTPUT.path)"
+    - name: upload
+      image: quay.io/konflux-ci/oras:latest@sha256:1beeecce012c99794568f74265c065839f9703d28306a8430b667f639343a98b
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          memory: 256Mi
+          cpu: 100m
+      workingDir: $(workspaces.workspace.path)/hacbs/$(context.task.name)
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+      script: |
+        #!/usr/bin/env bash
+
+        if [ -z "${IMAGE_URL}" ]; then
+          echo 'No image-url param provided. Skipping upload.'
+          exit 0;
+        fi
+
+        UPLOAD_FILES="sast_unicode_check_out.sarif excluded-findings.json"
+        for UPLOAD_FILE in ${UPLOAD_FILES}; do
+            if [ ! -f "${UPLOAD_FILE}" ]; then
+              echo "No ${UPLOAD_FILE} exists. Skipping upload."
+              continue
+            fi
+
+            if [ "${UPLOAD_FILE}" == "excluded-findings.json" ]; then
+                MEDIA_TYPE=application/json
+            else
+                MEDIA_TYPE=application/sarif+json
+            fi
+
+            echo "Selecting auth"
+            select-oci-auth "${IMAGE_URL}" > "${HOME}/auth.json"
+            echo "Attaching to ${IMAGE_URL}"
+            retry oras attach --no-tty --registry-config "$HOME/auth.json" --artifact-type "${MEDIA_TYPE}" "${IMAGE_URL}@${IMAGE_DIGEST}" "${UPLOAD_FILE}:${MEDIA_TYPE}"
+        done
+  workspaces:
+  - name: workspace

--- a/task/sast-unicode-check/0.3/tests/test-sast-unicode-check.yaml
+++ b/task/sast-unicode-check/0.3/tests/test-sast-unicode-check.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sast-unicode-check
+spec:
+  description: |
+    Test the sast-unicode-check task with a customer repository
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: init
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/init/0.2/init.yaml
+      params:
+        - name: image-url
+          value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-unicode-check:latest"
+        - name: image-digest
+          value: sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
+    - name: clone-repository
+      runAfter:
+        - init
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/test-data-sast
+        - name: revision
+          value: main
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+    - name: scan-with-unicode
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      runAfter:
+        - clone-repository
+      taskRef:
+        name: sast-unicode-check
+      params:
+        - name: image-url
+          value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-unicode-check:latest"
+        - name: image-digest
+          value: sha256:d9fea2ee280880feef6909bef3e18318444231c83736bcc41d54b4e5064f23c9
+    - name: check-result
+      runAfter:
+        - scan-with-unicode
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              echo "Check-result"
+              # Extract findings stats from the resulting SARIF data
+              output=$(csgrep --mode=evtstat "$(workspaces.workspace.path)"/hacbs/sast-unicode-check/sast_unicode_check_out.sarif | tr -d '\n')
+              expected="    196	UNICONTROL_WARNING                              	warning"
+              # Compare output with expected string
+              if [[ "$output" == "$expected" ]]; then
+                echo "Test passed!"
+              else
+                echo "Test failed!"
+                echo "Actual output: [$output]"
+                echo "Expected output: [$expected]"
+                return 1
+              fi


### PR DESCRIPTION
[PSSECAUT-1203](https://issues.redhat.com/browse/PSSECAUT-1203)

It seems as though in https://github.com/konflux-ci/build-definitions/pull/2018 the `image-digest` param was not made required for sast-unicode-check and had a default value of `""`. This caused upload to fail for pipelines that did not have image-digest set for this task.

There is also a small bugfix due to incorrect var name `UPLOAD_FILE` vs `UPLOAD_FILES`.

To fix I've creaated a new version, 0.3, and migration scripts. Also related to https://issues.redhat.com/browse/STONEINTG-1208
