### PR TITLE
hack: build-manifests: Replace pattern glob for native options in find

### DIFF
--- a/hack/build-manifests.sh
+++ b/hack/build-manifests.sh
@@ -33,7 +33,7 @@ warning_message="# WARNING: This is an auto generated file, do not modify this f
 main() {
     cd "$SCRIPT_DIR/.."
     local ret=0
-    find task/*/*/*.yaml -maxdepth 0 | awk -F '/' '{ print $0, $2, $3, $4 }' | \
+    find task -maxdepth 3 -mindepth 3 -type f -name "*.yaml" | awk -F '/' '{ print $0, $2, $3, $4 }' | \
     while read -r task_path task_name task_version file_name
     do
         if [[ "$file_name" == "kustomization.yaml" ]]; then
@@ -64,7 +64,7 @@ main() {
         ${SED_CMD} -i "1 i $warning_message" "task/$task_name/$task_version/$task_name.yaml"
     done
 
-    find pipelines/*/*.yaml -maxdepth 0 | awk -F '/' '{ print $0, $2, $3 }' | \
+    find pipelines -maxdepth 2 -mindepth 2 -type f -name "*.yaml" | awk -F '/' '{ print $0, $2, $3 }' | \
     while read -r pipeline_path pipeline_name file_name
     do
         if [[ "$file_name" == "kustomization.yaml" ]]; then


### PR DESCRIPTION
`$ find task/*/*/*.yaml -maxdept 0`

is only stable until symlinks are added to the equation. Everything is fine as long as one wants the symlinks to be included, however, since we gave find a fully resolved list of files based on the glob (which isn't capable of skipping symlinks) and limited its max descend level to 0 (which is questionable since we gave it a list of resolved paths to individual YAML files) it won't apply any further filtering options specified on the command line.

In our case, we don't intend to provide updates to tasks that have been moved to the 'archived-tasks' directory which happen to be symlinked to the 'task' directory.
Therefore, manifests would continue to be built AND verified for archived tasks as well. To prevent that, let's use filtering native to find to give us only paths to task YAML files (also limiting the descend level to 3 which seems to be the norm) and ignoring symlinks along the way:

`$ find task -maxdept 3 -type f -name "*.yaml"`
