### PR TITLE
sast-unicode: also get digest from build-container task

### DIFF
--- a/task/sast-unicode-check-oci-ta/0.3/migrations/0.3.sh
+++ b/task/sast-unicode-check-oci-ta/0.3/migrations/0.3.sh
@@ -18,8 +18,11 @@ if yq -e "$tasks_root"' | select(.name == "build-oci-artifact")' "$pipeline_file
 elif yq -e "$tasks_root"' | select(.name == "build-image-index")' "$pipeline_file" >/dev/null; then
     image_digest_value="\$(tasks.build-image-index.results.IMAGE_DIGEST)"
     image_url_value="\$(tasks.build-image-index.results.IMAGE_URL)"
+elif yq -e "$tasks_root"' | select(.name == "build-container")' "$pipeline_file" >/dev/null; then
+    image_digest_value="\$(tasks.build-container.results.IMAGE_DIGEST)"
+    image_url_value="\$(tasks.build-container.results.IMAGE_URL)"
 else
-    echo "Neither build-oci-artifact nor build-image-index tasks found."
+    echo "None of build-container, build-oci-artifact nor build-image-index tasks found."
     exit 0
 fi
 

--- a/task/sast-unicode-check/0.3/migrations/0.3.sh
+++ b/task/sast-unicode-check/0.3/migrations/0.3.sh
@@ -18,8 +18,11 @@ if yq -e "$tasks_root"' | select(.name == "build-oci-artifact")' "$pipeline_file
 elif yq -e "$tasks_root"' | select(.name == "build-image-index")' "$pipeline_file" >/dev/null; then
     image_digest_value="\$(tasks.build-image-index.results.IMAGE_DIGEST)"
     image_url_value="\$(tasks.build-image-index.results.IMAGE_URL)"
+elif yq -e "$tasks_root"' | select(.name == "build-container")' "$pipeline_file" >/dev/null; then
+    image_digest_value="\$(tasks.build-container.results.IMAGE_DIGEST)"
+    image_url_value="\$(tasks.build-container.results.IMAGE_URL)"
 else
-    echo "Neither build-oci-artifact nor build-image-index tasks found."
+    echo "None of build-container, build-oci-artifact nor build-image-index tasks found."
     exit 0
 fi
 


### PR DESCRIPTION
I noticed in one of other pipelines that this migration script did not handle the [case](https://gitlab.cee.redhat.com/osh/cov-sa-container/-/merge_requests/142#note_16828986) where there wasn't a build-oci-artifact or build-image-index task, but there was a build-container task.

We can also grab the image_digest from the build-container task, so added that to the migration script.