### PR TITLE
deprecate paketo builder task

### DIFF
--- a/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
+++ b/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
@@ -4,6 +4,7 @@ kind: Task
 metadata:
   name: build-paketo-builder-oci-ta
   annotations:
+    build.appstudio.redhat.com/expires-on: "2025-08-31T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, buildpack, paketo, konflux
   labels:


### PR DESCRIPTION
There are plans to archive this task.
Since someone might be using it (though most likely no one is), we want to deprecate it first.
