### PR TITLE
fix: added dependency of image url to update snyk task

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -46,8 +46,12 @@ spec:
         params:
           - name: ARGS
             value: --report --project-name=konflux-ci/build-definitions
+          - name: image-url
+            value: $(tasks.build-appstudio-utils.results.IMAGE_URL)
+          - name: image-digest
+            value: $(tasks.build-appstudio-utils.results.IMAGE_DIGEST)
         runAfter:
-          - clone-repository
+          - build-appstudio-utils
         taskRef:
           name: sast-snyk-check
         workspaces:


### PR DESCRIPTION
The updated snyk task had an additional requirement to pass the image URL and DIGEST. This was missed in #2485

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
