### PR TITLE
Update buildah-task image and disable masking of /proc/interrupts

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -246,7 +246,7 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     name: build
     script: |
       #!/bin/bash
@@ -386,6 +386,10 @@ spec:
       fi
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+      # TODO remove the option once all hosts were updated
+      BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
 
       if [ "${PRIVILEGED_NESTED}" == "true" ]; then
         BUILDAH_ARGS+=("--security-opt=label=disable")
@@ -604,7 +608,7 @@ spec:
   - env:
     - name: BUILDAH_FORMAT
       value: $(params.BUILDAH_FORMAT)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -281,7 +281,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -454,6 +454,10 @@ spec:
         fi
 
         BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+        # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+        # TODO remove the option once all hosts were updated
+        BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
 
         if [ "${PRIVILEGED_NESTED}" == "true" ]; then
           BUILDAH_ARGS+=("--security-opt=label=disable")
@@ -663,7 +667,7 @@ spec:
           add:
             - SETFCAP
     - name: push
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -242,7 +242,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -283,7 +283,7 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     name: build
     script: |-
       #!/bin/bash
@@ -493,6 +493,10 @@ spec:
       fi
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+      # TODO remove the option once all hosts were updated
+      BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
 
       if [ "${PRIVILEGED_NESTED}" == "true" ]; then
         BUILDAH_ARGS+=("--security-opt=label=disable")
@@ -793,7 +797,7 @@ spec:
     env:
     - name: BUILDAH_FORMAT
       value: $(params.BUILDAH_FORMAT)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -233,7 +233,7 @@ spec:
     - name: WORKINGDIR_MOUNT
       value: $(params.WORKINGDIR_MOUNT)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -260,7 +260,7 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     name: build
     script: |-
       #!/bin/bash
@@ -461,6 +461,10 @@ spec:
       fi
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+      # TODO remove the option once all hosts were updated
+      BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
 
       if [ "${PRIVILEGED_NESTED}" == "true" ]; then
         BUILDAH_ARGS+=("--security-opt=label=disable")
@@ -761,7 +765,7 @@ spec:
     env:
     - name: BUILDAH_FORMAT
       value: $(params.BUILDAH_FORMAT)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -214,7 +214,7 @@ spec:
       value: $(params.WORKINGDIR_MOUNT)
 
   steps:
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     name: build
     computeResources:
       limits:
@@ -373,6 +373,10 @@ spec:
       fi
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+      # TODO remove the option once all hosts were updated
+      BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
 
       if [ "${PRIVILEGED_NESTED}" == "true" ]; then
         BUILDAH_ARGS+=("--security-opt=label=disable")
@@ -590,7 +594,7 @@ spec:
       readOnly: true
     workingDir: $(workspaces.source.path)
   - name: push
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     env:
     - name: BUILDAH_FORMAT
       value: $(params.BUILDAH_FORMAT)

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -615,6 +615,10 @@ spec:
 
         BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
+        # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+        # TODO remove the option once all hosts were updated
+        BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
+
         if [ "${PRIVILEGED_NESTED}" == "true" ]; then
           BUILDAH_ARGS+=("--security-opt=label=disable")
           BUILDAH_ARGS+=("--cap-add=all")

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -618,6 +618,10 @@ spec:
 
         BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
+        # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+        # TODO remove the option once all hosts were updated
+        BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
+
         if [ "${PRIVILEGED_NESTED}" == "true" ]; then
           BUILDAH_ARGS+=("--security-opt=label=disable")
           BUILDAH_ARGS+=("--cap-add=all")

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -543,6 +543,10 @@ spec:
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
+      # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+      # TODO remove the option once all hosts were updated
+      BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
+
       if [ "${PRIVILEGED_NESTED}" == "true" ]; then
         BUILDAH_ARGS+=("--security-opt=label=disable")
         BUILDAH_ARGS+=("--cap-add=all")

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -544,6 +544,10 @@ spec:
 
       BUILDAH_ARGS+=("${BUILD_ARG_FLAGS[@]}")
 
+      # Necessary for newer version of buildah if the host system does not contain up to date version of container-selinux
+      # TODO remove the option once all hosts were updated
+      BUILDAH_ARGS+=("--security-opt=unmask=/proc/interrupts")
+
       if [ "${PRIVILEGED_NESTED}" == "true" ]; then
         BUILDAH_ARGS+=("--security-opt=label=disable")
         BUILDAH_ARGS+=("--cap-add=all")


### PR DESCRIPTION
Buildah introduced default masking of /proc/interrupts in https://github.com/containers/buildah/pull/6074, that itself does not work unless the host system has container-selinux version v2.237.0 and higher that allows that masking (https://github.com/containers/container-selinux/pull/367). Otherwise builds fail with something like:

error running subprocess: masking non-directory "/var/tmp/buildah88680233/mnt/rootfs/proc/interrupts" in mount namespace: permission denied

The new version of container-selinux might not be available for all versions of RHEL that are used as nodes, therefore the workaround with unmasking /proc/interrupts has to be used.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
