### PR TITLE
Create renovate group for Mobster

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,15 +7,15 @@
 /task/acs-image-check                       @konflux-ci/build-maintainers
 /task/acs-image-scan                        @konflux-ci/build-maintainers
 /task/apply-tags                            @konflux-ci/build-maintainers
-/task/build-image-index                     @konflux-ci/build-maintainers
-/task/build-image-manifest                  @konflux-ci/build-maintainers
-/task/buildah                               @konflux-ci/build-maintainers
-/task/buildah-min                           @konflux-ci/build-maintainers
-/task/buildah-oci-ta                        @konflux-ci/build-maintainers
-/task/buildah-remote                        @konflux-ci/build-maintainers
-/task/buildah-remote-oci-ta                 @konflux-ci/build-maintainers
-/task/buildah-rhtap                         @konflux-ci/build-maintainers
-/task/download-sbom-from-url-in-attestation @konflux-ci/build-maintainers
+/task/build-image-index                     @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/build-image-manifest                  @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/buildah                               @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/buildah-min                           @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/buildah-oci-ta                        @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/buildah-remote                        @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/buildah-remote-oci-ta                 @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/buildah-rhtap                         @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/download-sbom-from-url-in-attestation @konflux-ci/build-maintainers @konflux-ci/the-collective
 /task/gather-deploy-images                  @konflux-ci/build-maintainers
 /task/git-clone                             @konflux-ci/build-maintainers
 /task/git-clone-oci-ta                      @konflux-ci/build-maintainers
@@ -23,16 +23,16 @@
 /task/pnc-prebuild-git-clone-oci-ta         @konflux-ci/build-maintainers @rnc
 /task/push-dockerfile                       @konflux-ci/build-maintainers
 /task/push-dockerfile-oci-ta                @konflux-ci/build-maintainers
-/task/show-sbom                             @konflux-ci/build-maintainers
-/task/show-sbom-rhdh                        @konflux-ci/build-maintainers
+/task/show-sbom                             @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/show-sbom-rhdh                        @konflux-ci/build-maintainers @konflux-ci/the-collective
 /task/slack-webhook-notification            @konflux-ci/build-maintainers
 /task/slack-webhook-notification-oci-ta     @konflux-ci/build-maintainers
-/task/source-build                          @konflux-ci/build-maintainers
-/task/source-build-oci-ta                   @konflux-ci/build-maintainers
+/task/source-build                          @konflux-ci/build-maintainers @konflux-ci/the-collective
+/task/source-build-oci-ta                   @konflux-ci/build-maintainers @konflux-ci/the-collective
 /task/summary                               @konflux-ci/build-maintainers
 /task/update-deployment                     @konflux-ci/build-maintainers
 /task/update-infra-deployments              @konflux-ci/build-maintainers
-/task/upload-sbom-to-trustification         @konflux-ci/build-maintainers
+/task/upload-sbom-to-trustification         @konflux-ci/build-maintainers @konflux-ci/the-collective
 
 # renovate groupName=build-prefetch
 /task/prefetch-dependencies         @konflux-ci/build-maintainers @brunoapimentel @eskultety @taylormadore
@@ -55,7 +55,7 @@
 /task/fbc-fips-check                            @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/fbc-fips-check-oci-ta                     @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/fbc-target-index-pruning-check            @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
-/task/sbom-json-check                           @konflux-ci/integration-service-maintainers
+/task/sbom-json-check                           @konflux-ci/integration-service-maintainers @konflux-ci/the-collective
 /task/validate-fbc                              @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/fips-operator-bundle-check                @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
 /task/fips-operator-bundle-check-oci-ta         @konflux-ci/integration-service-maintainers @konflux-ci/operator-foundry
@@ -107,18 +107,18 @@
 /task/opm-render-bundles            @gurnben @jbpratt
 
 # renovate groupName=maven
-/task/build-maven-zip           @ligangty @yma96
-/task/build-maven-zip-oci-ta    @ligangty @yma96
+/task/build-maven-zip           @ligangty @yma96 @konflux-ci/the-collective
+/task/build-maven-zip-oci-ta    @ligangty @yma96 @konflux-ci/the-collective
 
 # renovate groupName=oci-copy
-/task/oci-copy          @ralphbean
-/task/oci-copy-oci-ta   @ralphbean
+/task/oci-copy          @ralphbean @konflux-ci/the-collective
+/task/oci-copy-oci-ta   @ralphbean @konflux-ci/the-collective
 
 # renovate groupName=modelcar-oci
-/task/modelcar-oci-ta   @Victoremepunto @ralphbean 
+/task/modelcar-oci-ta   @Victoremepunto @ralphbean @konflux-ci/the-collective
 
 # renovate groupName=buildpack
-/task/build-paketo-builder-oci-ta @cmoulliard
+/task/build-paketo-builder-oci-ta @cmoulliard @konflux-ci/the-collective
 
 # renovate groupName=oci-run-script
 /task/run-script-oci-ta @konflux-ci/build-maintainers @Zokormazo @arewm

--- a/renovate.json
+++ b/renovate.json
@@ -234,7 +234,16 @@
       "matchFileNames": [
         "task/run-script-oci-ta/**"
       ]
+    },
+    {
+      "groupName": "mobster",
+      "matchFileNames": [
+        "task/**"
+      ],
+      "matchManagers": ["regex"],
+      "matchPackageNames": ["quay.io/konflux-ci/mobster"]
     }
+
   ],
   "postUpdateOptions": [
     "gomodTidy"
@@ -297,6 +306,17 @@
       "depNameTemplate": "registry.access.redhat.com/ubi9/buildah",
       "datasourceTemplate": "docker",
       "versioningTemplate": "redhat"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "^task/[\\w-]+/[0-9.]+/[\\w-]+\\.yaml$"
+      ],
+      "matchStrings": [
+        "image: (?<depName>quay\\.io/konflux-ci/mobster[^:]*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "autoReplaceStringTemplate": "image: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
A new renovate group is created to update Mobster images in the Tekton task. The owners file is also updated to let The Collective team review tasks that relates to the SBOMs generation and processing.

JIRA: ISV-6065

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
