### PR TITLE
Remove matrix for clamav-scan task if present

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -319,12 +319,7 @@ spec:
       values:
       - "false"
     workspaces: []
-  - matrix:
-      params:
-      - name: image-arch
-        value:
-        - $(params.build-platforms)
-    name: clamav-scan
+  - name: clamav-scan
     params:
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/docker-build-multi-platform-oci-ta/patch.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/patch.yaml
@@ -93,9 +93,3 @@
     type: array
     default:
       - "linux/x86_64"
-- op: add
-  path: /spec/tasks/10/matrix
-  value:
-    params:
-      - name: image-arch
-        value: ["$(params.build-platforms)"]

--- a/task/clamav-scan/0.3/MIGRATION.md
+++ b/task/clamav-scan/0.3/MIGRATION.md
@@ -15,3 +15,18 @@ Changes:
 Renovate bot PR will be created with warning icon for a clamav-scan which is expected, no actions from users are required for the task.
 
 For multi-arch build, `matrix` will be added to build pipeline definition file automatically by script migrations/0.3.sh when MintMaker runs [pipeline-migration-tool](https://github.com/konflux-ci/pipeline-migration-tool).
+
+# Migration from 0.3 to 0.3.1
+
+Version 0.3.1:
+
+`matrix` section is removed from the pipelinerun.
+
+Changes:
+- `matrix` section is removed from the build pipeline definition file.
+
+## Action from users
+
+Renovate bot PR will be created with warning icon for a clamav-scan which is expected, no actions from users are required for the task.
+
+For multi-arch build, `matrix` section will be removed from build pipeline definition file automatically by script migrations/0.3.1.sh, if present, when MintMaker runs [pipeline-migration-tool](https://github.com/    ↪ konflux-ci/pipeline-migration-tool).

--- a/task/clamav-scan/0.3/clamav-scan.yaml
+++ b/task/clamav-scan/0.3/clamav-scan.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.3.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "virus, konflux"

--- a/task/clamav-scan/0.3/migrations/0.3.1.sh
+++ b/task/clamav-scan/0.3/migrations/0.3.1.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: clamav-scan@0.3.1
+# Creation time: 2025-08-06T08:32:56+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+TASK_NAME="clamav-scan"
+
+# Check if the pipeline has 'build-platforms' parameter
+if ! yq -e '.spec.params[] | select(.name == "build-platforms")' "$pipeline_file" >/dev/null 2>&1; then
+  echo "Matrix will not be added because the dependent parameter 'build-platforms' is not defined in the pipeline."
+  exit 0
+fi
+
+# Check if the task exists
+if ! yq -e '.spec.tasks[] | select(.name == "'"$TASK_NAME"'")' "$pipeline_file" >/dev/null 2>&1; then
+  echo "Task '$TASK_NAME' does not exist in the pipeline."
+  exit 0
+fi
+
+# Check if the task already has a matrix
+if yq -e '.spec.tasks[] | select(.name == "'"$TASK_NAME"'") | has("matrix")' "$pipeline_file" >/dev/null 2>&1; then
+  echo "Removing matrix from task '$TASK_NAME'..."
+  yq -i "(.spec.tasks[] | select(.name == \"clamav-scan\")) |= del(.matrix)" "$pipeline_file"
+  echo "Matrix removed from task '$TASK_NAME'."
+else
+  echo "No matrix found for task '$TASK_NAME'."
+fi


### PR DESCRIPTION
Currently, Conforma doesn't process `IMAGES_PROCESSED` results correctly when matrix is used in a PipelineRun (see [1]). Therefore, the matrix section for clamav-scan is removed from the multi-arch PipelineRun, and the migration script is updated to remove the matrix section from user existing PipelineRuns if presents.

[1] https://issues.redhat.com/browse/KONFLUX-9576