### PR TITLE
feat: add FIPS mode support to AWS cluster

### DIFF
--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/README.md
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/README.md
@@ -11,6 +11,7 @@ This StepAction provisions an ephemeral cluster using Hypershift with 3 worker n
 |insecureSkipTLSVerify|Skip TLS verification when accessing the EaaS hub cluster. This should not be set to "true" in a production environment.|false|false|
 |timeout|How long to wait for cluster provisioning to complete.|30m|false|
 |imageContentSources|Alternate registry information containing a list of sources and their mirrors in yaml format. See: https://hypershift-docs.netlify.app/how-to/disconnected/image-content-sources|""|false|
+|fips| Flag for hypershift cluster creation command to enable/disable FIPS for the cluster.| false| false
 
 ## Results
 |name|description|

--- a/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+++ b/stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
@@ -38,6 +38,10 @@ spec:
       description: >-
         Alternate registry information containing a list of sources and their mirrors in yaml format.
         See: https://hypershift-docs.netlify.app/how-to/disconnected/image-content-sources
+    - name: fips
+      type: string
+      default: "false"
+      description: Enable FIPS mode for the cluster.
   results:
     - name: clusterName
       description: The name of the generated ClusterTemplateInstance resource.
@@ -61,6 +65,8 @@ spec:
       value: "$(params.imageContentSources)"
     - name: TENANT
       value: "$(context.taskRun.namespace)"
+    - name: FIPS
+      value: "$(params.fips)"
   script: |
     #!/bin/bash
     set -eo pipefail
@@ -82,6 +88,7 @@ spec:
     yq -i '.spec.parameters += {"name": "version", "value": strenv(VERSION)}' cti.yaml
     yq -i '.spec.parameters += {"name": "timeout", "value": strenv(TIMEOUT)}' cti.yaml
     yq -i '.spec.parameters += {"name": "imageContentSources", "value": strenv(IMAGE_CONTENT_SOURCES)}' cti.yaml
+    yq -i '.spec.parameters += {"name": "fips", "value": strenv(FIPS)}' cti.yaml
 
     echo "Creating the following resource:"
     cat cti.yaml


### PR DESCRIPTION
- Introduce 'fips' parameter to enable or disable FIPS mode during cluster provisioning
- Pass 'fips' as an environment variable and include it in ClusterTemplateInstance parameters in the provisioning script
- Update README to document the new parameter and correct its default value

This allows users to provision clusters with FIPS mode enabled as needed.

Relevant pr in the helm chart to support this: https://github.com/konflux-ci/cluster-template-charts/pull/25
