### PR TITLE
fix(KONFLUX-9618): Manually pass Multiarch arguments to dockerfile-json

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -454,7 +454,28 @@ spec:
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
-      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
+      # Dockerfile-json cannot parse Buildah's host variables, we have to pass them manually
+      BUILDAH_INFO=$(buildah info)
+      BUILDAH_OS=$(jq -r '.host.os' <<< "$BUILDAH_INFO")
+      BUILDAH_ARCH=$(jq -r '.host.arch' <<< "$BUILDAH_INFO")
+      BUILDAH_VARIANT=$(jq -r '.host.variant' <<< "$BUILDAH_INFO")
+      BUILDAH_PLATFORM="${BUILDAH_OS}/${BUILDAH_ARCH}"
+
+      DOCKERFILE_ARG_FLAGS=()
+
+      # Reference for variables:
+      # https://docs.docker.com/build/building/variables/#pre-defined-build-arguments
+      PREFIXES=('BUILD' 'TARGET')
+      for PREFIX in "${PREFIXES[@]}"; do
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}PLATFORM=${BUILDAH_PLATFORM}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}OS=${BUILDAH_OS}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}ARCH=${BUILDAH_ARCH}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}VARIANT=${BUILDAH_VARIANT}")
+      done
+
+      DOCKERFILE_ARG_FLAGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      dockerfile-json "${DOCKERFILE_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
           jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
             tr -d '"' |

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -534,7 +534,28 @@ spec:
           BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
         done
 
-        dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
+        # Dockerfile-json cannot parse Buildah's host variables, we have to pass them manually
+        BUILDAH_INFO=$(buildah info)
+        BUILDAH_OS=$(jq -r '.host.os' <<<"$BUILDAH_INFO")
+        BUILDAH_ARCH=$(jq -r '.host.arch' <<<"$BUILDAH_INFO")
+        BUILDAH_VARIANT=$(jq -r '.host.variant' <<<"$BUILDAH_INFO")
+        BUILDAH_PLATFORM="${BUILDAH_OS}/${BUILDAH_ARCH}"
+
+        DOCKERFILE_ARG_FLAGS=()
+
+        # Reference for variables:
+        # https://docs.docker.com/build/building/variables/#pre-defined-build-arguments
+        PREFIXES=('BUILD' 'TARGET')
+        for PREFIX in "${PREFIXES[@]}"; do
+          DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}PLATFORM=${BUILDAH_PLATFORM}")
+          DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}OS=${BUILDAH_OS}")
+          DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}ARCH=${BUILDAH_ARCH}")
+          DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}VARIANT=${BUILDAH_VARIANT}")
+        done
+
+        DOCKERFILE_ARG_FLAGS+=("${BUILD_ARG_FLAGS[@]}")
+
+        dockerfile-json "${DOCKERFILE_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
         BASE_IMAGES=$(
           jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
             tr -d '"' |

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -563,7 +563,28 @@ spec:
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
-      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
+      # Dockerfile-json cannot parse Buildah's host variables, we have to pass them manually
+      BUILDAH_INFO=$(buildah info)
+      BUILDAH_OS=$(jq -r '.host.os' <<<"$BUILDAH_INFO")
+      BUILDAH_ARCH=$(jq -r '.host.arch' <<<"$BUILDAH_INFO")
+      BUILDAH_VARIANT=$(jq -r '.host.variant' <<<"$BUILDAH_INFO")
+      BUILDAH_PLATFORM="${BUILDAH_OS}/${BUILDAH_ARCH}"
+
+      DOCKERFILE_ARG_FLAGS=()
+
+      # Reference for variables:
+      # https://docs.docker.com/build/building/variables/#pre-defined-build-arguments
+      PREFIXES=('BUILD' 'TARGET')
+      for PREFIX in "${PREFIXES[@]}"; do
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}PLATFORM=${BUILDAH_PLATFORM}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}OS=${BUILDAH_OS}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}ARCH=${BUILDAH_ARCH}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}VARIANT=${BUILDAH_VARIANT}")
+      done
+
+      DOCKERFILE_ARG_FLAGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      dockerfile-json "${DOCKERFILE_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
       BASE_IMAGES=$(
         jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
           tr -d '"' |

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -531,7 +531,28 @@ spec:
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
-      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
+      # Dockerfile-json cannot parse Buildah's host variables, we have to pass them manually
+      BUILDAH_INFO=$(buildah info)
+      BUILDAH_OS=$(jq -r '.host.os' <<< "$BUILDAH_INFO")
+      BUILDAH_ARCH=$(jq -r '.host.arch' <<< "$BUILDAH_INFO")
+      BUILDAH_VARIANT=$(jq -r '.host.variant' <<< "$BUILDAH_INFO")
+      BUILDAH_PLATFORM="${BUILDAH_OS}/${BUILDAH_ARCH}"
+
+      DOCKERFILE_ARG_FLAGS=()
+
+      # Reference for variables:
+      # https://docs.docker.com/build/building/variables/#pre-defined-build-arguments
+      PREFIXES=('BUILD' 'TARGET')
+      for PREFIX in "${PREFIXES[@]}"; do
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}PLATFORM=${BUILDAH_PLATFORM}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}OS=${BUILDAH_OS}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}ARCH=${BUILDAH_ARCH}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}VARIANT=${BUILDAH_VARIANT}")
+      done
+
+      DOCKERFILE_ARG_FLAGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      dockerfile-json "${DOCKERFILE_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
           jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
             tr -d '"' |

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -441,7 +441,28 @@ spec:
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
-      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
+      # Dockerfile-json cannot parse Buildah's host variables, we have to pass them manually
+      BUILDAH_INFO=$(buildah info)
+      BUILDAH_OS=$(jq -r '.host.os' <<< "$BUILDAH_INFO")
+      BUILDAH_ARCH=$(jq -r '.host.arch' <<< "$BUILDAH_INFO")
+      BUILDAH_VARIANT=$(jq -r '.host.variant' <<< "$BUILDAH_INFO")
+      BUILDAH_PLATFORM="${BUILDAH_OS}/${BUILDAH_ARCH}"
+
+      DOCKERFILE_ARG_FLAGS=()
+
+      # Reference for variables:
+      # https://docs.docker.com/build/building/variables/#pre-defined-build-arguments
+      PREFIXES=('BUILD' 'TARGET')
+      for PREFIX in "${PREFIXES[@]}"; do
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}PLATFORM=${BUILDAH_PLATFORM}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}OS=${BUILDAH_OS}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}ARCH=${BUILDAH_ARCH}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}VARIANT=${BUILDAH_VARIANT}")
+      done
+
+      DOCKERFILE_ARG_FLAGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      dockerfile-json "${DOCKERFILE_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
           jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
             tr -d '"' |

--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -728,7 +728,28 @@ spec:
           BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
         done
 
-        dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
+        # Dockerfile-json cannot parse Buildah's host variables, we have to pass them manually
+        BUILDAH_INFO=$(buildah info)
+        BUILDAH_OS=$(jq -r '.host.os' <<<"$BUILDAH_INFO")
+        BUILDAH_ARCH=$(jq -r '.host.arch' <<<"$BUILDAH_INFO")
+        BUILDAH_VARIANT=$(jq -r '.host.variant' <<<"$BUILDAH_INFO")
+        BUILDAH_PLATFORM="${BUILDAH_OS}/${BUILDAH_ARCH}"
+
+        DOCKERFILE_ARG_FLAGS=()
+
+        # Reference for variables:
+        # https://docs.docker.com/build/building/variables/#pre-defined-build-arguments
+        PREFIXES=('BUILD' 'TARGET')
+        for PREFIX in "${PREFIXES[@]}"; do
+          DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}PLATFORM=${BUILDAH_PLATFORM}")
+          DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}OS=${BUILDAH_OS}")
+          DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}ARCH=${BUILDAH_ARCH}")
+          DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}VARIANT=${BUILDAH_VARIANT}")
+        done
+
+        DOCKERFILE_ARG_FLAGS+=("${BUILD_ARG_FLAGS[@]}")
+
+        dockerfile-json "${DOCKERFILE_ARG_FLAGS[@]}" "$dockerfile_copy" >/shared/parsed_dockerfile.json
         BASE_IMAGES=$(
           jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
             tr -d '"' |

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -641,7 +641,28 @@ spec:
         BUILD_ARG_FLAGS+=("--build-arg=$build_arg")
       done
 
-      dockerfile-json "${BUILD_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
+      # Dockerfile-json cannot parse Buildah's host variables, we have to pass them manually
+      BUILDAH_INFO=$(buildah info)
+      BUILDAH_OS=$(jq -r '.host.os' <<< "$BUILDAH_INFO")
+      BUILDAH_ARCH=$(jq -r '.host.arch' <<< "$BUILDAH_INFO")
+      BUILDAH_VARIANT=$(jq -r '.host.variant' <<< "$BUILDAH_INFO")
+      BUILDAH_PLATFORM="${BUILDAH_OS}/${BUILDAH_ARCH}"
+
+      DOCKERFILE_ARG_FLAGS=()
+
+      # Reference for variables:
+      # https://docs.docker.com/build/building/variables/#pre-defined-build-arguments
+      PREFIXES=('BUILD' 'TARGET')
+      for PREFIX in "${PREFIXES[@]}"; do
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}PLATFORM=${BUILDAH_PLATFORM}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}OS=${BUILDAH_OS}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}ARCH=${BUILDAH_ARCH}")
+        DOCKERFILE_ARG_FLAGS+=("--build-arg=${PREFIX}VARIANT=${BUILDAH_VARIANT}")
+      done
+
+      DOCKERFILE_ARG_FLAGS+=("${BUILD_ARG_FLAGS[@]}")
+
+      dockerfile-json "${DOCKERFILE_ARG_FLAGS[@]}" "$dockerfile_copy" > /shared/parsed_dockerfile.json
       BASE_IMAGES=$(
           jq -r '.Stages[] | select(.From | .Stage or .Scratch | not) | .BaseName | select(test("^oci-archive:") | not)' /shared/parsed_dockerfile.json |
             tr -d '"' |


### PR DESCRIPTION
Dockerfile-json doesn't recognize multiarch arg values by itself. This PR parses the values of these arguments from the output of `buildah info` and makes them available to the Dockerfile for a more durable Dockerfile parsing.