### PR TITLE
feat(ISV-5867): Use Mobster to generate oci image SBOM in build-maven-zip task

### DIFF
--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -187,7 +187,7 @@ spec:
         IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
         IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
 
-        # Use Mobster to generate maven-zip file using the Hermeto (Cachi2) output
+        # Use Mobster to generate maven-zip SBOM file using the Hermeto (Cachi2) output
         if [ -f "/var/workdir/cachi2/output/bom.json" ]; then
           mobster generate \
             --output sbom.json \

--- a/task/build-maven-zip/0.1/build-maven-zip.yaml
+++ b/task/build-maven-zip/0.1/build-maven-zip.yaml
@@ -161,7 +161,7 @@ spec:
       IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
       IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
 
-      # Use Mobster to generate maven-zip file using the Hermeto (Cachi2) output
+      # Use Mobster to generate maven-zip SBOM file using the Hermeto (Cachi2) output
       if [ -f "$(workspaces.source.path)/cachi2/output/bom.json" ]; then
         mobster generate \
                 --output sbom.json \


### PR DESCRIPTION
A [Mobster](https://github.com/konflux-ci/mobster) is a unified tool for generating SBOMs in Konflux. The oci image is another content type that is being ported to use Mobster.

JIRA: [ISV-5867](https://issues.redhat.com/browse/ISV-5867)

Signed-off-by: Jakub Gryc <jgryc@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
