### PR TITLE
Add INHERIT_BASE_IMAGE_LABELS parameter to buildah task

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -65,6 +65,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_APPEND_PLATFORM| Whether to append a sanitized platform architecture on the IMAGE tag| false| 'true'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
@@ -209,6 +210,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -63,6 +63,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
@@ -206,6 +207,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -62,6 +62,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
@@ -200,6 +201,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -64,6 +64,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_APPEND_PLATFORM| Whether to append a sanitized platform architecture on the IMAGE tag| false| 'true'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -98,6 +98,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | |

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -94,6 +94,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | |

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -159,6 +159,10 @@ spec:
       the build (see the CONTEXT param).
     name: WORKINGDIR_MOUNT
     type: string
+  - default: "true"
+    description: Determines if the image inherits the base image labels.
+    name: INHERIT_BASE_IMAGE_LABELS
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -224,6 +228,8 @@ spec:
       value: $(params.ANNOTATIONS_FILE)
     - name: WORKINGDIR_MOUNT
       value: $(params.WORKINGDIR_MOUNT)
+    - name: INHERIT_BASE_IMAGE_LABELS
+      value: $(params.INHERIT_BASE_IMAGE_LABELS)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -407,6 +413,10 @@ spec:
 
       if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
         BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ] ; then
+        BUILDAH_ARGS+=("--inherit-labels=false")
       fi
 
       VOLUME_MOUNTS=()

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -24,6 +24,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -91,6 +91,10 @@ spec:
         hours, days, and weeks, respectively.
       type: string
       default: ""
+    - name: INHERIT_BASE_IMAGE_LABELS
+      description: Determines if the image inherits the base image labels.
+      type: string
+      default: "true"
     - name: LABELS
       description: Additional key=value labels that should be applied to the
         image
@@ -237,6 +241,8 @@ spec:
         value: $(params.IMAGE)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.IMAGE_EXPIRES_AFTER)
+      - name: INHERIT_BASE_IMAGE_LABELS
+        value: $(params.INHERIT_BASE_IMAGE_LABELS)
       - name: PRIVILEGED_NESTED
         value: $(params.PRIVILEGED_NESTED)
       - name: SBOM_TYPE
@@ -475,6 +481,10 @@ spec:
 
         if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
           BUILDAH_ARGS+=("--skip-unused-stages=false")
+        fi
+
+        if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ]; then
+          BUILDAH_ARGS+=("--inherit-labels=false")
         fi
 
         VOLUME_MOUNTS=()

--- a/task/buildah-remote-oci-ta/0.4/README.md
+++ b/task/buildah-remote-oci-ta/0.4/README.md
@@ -8,9 +8,12 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |name|description|default value|required|
 |---|---|---|---|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
+|ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
+|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
@@ -21,17 +24,19 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
+|INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|
-|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|cyclonedx|false|
+|SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
-|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
 |YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|
 |YUM_REPOS_D_TARGET|Target path on the container in which yum repository files should be made available|/etc/yum.repos.d|false|

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -90,6 +90,10 @@ spec:
       respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
+  - default: "true"
+    description: Determines if the image inherits the base image labels.
+    name: INHERIT_BASE_IMAGE_LABELS
+    type: string
   - default: []
     description: Additional key=value labels that should be applied to the image
     name: LABELS
@@ -215,6 +219,8 @@ spec:
       value: $(params.IMAGE)
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: INHERIT_BASE_IMAGE_LABELS
+      value: $(params.INHERIT_BASE_IMAGE_LABELS)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
     - name: SBOM_TYPE
@@ -516,6 +522,10 @@ spec:
         BUILDAH_ARGS+=("--skip-unused-stages=false")
       fi
 
+      if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ]; then
+        BUILDAH_ARGS+=("--inherit-labels=false")
+      fi
+
       VOLUME_MOUNTS=()
 
       echo "[$(date --utc -Ins)] Setup prefetched"
@@ -732,6 +742,7 @@ spec:
           -e HERMETIC="${HERMETIC@Q}" \
           -e IMAGE="${IMAGE@Q}" \
           -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
+          -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
           -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
           -e SBOM_TYPE="${SBOM_TYPE@Q}" \
           -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \

--- a/task/buildah-remote/0.4/README.md
+++ b/task/buildah-remote/0.4/README.md
@@ -28,14 +28,18 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |SQUASH|Squash all new and previous layers added as a part of this build, as per --squash|false|false|
-|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
+|ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
+|ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
+|WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
+|INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |PLATFORM|The platform to build on||true|
 |IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
 

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -159,6 +159,10 @@ spec:
       the build (see the CONTEXT param).
     name: WORKINGDIR_MOUNT
     type: string
+  - default: "true"
+    description: Determines if the image inherits the base image labels.
+    name: INHERIT_BASE_IMAGE_LABELS
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -232,6 +236,8 @@ spec:
       value: $(params.ANNOTATIONS_FILE)
     - name: WORKINGDIR_MOUNT
       value: $(params.WORKINGDIR_MOUNT)
+    - name: INHERIT_BASE_IMAGE_LABELS
+      value: $(params.INHERIT_BASE_IMAGE_LABELS)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
     - name: PLATFORM
@@ -484,6 +490,10 @@ spec:
         BUILDAH_ARGS+=("--skip-unused-stages=false")
       fi
 
+      if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ] ; then
+        BUILDAH_ARGS+=("--inherit-labels=false")
+      fi
+
       VOLUME_MOUNTS=()
 
       echo "[$(date --utc -Ins)] Setup prefetched"
@@ -713,6 +723,7 @@ spec:
           -e SBOM_TYPE="${SBOM_TYPE@Q}" \
           -e ANNOTATIONS_FILE="${ANNOTATIONS_FILE@Q}" \
           -e WORKINGDIR_MOUNT="${WORKINGDIR_MOUNT@Q}" \
+          -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e DOCKERFILE="${DOCKERFILE@Q}" \
           -v "${BUILD_DIR@Q}/workspaces/source:$(workspaces.source.path):Z" \

--- a/task/buildah/0.4/README.md
+++ b/task/buildah/0.4/README.md
@@ -39,6 +39,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
 |ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
 |WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
+|INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -144,6 +144,11 @@ spec:
       context directory for the build (see the CONTEXT param).
     type: string
     default: ""
+  - name: INHERIT_BASE_IMAGE_LABELS
+    description: Determines if the image inherits the base image labels.
+    type: string
+    default: "true"
+
 
   results:
   - description: Digest of the image just built
@@ -212,6 +217,8 @@ spec:
       value: $(params.ANNOTATIONS_FILE)
     - name: WORKINGDIR_MOUNT
       value: $(params.WORKINGDIR_MOUNT)
+    - name: INHERIT_BASE_IMAGE_LABELS
+      value: $(params.INHERIT_BASE_IMAGE_LABELS)
 
   steps:
   - image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
@@ -394,6 +401,10 @@ spec:
 
       if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
         BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ] ; then
+        BUILDAH_ARGS+=("--inherit-labels=false")
       fi
 
       VOLUME_MOUNTS=()

--- a/task/sast-coverity-check-oci-ta/0.2/README.md
+++ b/task/sast-coverity-check-oci-ta/0.2/README.md
@@ -25,6 +25,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |IMP_FINDINGS_ONLY|Report only important findings. Default is true. To report all findings, specify "false"|true|false|
+|INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|

--- a/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.2/sast-coverity-check-oci-ta.yaml
@@ -103,6 +103,10 @@ spec:
         all findings, specify "false"
       type: string
       default: "true"
+    - name: INHERIT_BASE_IMAGE_LABELS
+      description: Determines if the image inherits the base image labels.
+      type: string
+      default: "true"
     - name: KFP_GIT_URL
       description: Known False Positives (KFP) git URL (optionally taking
         a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
@@ -261,6 +265,8 @@ spec:
         value: $(params.IMAGE)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.IMAGE_EXPIRES_AFTER)
+      - name: INHERIT_BASE_IMAGE_LABELS
+        value: $(params.INHERIT_BASE_IMAGE_LABELS)
       - name: PRIVILEGED_NESTED
         value: $(params.PRIVILEGED_NESTED)
       - name: SBOM_TYPE
@@ -635,6 +641,10 @@ spec:
 
         if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
           BUILDAH_ARGS+=("--skip-unused-stages=false")
+        fi
+
+        if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ]; then
+          BUILDAH_ARGS+=("--inherit-labels=false")
         fi
 
         VOLUME_MOUNTS=()

--- a/task/sast-coverity-check-oci-ta/0.3/README.md
+++ b/task/sast-coverity-check-oci-ta/0.3/README.md
@@ -25,6 +25,7 @@ Scans source code for security vulnerabilities, including common issues such as 
 |IMAGE|The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |IMP_FINDINGS_ONLY|Report only important findings. Default is true. To report all findings, specify "false"|true|false|
+|INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -106,6 +106,10 @@ spec:
         all findings, specify "false"
       type: string
       default: "true"
+    - name: INHERIT_BASE_IMAGE_LABELS
+      description: Determines if the image inherits the base image labels.
+      type: string
+      default: "true"
     - name: KFP_GIT_URL
       description: Known False Positives (KFP) git URL (optionally taking
         a revision delimited by \#). Defaults to "SITE_DEFAULT", which means
@@ -269,6 +273,8 @@ spec:
         value: $(params.IMAGE)
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.IMAGE_EXPIRES_AFTER)
+      - name: INHERIT_BASE_IMAGE_LABELS
+        value: $(params.INHERIT_BASE_IMAGE_LABELS)
       - name: PRIVILEGED_NESTED
         value: $(params.PRIVILEGED_NESTED)
       - name: SBOM_TYPE
@@ -638,6 +644,10 @@ spec:
 
         if [ "${SKIP_UNUSED_STAGES}" != "true" ]; then
           BUILDAH_ARGS+=("--skip-unused-stages=false")
+        fi
+
+        if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ]; then
+          BUILDAH_ARGS+=("--inherit-labels=false")
         fi
 
         VOLUME_MOUNTS=()

--- a/task/sast-coverity-check/0.2/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.2/sast-coverity-check.yaml
@@ -158,6 +158,10 @@ spec:
       the build (see the CONTEXT param).
     name: WORKINGDIR_MOUNT
     type: string
+  - default: "true"
+    description: Determines if the image inherits the base image labels.
+    name: INHERIT_BASE_IMAGE_LABELS
+    type: string
   - name: image-url
     type: string
   - default: cov-license
@@ -244,6 +248,8 @@ spec:
       value: $(params.ANNOTATIONS_FILE)
     - name: WORKINGDIR_MOUNT
       value: $(params.WORKINGDIR_MOUNT)
+    - name: INHERIT_BASE_IMAGE_LABELS
+      value: $(params.INHERIT_BASE_IMAGE_LABELS)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -563,6 +569,10 @@ spec:
 
       if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
         BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ] ; then
+        BUILDAH_ARGS+=("--inherit-labels=false")
       fi
 
       VOLUME_MOUNTS=()

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -160,6 +160,10 @@ spec:
       the build (see the CONTEXT param).
     name: WORKINGDIR_MOUNT
     type: string
+  - default: "true"
+    description: Determines if the image inherits the base image labels.
+    name: INHERIT_BASE_IMAGE_LABELS
+    type: string
   - description: Digest of the image to which the scan results should be associated.
     name: image-digest
     type: string
@@ -250,6 +254,8 @@ spec:
       value: $(params.ANNOTATIONS_FILE)
     - name: WORKINGDIR_MOUNT
       value: $(params.WORKINGDIR_MOUNT)
+    - name: INHERIT_BASE_IMAGE_LABELS
+      value: $(params.INHERIT_BASE_IMAGE_LABELS)
     volumeMounts:
     - mountPath: /shared
       name: shared
@@ -564,6 +570,10 @@ spec:
 
       if [ "${SKIP_UNUSED_STAGES}" != "true" ] ; then
         BUILDAH_ARGS+=("--skip-unused-stages=false")
+      fi
+
+      if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ] ; then
+        BUILDAH_ARGS+=("--inherit-labels=false")
       fi
 
       VOLUME_MOUNTS=()


### PR DESCRIPTION
This can be used by users to disable the inheritace of labels from the base/parent image.

The default behaviour is that the labels are inherited.

Resolves [STONEBLD-3455](https://issues.redhat.com//browse/STONEBLD-3455)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
