### PR TITLE
sast-coverity: add TARGET_DIRS parameter

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -223,6 +223,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
+|TARGET_DIRS| Target directories in component's source code. Multiple values should be separated with commas. This only applies to buildless capture, which is only attempted if buildful capture fails to produce and results.| .| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -220,6 +220,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
+|TARGET_DIRS| Target directories in component's source code. Multiple values should be separated with commas. This only applies to buildless capture, which is only attempted if buildful capture fails to produce and results.| .| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -213,6 +213,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
+|TARGET_DIRS| Target directories in component's source code. Multiple values should be separated with commas. This only applies to buildless capture, which is only attempted if buildful capture fails to produce and results.| .| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -111,6 +111,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
+|TARGET_DIRS| Target directories in component's source code. Multiple values should be separated with commas. This only applies to buildless capture, which is only attempted if buildful capture fails to produce and results.| .| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -106,6 +106,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
+|TARGET_DIRS| Target directories in component's source code. Multiple values should be separated with commas. This only applies to buildless capture, which is only attempted if buildful capture fails to produce and results.| .| |
 |TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| | |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| | |

--- a/task/sast-coverity-check-oci-ta/0.3/README.md
+++ b/task/sast-coverity-check-oci-ta/0.3/README.md
@@ -38,6 +38,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
+|TARGET_DIRS|Target directories in component's source code. Multiple values should be separated with commas. This only applies to buildless capture, which is only attempted if buildful capture fails to produce and results.|.|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
 |WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -168,6 +168,13 @@ spec:
       description: Storage driver to configure for buildah
       type: string
       default: overlay
+    - name: TARGET_DIRS
+      description: Target directories in component's source code. Multiple
+        values should be separated with commas. This only applies to buildless
+        capture, which is only attempted if buildful capture fails to produce
+        and results.
+      type: string
+      default: .
     - name: TARGET_STAGE
       description: Target stage in Dockerfile to build. If not specified,
         the Dockerfile is processed entirely to (and including) its last stage.
@@ -862,6 +869,8 @@ spec:
           value: $(params.PROJECT_NAME)
         - name: RECORD_EXCLUDED
           value: $(params.RECORD_EXCLUDED)
+        - name: TARGET_DIRS
+          value: $(params.TARGET_DIRS)
         - name: COMPONENT_LABEL
           valueFrom:
             fieldRef:
@@ -889,26 +898,49 @@ spec:
           update-ca-trust
         fi
 
+        # fallback to buildless scan if we have no scan results from buildful
         if [ -z "$(ls /shared/sast-results/)" ]; then (
           set +e
           set -x
 
-          # fallback to buildless scan if we have no scan results from buildful
-          # shellcheck disable=SC2086
-          env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "/var/workdir"
+          # generate full path for each directory in TARGET_DIRS separate by comma
+          SOURCE_CODE_DIR="/var/workdir/source"
+          count=0
+          IFS="," read -ra TARGETS_ARRAY <<<"$TARGET_DIRS"
+          for d in "${TARGETS_ARRAY[@]}"; do
+            potential_path="${SOURCE_CODE_DIR}/${d}"
+            resolved_path=$(realpath -m "$potential_path")
 
-          /opt/coverity/bin/coverity list --dir=/tmp/idir >"/shared/sast-results/coverity-buildless-summary.txt"
+            # ensure resolved path is still within SOURCE_CODE_DIR
+            if [[ ! "$resolved_path" == "$SOURCE_CODE_DIR"* ]]; then
+              echo "Error: path traversal attempt, '$potential_path' is outside '$SOURCE_CODE_DIR'"
+              exit 1
+            fi
 
-          # install Coverity license file
-          install -vm0644 /{shared,opt/coverity/bin}/license.dat
+            # ensure directory exists, as `coverity capture` doesn't
+            [ -d "$resolved_path" ] || (echo "Directory $resolved_path does not exist" && exit 1)
 
-          # shellcheck disable=SC2086
-          /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+            # shellcheck disable=SC2086
+            env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "${resolved_path}"
 
-          # export scan results
-          /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout |
-            csgrep --mode=json --embed-context=3 \
-              >/shared/sast-results/coverity-buildless.json
+            /opt/coverity/bin/coverity list --dir=/tmp/idir >"/shared/sast-results/coverity-buildless-${count}-summary.txt"
+
+            # install Coverity license file
+            install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+            # shellcheck disable=SC2086
+            /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+            # we want an empty scan result file, even if no scannable files were found
+            set +o pipefail
+            # export scan results
+            /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout |
+              csgrep --mode=json --embed-context=3 \
+                >"/shared/sast-results/coverity-buildless-${count}.json"
+            set -o pipefail
+
+            ((count++)) || true # prevent non-zero return code from arithmetic expression
+          done
         ); fi
 
         # collect capture stats (FIXME: this doe not take findings deduplication into account)

--- a/task/sast-coverity-check/0.3/README.md
+++ b/task/sast-coverity-check/0.3/README.md
@@ -4,11 +4,13 @@
 
 The sast-coverity-check task uses Coverity tool to perform Static Application Security Testing (SAST).
 
-The documentation for this mode can be found here: <https://sig-product-docs.synopsys.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html>
+The documentation for this mode can be found here: <https://documentation.blackduck.com/bundle/coverity-docs/page/commands/topics/coverity_capture.html>
 
-The characteristics of these tasks are:
+This task will first attempt buildful scannning which instruments the Containerfile, and builds the container. If that attempt fails, it will
+then perform buildless capture on the source code.
 
-- Perform buildful scanning with Coverity
+Other details:
+
 - Only important findings are reported by default.  A parameter ( `IMP_FINDINGS_ONLY`) is provided to override this configuration.
 - The csdiff/v1 SARIF fingerprints are provided for all findings
 - A parameter ( `KFP_GIT_URL`) is provided to remove false positives providing a known false positives repository. By default, no repository is provided.
@@ -26,6 +28,8 @@ The characteristics of these tasks are:
 | KFP_GIT_URL               | Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 | PROJECT_NAME              | Name of the scanned project, used to find path exclusions. By default, the Konflux component name will be used.                       | ""                        | no       |
 | RECORD_EXCLUDED           | If set to `true`, excluded findings will be written to a file named `excluded-findings.json` for auditing purposes.                   | false                     | no       |
+| TARGET_DIRS               |Target directories in component's source code. Multiple values should be separated with commas. This only applies to buildless capture, which is only attempted if buildful capture fails to produce and results.|.|no|
+
 |image-digest|Digest of the image to which the scan results should be associated.||true|
 |image-url|URL of the image to which the scan results should be associated.||true|
 

--- a/task/sast-coverity-check/0.3/patch.yaml
+++ b/task/sast-coverity-check/0.3/patch.yaml
@@ -124,6 +124,15 @@
 - op: add
   path: /spec/params/-
   value:
+    name: TARGET_DIRS
+    description: Target directories in component's source code. Multiple values should
+      be separated with commas. This only applies to buildless capture, which is only
+      attempted if buildful capture fails to produce and results.
+    type: string
+    default: "."
+- op: add
+  path: /spec/params/-
+  value:
     description: Arguments to be appended to the cov-analyze command
     name: COV_ANALYZE_ARGS
     type: string
@@ -337,6 +346,8 @@
         value: $(params.PROJECT_NAME)
       - name: RECORD_EXCLUDED
         value: $(params.RECORD_EXCLUDED)
+      - name: TARGET_DIRS
+        value: $(params.TARGET_DIRS)
       - name: COMPONENT_LABEL
         valueFrom:
           fieldRef:
@@ -366,26 +377,49 @@
         update-ca-trust
       fi
 
+      # fallback to buildless scan if we have no scan results from buildful
       if [ -z "$(ls /shared/sast-results/)" ]; then (
         set +e
         set -x
 
-        # fallback to buildless scan if we have no scan results from buildful
-        # shellcheck disable=SC2086
-        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
+        # generate full path for each directory in TARGET_DIRS separate by comma
+        SOURCE_CODE_DIR="$(workspaces.source.path)/source"
+        count=0
+        IFS="," read -ra TARGETS_ARRAY <<< "$TARGET_DIRS"
+        for d in "${TARGETS_ARRAY[@]}"; do
+          potential_path="${SOURCE_CODE_DIR}/${d}"
+          resolved_path=$(realpath -m "$potential_path")
 
-        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
+          # ensure resolved path is still within SOURCE_CODE_DIR
+          if [[ ! "$resolved_path" == "$SOURCE_CODE_DIR"* ]]; then
+            echo "Error: path traversal attempt, '$potential_path' is outside '$SOURCE_CODE_DIR'"
+            exit 1
+          fi
 
-        # install Coverity license file
-        install -vm0644 /{shared,opt/coverity/bin}/license.dat
+          # ensure directory exists, as `coverity capture` doesn't
+          [ -d "$resolved_path" ] || (echo "Directory $resolved_path does not exist" && exit 1)
 
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+          # shellcheck disable=SC2086
+          env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "${resolved_path}"
 
-        # export scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | csgrep --mode=json --embed-context=3 \
-          > /shared/sast-results/coverity-buildless.json
+          /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-${count}-summary.txt"
+
+          # install Coverity license file
+          install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+          # shellcheck disable=SC2086
+          /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+          # we want an empty scan result file, even if no scannable files were found
+          set +o pipefail
+          # export scan results
+          /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+            | csgrep --mode=json --embed-context=3 \
+            > "/shared/sast-results/coverity-buildless-${count}.json"
+          set -o pipefail
+
+          ((count++)) || true # prevent non-zero return code from arithmetic expression
+        done
       ) fi
 
       # collect capture stats (FIXME: this doe not take findings deduplication into account)

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -180,6 +180,12 @@ spec:
   - default: "false"
     name: RECORD_EXCLUDED
     type: string
+  - default: .
+    description: Target directories in component's source code. Multiple values should
+      be separated with commas. This only applies to buildless capture, which is only
+      attempted if buildful capture fails to produce and results.
+    name: TARGET_DIRS
+    type: string
   - default: --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096
     description: Arguments to be appended to the cov-analyze command
     name: COV_ANALYZE_ARGS
@@ -794,6 +800,8 @@ spec:
       value: $(params.PROJECT_NAME)
     - name: RECORD_EXCLUDED
       value: $(params.RECORD_EXCLUDED)
+    - name: TARGET_DIRS
+      value: $(params.TARGET_DIRS)
     - name: COMPONENT_LABEL
       valueFrom:
         fieldRef:
@@ -823,26 +831,49 @@ spec:
         update-ca-trust
       fi
 
+      # fallback to buildless scan if we have no scan results from buildful
       if [ -z "$(ls /shared/sast-results/)" ]; then (
         set +e
         set -x
 
-        # fallback to buildless scan if we have no scan results from buildful
-        # shellcheck disable=SC2086
-        env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "$(workspaces.source.path)"
+        # generate full path for each directory in TARGET_DIRS separate by comma
+        SOURCE_CODE_DIR="$(workspaces.source.path)/source"
+        count=0
+        IFS="," read -ra TARGETS_ARRAY <<< "$TARGET_DIRS"
+        for d in "${TARGETS_ARRAY[@]}"; do
+          potential_path="${SOURCE_CODE_DIR}/${d}"
+          resolved_path=$(realpath -m "$potential_path")
 
-        /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-summary.txt"
+          # ensure resolved path is still within SOURCE_CODE_DIR
+          if [[ ! "$resolved_path" == "$SOURCE_CODE_DIR"* ]]; then
+            echo "Error: path traversal attempt, '$potential_path' is outside '$SOURCE_CODE_DIR'"
+            exit 1
+          fi
 
-        # install Coverity license file
-        install -vm0644 /{shared,opt/coverity/bin}/license.dat
+          # ensure directory exists, as `coverity capture` doesn't
+          [ -d "$resolved_path" ] || (echo "Directory $resolved_path does not exist" && exit 1)
 
-        # shellcheck disable=SC2086
-        /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+          # shellcheck disable=SC2086
+          env HOME=/var/tmp/coverity/home /opt/coverity/bin/coverity capture --disable-build-command-inference --dir /tmp/idir --project-dir "${resolved_path}"
 
-        # export scan results
-        /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
-          | csgrep --mode=json --embed-context=3 \
-          > /shared/sast-results/coverity-buildless.json
+          /opt/coverity/bin/coverity list --dir=/tmp/idir > "/shared/sast-results/coverity-buildless-${count}-summary.txt"
+
+          # install Coverity license file
+          install -vm0644 /{shared,opt/coverity/bin}/license.dat
+
+          # shellcheck disable=SC2086
+          /opt/coverity/bin/cov-analyze $COV_ANALYZE_ARGS --dir=/tmp/idir
+
+          # we want an empty scan result file, even if no scannable files were found
+          set +o pipefail
+          # export scan results
+          /opt/coverity/bin/cov-format-errors --dir=/tmp/idir --json-output-v10 /dev/stdout \
+            | csgrep --mode=json --embed-context=3 \
+            > "/shared/sast-results/coverity-buildless-${count}.json"
+          set -o pipefail
+
+          ((count++)) || true # prevent non-zero return code from arithmetic expression
+        done
       ) fi
 
       # collect capture stats (FIXME: this doe not take findings deduplication into account)


### PR DESCRIPTION
[PSSECAUT-1198](https://issues.redhat.com/browse/PSSECAUT-1198)

Tested https://konflux-ui.apps.stone-prod-p02.hjvn.p1.openshiftapps.com/ns/sfowler-tenant/applications/snr-0-9/pipelineruns/snr-bundle-0-9-on-pull-request-cs2bc

~This test seemed to reveal another issue, but I don't think it's related to this change:~

```
+ /opt/coverity/bin/cov-analyze '--enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096' --dir=/tmp/idir
[COMMAND LINE ERROR] Undefined option 'enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem'
Did you mean to pass '--enable', 'HARDCODED_CREDENTIALS', '--security', '--concurrency' and '--spotbugs-max-mem=4096' as separate arguments?
Check your shell quoting rules, and note that response files allow only one argument per line.
Specify --help for assistance.
```

~Will follow that up separately.~

EDIT: turns out this was a bug introduced by the IFS value used in the new for loop. Should be fixed now.
