### PR TITLE
sast-coverity-check: always pull coverity image

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -444,6 +444,7 @@ spec:
         fi
     - name: build
       image: quay.io/redhat-services-prod/sast/coverity:202503.1
+      imagePullPolicy: Always
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])

--- a/task/sast-coverity-check/0.3/patch.yaml
+++ b/task/sast-coverity-check/0.3/patch.yaml
@@ -73,6 +73,11 @@
   # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
   value: quay.io/redhat-services-prod/sast/coverity:202503.1
 
+- op: replace
+  path: /spec/steps/0/imagePullPolicy
+  # We reference the Coverity image by floating tag, make sure to always pull the latest revision.
+  value: Always
+
 # Change build step resources
 - op: replace
   path: /spec/steps/0/computeResources/limits/memory

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -410,6 +410,7 @@ spec:
         /shared/license.dat:/opt/coverity/bin/license.dat
         /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
     image: quay.io/redhat-services-prod/sast/coverity:202503.1
+    imagePullPolicy: Always
     name: build
     script: |
       #!/bin/bash


### PR DESCRIPTION
The task references the image by a non-latest floating tag only, not by digest. The default pull policy in that case is IfNotPresent [1], which means that Nodes which already have the image cached will not attempt to pull a newer revision.

Make sure the task always uses the latest image by explicitly setting the pull policy to Always.

[1]: https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
