### PR TITLE
renovate: group and automerge Go module updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -138,6 +138,16 @@
       "automerge": true
     },
     {
+      "groupName": "go-modules",
+      "matchManagers": [
+        "gomod"
+      ],
+      "schedule": [
+        "on sunday"
+      ],
+      "automerge": true
+    },
+    {
       "matchPackageNames": [
         "quay.io/konflux-ci/clamav-db"
       ],


### PR DESCRIPTION
The only Go code in this repo is for CI - the buildah-remote generator and the trusted task generator. Automerging Go modules if CI passes should be safe.

Also run Go module updates only on sundays, same as GH action updates.
