### PR TITLE
Remove @kdudka from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -64,16 +64,16 @@
 /stepactions/fips-operator-check-step-action    @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 
 # renovate groupName=integration
-/task/coverity-availability-check           @konflux-ci/integration-service-maintainers @kdudka @sfowl
-/task/coverity-availability-check-oci-ta    @konflux-ci/integration-service-maintainers @kdudka @sfowl
-/task/sast-coverity-check                   @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @kdudka @sfowl
-/task/sast-coverity-check-oci-ta            @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @kdudka @sfowl
-/task/sast-shell-check                      @konflux-ci/integration-service-maintainers @kdudka @sfowl
-/task/sast-shell-check-oci-ta               @konflux-ci/integration-service-maintainers @kdudka @sfowl
-/task/sast-snyk-check                       @konflux-ci/integration-service-maintainers @kdudka @sfowl
-/task/sast-snyk-check-oci-ta                @konflux-ci/integration-service-maintainers @kdudka @sfowl
-/task/sast-unicode-check                    @konflux-ci/integration-service-maintainers @kdudka @sfowl
-/task/sast-unicode-check-oci-ta             @konflux-ci/integration-service-maintainers @kdudka @sfowl
+/task/coverity-availability-check           @konflux-ci/integration-service-maintainers @sfowl
+/task/coverity-availability-check-oci-ta    @konflux-ci/integration-service-maintainers @sfowl
+/task/sast-coverity-check                   @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @sfowl
+/task/sast-coverity-check-oci-ta            @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @sfowl
+/task/sast-shell-check                      @konflux-ci/integration-service-maintainers @sfowl
+/task/sast-shell-check-oci-ta               @konflux-ci/integration-service-maintainers @sfowl
+/task/sast-snyk-check                       @konflux-ci/integration-service-maintainers @sfowl
+/task/sast-snyk-check-oci-ta                @konflux-ci/integration-service-maintainers @sfowl
+/task/sast-unicode-check                    @konflux-ci/integration-service-maintainers @sfowl
+/task/sast-unicode-check-oci-ta             @konflux-ci/integration-service-maintainers @sfowl
 
 # renovate groupName=preflight
 /task/ecosystem-cert-preflight-checks   @acornett21 @bcrochet @komish @skattoju @caxu-rh


### PR DESCRIPTION
I stopped working on Konflux 3 months ago and I am not following the project closely enough any more.  I can still be tagged for questions about OpenScanHub and the initial implementation of SAST scanning in Konflux.  But I do not think I should be authoritatively approving code changes going to this repository any more.