### PR TITLE
feat(ISV-5866): Use Mobster to generate oci image SBOMs

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -585,7 +585,8 @@ spec:
       touch /shared/base_images_digests
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
-        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # Get the image pullspec and filter out a tag if it is not set
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
@@ -743,7 +744,7 @@ spec:
       requests:
         cpu: 10m
         memory: 128Mi
-    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1b714c468641e910f37c15aa53b867f0b9550a06650e07ffc0583338b963e7af
+    image: quay.io/konflux-ci/mobster:0.5.0-1752493098@sha256:51109021a96e12ad19de9f5ab7a076683250af18d98532385a033916882cd294
     name: prepare-sboms
     script: |
       #!/bin/bash
@@ -756,43 +757,13 @@ spec:
         exit 0
       fi
 
-      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
-
-      if [ -f "sbom-cachi2.json" ]; then
-        sboms_to_merge+=(cachi2:sbom-cachi2.json)
-      fi
-
-      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
-      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom.json
-
-      echo "Adding image reference to sbom"
-      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
-      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
-
-      python3 /scripts/add_image_reference.py \
-        --image-url "$IMAGE_URL" \
-        --image-digest "$IMAGE_DIGEST" \
-        --input-file sbom.json \
-        --output-file /tmp/sbom.tmp.json
-
-      mv /tmp/sbom.tmp.json sbom.json
-
-      echo "Adding base images data to sbom.json"
-      python3 /scripts/base_images_sbom_script.py \
-        --sbom=sbom.json \
-        --parsed-dockerfile=/shared/parsed_dockerfile.json \
-        --base-images-digests=/shared/base_images_digests
-
+      # Convert Tekton array params into Mobster params
       ADDITIONAL_BASE_IMAGES=()
       while [[ $# -gt 0 ]]; do
         case $1 in
           --additional-base-images)
             shift
-            while [[ $# -gt 0 && $1 != --* ]]
-            do
-              ADDITIONAL_BASE_IMAGES+=("$1")
-              shift
-            done
+            while [[ $# -gt 0 && $1 != --* ]]; do ADDITIONAL_BASE_IMAGES+=("$1"); shift; done
             ;;
           *)
             echo "unexpected argument: $1" >&2
@@ -801,16 +772,32 @@ spec:
         esac
       done
 
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+      echo "[$(date --utc -Ins)] Generate SBOM with mobster"
+
+      mobster_args=(
+        generate
+        --output sbom.json
+        oci-image
+        --from-syft "$(workspaces.source.path)/sbom-source.json"
+        --from-syft "$(workspaces.source.path)/sbom-image.json"
+        --image-pullspec "$IMAGE_URL"
+        --image-digest "$IMAGE_DIGEST"
+        --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+        --base-image-digest-file "/shared/base_images_digests"
+      )
+
+      if [ -f "$(workspaces.source.path)/sbom-cachi2.json" ]; then
+        mobster_args+=(--from-hermeto "$(workspaces.source.path)/sbom-cachi2.json")
+      fi
+
       for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-        IFS="@" read -ra BASE_IMAGE <<< "${ADDITIONAL_BASE_IMAGE}"
-        python3 /scripts/add_image_reference.py \
-          --builder-image \
-          --image-url "${BASE_IMAGE[0]}" \
-          --image-digest "${BASE_IMAGE[1]}" \
-          --input-file sbom.json \
-          --output-file /tmp/sbom.tmp.json
-        mv /tmp/sbom.tmp.json sbom.json
+        mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
       done
+
+      mobster "${mobster_args[@]}"
 
       echo "[$(date --utc -Ins)] End prepare-sboms"
     securityContext:

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -653,7 +653,8 @@ spec:
         touch /shared/base_images_digests
         echo "Recording base image digests used"
         for image in $BASE_IMAGES; do
-          base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+          # Get the image pullspec and filter out a tag if it is not set
+          base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
           # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
           # if buildah did not use that particular image during build because it was skipped
           if [ -n "$base_image_digest" ]; then
@@ -796,7 +797,7 @@ spec:
 
         echo "[$(date --utc -Ins)] End sbom-syft-generate"
     - name: prepare-sboms
-      image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1b714c468641e910f37c15aa53b867f0b9550a06650e07ffc0583338b963e7af
+      image: quay.io/konflux-ci/mobster:0.5.0-1752493098@sha256:51109021a96e12ad19de9f5ab7a076683250af18d98532385a033916882cd294
       args:
         - --additional-base-images
         - $(params.ADDITIONAL_BASE_IMAGES[*])
@@ -812,33 +813,7 @@ spec:
           exit 0
         fi
 
-        sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
-
-        if [ -f "sbom-cachi2.json" ]; then
-          sboms_to_merge+=(cachi2:sbom-cachi2.json)
-        fi
-
-        echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
-        python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" >sbom.json
-
-        echo "Adding image reference to sbom"
-        IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
-        IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
-
-        python3 /scripts/add_image_reference.py \
-          --image-url "$IMAGE_URL" \
-          --image-digest "$IMAGE_DIGEST" \
-          --input-file sbom.json \
-          --output-file /tmp/sbom.tmp.json
-
-        mv /tmp/sbom.tmp.json sbom.json
-
-        echo "Adding base images data to sbom.json"
-        python3 /scripts/base_images_sbom_script.py \
-          --sbom=sbom.json \
-          --parsed-dockerfile=/shared/parsed_dockerfile.json \
-          --base-images-digests=/shared/base_images_digests
-
+        # Convert Tekton array params into Mobster params
         ADDITIONAL_BASE_IMAGES=()
         while [[ $# -gt 0 ]]; do
           case $1 in
@@ -856,16 +831,32 @@ spec:
           esac
         done
 
+        IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+        IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+        echo "[$(date --utc -Ins)] Generate SBOM with mobster"
+
+        mobster_args=(
+          generate
+          --output sbom.json
+          oci-image
+          --from-syft "/var/workdir/sbom-source.json"
+          --from-syft "/var/workdir/sbom-image.json"
+          --image-pullspec "$IMAGE_URL"
+          --image-digest "$IMAGE_DIGEST"
+          --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+          --base-image-digest-file "/shared/base_images_digests"
+        )
+
+        if [ -f "/var/workdir/sbom-cachi2.json" ]; then
+          mobster_args+=(--from-hermeto "/var/workdir/sbom-cachi2.json")
+        fi
+
         for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-          IFS="@" read -ra BASE_IMAGE <<<"${ADDITIONAL_BASE_IMAGE}"
-          python3 /scripts/add_image_reference.py \
-            --builder-image \
-            --image-url "${BASE_IMAGE[0]}" \
-            --image-digest "${BASE_IMAGE[1]}" \
-            --input-file sbom.json \
-            --output-file /tmp/sbom.tmp.json
-          mv /tmp/sbom.tmp.json sbom.json
+          mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
         done
+
+        mobster "${mobster_args[@]}"
 
         echo "[$(date --utc -Ins)] End prepare-sboms"
       computeResources:

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -692,7 +692,8 @@ spec:
       touch /shared/base_images_digests
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
-        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # Get the image pullspec and filter out a tag if it is not set
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
@@ -944,7 +945,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1b714c468641e910f37c15aa53b867f0b9550a06650e07ffc0583338b963e7af
+    image: quay.io/konflux-ci/mobster:0.5.0-1752493098@sha256:51109021a96e12ad19de9f5ab7a076683250af18d98532385a033916882cd294
     name: prepare-sboms
     script: |
       #!/bin/bash
@@ -961,33 +962,7 @@ spec:
         exit 0
       fi
 
-      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
-
-      if [ -f "sbom-cachi2.json" ]; then
-        sboms_to_merge+=(cachi2:sbom-cachi2.json)
-      fi
-
-      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
-      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" >sbom.json
-
-      echo "Adding image reference to sbom"
-      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
-      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
-
-      python3 /scripts/add_image_reference.py \
-        --image-url "$IMAGE_URL" \
-        --image-digest "$IMAGE_DIGEST" \
-        --input-file sbom.json \
-        --output-file /tmp/sbom.tmp.json
-
-      mv /tmp/sbom.tmp.json sbom.json
-
-      echo "Adding base images data to sbom.json"
-      python3 /scripts/base_images_sbom_script.py \
-        --sbom=sbom.json \
-        --parsed-dockerfile=/shared/parsed_dockerfile.json \
-        --base-images-digests=/shared/base_images_digests
-
+      # Convert Tekton array params into Mobster params
       ADDITIONAL_BASE_IMAGES=()
       while [[ $# -gt 0 ]]; do
         case $1 in
@@ -1005,16 +980,32 @@ spec:
         esac
       done
 
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+      echo "[$(date --utc -Ins)] Generate SBOM with mobster"
+
+      mobster_args=(
+        generate
+        --output sbom.json
+        oci-image
+        --from-syft "/var/workdir/sbom-source.json"
+        --from-syft "/var/workdir/sbom-image.json"
+        --image-pullspec "$IMAGE_URL"
+        --image-digest "$IMAGE_DIGEST"
+        --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+        --base-image-digest-file "/shared/base_images_digests"
+      )
+
+      if [ -f "/var/workdir/sbom-cachi2.json" ]; then
+        mobster_args+=(--from-hermeto "/var/workdir/sbom-cachi2.json")
+      fi
+
       for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-        IFS="@" read -ra BASE_IMAGE <<<"${ADDITIONAL_BASE_IMAGE}"
-        python3 /scripts/add_image_reference.py \
-          --builder-image \
-          --image-url "${BASE_IMAGE[0]}" \
-          --image-digest "${BASE_IMAGE[1]}" \
-          --input-file sbom.json \
-          --output-file /tmp/sbom.tmp.json
-        mv /tmp/sbom.tmp.json sbom.json
+        mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
       done
+
+      mobster "${mobster_args[@]}"
 
       echo "[$(date --utc -Ins)] End prepare-sboms"
     securityContext:

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -660,7 +660,8 @@ spec:
       touch /shared/base_images_digests
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
-        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # Get the image pullspec and filter out a tag if it is not set
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
@@ -912,7 +913,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1b714c468641e910f37c15aa53b867f0b9550a06650e07ffc0583338b963e7af
+    image: quay.io/konflux-ci/mobster:0.5.0-1752493098@sha256:51109021a96e12ad19de9f5ab7a076683250af18d98532385a033916882cd294
     name: prepare-sboms
     script: |
       #!/bin/bash
@@ -929,43 +930,13 @@ spec:
         exit 0
       fi
 
-      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
-
-      if [ -f "sbom-cachi2.json" ]; then
-        sboms_to_merge+=(cachi2:sbom-cachi2.json)
-      fi
-
-      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
-      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom.json
-
-      echo "Adding image reference to sbom"
-      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
-      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
-
-      python3 /scripts/add_image_reference.py \
-        --image-url "$IMAGE_URL" \
-        --image-digest "$IMAGE_DIGEST" \
-        --input-file sbom.json \
-        --output-file /tmp/sbom.tmp.json
-
-      mv /tmp/sbom.tmp.json sbom.json
-
-      echo "Adding base images data to sbom.json"
-      python3 /scripts/base_images_sbom_script.py \
-        --sbom=sbom.json \
-        --parsed-dockerfile=/shared/parsed_dockerfile.json \
-        --base-images-digests=/shared/base_images_digests
-
+      # Convert Tekton array params into Mobster params
       ADDITIONAL_BASE_IMAGES=()
       while [[ $# -gt 0 ]]; do
         case $1 in
           --additional-base-images)
             shift
-            while [[ $# -gt 0 && $1 != --* ]]
-            do
-              ADDITIONAL_BASE_IMAGES+=("$1")
-              shift
-            done
+            while [[ $# -gt 0 && $1 != --* ]]; do ADDITIONAL_BASE_IMAGES+=("$1"); shift; done
             ;;
           *)
             echo "unexpected argument: $1" >&2
@@ -974,16 +945,32 @@ spec:
         esac
       done
 
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+      echo "[$(date --utc -Ins)] Generate SBOM with mobster"
+
+      mobster_args=(
+        generate
+        --output sbom.json
+        oci-image
+        --from-syft "$(workspaces.source.path)/sbom-source.json"
+        --from-syft "$(workspaces.source.path)/sbom-image.json"
+        --image-pullspec "$IMAGE_URL"
+        --image-digest "$IMAGE_DIGEST"
+        --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+        --base-image-digest-file "/shared/base_images_digests"
+      )
+
+      if [ -f "$(workspaces.source.path)/sbom-cachi2.json" ]; then
+        mobster_args+=(--from-hermeto "$(workspaces.source.path)/sbom-cachi2.json")
+      fi
+
       for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-        IFS="@" read -ra BASE_IMAGE <<< "${ADDITIONAL_BASE_IMAGE}"
-        python3 /scripts/add_image_reference.py \
-          --builder-image \
-          --image-url "${BASE_IMAGE[0]}" \
-          --image-digest "${BASE_IMAGE[1]}" \
-          --input-file sbom.json \
-          --output-file /tmp/sbom.tmp.json
-        mv /tmp/sbom.tmp.json sbom.json
+        mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
       done
+
+      mobster "${mobster_args[@]}"
 
       echo "[$(date --utc -Ins)] End prepare-sboms"
     securityContext:

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -573,7 +573,8 @@ spec:
       touch /shared/base_images_digests
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
-        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # Get the image pullspec and filter out a tag if it is not set
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then
@@ -729,7 +730,7 @@ spec:
       subPath: ca-bundle.crt
 
   - name: prepare-sboms
-    image: quay.io/konflux-ci/sbom-utility-scripts@sha256:1b714c468641e910f37c15aa53b867f0b9550a06650e07ffc0583338b963e7af
+    image: quay.io/konflux-ci/mobster:0.5.0-1752493098@sha256:51109021a96e12ad19de9f5ab7a076683250af18d98532385a033916882cd294
     computeResources:
       limits:
         memory: 512Mi
@@ -750,43 +751,13 @@ spec:
         exit 0
       fi
 
-      sboms_to_merge=(syft:sbom-source.json syft:sbom-image.json)
-
-      if [ -f "sbom-cachi2.json" ]; then
-        sboms_to_merge+=(cachi2:sbom-cachi2.json)
-      fi
-
-      echo "Merging sboms: (${sboms_to_merge[*]}) => sbom.json"
-      python3 /scripts/merge_sboms.py "${sboms_to_merge[@]}" > sbom.json
-
-      echo "Adding image reference to sbom"
-      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
-      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
-
-      python3 /scripts/add_image_reference.py \
-        --image-url "$IMAGE_URL" \
-        --image-digest "$IMAGE_DIGEST" \
-        --input-file sbom.json \
-        --output-file /tmp/sbom.tmp.json
-
-      mv /tmp/sbom.tmp.json sbom.json
-
-      echo "Adding base images data to sbom.json"
-      python3 /scripts/base_images_sbom_script.py \
-        --sbom=sbom.json \
-        --parsed-dockerfile=/shared/parsed_dockerfile.json \
-        --base-images-digests=/shared/base_images_digests
-
+      # Convert Tekton array params into Mobster params
       ADDITIONAL_BASE_IMAGES=()
       while [[ $# -gt 0 ]]; do
         case $1 in
           --additional-base-images)
             shift
-            while [[ $# -gt 0 && $1 != --* ]]
-            do
-              ADDITIONAL_BASE_IMAGES+=("$1")
-              shift
-            done
+            while [[ $# -gt 0 && $1 != --* ]]; do ADDITIONAL_BASE_IMAGES+=("$1"); shift; done
             ;;
           *)
             echo "unexpected argument: $1" >&2
@@ -795,16 +766,32 @@ spec:
         esac
       done
 
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+
+      echo "[$(date --utc -Ins)] Generate SBOM with mobster"
+
+      mobster_args=(
+        generate
+        --output sbom.json
+        oci-image
+        --from-syft "$(workspaces.source.path)/sbom-source.json"
+        --from-syft "$(workspaces.source.path)/sbom-image.json"
+        --image-pullspec "$IMAGE_URL"
+        --image-digest "$IMAGE_DIGEST"
+        --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+        --base-image-digest-file "/shared/base_images_digests"
+      )
+
+      if [ -f "$(workspaces.source.path)/sbom-cachi2.json" ]; then
+        mobster_args+=(--from-hermeto "$(workspaces.source.path)/sbom-cachi2.json")
+      fi
+
       for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-        IFS="@" read -ra BASE_IMAGE <<< "${ADDITIONAL_BASE_IMAGE}"
-        python3 /scripts/add_image_reference.py \
-          --builder-image \
-          --image-url "${BASE_IMAGE[0]}" \
-          --image-digest "${BASE_IMAGE[1]}" \
-          --input-file sbom.json \
-          --output-file /tmp/sbom.tmp.json
-        mv /tmp/sbom.tmp.json sbom.json
+        mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
       done
+
+      mobster "${mobster_args[@]}"
 
       echo "[$(date --utc -Ins)] End prepare-sboms"
     workingDir: $(workspaces.source.path)

--- a/task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -96,11 +96,20 @@ spec:
                     .formulation[]?
                     | .components[]?
                     | select(any(.properties[]?; .name | test("^konflux:container:is_(base|builder)_image")))
-                    | .name
+                    | (
+                        .purl
+                        | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                      ) as $matched
+                    | $matched.repository_url
                 else
                     .packages[]
                     | select(any(.annotations[]?.comment; (fromjson?).name? | test("^konflux:container:is_(base|builder)_image")?))
-                    | .name
+                    | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                    | (
+                        $purls | first
+                        | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                      ) as $matched
+                    | $matched.repository_url
                 end
             ' >> "${IMAGES_TO_BE_PROCESSED_PATH}"
             echo "Detected base images from $arch SBOM:"

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -824,7 +824,8 @@ spec:
         touch /shared/base_images_digests
         echo "Recording base image digests used"
         for image in $BASE_IMAGES; do
-          base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+          # Get the image pullspec and filter out a tag if it is not set
+          base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
           # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
           # if buildah did not use that particular image during build because it was skipped
           if [ -n "$base_image_digest" ]; then

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -749,7 +749,8 @@ spec:
       touch /shared/base_images_digests
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
-        base_image_digest=$(buildah images --format '{{ .Name }}:{{ .Tag }}@{{ .Digest }}' --filter reference="$image")
+        # Get the image pullspec and filter out a tag if it is not set
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then

--- a/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
@@ -142,17 +142,24 @@ spec:
                 .formulation[]?
                 | .components[]?
                 | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
-                | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
-                | .name + "@" + $matched.digest
+                | (
+                    .purl
+                    | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                  ) as $matched
+                | $matched.repository_url + "@" + $matched.digest
             ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
         else
           echo ' (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)'
           jq -r '
-                .packages[]
-                | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
-                | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
-                | ($purls | first | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
-                | .name + "@" + $matched.digest
+                  .packages[]
+                  | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
+                  | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                  | (
+                      $purls | first
+                      | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                    ) as $matched
+                  | $matched.repository_url + "@" + $matched.digest
+
             ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
         fi
     - name: build

--- a/task/source-build/0.3/source-build.yaml
+++ b/task/source-build/0.3/source-build.yaml
@@ -131,17 +131,24 @@ spec:
                 .formulation[]?
                 | .components[]?
                 | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
-                | (.purl | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
-                | .name + "@" + $matched.digest
+                | (
+                    .purl
+                    | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                  ) as $matched
+                | $matched.repository_url + "@" + $matched.digest
             ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
         else
             echo ' (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)'
             jq -r '
-                .packages[]
-                | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
-                | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
-                | ($purls | first | capture("^pkg:oci/.*?@(?<digest>.*?:[a-f0-9]*)")) as $matched
-                | .name + "@" + $matched.digest
+                  .packages[]
+                  | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
+                  | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                  | (
+                      $purls | first
+                      | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                    ) as $matched
+                  | $matched.repository_url + "@" + $matched.digest
+
             ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
         fi
 


### PR DESCRIPTION
A Mobster is a unified tool for generating SBOMs in Konflux. The oci image is another content type that is being ported to use Mobster.

A Mobster handles a logic of previously defined scripts and unifies the output across all SBOMs produced by the SBOM.

The oci-image generator executes following steps internally:
- merge syft and hermeto outputs
- add reference to the image and updates relationship
- add base images used to build an image
- add additional base images
- validate a format of the spdx or cyclonedx schema

JIRA: [ISV-5866](https://issues.redhat.com//browse/ISV-5866)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
