### PR TITLE
sast-shell-check: set ShellCheck jobs based on cgroup v2 CPU limits

### DIFF
--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -149,8 +149,8 @@ spec:
 
         # generate full path for each dirname separated by comma
         declare -a ALL_TARGETS
-        IFS=","
-        for d in $TARGET_DIRS; do
+        IFS="," read -ra TARGET_ARRAY <<<"$TARGET_DIRS"
+        for d in "${TARGET_ARRAY[@]}"; do
           potential_path="${SOURCE_CODE_DIR}/${d}"
 
           resolved_path=$(realpath -m "$potential_path")
@@ -163,6 +163,16 @@ spec:
             exit 1
           fi
         done
+
+        # determine number of available CPU cores for shellcheck based on container cgroup v2 CPU limits
+        # this calculates the ceiling, so if the cpu limit is 0.5, the number of jobs will be 1.
+        if [ -z "$SC_JOBS" ] && [ -r "/sys/fs/cgroup/cpu.max" ]; then
+          read -r quota period </sys/fs/cgroup/cpu.max
+          if [ "$quota" != "max" ] && [ -n "$period" ] && [ "$period" -gt 0 ]; then
+            export SC_JOBS=$(((quota + period - 1) / period))
+            echo "INFO: Setting SC_JOBS=${SC_JOBS} based on cgroups v2 max for run-shellcheck.sh"
+          fi
+        fi
 
         # generate all shellcheck result JSON files to $SC_RESULTS_DIR, which defaults to ./shellcheck-results/
         /usr/share/csmock/scripts/run-shellcheck.sh "${ALL_TARGETS[@]}"
@@ -251,6 +261,7 @@ spec:
         echo "${TEST_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
       computeResources:
         limits:
+          cpu: "8"
           memory: 4Gi
         requests:
           cpu: "1"

--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -97,7 +97,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: sast-shell-check
-      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      image: quay.io/konflux-ci/konflux-test:v1.4.32@sha256:7e04a34cc9adb5fa0bfe5070d1a60321205f5e6f0cd3fb2e8a33a5ec8508fd29
       workingDir: /var/workdir/source
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/sast-shell-check/0.1/README.md
+++ b/task/sast-shell-check/0.1/README.md
@@ -2,9 +2,11 @@
 
 ## Description
 
-The sast-shell-check task uses [shellcheck](https://www.shellcheck.net/) to perform Static Application Security Testing (SAST). This task leverages a shellcheck wrapper ([csmock-plugin-shellcheck-core](https://github.com/csutils/csmock)) to run shellcheck on a directory tree.
+The sast-shell-check task uses [shellcheck](https://www.shellcheck.net/), which gives warnings and suggestions for bash/sh shell scripts, to perform Static Application Security Testing (SAST).
 
-ShellCheck is a static analysis tool, gives warnings and suggestions for bash/sh shell scripts.
+This task leverages a shellcheck wrapper ([csmock-plugin-shellcheck-core](https://github.com/csutils/csmock)) to run shellcheck on a directory tree.
+
+The number of shellcheck instances run in parallel can be indirectly configured by modifying the task CPU limit.
 
 ## Params
 

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -68,7 +68,7 @@ spec:
         optional: true
   steps:
     - name: sast-shell-check
-      image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+      image: quay.io/konflux-ci/konflux-test:v1.4.32@sha256:7e04a34cc9adb5fa0bfe5070d1a60321205f5e6f0cd3fb2e8a33a5ec8508fd29
       computeResources:
         limits:
           memory: 4Gi

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -72,6 +72,7 @@ spec:
       computeResources:
         limits:
           memory: 4Gi
+          cpu: "8"
         requests:
           memory: 4Gi
           cpu: "1"
@@ -128,8 +129,8 @@ spec:
 
         # generate full path for each dirname separated by comma
         declare -a ALL_TARGETS
-        IFS=","
-        for d in $TARGET_DIRS; do
+        IFS="," read -ra TARGET_ARRAY <<< "$TARGET_DIRS"
+        for d in "${TARGET_ARRAY[@]}"; do
           potential_path="${SOURCE_CODE_DIR}/${d}"
 
           resolved_path=$(realpath -m "$potential_path")
@@ -142,6 +143,16 @@ spec:
             exit 1
           fi
         done
+
+        # determine number of available CPU cores for shellcheck based on container cgroup v2 CPU limits
+        # this calculates the ceiling, so if the cpu limit is 0.5, the number of jobs will be 1.
+        if [ -z "$SC_JOBS" ] && [ -r "/sys/fs/cgroup/cpu.max" ]; then
+            read -r quota period < /sys/fs/cgroup/cpu.max
+            if [ "$quota" != "max" ] && [ -n "$period" ] && [ "$period" -gt 0 ]; then
+                export SC_JOBS=$(((quota + period - 1) / period))
+                echo "INFO: Setting SC_JOBS=${SC_JOBS} based on cgroups v2 max for run-shellcheck.sh"
+            fi
+        fi
 
         # generate all shellcheck result JSON files to $SC_RESULTS_DIR, which defaults to ./shellcheck-results/
         /usr/share/csmock/scripts/run-shellcheck.sh "${ALL_TARGETS[@]}"


### PR DESCRIPTION
- [PSSECAUT-1196](https://issues.redhat.com//browse/PSSECAUT-1196)
- set sast-shell-check default CPU limit to 8
- set SC_JOBS equal to CPU limit (rounded up) based on cgroups v2 max
- fix issue with IFS=, affecting word splitting (which impacted `read -r quota period < /sys/fs/cgroup/cpu.max`)

~Marked as draft for now~, as it requires an updated version of the quay.io/konflux-ci/konflux-test image with a new epel9 release of csmock-plugins-shellcheck-core with this [change](https://github.com/csutils/csmock/pull/205).

EDIT: konflux-test image has been updated, ready for merge