### PR TITLE
Fix malformed IMAGES_PROCESSED json in task result

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -366,7 +366,7 @@ spec:
 
         # Extract processed image digests from "/artifacts/$arch/cert-image.json"
         while read -r cert_image_file; do
-          docker_image_digest=$(jq '.docker_image_digest' "$cert_image_file")
+          docker_image_digest=$(jq -r '.docker_image_digest' "$cert_image_file")
           if [[ -n "$docker_image_digest" && ! " ${digests_processed[*]} " == *" \"$docker_image_digest\" "* ]]; then
             digests_processed+=("\"$docker_image_digest\"")
           fi


### PR DESCRIPTION
The task 'ecosystem-cert-preflight-checks' is currently generating a malformed JSON in its IMAGES_PROCESSED result: it sometimes wraps the first digest between two double-quotes.
This happens because when jq extracts .docker_image_digest, it returns the value with quotes included (e.g., "sha256:abc123...").

Using 'jq -r' will extract the raw string and hence avoid the double double-quotes (no pun intended)

Ref: https://issues.redhat.com/browse/KFLUXSPRT-4562

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
