### PR TITLE
feat(STONEINTG-1232): attach migration script to task bundle image

### DIFF
--- a/task/tkn-bundle-oci-ta/0.2/MIGRATION.md
+++ b/task/tkn-bundle-oci-ta/0.2/MIGRATION.md
@@ -1,6 +1,8 @@
 # Migration from 0.1 to 0.2
 The parameter `URL` was added to the task.
 The parameter `REVISION` was added to the task.
+The parameter `depth` is set to `100` in `clone-repository` task if `tkn-bundle-oci-ta` task or `tkn-bundle` task exists in pipeline
 
 ## Action from users
 Add the `URL` and `REVISION` parameters to the `tkn-bundle-oci-ta` task.
+Set the `depth` to `100` in `clone-repository` task if `tkn-bundle-oci-ta` task or `tkn-bundle` task exists in pipeline

--- a/task/tkn-bundle-oci-ta/0.2/migrations/0.2.1.sh
+++ b/task/tkn-bundle-oci-ta/0.2/migrations/0.2.1.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: tkn-bundle-oci-ta@0.2
+# Creation time: 2025-08-15
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# Check if depth parameter already exists in task clone-repository if tkn-bundle* task exists in pipeline
+if yq -e '.spec.tasks[] | select(.name == "build-container").taskRef.params[] | select(.name == "name" and .value == "tkn-bundle")' "$pipeline_file" >/dev/null 2>/dev/null && ! yq -e '.spec.tasks[] | select(.name == "clone-repository").params[] | select(.name == "depth")' "$pipeline_file" >/dev/null 2>/dev/null; then
+    echo "set depth to 100 in clone-repository task if tkn-bundle task exists in pipeline"
+    yq -i "(.spec.tasks[] | select(.name == \"clone-repository\")).params += [{\"name\": \"depth\", \"value\": \"100\"}]" "$pipeline_file"
+elif yq -e '.spec.tasks[] | select(.name == "build-container").taskRef.params[] | select(.name == "name" and .value == "tkn-bundle-oci-ta")' "$pipeline_file" >/dev/null 2>/dev/null && ! yq -e '.spec.tasks[] | select(.name == "clone-repository").params[] | select(.name == "depth")' "$pipeline_file" >/dev/null 2>/dev/null; then
+    echo "set depth to 100 in clone-repository task if tkn-bundle-oci-ta task exists in pipeline"
+    yq -i "(.spec.tasks[] | select(.name == \"clone-repository\")).params += [{\"name\": \"depth\", \"value\": \"100\"}]" "$pipeline_file"
+else
+    echo "depth parameter already exists in clone-repository task or task tkn-bundle(-oci-ta) doesn't exist. No changes needed."
+fi

--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: 0.2.1
     build.appstudio.redhat.com/build_type: tkn-bundle
 spec:
   description: Creates and pushes a Tekton bundle containing the specified
@@ -62,7 +62,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:5dcb1a5e2054d9bb90b52bb98b670edf3ecfcf90cf0cdb8f6970e8a28cd4f260
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -156,6 +156,13 @@ spec:
         set -o pipefail
         set -o nounset
 
+        declare -r ANNOTATION_HAS_MIGRATION="dev.konflux-ci.task.has-migration"
+        declare -r ANNOTATION_IS_MIGRATION="dev.konflux-ci.task.is-migration"
+        declare -r ARTIFACT_TYPE_TEXT_XSHELLSCRIPT="text/x-shellscript"
+        # The annotation value points to the task bundle which has a migration that's most recent to the task with the annotation
+        declare -r ANNOTATION_PREVIOUS_MIGRATION_BUNDLE="dev.konflux-ci.task.previous-migration-bundle"
+
+        # shellcheck disable=SC2153
         mapfile -t FILES <"${TASK_FILE}"
         [[ ${#FILES[@]} -eq 0 ]] &&
           echo "No YAML files matched by \"$CONTEXT\" in \"/var/workdir/${SOURCE_CODE_DIR}\", aborting the build" &&
@@ -191,9 +198,180 @@ spec:
           echo "$prepared_task_file"
         }
 
-        # task_dir is where all the tasks definitions reside
-        # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
+        # Get task version from task definition rather than the version in the directory path.
+        # Arguments: task_file
+        # The version is output to stdout.
+        get_concrete_task_version() {
+          local -r task_file=$1
+          # Ensure an empty string is output rather than string "null" if the version label is not present
+          yq '.metadata.labels."app.kubernetes.io/version"' "$task_file" | sed '/null/d' | tr -d '[:space:]'
+        }
+
+        # check if migration script file exists in given task bundle and task_version.
+        # Arguments: task_bundle, task_version, migration_file
+        bundle_has_migration() {
+          local -r task_bundle=$1
+          local -r task_version=$2
+          local -r migration_file=$3
+
+          # Check if task bundle has an attached migration script file.
+          local filename
+          local found=
+          local artifact_refs
+
+          # List attached artifacts, that have specific artifact type and annotation.
+          # Then, find out the migration artifact.
+          #
+          # Minimum version oras 1.2.0 is required for option --format
+          artifact_refs=$(
+            oras discover "$task_bundle" --artifact-type "$ARTIFACT_TYPE_TEXT_XSHELLSCRIPT" --format json |
+              jq -r "
+              .manifests[]
+              | select(.annotations.\"${ANNOTATION_IS_MIGRATION}\" == \"true\")
+              | .reference"
+          )
+          while read -r artifact_ref; do
+            if [ -z "$artifact_ref" ]; then
+              continue
+            fi
+            filename=$(
+              retry oras pull --format json "$artifact_ref" | jq -r "
+                .files[]
+                | select(.annotations.\"org.opencontainers.image.title\" == \"${task_version}.sh\")
+                | .annotations.\"org.opencontainers.image.title\"
+                "
+            )
+
+            if [ -n "$filename" ]; then
+              if diff "$filename" "$migration_file" >/dev/null; then
+                found=true
+                break
+              else
+                echo "error: task bundle $task_bundle has migration artifact $artifact_ref, but the migration content is different: $filename" 1>&2
+                exit 1
+              fi
+            fi
+          done <<<"$artifact_refs"
+
+          # the same migration script file exist
+          if [ "$found" == "true" ]; then
+            echo true
+          fi
+          # migratioan file doesn't exist
+          echo false
+        }
+
+        attach_migration_file() {
+          local -r task_bundle=$1
+          local -r task_version=$2
+          local -r migration_file=$3
+          local -r auth_json=$4
+
+          pushd "${migration_file%/*}"
+          retry oras attach \
+            --registry-config "${auth_json}" \
+            --artifact-type "$ARTIFACT_TYPE_TEXT_XSHELLSCRIPT" \
+            --annotation "${ANNOTATION_IS_MIGRATION}=true" \
+            "$task_bundle" "${migration_file##*/}"
+          popd
+
+          local status=$?
+          if [[ $status -ne 0 ]]; then
+            echo "failed to attach migration script file to $task_bundle"
+            return 1
+          fi
+
+          echo "Attached migration script file $migration_file to $task_bundle"
+
+          return 0
+        }
+
+        # Find previous bundle that has a migration script file and output its digest.
+        find_previous_migration_bundle_digest() {
+          local ns_repo=${IMAGE%:*} # remove tag if exists
+          ns_repo=${ns_repo#*/}     # remove registry
+          local page=1 url
+          local manifest_file="${HOME}/manifest.json"
+
+          is_task_bundle() {
+            local digest=$1
+            local url="https://quay.io/v2/${ns_repo}/manifests/${digest}"
+            if ! retry curl --fail -L --no-progress-meter -o "$manifest_file" "$url"; then
+              echo "failed to get manifest from $url "
+              return 1
+            fi
+
+            if jq -e '(.mediaType == "application/vnd.docker.distribution.manifest.v2+json") and
+                       (.layers[0].annotations["dev.tekton.image.kind"]? == "task")' "$manifest_file" >/dev/null; then
+              echo "true"
+            else
+              echo "false"
+            fi
+            return 0
+          }
+
+          # iterate all pages
+          while :; do
+            url="https://quay.io/api/v1/repository/${ns_repo}/tag/?onlyActiveTags=true&limit=50&page=$page"
+
+            # get tag list of page $page
+            local response
+            if ! response=$(retry curl --fail -L --no-progress-meter "$url"); then
+              # failed to get the tag list from $url
+              return 1
+            fi
+
+            # try to get task bundle built from push event by matching its tag name format since tag name is commit revision
+            local manifest_digests
+            manifest_digests=$(echo "$response" | jq -r '.tags[] | select(.name | test("^[0-9a-f]+$")) | .manifest_digest')
+            if [ -z "$manifest_digests" ]; then
+              # There is no tag yet. That would mean this is the first time to build the task bundle.
+              echo
+              break
+            fi
+
+            # find a task bundle and check migration script file in gotten manifests in case artifact manifests are mixed with task bundle manifests
+            for manifest_digest in $manifest_digests; do
+              local is_task=false
+              if ! is_task=$(is_task_bundle "$manifest_digest"); then
+                return 1
+              fi
+
+              # get the digest with migration script file
+              if [ "$is_task" = "true" ]; then
+                local has_migration
+                has_migration=$(jq -r ".annotations.\"${ANNOTATION_HAS_MIGRATION}\"" "$manifest_file")
+                if [ "$has_migration" == "true" ]; then
+                  echo "$manifest_digest"
+                  return 0
+                fi
+
+                local prev_bundle_digest
+                prev_bundle_digest=$(jq -r ".annotations.\"${ANNOTATION_PREVIOUS_MIGRATION_BUNDLE}\"" "$manifest_file")
+                if [ -n "$prev_bundle_digest" ] && [ "$prev_bundle_digest" != "null" ]; then
+                  # This bundle points to a previous bundle that has migration.
+                  echo "$prev_bundle_digest"
+                  return 0
+                fi
+                echo
+                return 0
+              fi
+              continue
+            done
+
+            # check pagination
+            echo "$response" | jq -e '.has_additional != true' >/dev/null && break
+            ((page++))
+          done
+
+          echo # return empty if unfound
+          return 0
+        }
+
+        # task_dir is where the task definition reside
+        # this task run for only one task file, so extracting it from the first element is enough
         task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
+        task_version=$(get_concrete_task_version "${FILES[0]}")
 
         # If task is kustomized, generate it and replace the FILES value with the value of the generated task
         # All other files will be ignored.
@@ -204,13 +382,37 @@ spec:
           echo "Task is not Kustomized - continue"
         fi
 
+        echo "info: finding the previous task bundle that has a migration" 1>&2
+        previous_migration_bundle_digest=$(find_previous_migration_bundle_digest)
+
+        # check if migration script file exists in commit
+        has_migration=false
+        migration_file="${task_dir}/migrations/${task_version}.sh"
+        pushd "/var/workdir/${SOURCE_CODE_DIR}"
+
+        if [ ! -d ".git" ]; then
+          echo ".git folder is not found, please switch to correct git root directory and check it again"
+          exit 1
+        fi
+        if [ -f "$migration_file" ]; then
+          prefix="/var/workdir/${SOURCE_CODE_DIR}/"
+          relative_migration_file_path=$(realpath --relative-to="$prefix" "$migration_file") # get the relative migration script file path like task/<task-name>/<task_major_version>/migrations/<task_version>.sh
+
+          relative_task_file_path=$(realpath --relative-to="$prefix" "${FILES[0]}")
+          task_file_sha=$(git log -n 1 --pretty=format:%H -- "$relative_task_file_path")
+          if git show "$task_file_sha" --oneline --name-only | grep -q "$relative_migration_file_path"; then
+            # There is a migration script file matching the task concrete version and
+            # is included in the same commit with the task.
+            echo "there is a migration script file ${relative_migration_file_path} in revision ${task_file_sha}"
+            has_migration=true
+          fi
+        fi
+        popd
+
         ANNOTATIONS=()
         ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
         ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
         ANNOTATIONS+=("org.opencontainers.image.url=${URL}/tree/${REVISION}/${CONTEXT}")
-
-        # Ensure an empty string is output rather than string "null" if the version label is not present
-        task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
         ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
 
         if [ -f "${task_dir}/README.md" ]; then
@@ -227,6 +429,12 @@ spec:
         description=$(yq '.spec.description' "${FILES[@]}" | sed '/null/d' | tr -d '')
         ANNOTATIONS+=("org.opencontainers.image.description=${description}")
 
+        if [ "$has_migration" == "true" ]; then
+          ANNOTATIONS+=("${ANNOTATION_HAS_MIGRATION}=true")
+        fi
+
+        ANNOTATIONS+=("${ANNOTATION_PREVIOUS_MIGRATION_BUNDLE}=${previous_migration_bundle_digest}")
+
         echo "Added annotations:"
         ANNOTATION_FLAGS=()
         for annotation in "${ANNOTATIONS[@]}"; do
@@ -242,12 +450,35 @@ spec:
           echo "Failed to push bundle ${IMAGE} to registry"
           exit 1
         fi
-        echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"
+
         digest="${OUT#*Pushed Tekton Bundle to *@}"
+        IMAGE_REF="${IMAGE}@${digest}"
+
+        echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"
         echo -n "${digest}" >"$(results.IMAGE_DIGEST.path)"
-        echo -n "${IMAGE}@${digest}" >"$(results.IMAGE_REF.path)"
+        echo -n "${IMAGE_REF}" >"$(results.IMAGE_REF.path)"
+
+        if [ "$has_migration" == "true" ]; then
+          has_migration_file=$(bundle_has_migration "${IMAGE_REF}" "${task_version}" "${migration_file}")
+          if [[ -z ${has_migration_file} ]]; then
+            echo "there is different migration script file in task bundle ${IMAGE_REF}, failed"
+            exit 1
+          fi
+
+          if [[ "${has_migration_file}" == "true" ]]; then
+            echo "the same migration script file exists in task bundle ${IMAGE_REF}, skipped"
+            exit 0
+          fi
+
+          echo "attach migration script to $IMAGE_REF"
+          select-oci-auth "${IMAGE_REF}" >"${HOME}/auth.json"
+          if ! attach_migration_file "${IMAGE_REF}" "${task_version}" "${migration_file}" "${HOME}/auth.json"; then
+            exit 1
+          fi
+        fi
 
         # cleanup task file
+        # shellcheck disable=SC2153
         [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"
       securityContext:
         runAsUser: 0

--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -338,7 +338,7 @@ spec:
               fi
 
               # get the digest with migration script file
-              if [ "$is_task" = "true" ]; then
+              if [ "$is_task" == "true" ]; then
                 local has_migration
                 has_migration=$(jq -r ".annotations.\"${ANNOTATION_HAS_MIGRATION}\"" "$manifest_file")
                 if [ "$has_migration" == "true" ]; then
@@ -394,12 +394,14 @@ spec:
           echo ".git folder is not found, please switch to correct git root directory and check it again"
           exit 1
         fi
+
         if [ -f "$migration_file" ]; then
           prefix="/var/workdir/${SOURCE_CODE_DIR}/"
           relative_migration_file_path=$(realpath --relative-to="$prefix" "$migration_file") # get the relative migration script file path like task/<task-name>/<task_major_version>/migrations/<task_version>.sh
 
           relative_task_file_path=$(realpath --relative-to="$prefix" "${FILES[0]}")
           task_file_sha=$(git log -n 1 --pretty=format:%H -- "$relative_task_file_path")
+
           if git show "$task_file_sha" --oneline --name-only | grep -q "$relative_migration_file_path"; then
             # There is a migration script file matching the task concrete version and
             # is included in the same commit with the task.
@@ -429,11 +431,20 @@ spec:
         description=$(yq '.spec.description' "${FILES[@]}" | sed '/null/d' | tr -d '')
         ANNOTATIONS+=("org.opencontainers.image.description=${description}")
 
-        if [ "$has_migration" == "true" ]; then
-          ANNOTATIONS+=("${ANNOTATION_HAS_MIGRATION}=true")
-        fi
-
         ANNOTATIONS+=("${ANNOTATION_PREVIOUS_MIGRATION_BUNDLE}=${previous_migration_bundle_digest}")
+
+        if [ "$has_migration" == "true" ]; then
+          if [ -n "$previous_migration_bundle_digest" ]; then
+            previous_task_bundle="${IMAGE%%:*}@${previous_migration_bundle_digest}"
+            if ! has_same_migration_in_previous_task_bundle=$(bundle_has_migration "${previous_task_bundle}" "${task_version}" "${migration_file}") || [[ "${has_same_migration_in_previous_task_bundle}" == "false" ]]; then
+              ANNOTATIONS+=("${ANNOTATION_HAS_MIGRATION}=true")
+            fi
+            # still ignore the migration script file if the same migration script file has been attached to previous task bundle
+            # especially for repush or PR with .tekton/ files change only
+            echo "the same migration script file exists in previous task bundle ${previous_task_bundle} for pushed event, skipped"
+            has_migration=false
+          fi
+        fi
 
         echo "Added annotations:"
         ANNOTATION_FLAGS=()

--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -438,11 +438,12 @@ spec:
             previous_task_bundle="${IMAGE%%:*}@${previous_migration_bundle_digest}"
             if ! has_same_migration_in_previous_task_bundle=$(bundle_has_migration "${previous_task_bundle}" "${task_version}" "${migration_file}") || [[ "${has_same_migration_in_previous_task_bundle}" == "false" ]]; then
               ANNOTATIONS+=("${ANNOTATION_HAS_MIGRATION}=true")
+            else
+              # still ignore the migration script file if the same migration script file has been attached to previous task bundle
+              # especially for repush or PR with .tekton/ files change only
+              echo "the same migration script file exists in previous task bundle ${previous_task_bundle} for pushed event, skipped"
+              has_migration=false
             fi
-            # still ignore the migration script file if the same migration script file has been attached to previous task bundle
-            # especially for repush or PR with .tekton/ files change only
-            echo "the same migration script file exists in previous task bundle ${previous_task_bundle} for pushed event, skipped"
-            has_migration=false
           fi
         fi
 

--- a/task/tkn-bundle/0.2/MIGRATION.md
+++ b/task/tkn-bundle/0.2/MIGRATION.md
@@ -1,6 +1,8 @@
 # Migration from 0.1 to 0.2
 The parameter `URL` was added to the task.
 The parameter `REVISION` was added to the task.
+The parameter `depth` is set to `100` in `clone-repository` task if `tkn-bundle-oci-ta` task or `tkn-bundle` task exists in pieline
 
 ## Action from users
 Add the `URL` and `REVISION` parameters to the `tkn-bundle` task.
+Set the `depth` to `100` in `clone-repository` task if `tkn-bundle` task exists in pipeline

--- a/task/tkn-bundle/0.2/migrations/0.2.1.sh
+++ b/task/tkn-bundle/0.2/migrations/0.2.1.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: tkn-bundle@0.2
+# Creation time: 2025-08-15
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# Check if depth parameter already exists in task clone-repository if tkn-bundle* task exists in pipeline
+if yq -e '.spec.tasks[] | select(.name == "build-container").taskRef.params[] | select(.name == "name" and .value == "tkn-bundle")' "$pipeline_file" >/dev/null 2>/dev/null && ! yq -e '.spec.tasks[] | select(.name == "clone-repository").params[] | select(.name == "depth")' "$pipeline_file" >/dev/null 2>/dev/null; then
+    echo "set depth to 100 in clone-repository task if tkn-bundle task exists in pipeline"
+    yq -i "(.spec.tasks[] | select(.name == \"clone-repository\")).params += [{\"name\": \"depth\", \"value\": \"100\"}]" "$pipeline_file"
+else
+    echo "depth parameter already exists in clone-repository task or task tkn-bundle doesn't exist. No changes needed."
+fi

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.2.1"
     build.appstudio.redhat.com/build_type: "tkn-bundle"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -138,6 +138,13 @@ spec:
       set -o pipefail
       set -o nounset
 
+      declare -r ANNOTATION_HAS_MIGRATION="dev.konflux-ci.task.has-migration"
+      declare -r ANNOTATION_IS_MIGRATION="dev.konflux-ci.task.is-migration"
+      declare -r ARTIFACT_TYPE_TEXT_XSHELLSCRIPT="text/x-shellscript"
+      # The annotation value points to the task bundle which has a migration that's most recent to the task with the annotation
+      declare -r ANNOTATION_PREVIOUS_MIGRATION_BUNDLE="dev.konflux-ci.task.previous-migration-bundle"
+
+      # shellcheck disable=SC2153
       mapfile -t FILES <"${TASK_FILE}"
       [[ ${#FILES[@]} -eq 0 ]] &&
         echo "No YAML files matched by \"$CONTEXT\" in \"/var/workdir/${SOURCE_CODE_DIR}\", aborting the build" &&
@@ -173,9 +180,181 @@ spec:
         echo "$prepared_task_file"
       }
 
-      # task_dir is where all the tasks definitions reside
-      # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
+      # Get task version from task definition rather than the version in the directory path.
+      # Arguments: task_file
+      # The version is output to stdout.
+      get_concrete_task_version() {
+        local -r task_file=$1
+        # Ensure an empty string is output rather than string "null" if the version label is not present
+        yq '.metadata.labels."app.kubernetes.io/version"' "$task_file" | sed '/null/d' | tr -d '[:space:]'
+      }
+
+      # check if migration script file exists in given task bundle and task_version.
+      # Arguments: task_bundle, task_version, migration_file
+      bundle_has_migration() {
+        local -r task_bundle=$1
+        local -r task_version=$2
+        local -r migration_file=$3
+
+        # Check if task bundle has an attached migration script file.
+        local filename
+        local found=
+        local artifact_refs
+
+        # List attached artifacts, that have specific artifact type and annotation.
+        # Then, find out the migration artifact.
+        #
+        # Minimum version oras 1.2.0 is required for option --format
+        artifact_refs=$(
+          oras discover "$task_bundle" --artifact-type "$ARTIFACT_TYPE_TEXT_XSHELLSCRIPT" --format json | \
+          jq -r "
+            .manifests[]
+            | select(.annotations.\"${ANNOTATION_IS_MIGRATION}\" == \"true\")
+            | .reference"
+        )
+        while read -r artifact_ref; do
+          if [ -z "$artifact_ref" ]; then
+              continue
+          fi
+          filename=$(
+            retry oras pull --format json "$artifact_ref" | jq -r "
+              .files[]
+              | select(.annotations.\"org.opencontainers.image.title\" == \"${task_version}.sh\")
+              | .annotations.\"org.opencontainers.image.title\"
+              "
+          )
+
+          if [ -n "$filename" ]; then
+            if diff "$filename" "$migration_file" >/dev/null; then
+              found=true
+              break
+            else
+              echo "error: task bundle $task_bundle has migration artifact $artifact_ref, but the migration content is different: $filename" 1>&2
+              exit 1
+            fi
+          fi
+        done <<<"$artifact_refs"
+
+        # the same migration script file exist
+        if [ "$found" == "true" ]; then
+          echo true
+        fi
+        # migratioan file doesn't exist
+        echo false
+      }
+
+      attach_migration_file() {
+        local -r task_bundle=$1
+        local -r task_version=$2
+        local -r migration_file=$3
+        local -r auth_json=$4
+
+        pushd "${migration_file%/*}"
+        retry oras attach \
+          --registry-config "${auth_json}" \
+          --artifact-type "$ARTIFACT_TYPE_TEXT_XSHELLSCRIPT" \
+          --annotation "${ANNOTATION_IS_MIGRATION}=true" \
+          "$task_bundle" "${migration_file##*/}"
+        popd
+
+        local status=$?
+        if [[ $status -ne 0 ]]; then
+          echo "failed to attach migration script file to $task_bundle"
+          return 1
+        fi
+
+        echo "Attached migration script file $migration_file to $task_bundle"
+
+        return 0
+      }
+
+      # Find previous bundle that has a migration script file and output its digest.
+      find_previous_migration_bundle_digest() {
+        local ns_repo=${IMAGE%:*}  # remove tag if exists
+        ns_repo=${ns_repo#*/}  # remove registry
+        local page=1 url
+        local manifest_file="${HOME}/manifest.json"
+
+        is_task_bundle() {
+            local digest=$1
+            local url="https://quay.io/v2/${ns_repo}/manifests/${digest}"
+            if ! retry curl --fail -L --no-progress-meter -o "$manifest_file" "$url"; then
+                echo "failed to get manifest from $url "
+                return 1
+            fi
+
+            if jq -e '(.mediaType == "application/vnd.docker.distribution.manifest.v2+json") and
+                     (.layers[0].annotations["dev.tekton.image.kind"]? == "task")' "$manifest_file" >/dev/null; then
+                echo "true"
+            else
+                echo "false"
+            fi
+            return 0
+        }
+
+        # iterate all pages
+        while :; do
+          url="https://quay.io/api/v1/repository/${ns_repo}/tag/?onlyActiveTags=true&limit=50&page=$page"
+
+          # get tag list of page $page
+          local response
+          if ! response=$(retry curl --fail -L --no-progress-meter "$url"); then
+            # failed to get the tag list from $url
+            return 1
+          fi
+
+          # try to get task bundle built from push event by matching its tag name format since tag name is commit revision
+          local manifest_digests
+          manifest_digests=$(echo "$response" | jq -r '.tags[] | select(.name | test("^[0-9a-f]+$")) | .manifest_digest')
+          if [ -z "$manifest_digests" ]; then
+            # There is no tag yet. That would mean this is the first time to build the task bundle.
+            echo
+            break
+          fi
+
+          # find a task bundle and check migration script file in gotten manifests in case artifact manifests are mixed with task bundle manifests
+          for manifest_digest in $manifest_digests
+          do
+            local is_task=false
+            if ! is_task=$(is_task_bundle "$manifest_digest"); then
+              return 1
+            fi
+
+            # get the digest with migration script file
+            if [ "$is_task" = "true" ]; then
+              local has_migration
+              has_migration=$(jq -r ".annotations.\"${ANNOTATION_HAS_MIGRATION}\"" "$manifest_file")
+              if [ "$has_migration" == "true" ]; then
+                  echo "$manifest_digest"
+                  return 0
+              fi
+
+              local prev_bundle_digest
+              prev_bundle_digest=$(jq -r ".annotations.\"${ANNOTATION_PREVIOUS_MIGRATION_BUNDLE}\"" "$manifest_file")
+              if [ -n "$prev_bundle_digest" ] && [ "$prev_bundle_digest" != "null" ]; then
+                  # This bundle points to a previous bundle that has migration.
+                  echo "$prev_bundle_digest"
+                  return 0
+              fi
+              echo
+              return 0
+            fi
+            continue
+          done
+
+          # check pagination
+          echo "$response" | jq -e '.has_additional != true' >/dev/null && break
+          ((page++))
+        done
+
+        echo  # return empty if unfound
+        return 0
+      }
+
+      # task_dir is where the task definition reside
+      # this task run for only one task file, so extracting it from the first element is enough
       task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
+      task_version=$(get_concrete_task_version "${FILES[0]}")
 
       # If task is kustomized, generate it and replace the FILES value with the value of the generated task
       # All other files will be ignored.
@@ -186,13 +365,37 @@ spec:
         echo "Task is not Kustomized - continue"
       fi
 
+      echo "info: finding the previous task bundle that has a migration" 1>&2
+      previous_migration_bundle_digest=$(find_previous_migration_bundle_digest)
+
+      # check if migration script file exists in commit
+      has_migration=false
+      migration_file="${task_dir}/migrations/${task_version}.sh"
+      pushd "$(workspaces.source.path)/${SOURCE_CODE_DIR}"
+
+      if [ ! -d ".git" ]; then
+        echo ".git folder is not found, please switch to correct git root directory and check it again"
+        exit 1
+      fi
+      if [ -f "$migration_file" ]; then
+        prefix="$(workspaces.source.path)/${SOURCE_CODE_DIR}/"
+        relative_migration_file_path=$(realpath --relative-to="$prefix" "$migration_file") # get the relative migration script file path like task/<task-name>/<task_major_version>/migrations/<task_version>.sh
+
+        relative_task_file_path=$(realpath --relative-to="$prefix" "${FILES[0]}")
+        task_file_sha=$(git log -n 1 --pretty=format:%H -- "$relative_task_file_path")
+        if git show "$task_file_sha" --oneline --name-only | grep -q "$relative_migration_file_path"; then
+          # There is a migration script file matching the task concrete version and
+          # is included in the same commit with the task.
+          echo "there is a migration script file ${relative_migration_file_path} in revision ${task_file_sha}"
+          has_migration=true
+        fi
+      fi
+      popd
+
       ANNOTATIONS=()
       ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
       ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
       ANNOTATIONS+=("org.opencontainers.image.url=${URL}/tree/${REVISION}/${CONTEXT}")
-
-      # Ensure an empty string is output rather than string "null" if the version label is not present
-      task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
       ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
 
       if [ -f "${task_dir}/README.md" ]; then
@@ -208,6 +411,12 @@ spec:
       fi
       description=$(yq '.spec.description' "${FILES[@]}" | sed '/null/d' | tr -d '')
       ANNOTATIONS+=("org.opencontainers.image.description=${description}")
+
+      if [ "$has_migration" == "true" ]; then
+        ANNOTATIONS+=("${ANNOTATION_HAS_MIGRATION}=true")
+      fi
+
+      ANNOTATIONS+=("${ANNOTATION_PREVIOUS_MIGRATION_BUNDLE}=${previous_migration_bundle_digest}")
 
       echo "Added annotations:"
       ANNOTATION_FLAGS=()
@@ -225,12 +434,36 @@ spec:
         echo "Failed to push bundle ${IMAGE} to registry"
         exit 1
       fi
-      echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"
+
       digest="${OUT#*Pushed Tekton Bundle to *@}"
+      IMAGE_REF="${IMAGE}@${digest}"
+
+      echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"
       echo -n "${digest}" >"$(results.IMAGE_DIGEST.path)"
-      echo -n "${IMAGE}@${digest}" >"$(results.IMAGE_REF.path)"
+      echo -n "${IMAGE_REF}" >"$(results.IMAGE_REF.path)"
+
+      if [ "$has_migration" == "true" ]; then
+        has_migration_file=$(bundle_has_migration "${IMAGE_REF}" "${task_version}" "${migration_file}")
+        if [[ -z ${has_migration_file} ]]; then
+          echo "there is different migration script file in task bundle ${IMAGE_REF}, failed"
+          exit 1
+        fi
+
+        if [[ "${has_migration_file}" == "true" ]]; then
+          echo "the same migration script file exists in task bundle ${IMAGE_REF}, skipped"
+          exit 0
+        fi
+
+        echo "attach migration script to $IMAGE_REF"
+        select-oci-auth "${IMAGE_REF}" > "${HOME}/auth.json"
+        if ! attach_migration_file "${IMAGE_REF}" "${task_version}" "${migration_file}" "${HOME}/auth.json"
+        then
+          exit 1
+        fi
+      fi
 
       # cleanup task file
+      # shellcheck disable=SC2153
       [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"
     securityContext:
       runAsUser: 0

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -321,7 +321,7 @@ spec:
             fi
 
             # get the digest with migration script file
-            if [ "$is_task" = "true" ]; then
+            if [ "$is_task" == "true" ]; then
               local has_migration
               has_migration=$(jq -r ".annotations.\"${ANNOTATION_HAS_MIGRATION}\"" "$manifest_file")
               if [ "$has_migration" == "true" ]; then
@@ -377,12 +377,14 @@ spec:
         echo ".git folder is not found, please switch to correct git root directory and check it again"
         exit 1
       fi
+
       if [ -f "$migration_file" ]; then
         prefix="$(workspaces.source.path)/${SOURCE_CODE_DIR}/"
         relative_migration_file_path=$(realpath --relative-to="$prefix" "$migration_file") # get the relative migration script file path like task/<task-name>/<task_major_version>/migrations/<task_version>.sh
 
         relative_task_file_path=$(realpath --relative-to="$prefix" "${FILES[0]}")
         task_file_sha=$(git log -n 1 --pretty=format:%H -- "$relative_task_file_path")
+
         if git show "$task_file_sha" --oneline --name-only | grep -q "$relative_migration_file_path"; then
           # There is a migration script file matching the task concrete version and
           # is included in the same commit with the task.
@@ -412,11 +414,20 @@ spec:
       description=$(yq '.spec.description' "${FILES[@]}" | sed '/null/d' | tr -d '')
       ANNOTATIONS+=("org.opencontainers.image.description=${description}")
 
-      if [ "$has_migration" == "true" ]; then
-        ANNOTATIONS+=("${ANNOTATION_HAS_MIGRATION}=true")
-      fi
-
       ANNOTATIONS+=("${ANNOTATION_PREVIOUS_MIGRATION_BUNDLE}=${previous_migration_bundle_digest}")
+
+      if [ "$has_migration" == "true" ]; then
+        if [ -n "$previous_migration_bundle_digest" ]; then
+          previous_task_bundle="${IMAGE%%:*}@${previous_migration_bundle_digest}"
+          if ! has_same_migration_in_previous_task_bundle=$(bundle_has_migration "${previous_task_bundle}" "${task_version}" "${migration_file}") || [[ "${has_same_migration_in_previous_task_bundle}" == "false" ]]; then
+            ANNOTATIONS+=("${ANNOTATION_HAS_MIGRATION}=true")
+          fi
+          # still ignore the migration script file if the same migration script file has been attached to previous task bundle
+          # especially for repush or PR with .tekton/ files change only
+          echo "the same migration script file exists in previous task bundle ${previous_task_bundle} for pushed event, skipped"
+          has_migration=false
+        fi
+      fi
 
       echo "Added annotations:"
       ANNOTATION_FLAGS=()

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -132,106 +132,106 @@ spec:
     - name: REVISION
       value: $(params.REVISION)
     script: |
-        #!/bin/env bash
+      #!/bin/env bash
 
-        set -o errexit
-        set -o pipefail
-        set -o nounset
+      set -o errexit
+      set -o pipefail
+      set -o nounset
 
-        mapfile -t FILES <"${TASK_FILE}"
-        [[ ${#FILES[@]} -eq 0 ]] &&
-          echo "No YAML files matched by \"$CONTEXT\" in \"/var/workdir/${SOURCE_CODE_DIR}\", aborting the build" &&
-          exit 1
-        exec 3>&1
+      mapfile -t FILES <"${TASK_FILE}"
+      [[ ${#FILES[@]} -eq 0 ]] &&
+        echo "No YAML files matched by \"$CONTEXT\" in \"/var/workdir/${SOURCE_CODE_DIR}\", aborting the build" &&
+        exit 1
+      exec 3>&1
 
-        function escape_tkn_bundle_arg() {
-          # the arguments to `tkn bundle --annotate` need to be escaped in a curious way
-          # see https://github.com/tektoncd/cli/issues/2402 for details
+      function escape_tkn_bundle_arg() {
+        # the arguments to `tkn bundle --annotate` need to be escaped in a curious way
+        # see https://github.com/tektoncd/cli/issues/2402 for details
 
-          local arg=$1
-          # replace single double-quotes with double double-quotes (this escapes the double-quotes)
-          local escaped_arg=${arg//\"/\"\"}
-          # wrap the whole thing in double-quotes (this escapes commas)
-          printf '"%s"' "$escaped_arg"
-        }
+        local arg=$1
+        # replace single double-quotes with double double-quotes (this escapes the double-quotes)
+        local escaped_arg=${arg//\"/\"\"}
+        # wrap the whole thing in double-quotes (this escapes commas)
+        printf '"%s"' "$escaped_arg"
+      }
 
-        # Check if task is kustomized
-        # A task considered to be kustomized when a kustomization file is found in the task dir
-        is_kustomized_task() {
-            local -r task_dir=$1
-            if [[ -f "$task_dir/kustomization.yaml" || -f "$task_dir/kustomization.yml" ]] ; then
-                return 0
-            fi
-            return 1
-        }
-
-        # Generate a task from the kustomization file
-        generate_kustomized_task() {
-            local -r task_dir=$1
-            local -r prepared_task_file="$task_dir/generated-kustomized-task.yaml"
-            kubectl kustomize "$task_dir" >"$prepared_task_file"
-            echo "$prepared_task_file"
-        }
-
-        # task_dir is where all the tasks definitions reside
-        # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
-        task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
-
-        # If task is kustomized, generate it and replace the FILES value with the value of the generated task
-        # All other files will be ignored.
-        if is_kustomized_task "$task_dir"; then
-            echo "Generating a kustomized task from $task_dir"
-            FILES=("$(generate_kustomized_task "$task_dir")")
-        else
-            echo "Task is not Kustomized - continue"
+      # Check if task is kustomized
+      # A task considered to be kustomized when a kustomization file is found in the task dir
+      is_kustomized_task() {
+        local -r task_dir=$1
+        if [[ -f "$task_dir/kustomization.yaml" || -f "$task_dir/kustomization.yml" ]] ; then
+          return 0
         fi
+        return 1
+      }
 
-        ANNOTATIONS=()
-        ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
-        ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
-        ANNOTATIONS+=("org.opencontainers.image.url=${URL}/tree/${REVISION}/${CONTEXT}")
+      # Generate a task from the kustomization file
+      generate_kustomized_task() {
+        local -r task_dir=$1
+        local -r prepared_task_file="$task_dir/generated-kustomized-task.yaml"
+        kubectl kustomize "$task_dir" >"$prepared_task_file"
+        echo "$prepared_task_file"
+      }
 
-        # Ensure an empty string is output rather than string "null" if the version label is not present
-        task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
-        ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
+      # task_dir is where all the tasks definitions reside
+      # all tasks definitions are in the same task_dir, so extracting it from the first element is enough
+      task_dir=$(echo "${FILES[0]}" | awk -F'/' '{NF--; print $0}' OFS='/')
 
-        if [ -f "${task_dir}/README.md" ]; then
-          ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")
-        fi
+      # If task is kustomized, generate it and replace the FILES value with the value of the generated task
+      # All other files will be ignored.
+      if is_kustomized_task "$task_dir"; then
+        echo "Generating a kustomized task from $task_dir"
+        FILES=("$(generate_kustomized_task "$task_dir")")
+      else
+        echo "Task is not Kustomized - continue"
+      fi
 
-        if [ -f "${task_dir}/TROUBLESHOOTING.md" ]; then
-          ANNOTATIONS+=("dev.tekton.docs.troubleshooting=${URL}/tree/${REVISION}/${CONTEXT}/TROUBLESHOOTING.md")
-        fi
+      ANNOTATIONS=()
+      ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
+      ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
+      ANNOTATIONS+=("org.opencontainers.image.url=${URL}/tree/${REVISION}/${CONTEXT}")
 
-        if [ -f "${task_dir}/USAGE.md" ]; then
-          ANNOTATIONS+=("dev.tekton.docs.usage=${URL}/tree/${REVISION}/${CONTEXT}/USAGE.md")
-        fi
-        description=$(yq '.spec.description' "${FILES[@]}" | sed '/null/d' | tr -d '')
-        ANNOTATIONS+=("org.opencontainers.image.description=${description}")
+      # Ensure an empty string is output rather than string "null" if the version label is not present
+      task_version=$(yq '.metadata.labels."app.kubernetes.io/version"' "${FILES[@]}" | sed '/null/d' | tr -d '[:space:]')
+      ANNOTATIONS+=("org.opencontainers.image.version=${task_version}")
 
-        echo "Added annotations:"
-        ANNOTATION_FLAGS=()
-        for annotation in "${ANNOTATIONS[@]}"; do
-          ANNOTATION_FLAGS+=("--annotate" "$(escape_tkn_bundle_arg "$annotation")")
-          echo "    - $annotation"
-        done
+      if [ -f "${task_dir}/README.md" ]; then
+        ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")
+      fi
 
-        echo "Pushing bundle ${IMAGE} to registry"
-        # shellcheck disable=SC2046
-        if ! OUT="$(retry tkn bundle push "${ANNOTATION_FLAGS[@]}" "$IMAGE" \
-          $(printf ' -f %s' "${FILES[@]}") |
-          tee /proc/self/fd/3)"
-        then
-          echo "Failed to push bundle ${IMAGE} to registry"
-          exit 1
-        fi
-        echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"
-        digest="${OUT#*Pushed Tekton Bundle to *@}"
-        echo -n "${digest}" >"$(results.IMAGE_DIGEST.path)"
-        echo -n "${IMAGE}@${digest}" >"$(results.IMAGE_REF.path)"
+      if [ -f "${task_dir}/TROUBLESHOOTING.md" ]; then
+        ANNOTATIONS+=("dev.tekton.docs.troubleshooting=${URL}/tree/${REVISION}/${CONTEXT}/TROUBLESHOOTING.md")
+      fi
 
-        # cleanup task file
-        [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"
+      if [ -f "${task_dir}/USAGE.md" ]; then
+        ANNOTATIONS+=("dev.tekton.docs.usage=${URL}/tree/${REVISION}/${CONTEXT}/USAGE.md")
+      fi
+      description=$(yq '.spec.description' "${FILES[@]}" | sed '/null/d' | tr -d '')
+      ANNOTATIONS+=("org.opencontainers.image.description=${description}")
+
+      echo "Added annotations:"
+      ANNOTATION_FLAGS=()
+      for annotation in "${ANNOTATIONS[@]}"; do
+        ANNOTATION_FLAGS+=("--annotate" "$(escape_tkn_bundle_arg "$annotation")")
+        echo "    - $annotation"
+      done
+
+      echo "Pushing bundle ${IMAGE} to registry"
+      # shellcheck disable=SC2046
+      if ! OUT="$(retry tkn bundle push "${ANNOTATION_FLAGS[@]}" "$IMAGE" \
+        $(printf ' -f %s' "${FILES[@]}") |
+        tee /proc/self/fd/3)"
+      then
+        echo "Failed to push bundle ${IMAGE} to registry"
+        exit 1
+      fi
+      echo -n "$IMAGE" >"$(results.IMAGE_URL.path)"
+      digest="${OUT#*Pushed Tekton Bundle to *@}"
+      echo -n "${digest}" >"$(results.IMAGE_DIGEST.path)"
+      echo -n "${IMAGE}@${digest}" >"$(results.IMAGE_REF.path)"
+
+      # cleanup task file
+      [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"
     securityContext:
       runAsUser: 0
     workingDir: $(workspaces.source.path)

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -421,11 +421,12 @@ spec:
           previous_task_bundle="${IMAGE%%:*}@${previous_migration_bundle_digest}"
           if ! has_same_migration_in_previous_task_bundle=$(bundle_has_migration "${previous_task_bundle}" "${task_version}" "${migration_file}") || [[ "${has_same_migration_in_previous_task_bundle}" == "false" ]]; then
             ANNOTATIONS+=("${ANNOTATION_HAS_MIGRATION}=true")
+          else
+            # still ignore the migration script file if the same migration script file has been attached to previous task bundle
+            # especially for repush or PR with .tekton/ files change only
+            echo "the same migration script file exists in previous task bundle ${previous_task_bundle} for pushed event, skipped"
+            has_migration=false
           fi
-          # still ignore the migration script file if the same migration script file has been attached to previous task bundle
-          # especially for repush or PR with .tekton/ files change only
-          echo "the same migration script file exists in previous task bundle ${previous_task_bundle} for pushed event, skipped"
-          has_migration=false
         fi
       fi
 


### PR DESCRIPTION
This PR replace https://github.com/konflux-ci/build-definitions/pull/2564 and it will also get the task bundle in addition to the code change in https://github.com/konflux-ci/build-definitions/pull/2564

* copy the code from build-and-push.sh including functions mainly find_previous_migration_bundle_digest, attach_migration_file, get_concrete_task_version
* annotate dev.konflux-ci.task.has-migration to task bundle when has_migration script bundle has migration script
* annotate dev.konflux-ci.task.previous-migration-bundle to task bundle if migration script file is found in previous digest
* split long function attach_migration_file since generate-ta-task.sh can't handle it well
* remove the limit when get task bundle image tag list
* get task bundle by checking content_type and layers[0] annotation
* paginate task bundle tag list
* reduce find_previous_migration_bundle_digest complexity by including code to function process_single_digest to make generate-ta-tasks.sh generate a well-fomatted oci-ta task file
* use pushd and popd in attach_migration_file to make generate-ta-tasks.sh generate a well-formatted oci-ta task file
* add function is_task_bundle to make function return 1 on error only
* add migration files to set depth of clone-repository in pipeline to 100 since the default shadow clone cannot meet git show revision requirement
* bump tkn-bundle* to 0.2.1

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
