### PR TITLE
Remove migration script from clamav-scan v0.3

### DIFF
--- a/task/clamav-scan/0.3/MIGRATION.md
+++ b/task/clamav-scan/0.3/MIGRATION.md
@@ -14,4 +14,5 @@ Changes:
 
 Renovate bot PR will be created with warning icon for a clamav-scan which is expected, no actions from users are required for the task.
 
-For multi-arch build, `matrix` will be added to build pipeline definition file automatically by script migrations/0.3.sh when MintMaker runs [pipeline-migration-tool](https://github.com/konflux-ci/pipeline-migration-tool).
+Important:
+Do not enable matrix in PipelineRuns until https://issues.redhat.com/browse/KONFLUX-9576 is resolved.

--- a/task/clamav-scan/0.3/migrations/0.3.sh
+++ b/task/clamav-scan/0.3/migrations/0.3.sh
@@ -21,22 +21,22 @@ if ! yq -e '.spec.tasks[] | select(.name == "'"$TASK_NAME"'")' "$pipeline_file" 
 fi
 
 # Check if the task already has a matrix
-if yq -e '.spec.tasks[] | select(.name == "'"$TASK_NAME"'") | has("matrix")' "$pipeline_file" >/dev/null 2>&1; then
-  echo "Matrix already exists for task '$TASK_NAME'. No changes made."
-else
-  echo "Adding matrix for task '$TASK_NAME'..."
-  yq -i "
-  (.spec.tasks[] 
-    | select(.name == \"clamav-scan\" and .matrix == null)
-  ).matrix = {
-    \"params\": [
-      {
-        \"name\": \"image-arch\",
-        \"value\": [\"\$(params.build-platforms)\"]
-      }
-    ]
-  }
-" "$pipeline_file"
-
-  echo "Adding matrix for task '$TASK_NAME' completed!"
-fi
+#if yq -e '.spec.tasks[] | select(.name == "'"$TASK_NAME"'") | has("matrix")' "$pipeline_file" >/dev/null 2>&1; then
+#  echo "Matrix already exists for task '$TASK_NAME'. No changes made."
+#else
+#  echo "Adding matrix for task '$TASK_NAME'..."
+#  yq -i "
+#  (.spec.tasks[]
+#    | select(.name == \"clamav-scan\" and .matrix == null)
+#  ).matrix = {
+#    \"params\": [
+#      {
+#        \"name\": \"image-arch\",
+#        \"value\": [\"\$(params.build-platforms)\"]
+#      }
+#    ]
+#  }
+#" "$pipeline_file"
+#
+#  echo "Adding matrix for task '$TASK_NAME' completed!"
+#fi


### PR DESCRIPTION
Currently, Conforma doesn't process `IMAGES_PROCESSED` results correctly when matrix is used in a PipelineRun (see [1]). To prevent users from adopting matrix, we are removing the migration script that otherwise enable it.

[1] https://issues.redhat.com/browse/KONFLUX-9576
