### PR TITLE
oras attach snyk stdout file on sast-snyk-check

### DIFF
--- a/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -317,14 +317,16 @@ spec:
           exit 0
         fi
 
-        UPLOAD_FILES="sast_snyk_check_out.sarif excluded-findings.json"
+        UPLOAD_FILES="sast_snyk_check_out.sarif excluded-findings.json stdout.txt"
         for UPLOAD_FILE in ${UPLOAD_FILES}; do
           if [ ! -f "${UPLOAD_FILE}" ]; then
             echo "No ${UPLOAD_FILE} exists. Skipping upload."
             continue
           fi
-          if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+          if [ "${UPLOAD_FILE}" == "excluded-findings.json" ]; then
             MEDIA_TYPE=application/json
+          elif [ "${UPLOAD_FILE}" == "stdout.txt" ]; then
+            MEDIA_TYPE=text/plain
           else
             MEDIA_TYPE=application/sarif+json
           fi

--- a/task/sast-snyk-check/0.4/sast-snyk-check.yaml
+++ b/task/sast-snyk-check/0.4/sast-snyk-check.yaml
@@ -299,14 +299,16 @@ spec:
           exit 0
         fi
 
-        UPLOAD_FILES="sast_snyk_check_out.sarif excluded-findings.json"
+        UPLOAD_FILES="sast_snyk_check_out.sarif excluded-findings.json stdout.txt"
         for UPLOAD_FILE in ${UPLOAD_FILES}; do
             if [ ! -f "${UPLOAD_FILE}" ]; then
               echo "No ${UPLOAD_FILE} exists. Skipping upload."
               continue
             fi
-            if [ "${UPLOAD_FILES}" == "excluded-findings.json" ]; then
+            if [ "${UPLOAD_FILE}" == "excluded-findings.json" ]; then
                 MEDIA_TYPE=application/json
+            elif [ "${UPLOAD_FILE}" == "stdout.txt" ]; then
+                MEDIA_TYPE=text/plain
             else
                 MEDIA_TYPE=application/sarif+json
             fi


### PR DESCRIPTION
Oras attach snyk stdout for postmortem analysis when snyk fails.

I notice the logic around mime types was using the wrong var, fix that along the way too


