### PR TITLE
sast-shell-check: fix param name typo in README

### DIFF
--- a/task/sast-shell-check/0.1/README.md
+++ b/task/sast-shell-check/0.1/README.md
@@ -14,7 +14,7 @@ ShellCheck is a static analysis tool, gives warnings and suggestions for bash/sh
 | PROJECT_NAME      | Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.                                        | ""            | No       |
 | RECORD_EXCLUDED   | Whether to record the excluded findings to file, Useful for auditing.<br/>If "true", the excluded findings will be stored in `excluded-findings.json`. | "false"       | No       |
 | IMP_FINDINGS_ONLY | Whether to report only important findings. To report all findings, specify "false".                                                                    | "true"        | No       |
-| TARGET_DIR        | Target directories in component's source code. Multiple values should be separated with commas.                                                        | "."           | No       |
+| TARGET_DIRS       | Target directories in component's source code. Multiple values should be separated with commas.                                                        | "."           | No       |
 
 For path exclusions defined in the known-false-positives (KFP) repo to be applied to scan results, the component name should match the respective directory in KFP. By default this is sourced from the `"appstudio.openshift.io/component"` label, but the `PROJECT_NAME` parameter can be used to override this.
 


### PR DESCRIPTION
Oops. Should already be correct everywhere else.
