### PR TITLE
fix: try to fix renovate config for build-vm-image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -278,9 +278,9 @@
         "^task/build-vm-image/.*/build-vm-image.yaml"
       ],
       "matchStrings": [
-        "BUILDAH_IMAGE\\s*\\n\\s*value:\\s*['\"]?(?<depName>[^'\":]+):(?<currentValue>[^'\":\\s]+)['\"]?"
+        "value: (?<depName>registry\\.access\\.redhat\\.com/ubi9/buildah[^:]*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
-      "depNameTemplate": "registry.access.redhat.com/ubi9/buildah",
+      "autoReplaceStringTemplate": "value: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "redhat"
     }

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -64,7 +64,7 @@ spec:
       - name: STORAGE_DRIVER
         value: $(params.STORAGE_DRIVER)
       - name: BUILDAH_IMAGE
-        value: 'registry.access.redhat.com/ubi9/buildah:9.5-1739778322'
+        value: registry.access.redhat.com/ubi9/buildah:9.5-1739778322@sha256:a6e04c061b8d261dba85d01dcb64d3f7dba8c0b9765e03f05ec79850a248d75a
       - name: PLATFORM
         value: $(params.PLATFORM)
       - name: IMAGE_APPEND_PLATFORM


### PR DESCRIPTION
This has never fired since it was put in place and there have definitely been new versions of this image produced.

Note, here, I'm not actually bumping the image reference. I want to confirm that renovate will do it correctly.


