### PR TITLE
update CODEOWNERS, delegating paketo-builder task to the build team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,6 +9,7 @@
 /task/apply-tags                            @konflux-ci/build-maintainers
 /task/build-image-index                     @konflux-ci/build-maintainers @Allda @jedinym
 /task/build-image-manifest                  @konflux-ci/build-maintainers @Allda @jedinym
+/task/build-paketo-builder-oci-ta           @konflux-ci/build-maintainers @Allda @jedinym
 /task/buildah                               @konflux-ci/build-maintainers @Allda @jedinym
 /task/buildah-min                           @konflux-ci/build-maintainers @Allda @jedinym
 /task/buildah-oci-ta                        @konflux-ci/build-maintainers @Allda @jedinym
@@ -117,9 +118,6 @@
 
 # renovate groupName=modelcar-oci
 /task/modelcar-oci-ta   @Victoremepunto @ralphbean @Allda @jedinym
-
-# renovate groupName=buildpack
-/task/build-paketo-builder-oci-ta @cmoulliard @Allda @jedinym
 
 # renovate groupName=oci-run-script
 /task/run-script-oci-ta @konflux-ci/build-maintainers @Zokormazo @arewm

--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,7 @@
         "task/apply-tags/**",
         "task/build-image-index/**",
         "task/build-image-manifest/**",
+        "task/build-paketo-builder-oci-ta/**",
         "task/buildah-min/**",
         "task/buildah-oci-ta/**",
         "task/buildah-remote-oci-ta/**",
@@ -206,12 +207,6 @@
         "task/rpms-signature-scan/**"
       ],
       "enabled": false
-    },
-    {
-      "groupName": "buildpack",
-      "matchFileNames": [
-        "task/build-paketo-builder-oci-ta/**"
-      ]
     },
     {
       "groupName": "sealights",


### PR DESCRIPTION
There have been many discussions recently, to delegate paketo-builder-oci-ta task to the build team.

The maintainer of the task has left to IBM and the task almost certainly does not have any users. Becasue of this, we plan to archive this task in the future. On top of that, reviews of PRs usually block us for a long time and sometimes there is no other choice than to use force merge.