### PR TITLE
sast-coverity: bump image for 202503.2 release

### DIFF
--- a/policies/all-tasks.yaml
+++ b/policies/all-tasks.yaml
@@ -34,6 +34,7 @@ sources:
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202412.7
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202503.0
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202503.1
+        - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202503.2
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/nodejs-$(params.nodejs-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/python-$(params.python-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/go-toolset:$(params.go-version)

--- a/policies/step-actions.yaml
+++ b/policies/step-actions.yaml
@@ -19,6 +19,7 @@ sources:
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202412.7
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202503.0
         - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202503.1
+        - step_images.step_images_accessible:quay.io/redhat-services-prod/sast/coverity:202503.2
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/nodejs-$(params.nodejs-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/python-$(params.python-version):latest
         - step_images.step_images_accessible:registry.access.redhat.com/ubi8/go-toolset:$(params.go-version)

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -326,7 +326,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: prepare
-      image: quay.io/redhat-services-prod/sast/coverity:202503.1
+      image: quay.io/redhat-services-prod/sast/coverity:202503.2
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /etc/secrets/cov
@@ -450,7 +450,7 @@ spec:
           exit $EC
         fi
     - name: build
-      image: quay.io/redhat-services-prod/sast/coverity:202503.1
+      image: quay.io/redhat-services-prod/sast/coverity:202503.2
       imagePullPolicy: Always
       args:
         - --build-args
@@ -857,7 +857,7 @@ spec:
           add:
             - SETFCAP
     - name: postprocess
-      image: quay.io/redhat-services-prod/sast/coverity:202503.1
+      image: quay.io/redhat-services-prod/sast/coverity:202503.2
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/sast-coverity-check/0.3/patch.yaml
+++ b/task/sast-coverity-check/0.3/patch.yaml
@@ -71,7 +71,7 @@
 - op: replace
   path: /spec/steps/0/image
   # New image shoould be based on quay.io/konflux-ci/buildah-task:latest or have all the tooling that the original image has.
-  value: quay.io/redhat-services-prod/sast/coverity:202503.1
+  value: quay.io/redhat-services-prod/sast/coverity:202503.2
 
 - op: replace
   path: /spec/steps/0/imagePullPolicy
@@ -180,7 +180,7 @@
   path: /spec/steps/0
   value:
     name: prepare
-    image: quay.io/redhat-services-prod/sast/coverity:202503.1
+    image: quay.io/redhat-services-prod/sast/coverity:202503.2
     workingDir: $(workspaces.source.path)
     env:
       - name: COV_ANALYZE_ARGS
@@ -320,7 +320,7 @@
   path: /spec/steps/2
   value:
     name: postprocess
-    image: quay.io/redhat-services-prod/sast/coverity:202503.1
+    image: quay.io/redhat-services-prod/sast/coverity:202503.2
     computeResources:
       limits:
         memory: 16Gi

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -271,7 +271,7 @@ spec:
       value: $(params.COV_ANALYZE_ARGS)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
-    image: quay.io/redhat-services-prod/sast/coverity:202503.1
+    image: quay.io/redhat-services-prod/sast/coverity:202503.2
     name: prepare
     script: |
       #!/bin/bash
@@ -415,7 +415,7 @@ spec:
         /shared:/shared
         /shared/license.dat:/opt/coverity/bin/license.dat
         /usr/libexec/csgrep-static:/usr/libexec/csgrep-static
-    image: quay.io/redhat-services-prod/sast/coverity:202503.1
+    image: quay.io/redhat-services-prod/sast/coverity:202503.2
     imagePullPolicy: Always
     name: build
     script: |
@@ -821,7 +821,7 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: metadata.annotations['pipelinesascode.tekton.dev/log-url']
-    image: quay.io/redhat-services-prod/sast/coverity:202503.1
+    image: quay.io/redhat-services-prod/sast/coverity:202503.2
     name: postprocess
     script: |
       #!/bin/bash -e


### PR DESCRIPTION
This includes an update to the base konflux-test image, with an RPM update to csdiff, resolving bug PSSECAUT-1207.

Replaces https://github.com/konflux-ci/build-definitions/pull/2563

