### PR TITLE
Add proxy support to buildah tasks

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -62,14 +62,18 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_APPEND_PLATFORM| Whether to append a sanitized platform architecture on the IMAGE tag| false| 'true'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
@@ -209,15 +213,19 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |PROJECT_NAME| | | |
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |RECORD_EXCLUDED| | false| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -61,12 +61,16 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
@@ -206,15 +210,19 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |PROJECT_NAME| | | |
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |RECORD_EXCLUDED| | false| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -60,12 +60,16 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
@@ -200,15 +204,19 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |PROJECT_NAME| | | |
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |RECORD_EXCLUDED| | false| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -61,14 +61,18 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_APPEND_PLATFORM| Whether to append a sanitized platform architecture on the IMAGE tag| false| 'true'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -95,15 +95,19 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| |
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| |
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | |
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |PROJECT_NAME| | | |
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |RECORD_EXCLUDED| | false| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -91,15 +91,19 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| |
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| |
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| | |
 |IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| | |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | |
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |PROJECT_NAME| | | |
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |RECORD_EXCLUDED| | false| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -163,6 +163,25 @@ spec:
     description: Determines if the image inherits the base image labels.
     name: INHERIT_BASE_IMAGE_LABELS
     type: string
+  - default: ""
+    description: HTTP/HTTPS proxy to use for the buildah pull and build operations.
+      Will not be passed through to the container during the build process.
+    name: HTTP_PROXY
+    type: string
+  - default: ""
+    description: Comma separated list of hosts or domains which should bypass the
+      HTTP/HTTPS proxy.
+    name: NO_PROXY
+    type: string
+  - default: proxy-ca-bundle
+    description: The name of the ConfigMap to read proxy CA bundle data from.
+    name: PROXY_CA_TRUST_CONFIG_MAP_NAME
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the proxy CA bundle
+      data.
+    name: PROXY_CA_TRUST_CONFIG_MAP_KEY
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -252,11 +271,33 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
+    - name: BUILDAH_HTTP_PROXY
+      value: $(params.HTTP_PROXY)
+    - name: BUILDAH_NO_PROXY
+      value: $(params.NO_PROXY)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:121ccc64ade7c25fa85e9476d6a318d0020afb159cfc0217c082c04261b3bfdf
     name: build
     script: |
       #!/bin/bash
       set -euo pipefail
+
+      function set_proxy {
+        if [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+          echo "[$(date --utc -Ins)] Setting proxy to ${BUILDAH_HTTP_PROXY}"
+          export HTTP_PROXY="${BUILDAH_HTTP_PROXY}"
+          export HTTPS_PROXY="${BUILDAH_HTTP_PROXY}"
+          export ALL_PROXY="${BUILDAH_HTTP_PROXY}"
+          if [ -n "${BUILDAH_NO_PROXY}" ]; then
+            echo "[$(date --utc -Ins)] Bypassing proxy for ${BUILDAH_NO_PROXY}"
+            export NO_PROXY="${BUILDAH_NO_PROXY}"
+          fi
+        fi
+      }
+
+      function unset_proxy {
+        echo "[$(date --utc -Ins)] Unsetting proxy"
+        unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
+      }
 
       echo "[$(date --utc -Ins)] Validate context path"
 
@@ -283,9 +324,22 @@ spec:
       echo "[$(date --utc -Ins)] Update CA trust"
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      proxy_ca_bundle=/mnt/proxy-ca-bundle/ca-bundle.crt
+      update_ca_trust=false
+
       if [ -f "$ca_bundle" ]; then
-        echo "INFO: Using mounted CA bundle: $ca_bundle"
-        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        echo "[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ -f "$proxy_ca_bundle" ] && [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+        echo "[$(date --utc -Ins)] Using mounted proxy CA bundle: $proxy_ca_bundle"
+        cp -vf $proxy_ca_bundle /etc/pki/ca-trust/source/anchors/proxy-ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ "$update_ca_trust" = "true" ]; then
         update-ca-trust
       fi
 
@@ -404,6 +458,8 @@ spec:
         UNSHARE_ARGS+=("--net")
         buildah_retries=3
 
+        set_proxy
+
         for image in $BASE_IMAGES; do
           if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"
           then
@@ -411,6 +467,9 @@ spec:
             exit 1
           fi
         done
+
+        unset_proxy
+
         echo "Build will be executed with network isolation"
       fi
 
@@ -588,6 +647,7 @@ spec:
           "${ANNOTATIONS[@]}"
           --tls-verify="$TLSVERIFY" --no-cache
           --ulimit nofile=4096:4096
+          --http-proxy=false
           -f "$dockerfile_copy" -t "$IMAGE" .
       )
       buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
@@ -602,10 +662,14 @@ spec:
       # disable host subcription manager integration
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
+      set_proxy
+
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
+
+      unset_proxy
 
       echo "[$(date --utc -Ins)] Add metadata"
 
@@ -647,6 +711,9 @@ spec:
       name: additional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
+      readOnly: true
+    - mountPath: /mnt/proxy-ca-bundle
+      name: proxy-ca-bundle
       readOnly: true
     workingDir: $(workspaces.source.path)
   - env:
@@ -914,6 +981,13 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
+  - configMap:
+      items:
+      - key: $(params.PROXY_CA_TRUST_CONFIG_MAP_KEY)
+        path: ca-bundle.crt
+      name: $(params.PROXY_CA_TRUST_CONFIG_MAP_NAME)
+      optional: true
+    name: proxy-ca-bundle
   workspaces:
   - description: Workspace containing the source code to build.
     name: source

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -22,12 +22,16 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |HERMETIC|Determines if build will be executed without network access.|false|false|
+|HTTP_PROXY|HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.|""|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|NO_PROXY|Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.|""|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|
+|PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
+|PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|proxy-ca-bundle|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -82,6 +82,12 @@ spec:
       description: Determines if build will be executed without network access.
       type: string
       default: "false"
+    - name: HTTP_PROXY
+      description: HTTP/HTTPS proxy to use for the buildah pull and build
+        operations. Will not be passed through to the container during the
+        build process.
+      type: string
+      default: ""
     - name: IMAGE
       description: Reference of the image buildah will produce.
       type: string
@@ -100,6 +106,11 @@ spec:
         image
       type: array
       default: []
+    - name: NO_PROXY
+      description: Comma separated list of hosts or domains which should bypass
+        the HTTP/HTTPS proxy.
+      type: string
+      default: ""
     - name: PREFETCH_INPUT
       description: In case it is not empty, the prefetched content should
         be made available to the build.
@@ -110,6 +121,16 @@ spec:
         with remote VMs
       type: string
       default: "false"
+    - name: PROXY_CA_TRUST_CONFIG_MAP_KEY
+      description: The name of the key in the ConfigMap that contains the
+        proxy CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: PROXY_CA_TRUST_CONFIG_MAP_NAME
+      description: The name of the ConfigMap to read proxy CA bundle data
+        from.
+      type: string
+      default: proxy-ca-bundle
     - name: SBOM_TYPE
       description: 'Select the SBOM format to generate. Valid values: spdx,
         cyclonedx. Note: the SBOM from the prefetch task - if there is one
@@ -200,6 +221,13 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
+    - name: proxy-ca-bundle
+      configMap:
+        items:
+          - key: $(params.PROXY_CA_TRUST_CONFIG_MAP_KEY)
+            path: ca-bundle.crt
+        name: $(params.PROXY_CA_TRUST_CONFIG_MAP_NAME)
+        optional: true
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -308,14 +336,39 @@ spec:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
+        - mountPath: /mnt/proxy-ca-bundle
+          name: proxy-ca-bundle
+          readOnly: true
       env:
         - name: COMMIT_SHA
           value: $(params.COMMIT_SHA)
         - name: DOCKERFILE
           value: $(params.DOCKERFILE)
+        - name: BUILDAH_HTTP_PROXY
+          value: $(params.HTTP_PROXY)
+        - name: BUILDAH_NO_PROXY
+          value: $(params.NO_PROXY)
       script: |
         #!/bin/bash
         set -euo pipefail
+
+        function set_proxy {
+          if [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+            echo "[$(date --utc -Ins)] Setting proxy to ${BUILDAH_HTTP_PROXY}"
+            export HTTP_PROXY="${BUILDAH_HTTP_PROXY}"
+            export HTTPS_PROXY="${BUILDAH_HTTP_PROXY}"
+            export ALL_PROXY="${BUILDAH_HTTP_PROXY}"
+            if [ -n "${BUILDAH_NO_PROXY}" ]; then
+              echo "[$(date --utc -Ins)] Bypassing proxy for ${BUILDAH_NO_PROXY}"
+              export NO_PROXY="${BUILDAH_NO_PROXY}"
+            fi
+          fi
+        }
+
+        function unset_proxy {
+          echo "[$(date --utc -Ins)] Unsetting proxy"
+          unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
+        }
 
         echo "[$(date --utc -Ins)] Validate context path"
 
@@ -342,9 +395,22 @@ spec:
         echo "[$(date --utc -Ins)] Update CA trust"
 
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        proxy_ca_bundle=/mnt/proxy-ca-bundle/ca-bundle.crt
+        update_ca_trust=false
+
         if [ -f "$ca_bundle" ]; then
-          echo "INFO: Using mounted CA bundle: $ca_bundle"
-          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          echo "[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+          update_ca_trust=true
+        fi
+
+        if [ -f "$proxy_ca_bundle" ] && [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+          echo "[$(date --utc -Ins)] Using mounted proxy CA bundle: $proxy_ca_bundle"
+          cp -vf $proxy_ca_bundle /etc/pki/ca-trust/source/anchors/proxy-ca-bundle.crt
+          update_ca_trust=true
+        fi
+
+        if [ "$update_ca_trust" = "true" ]; then
           update-ca-trust
         fi
 
@@ -472,12 +538,17 @@ spec:
           UNSHARE_ARGS+=("--net")
           buildah_retries=3
 
+          set_proxy
+
           for image in $BASE_IMAGES; do
             if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"; then
               echo "Failed to pull base image ${image}"
               exit 1
             fi
           done
+
+          unset_proxy
+
           echo "Build will be executed with network isolation"
         fi
 
@@ -654,6 +725,7 @@ spec:
           "${ANNOTATIONS[@]}"
           --tls-verify="$TLSVERIFY" --no-cache
           --ulimit nofile=4096:4096
+          --http-proxy=false
           -f "$dockerfile_copy" -t "$IMAGE" .
         )
         buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
@@ -668,10 +740,14 @@ spec:
         # disable host subcription manager integration
         find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
+        set_proxy
+
         echo "[$(date --utc -Ins)] Run buildah build"
         echo "[$(date --utc -Ins)] ${command}"
 
         unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
+
+        unset_proxy
 
         echo "[$(date --utc -Ins)] Add metadata"
 

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -81,6 +81,11 @@ spec:
     description: Determines if build will be executed without network access.
     name: HERMETIC
     type: string
+  - default: ""
+    description: HTTP/HTTPS proxy to use for the buildah pull and build operations.
+      Will not be passed through to the container during the build process.
+    name: HTTP_PROXY
+    type: string
   - description: Reference of the image buildah will produce.
     name: IMAGE
     type: string
@@ -99,6 +104,11 @@ spec:
     name: LABELS
     type: array
   - default: ""
+    description: Comma separated list of hosts or domains which should bypass the
+      HTTP/HTTPS proxy.
+    name: NO_PROXY
+    type: string
+  - default: ""
     description: In case it is not empty, the prefetched content should be made available
       to the build.
     name: PREFETCH_INPUT
@@ -107,6 +117,15 @@ spec:
     description: Whether to enable privileged mode, should be used only with remote
       VMs
     name: PRIVILEGED_NESTED
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the proxy CA bundle
+      data.
+    name: PROXY_CA_TRUST_CONFIG_MAP_KEY
+    type: string
+  - default: proxy-ca-bundle
+    description: The name of the ConfigMap to read proxy CA bundle data from.
+    name: PROXY_CA_TRUST_CONFIG_MAP_NAME
     type: string
   - default: spdx
     description: 'Select the SBOM format to generate. Valid values: spdx, cyclonedx.
@@ -289,6 +308,10 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
+    - name: BUILDAH_HTTP_PROXY
+      value: $(params.HTTP_PROXY)
+    - name: BUILDAH_NO_PROXY
+      value: $(params.NO_PROXY)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:121ccc64ade7c25fa85e9476d6a318d0020afb159cfc0217c082c04261b3bfdf
     name: build
     script: |-
@@ -343,6 +366,7 @@ spec:
         rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
         rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
         rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
+        rsync -ra /mnt/proxy-ca-bundle/ "$SSH_HOST:$BUILD_DIR/volumes/proxy-ca-bundle/"
         rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
         rsync -ra --mkpath "/usr/bin/retry" "$SSH_HOST:$BUILD_DIR/usr/bin/retry"
         rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/results/"
@@ -356,6 +380,24 @@ spec:
       #!/bin/bash
       set -euo pipefail
       cd /var/workdir
+
+      function set_proxy {
+        if [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+          echo "[$(date --utc -Ins)] Setting proxy to ${BUILDAH_HTTP_PROXY}"
+          export HTTP_PROXY="${BUILDAH_HTTP_PROXY}"
+          export HTTPS_PROXY="${BUILDAH_HTTP_PROXY}"
+          export ALL_PROXY="${BUILDAH_HTTP_PROXY}"
+          if [ -n "${BUILDAH_NO_PROXY}" ]; then
+            echo "[$(date --utc -Ins)] Bypassing proxy for ${BUILDAH_NO_PROXY}"
+            export NO_PROXY="${BUILDAH_NO_PROXY}"
+          fi
+        fi
+      }
+
+      function unset_proxy {
+        echo "[$(date --utc -Ins)] Unsetting proxy"
+        unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
+      }
 
       echo "[$(date --utc -Ins)] Validate context path"
 
@@ -382,9 +424,22 @@ spec:
       echo "[$(date --utc -Ins)] Update CA trust"
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      proxy_ca_bundle=/mnt/proxy-ca-bundle/ca-bundle.crt
+      update_ca_trust=false
+
       if [ -f "$ca_bundle" ]; then
-        echo "INFO: Using mounted CA bundle: $ca_bundle"
-        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        echo "[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ -f "$proxy_ca_bundle" ] && [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+        echo "[$(date --utc -Ins)] Using mounted proxy CA bundle: $proxy_ca_bundle"
+        cp -vf $proxy_ca_bundle /etc/pki/ca-trust/source/anchors/proxy-ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ "$update_ca_trust" = "true" ]; then
         update-ca-trust
       fi
 
@@ -512,12 +567,17 @@ spec:
         UNSHARE_ARGS+=("--net")
         buildah_retries=3
 
+        set_proxy
+
         for image in $BASE_IMAGES; do
           if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"; then
             echo "Failed to pull base image ${image}"
             exit 1
           fi
         done
+
+        unset_proxy
+
         echo "Build will be executed with network isolation"
       fi
 
@@ -694,6 +754,7 @@ spec:
         "${ANNOTATIONS[@]}"
         --tls-verify="$TLSVERIFY" --no-cache
         --ulimit nofile=4096:4096
+        --http-proxy=false
         -f "$dockerfile_copy" -t "$IMAGE" .
       )
       buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
@@ -708,10 +769,14 @@ spec:
       # disable host subcription manager integration
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
+      set_proxy
+
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
+
+      unset_proxy
 
       echo "[$(date --utc -Ins)] Add metadata"
 
@@ -791,12 +856,15 @@ spec:
           -e YUM_REPOS_D_TARGET="${YUM_REPOS_D_TARGET@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -e BUILDAH_HTTP_PROXY="${BUILDAH_HTTP_PROXY@Q}" \
+          -e BUILDAH_NO_PROXY="${BUILDAH_NO_PROXY@Q}" \
           -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
           -v "${BUILD_DIR@Q}/volumes/workdir:/var/workdir:Z" \
           -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
           -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
           -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
           -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/volumes/proxy-ca-bundle:/mnt/proxy-ca-bundle:Z" \
           -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
           -v "${BUILD_DIR@Q}/usr/bin/retry:/usr/bin/retry:Z" \
           -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
@@ -833,6 +901,9 @@ spec:
       name: additional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
+      readOnly: true
+    - mountPath: /mnt/proxy-ca-bundle
+      name: proxy-ca-bundle
       readOnly: true
     - mountPath: /ssh
       name: ssh
@@ -1114,6 +1185,13 @@ spec:
     secret:
       optional: true
       secretName: $(params.ENTITLEMENT_SECRET)
+  - configMap:
+      items:
+      - key: $(params.PROXY_CA_TRUST_CONFIG_MAP_KEY)
+        path: ca-bundle.crt
+      name: $(params.PROXY_CA_TRUST_CONFIG_MAP_NAME)
+      optional: true
+    name: proxy-ca-bundle
   - emptyDir: {}
     name: shared
   - configMap:

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -163,6 +163,25 @@ spec:
     description: Determines if the image inherits the base image labels.
     name: INHERIT_BASE_IMAGE_LABELS
     type: string
+  - default: ""
+    description: HTTP/HTTPS proxy to use for the buildah pull and build operations.
+      Will not be passed through to the container during the build process.
+    name: HTTP_PROXY
+    type: string
+  - default: ""
+    description: Comma separated list of hosts or domains which should bypass the
+      HTTP/HTTPS proxy.
+    name: NO_PROXY
+    type: string
+  - default: proxy-ca-bundle
+    description: The name of the ConfigMap to read proxy CA bundle data from.
+    name: PROXY_CA_TRUST_CONFIG_MAP_NAME
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the proxy CA bundle
+      data.
+    name: PROXY_CA_TRUST_CONFIG_MAP_KEY
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -266,6 +285,10 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
+    - name: BUILDAH_HTTP_PROXY
+      value: $(params.HTTP_PROXY)
+    - name: BUILDAH_NO_PROXY
+      value: $(params.NO_PROXY)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:121ccc64ade7c25fa85e9476d6a318d0020afb159cfc0217c082c04261b3bfdf
     name: build
     script: |-
@@ -320,6 +343,7 @@ spec:
         rsync -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/volumes/activation-key/"
         rsync -ra /additional-secret/ "$SSH_HOST:$BUILD_DIR/volumes/additional-secret/"
         rsync -ra /mnt/trusted-ca/ "$SSH_HOST:$BUILD_DIR/volumes/trusted-ca/"
+        rsync -ra /mnt/proxy-ca-bundle/ "$SSH_HOST:$BUILD_DIR/volumes/proxy-ca-bundle/"
         rsync -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
         rsync -ra --mkpath "/usr/bin/retry" "$SSH_HOST:$BUILD_DIR/usr/bin/retry"
         rsync -ra "/tekton/results/" "$SSH_HOST:$BUILD_DIR/results/"
@@ -333,6 +357,24 @@ spec:
       #!/bin/bash
       set -euo pipefail
       cd $(workspaces.source.path)
+
+      function set_proxy {
+        if [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+          echo "[$(date --utc -Ins)] Setting proxy to ${BUILDAH_HTTP_PROXY}"
+          export HTTP_PROXY="${BUILDAH_HTTP_PROXY}"
+          export HTTPS_PROXY="${BUILDAH_HTTP_PROXY}"
+          export ALL_PROXY="${BUILDAH_HTTP_PROXY}"
+          if [ -n "${BUILDAH_NO_PROXY}" ]; then
+            echo "[$(date --utc -Ins)] Bypassing proxy for ${BUILDAH_NO_PROXY}"
+            export NO_PROXY="${BUILDAH_NO_PROXY}"
+          fi
+        fi
+      }
+
+      function unset_proxy {
+        echo "[$(date --utc -Ins)] Unsetting proxy"
+        unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
+      }
 
       echo "[$(date --utc -Ins)] Validate context path"
 
@@ -359,9 +401,22 @@ spec:
       echo "[$(date --utc -Ins)] Update CA trust"
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      proxy_ca_bundle=/mnt/proxy-ca-bundle/ca-bundle.crt
+      update_ca_trust=false
+
       if [ -f "$ca_bundle" ]; then
-        echo "INFO: Using mounted CA bundle: $ca_bundle"
-        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        echo "[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ -f "$proxy_ca_bundle" ] && [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+        echo "[$(date --utc -Ins)] Using mounted proxy CA bundle: $proxy_ca_bundle"
+        cp -vf $proxy_ca_bundle /etc/pki/ca-trust/source/anchors/proxy-ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ "$update_ca_trust" = "true" ]; then
         update-ca-trust
       fi
 
@@ -480,6 +535,8 @@ spec:
         UNSHARE_ARGS+=("--net")
         buildah_retries=3
 
+        set_proxy
+
         for image in $BASE_IMAGES; do
           if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"
           then
@@ -487,6 +544,9 @@ spec:
             exit 1
           fi
         done
+
+        unset_proxy
+
         echo "Build will be executed with network isolation"
       fi
 
@@ -664,6 +724,7 @@ spec:
           "${ANNOTATIONS[@]}"
           --tls-verify="$TLSVERIFY" --no-cache
           --ulimit nofile=4096:4096
+          --http-proxy=false
           -f "$dockerfile_copy" -t "$IMAGE" .
       )
       buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
@@ -678,10 +739,14 @@ spec:
       # disable host subcription manager integration
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
+      set_proxy
+
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
+
+      unset_proxy
 
       echo "[$(date --utc -Ins)] Add metadata"
 
@@ -761,12 +826,15 @@ spec:
           -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e DOCKERFILE="${DOCKERFILE@Q}" \
+          -e BUILDAH_HTTP_PROXY="${BUILDAH_HTTP_PROXY@Q}" \
+          -e BUILDAH_NO_PROXY="${BUILDAH_NO_PROXY@Q}" \
           -v "${BUILD_DIR@Q}/workspaces/source:$(workspaces.source.path):Z" \
           -v "${BUILD_DIR@Q}/volumes/shared:/shared:Z" \
           -v "${BUILD_DIR@Q}/volumes/etc-pki-entitlement:/entitlement:Z" \
           -v "${BUILD_DIR@Q}/volumes/activation-key:/activation-key:Z" \
           -v "${BUILD_DIR@Q}/volumes/additional-secret:/additional-secret:Z" \
           -v "${BUILD_DIR@Q}/volumes/trusted-ca:/mnt/trusted-ca:Z" \
+          -v "${BUILD_DIR@Q}/volumes/proxy-ca-bundle:/mnt/proxy-ca-bundle:Z" \
           -v "${BUILD_DIR@Q}/.docker/:/root/.docker:Z" \
           -v "${BUILD_DIR@Q}/usr/bin/retry:/usr/bin/retry:Z" \
           -v "${BUILD_DIR@Q}/results/:/tekton/results:Z" \
@@ -803,6 +871,9 @@ spec:
       name: additional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
+      readOnly: true
+    - mountPath: /mnt/proxy-ca-bundle
+      name: proxy-ca-bundle
       readOnly: true
     - mountPath: /ssh
       name: ssh
@@ -1093,6 +1164,13 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
+  - configMap:
+      items:
+      - key: $(params.PROXY_CA_TRUST_CONFIG_MAP_KEY)
+        path: ca-bundle.crt
+      name: $(params.PROXY_CA_TRUST_CONFIG_MAP_NAME)
+      optional: true
+    name: proxy-ca-bundle
   - name: ssh
     secret:
       optional: false

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -148,7 +148,24 @@ spec:
     description: Determines if the image inherits the base image labels.
     type: string
     default: "true"
-
+  - name: HTTP_PROXY
+    description: >-
+      HTTP/HTTPS proxy to use for the buildah pull and build operations.
+      Will not be passed through to the container during the build process.
+    type: string
+    default: ""
+  - name: NO_PROXY
+    description: Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.
+    type: string
+    default: ""
+  - name: PROXY_CA_TRUST_CONFIG_MAP_NAME
+    type: string
+    description: The name of the ConfigMap to read proxy CA bundle data from.
+    default: proxy-ca-bundle
+  - name: PROXY_CA_TRUST_CONFIG_MAP_KEY
+    type: string
+    description: The name of the key in the ConfigMap that contains the proxy CA bundle data.
+    default: ca-bundle.crt
 
   results:
   - description: Digest of the image just built
@@ -234,6 +251,12 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: $(params.DOCKERFILE)
+    # Avoid using the HTTP_PROXY and NO_PROXY environment vars since these are recognized by many tools
+    # and can cause unexpected behavior.
+    - name: BUILDAH_HTTP_PROXY
+      value: $(params.HTTP_PROXY)
+    - name: BUILDAH_NO_PROXY
+      value: $(params.NO_PROXY)
     args:
       - --build-args
       - $(params.BUILD_ARGS[*])
@@ -245,6 +268,24 @@ spec:
     script: |
       #!/bin/bash
       set -euo pipefail
+
+      function set_proxy {
+        if [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+          echo "[$(date --utc -Ins)] Setting proxy to ${BUILDAH_HTTP_PROXY}"
+          export HTTP_PROXY="${BUILDAH_HTTP_PROXY}"
+          export HTTPS_PROXY="${BUILDAH_HTTP_PROXY}"
+          export ALL_PROXY="${BUILDAH_HTTP_PROXY}"
+          if [ -n "${BUILDAH_NO_PROXY}" ]; then
+            echo "[$(date --utc -Ins)] Bypassing proxy for ${BUILDAH_NO_PROXY}"
+            export NO_PROXY="${BUILDAH_NO_PROXY}"
+          fi
+        fi
+      }
+
+      function unset_proxy {
+        echo "[$(date --utc -Ins)] Unsetting proxy"
+        unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
+      }
 
       echo "[$(date --utc -Ins)] Validate context path"
 
@@ -271,9 +312,22 @@ spec:
       echo "[$(date --utc -Ins)] Update CA trust"
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      proxy_ca_bundle=/mnt/proxy-ca-bundle/ca-bundle.crt
+      update_ca_trust=false
+
       if [ -f "$ca_bundle" ]; then
-        echo "INFO: Using mounted CA bundle: $ca_bundle"
-        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        echo "[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ -f "$proxy_ca_bundle" ] && [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+        echo "[$(date --utc -Ins)] Using mounted proxy CA bundle: $proxy_ca_bundle"
+        cp -vf $proxy_ca_bundle /etc/pki/ca-trust/source/anchors/proxy-ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ "$update_ca_trust" = "true" ]; then
         update-ca-trust
       fi
 
@@ -392,6 +446,8 @@ spec:
         UNSHARE_ARGS+=("--net")
         buildah_retries=3
 
+        set_proxy
+
         for image in $BASE_IMAGES; do
           if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"
           then
@@ -399,6 +455,9 @@ spec:
             exit 1
           fi
         done
+
+        unset_proxy
+
         echo "Build will be executed with network isolation"
       fi
 
@@ -576,6 +635,7 @@ spec:
           "${ANNOTATIONS[@]}"
           --tls-verify="$TLSVERIFY" --no-cache
           --ulimit nofile=4096:4096
+          --http-proxy=false
           -f "$dockerfile_copy" -t "$IMAGE" .
       )
       buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
@@ -590,10 +650,14 @@ spec:
       # disable host subcription manager integration
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
+      set_proxy
+
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
+
+      unset_proxy
 
       echo "[$(date --utc -Ins)] Add metadata"
 
@@ -636,6 +700,9 @@ spec:
       name: additional-secret
     - name: trusted-ca
       mountPath: /mnt/trusted-ca
+      readOnly: true
+    - name: proxy-ca-bundle
+      mountPath: /mnt/proxy-ca-bundle
       readOnly: true
     workingDir: $(workspaces.source.path)
   - name: push
@@ -909,6 +976,13 @@ spec:
       name: $(params.caTrustConfigMapName)
       items:
         - key: $(params.caTrustConfigMapKey)
+          path: ca-bundle.crt
+      optional: true
+  - name: proxy-ca-bundle
+    configMap:
+      name: $(params.PROXY_CA_TRUST_CONFIG_MAP_NAME)
+      items:
+        - key: $(params.PROXY_CA_TRUST_CONFIG_MAP_KEY)
           path: ca-bundle.crt
       optional: true
   workspaces:

--- a/task/sast-coverity-check-oci-ta/0.3/README.md
+++ b/task/sast-coverity-check-oci-ta/0.3/README.md
@@ -22,15 +22,19 @@ Scans source code for security vulnerabilities, including common issues such as 
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |HERMETIC|Determines if build will be executed without network access.|false|false|
+|HTTP_PROXY|HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.|""|false|
 |IMAGE|The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |IMP_FINDINGS_ONLY|Report only important findings. Default is true. To report all findings, specify "false"|true|false|
 |INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |KFP_GIT_URL|Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.|SITE_DEFAULT|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|NO_PROXY|Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.|""|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|
 |PROJECT_NAME||""|false|
+|PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
+|PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|proxy-ca-bundle|false|
 |RECORD_EXCLUDED||false|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -89,6 +89,12 @@ spec:
       description: Determines if build will be executed without network access.
       type: string
       default: "false"
+    - name: HTTP_PROXY
+      description: HTTP/HTTPS proxy to use for the buildah pull and build
+        operations. Will not be passed through to the container during the
+        build process.
+      type: string
+      default: ""
     - name: IMAGE
       description: The task will build a container image and tag it locally
         as $IMAGE, but will not push the image anywhere. Due to the relationship
@@ -123,6 +129,11 @@ spec:
         image
       type: array
       default: []
+    - name: NO_PROXY
+      description: Comma separated list of hosts or domains which should bypass
+        the HTTP/HTTPS proxy.
+      type: string
+      default: ""
     - name: PREFETCH_INPUT
       description: In case it is not empty, the prefetched content should
         be made available to the build.
@@ -136,6 +147,16 @@ spec:
     - name: PROJECT_NAME
       type: string
       default: ""
+    - name: PROXY_CA_TRUST_CONFIG_MAP_KEY
+      description: The name of the key in the ConfigMap that contains the
+        proxy CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: PROXY_CA_TRUST_CONFIG_MAP_NAME
+      description: The name of the ConfigMap to read proxy CA bundle data
+        from.
+      type: string
+      default: proxy-ca-bundle
     - name: RECORD_EXCLUDED
       type: string
       default: "false"
@@ -239,6 +260,13 @@ spec:
       secret:
         optional: true
         secretName: $(params.ENTITLEMENT_SECRET)
+    - name: proxy-ca-bundle
+      configMap:
+        items:
+          - key: $(params.PROXY_CA_TRUST_CONFIG_MAP_KEY)
+            path: ca-bundle.crt
+        name: $(params.PROXY_CA_TRUST_CONFIG_MAP_NAME)
+        optional: true
     - name: shared
       emptyDir: {}
     - name: trusted-ca
@@ -495,11 +523,18 @@ spec:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
+        - mountPath: /mnt/proxy-ca-bundle
+          name: proxy-ca-bundle
+          readOnly: true
       env:
         - name: COMMIT_SHA
           value: $(params.COMMIT_SHA)
         - name: DOCKERFILE
           value: /shared/Containerfile
+        - name: BUILDAH_HTTP_PROXY
+          value: $(params.HTTP_PROXY)
+        - name: BUILDAH_NO_PROXY
+          value: $(params.NO_PROXY)
         - name: ADDITIONAL_VOLUME_MOUNTS
           value: |-
             /opt/coverity:/opt/coverity
@@ -510,6 +545,24 @@ spec:
       script: |
         #!/bin/bash
         set -euo pipefail
+
+        function set_proxy {
+          if [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+            echo "[$(date --utc -Ins)] Setting proxy to ${BUILDAH_HTTP_PROXY}"
+            export HTTP_PROXY="${BUILDAH_HTTP_PROXY}"
+            export HTTPS_PROXY="${BUILDAH_HTTP_PROXY}"
+            export ALL_PROXY="${BUILDAH_HTTP_PROXY}"
+            if [ -n "${BUILDAH_NO_PROXY}" ]; then
+              echo "[$(date --utc -Ins)] Bypassing proxy for ${BUILDAH_NO_PROXY}"
+              export NO_PROXY="${BUILDAH_NO_PROXY}"
+            fi
+          fi
+        }
+
+        function unset_proxy {
+          echo "[$(date --utc -Ins)] Unsetting proxy"
+          unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
+        }
 
         echo "[$(date --utc -Ins)] Validate context path"
 
@@ -536,9 +589,22 @@ spec:
         echo "[$(date --utc -Ins)] Update CA trust"
 
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        proxy_ca_bundle=/mnt/proxy-ca-bundle/ca-bundle.crt
+        update_ca_trust=false
+
         if [ -f "$ca_bundle" ]; then
-          echo "INFO: Using mounted CA bundle: $ca_bundle"
-          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+          echo "[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle"
+          cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+          update_ca_trust=true
+        fi
+
+        if [ -f "$proxy_ca_bundle" ] && [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+          echo "[$(date --utc -Ins)] Using mounted proxy CA bundle: $proxy_ca_bundle"
+          cp -vf $proxy_ca_bundle /etc/pki/ca-trust/source/anchors/proxy-ca-bundle.crt
+          update_ca_trust=true
+        fi
+
+        if [ "$update_ca_trust" = "true" ]; then
           update-ca-trust
         fi
 
@@ -666,12 +732,17 @@ spec:
           UNSHARE_ARGS+=("--net")
           buildah_retries=3
 
+          set_proxy
+
           for image in $BASE_IMAGES; do
             if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"; then
               echo "Failed to pull base image ${image}"
               exit 1
             fi
           done
+
+          unset_proxy
+
           echo "Build will be executed with network isolation"
         fi
 
@@ -848,6 +919,7 @@ spec:
           "${ANNOTATIONS[@]}"
           --tls-verify="$TLSVERIFY" --no-cache
           --ulimit nofile=4096:4096
+          --http-proxy=false
           -f "$dockerfile_copy" -t "$IMAGE" .
         )
         buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
@@ -862,10 +934,14 @@ spec:
         # disable host subcription manager integration
         find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
+        set_proxy
+
         echo "[$(date --utc -Ins)] Run buildah build"
         echo "[$(date --utc -Ins)] ${command}"
 
         unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
+
+        unset_proxy
 
         echo "[$(date --utc -Ins)] Add metadata"
 

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -164,6 +164,25 @@ spec:
     description: Determines if the image inherits the base image labels.
     name: INHERIT_BASE_IMAGE_LABELS
     type: string
+  - default: ""
+    description: HTTP/HTTPS proxy to use for the buildah pull and build operations.
+      Will not be passed through to the container during the build process.
+    name: HTTP_PROXY
+    type: string
+  - default: ""
+    description: Comma separated list of hosts or domains which should bypass the
+      HTTP/HTTPS proxy.
+    name: NO_PROXY
+    type: string
+  - default: proxy-ca-bundle
+    description: The name of the ConfigMap to read proxy CA bundle data from.
+    name: PROXY_CA_TRUST_CONFIG_MAP_NAME
+    type: string
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the proxy CA bundle
+      data.
+    name: PROXY_CA_TRUST_CONFIG_MAP_KEY
+    type: string
   - description: Digest of the image to which the scan results should be associated.
     name: image-digest
     type: string
@@ -431,6 +450,10 @@ spec:
       value: $(params.COMMIT_SHA)
     - name: DOCKERFILE
       value: /shared/Containerfile
+    - name: BUILDAH_HTTP_PROXY
+      value: $(params.HTTP_PROXY)
+    - name: BUILDAH_NO_PROXY
+      value: $(params.NO_PROXY)
     - name: ADDITIONAL_VOLUME_MOUNTS
       value: |-
         /opt/coverity:/opt/coverity
@@ -444,6 +467,24 @@ spec:
     script: |
       #!/bin/bash
       set -euo pipefail
+
+      function set_proxy {
+        if [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+          echo "[$(date --utc -Ins)] Setting proxy to ${BUILDAH_HTTP_PROXY}"
+          export HTTP_PROXY="${BUILDAH_HTTP_PROXY}"
+          export HTTPS_PROXY="${BUILDAH_HTTP_PROXY}"
+          export ALL_PROXY="${BUILDAH_HTTP_PROXY}"
+          if [ -n "${BUILDAH_NO_PROXY}" ]; then
+            echo "[$(date --utc -Ins)] Bypassing proxy for ${BUILDAH_NO_PROXY}"
+            export NO_PROXY="${BUILDAH_NO_PROXY}"
+          fi
+        fi
+      }
+
+      function unset_proxy {
+        echo "[$(date --utc -Ins)] Unsetting proxy"
+        unset HTTP_PROXY HTTPS_PROXY ALL_PROXY NO_PROXY
+      }
 
       echo "[$(date --utc -Ins)] Validate context path"
 
@@ -470,9 +511,22 @@ spec:
       echo "[$(date --utc -Ins)] Update CA trust"
 
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      proxy_ca_bundle=/mnt/proxy-ca-bundle/ca-bundle.crt
+      update_ca_trust=false
+
       if [ -f "$ca_bundle" ]; then
-        echo "INFO: Using mounted CA bundle: $ca_bundle"
-        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        echo "[$(date --utc -Ins)] Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ -f "$proxy_ca_bundle" ] && [ -n "${BUILDAH_HTTP_PROXY}" ]; then
+        echo "[$(date --utc -Ins)] Using mounted proxy CA bundle: $proxy_ca_bundle"
+        cp -vf $proxy_ca_bundle /etc/pki/ca-trust/source/anchors/proxy-ca-bundle.crt
+        update_ca_trust=true
+      fi
+
+      if [ "$update_ca_trust" = "true" ]; then
         update-ca-trust
       fi
 
@@ -591,6 +645,8 @@ spec:
         UNSHARE_ARGS+=("--net")
         buildah_retries=3
 
+        set_proxy
+
         for image in $BASE_IMAGES; do
           if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"
           then
@@ -598,6 +654,9 @@ spec:
             exit 1
           fi
         done
+
+        unset_proxy
+
         echo "Build will be executed with network isolation"
       fi
 
@@ -775,6 +834,7 @@ spec:
           "${ANNOTATIONS[@]}"
           --tls-verify="$TLSVERIFY" --no-cache
           --ulimit nofile=4096:4096
+          --http-proxy=false
           -f "$dockerfile_copy" -t "$IMAGE" .
       )
       buildah_cmd=$(printf "%q " "${buildah_cmd_array[@]}")
@@ -789,10 +849,14 @@ spec:
       # disable host subcription manager integration
       find /usr/share/rhel/secrets -type l -exec unlink {} \;
 
+      set_proxy
+
       echo "[$(date --utc -Ins)] Run buildah build"
       echo "[$(date --utc -Ins)] ${command}"
 
       unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w "${SOURCE_CODE_DIR}/$CONTEXT" --mount -- sh -c "$command"
+
+      unset_proxy
 
       echo "[$(date --utc -Ins)] Add metadata"
 
@@ -834,6 +898,9 @@ spec:
       name: additional-secret
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
+      readOnly: true
+    - mountPath: /mnt/proxy-ca-bundle
+      name: proxy-ca-bundle
       readOnly: true
     workingDir: $(workspaces.source.path)
   - computeResources:
@@ -1071,6 +1138,13 @@ spec:
       name: $(params.caTrustConfigMapName)
       optional: true
     name: trusted-ca
+  - configMap:
+      items:
+      - key: $(params.PROXY_CA_TRUST_CONFIG_MAP_KEY)
+        path: ca-bundle.crt
+      name: $(params.PROXY_CA_TRUST_CONFIG_MAP_NAME)
+      optional: true
+    name: proxy-ca-bundle
   - name: cov-license
     secret:
       optional: false


### PR DESCRIPTION
If specified, the proxy is only configured for buildah pull or build operations to prevent unintentional use by other processes.

Assisted-by: cursor (claude-3.5-sonnet)
