### PR TITLE
Revert "hack: build-manifest: Tell find to follow symbolic links"

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -33,7 +33,7 @@ warning_message="# WARNING: This is an auto generated file, do not modify this f
 main() {
     cd "$SCRIPT_DIR/.."
     local ret=0
-    find -L task/*/*/*.yaml -maxdepth 0 | awk -F '/' '{ print $0, $2, $3, $4 }' | \
+    find task/*/*/*.yaml -maxdepth 0 | awk -F '/' '{ print $0, $2, $3, $4 }' | \
     while read -r task_path task_name task_version file_name
     do
         if [[ "$file_name" == "kustomization.yaml" ]]; then
@@ -64,7 +64,7 @@ main() {
         ${SED_CMD} -i "1 i $warning_message" "task/$task_name/$task_version/$task_name.yaml"
     done
 
-    find -L pipelines/*/*.yaml -maxdepth 0 | awk -F '/' '{ print $0, $2, $3 }' | \
+    find pipelines/*/*.yaml -maxdepth 0 | awk -F '/' '{ print $0, $2, $3 }' | \
     while read -r pipeline_path pipeline_name file_name
     do
         if [[ "$file_name" == "kustomization.yaml" ]]; then


### PR DESCRIPTION
This reverts commit dfc3b54a3321937468c5f0b36f50ccc61d36b61f.

This actually caused more bad than good, so let's drop it. Specifically with tasks, once a task makes it to archived-tasks then such task should no longer be considered to be used for anything and especially not by any generators/validators.

**Depends on: https://github.com/konflux-ci/build-definitions/pull/2497**
