### PR TITLE
Add CI check for task version labels

### DIFF
--- a/.github/workflows/check-task-owners.yaml
+++ b/.github/workflows/check-task-owners.yaml
@@ -16,6 +16,10 @@ jobs:
         run: |
           ./hack/check-task-owners.sh
 
+      - name: Check task version labels
+        run: |
+          ./hack/check-task-version-labels.sh
+
       - name: Check renovate.json groups
         run: |
           #!/bin/bash


### PR DESCRIPTION
PRs #2129 and #2128 added some missing or mismatched task version labels. This change adds some CI that should prevent future missing or mismatched task version labels.

I added it as a step in an existing workflow rather than creating a whole new workflow. Let me know if you have a preference for putting it somewhere else.