### PR TITLE
fix: FBC does not need to generate SBOMs

### DIFF
--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -70,7 +70,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| | '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
-|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| 'true'|
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -181,6 +181,8 @@ spec:
       value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
+    - name: SKIP_SBOM_GENERATION
+      value: "true"
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -101,6 +101,11 @@
 - op: remove           # build-images -> PRIVILEGED_NESTED
   path: /spec/tasks/3/params/9
 - op: add
+  path: /spec/tasks/3/params/-
+  value:
+    name: SKIP_SBOM_GENERATION
+    value: "true"
+- op: add
   path: /spec/tasks/-
   value:
     name: validate-fbc


### PR DESCRIPTION
FBC fragments are not used on their own, instead the catalog is extracted from them and pushed to production. Since we don't use the SBOM, we can just not produce it.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
