### PR TITLE
Describe why setup-tektoncd fails in GH Actions

### DIFF
--- a/.github/workflows/check-task-and-pipeline-yamls.yaml
+++ b/.github/workflows/check-task-and-pipeline-yamls.yaml
@@ -22,9 +22,20 @@ jobs:
           cluster_name: kind
 
       - name: Set up Tekton
+        id: setup-tektoncd
         uses: tektoncd/actions/setup-tektoncd@main
         with:
           pipeline_version: latest
+        continue-on-error: true
+
+      - name: Describe setup-tektoncd failure
+        if: steps.setup-tektoncd.outcome != 'success'
+        run: |
+          curl -s https://api.github.com/repos/tektoncd/pipeline/releases/latest | jq
+          echo "The previous action setup-tektoncd seems to have failed due to a known issue caused by hitting the rate-limit"
+          echo "For more information, follow the following issue: https://github.com/tektoncd/actions/issues/9"
+          echo "The only known workaround at the moment is to re-run this workflow."
+          exit 1
 
       - name: Apply all Task & Pipeline YAMLs
         run: |

--- a/.github/workflows/check-task-migration.yaml
+++ b/.github/workflows/check-task-migration.yaml
@@ -17,8 +17,18 @@ jobs:
         with:
           cluster_name: kind
       - uses: tektoncd/actions/setup-tektoncd@main
+        id: setup-tektoncd
         with:
           pipeline_version: latest
+        continue-on-error: true
+      - name: Describe setup-tektoncd failure
+        if: steps.setup-tektoncd.outcome != 'success'
+        run: |
+          curl -s https://api.github.com/repos/tektoncd/pipeline/releases/latest | jq
+          echo "The previous action setup-tektoncd seems to have failed due to a known issue caused by hitting the rate-limit"
+          echo "For more information, follow the following issue: https://github.com/tektoncd/actions/issues/9"
+          echo "The only known workaround at the moment is to re-run this workflow."
+          exit 1
       - name: Run check
         run: |
           DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
GitHub Actions using the setup-tektoncd step have recently started intermittently failing with a somewhat cryptic error message `jq: error (at <stdin>:1): Cannot iterate over null (null)`

Upstream issue for setup-tektoncd has been filed at https://github.com/tektoncd/actions/issues/9

Until the issue is fixed in upstream, inform users that the issue is known, link it and tell them that they should re-run the workflow.