### PR TITLE
do-not-merge: Check the GH API response

### DIFF
--- a/.github/workflows/check-task-and-pipeline-yamls.yaml
+++ b/.github/workflows/check-task-and-pipeline-yamls.yaml
@@ -21,12 +21,16 @@ jobs:
         with:
           cluster_name: kind
 
+      - name: DEBUG - Display curl call
+        run: curl -s https://api.github.com/repos/tektoncd/pipeline/releases/latest | jq
+        if: always()
+
       - name: Set up Tekton
         uses: tektoncd/actions/setup-tektoncd@main
         with:
           pipeline_version: latest
 
-      - name: Apply all Task & Pipeline YAMLs
-        run: |
-          set -e
-          ./.github/scripts/check_task_and_pipeline_yamls.sh
+      - name: DEBUG - Display curl call
+        run: curl -s https://api.github.com/repos/tektoncd/pipeline/releases/latest | jq
+        if: always()
+


### PR DESCRIPTION
Try the same curl call that seems to be the cause of failure of the Setup TektonCD GitHub Actions.

This is only for debugging, do not merge.