### PR TITLE
fix(KONFLUX-5311): Run replace pullspec before opm 

### DIFF
--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -158,11 +158,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### run-opm-command-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
-|IDMS_PATH| Optional, path for ImageDigestMirrorSet file. It defaults to .tekton/images-mirror-set.yaml`| .tekton/images-mirror-set.yaml| |
-|OPM_ARGS| The array of arguments to pass to the 'opm' command (e.g., [ 'alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']).| None| []|
+|FILE_TO_UPDATE_PULLSPEC| Optional. Relative path to a file (e.g., catalog-template.yml) in which pullspecs should be updated before running opm.| | |
+|IDMS_PATH| Optional, path for ImageDigestMirrorSet file. It defaults to '.tekton/images-mirror-set.yaml'| .tekton/images-mirror-set.yaml| |
+|OPM_ARGS| The array of arguments to pass to the 'opm' command. (e.g., [ 'alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']).| []| []|
 |OPM_OUTPUT_PATH| Relative path for the opm command's output file (e.g. 'v4.18/catalog/example-operator/catalog.json'). Relative to the root directory of given source code (Git repository).| None| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
-|ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| None| '$(params.image-expires-after)'|
+|ociArtifactExpiresAfter| Expiration date for the trusted artifacts. Empty string means no expiration.| None| '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).opm'|
 ### show-sbom:0.1 task parameters
 |name|description|default value|already set by|

--- a/task/run-opm-command-oci-ta/0.1/README.md
+++ b/task/run-opm-command-oci-ta/0.1/README.md
@@ -1,8 +1,6 @@
 # run-opm-command-oci-ta task
 
-This Task allows you to execute `opm` (Operator Package Manager) commands 
-within a Tekton Pipeline. It's designed to work with **Trusted Artifacts** 
-and helps in automating the process of generating and validating OPM-related outputs, such as file-based catalogs.
+This Task allows you to execute `opm` (Operator Package Manager) commands within a Tekton Pipeline. It's designed to work with **Trusted Artifacts** and helps in automating the process of generating and validating OPM-related outputs, such as file-based catalogs.
 
 ---
 
@@ -18,29 +16,29 @@ and helps in automating the process of generating and validating OPM-related out
 
 The `run-opm-command-oci-ta` Task performs the following key steps:
 
-1.  **Retrieves Source Artifacts**: Downloads your application's source code, which should contain any necessary `opm` inputs (e.g., catalog templates).
-2.  **Executes OPM Command**: Runs the `opm` command with user-defined arguments and redirects the output to a specified file within the source directory. This step is configured to fail if the output path is not provided or is absolute.
-3.  **Applies ImageDigestMirrorSet (Optional)**: If an `ImageDigestMirrorSet` (IDMS) file is provided, this step replaces image pull specifications in the generated OPM output (e.g., in a catalog) based on the mirror definitions in the IDMS file. This is crucial for environments where images need to be pulled from internal registries.
-4.  **Validates Catalog**: Runs `opm validate` on the generated output to ensure its correctness.
-5.  **Creates Trusted Artifact**: Uploads the modified source directory (including the `opm` command's output) as a new Trusted Artifact.
+1.  **Retrieves Source Artifacts**: Downloads your application's source code, which should contain any necessary `opm` inputs (e.g., catalog templates). This is done using the `use-trusted-artifact` step.
+2.  **Applies ImageDigestMirrorSet (Optional)**: If an `ImageDigestMirrorSet` (IDMS) file is provided, this step replaces image pull specifications in the generated OPM output. This is handled by the `replace-related-images-pullspec-in-file` step which modifies a specified file before the `opm` command is run. 
+3.  **Executes OPM Command**: Runs the `opm` command with user-defined arguments and redirects the output to a specified file within the source directory. This step is configured to fail if the output path is not provided or is absolute.
+4.  **Creates Trusted Artifact**: Uploads the modified source directory (including the `opm` command's output) as a new Trusted Artifact.
 
 ---
 
 ## Parameters
 
-| Parameter           | Description                                                                                                                                                       | Type    | Required | Default               |
-| :------------------ |:------------------------------------------------------------------------------------------------------------------------------------------------------------------| :------ | :------- | :-------------------- |
-| `SOURCE_ARTIFACT`   | The Trusted Artifact URI pointing to the artifact with the application source code.                                                                               | `string`| Yes      |                       |
-| `ociStorage`        | The OCI repository where the Trusted Artifacts are stored.                                                                                                        | `string`| Yes      |                       |
-| `OPM_ARGS`          | An array of arguments to pass directly to the `opm` command (e.g., `['alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']`).                       | `array` | Yes      |                       |
-| `OPM_OUTPUT_PATH`   | The relative path for the `opm` command's output file (e.g., `'v4.18/catalog/example-operator/catalog.json'`). Relative to the root directory of the source code. | `string`| Yes      |                       |
-| `IDMS_PATH`         | Path to an `ImageDigestMirrorSet` file (e.g., `.tekton/images-mirror-set.yaml`). Used to replace related image pullspecs in the catalog.                          | `string`| No       | `""` (empty string) |
+| Parameter                   | Description                                                                                                                                                              | Type     | Required | Default                              |
+| :-------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------- | :------- | :----------------------------------- |
+| `SOURCE_ARTIFACT`           | The Trusted Artifact URI pointing to the artifact with the application source code.                                                                           | `string` | Yes      |                                      |
+| `ociStorage`                | The OCI repository where the Trusted Artifacts are stored.                                                                                                    | `string` | Yes      |                                      |
+| `ociArtifactExpiresAfter`   | Expiration date for the trusted artifacts. Empty string means no expiration.                                                                           | `string` | No       | `""` (empty string)                  |
+| `FILE_TO_UPDATE_PULLSPEC`   | Optional. Relative path to a file (e.g., catalog-template.yml) in which pullspecs should be updated before running opm.                              | `string` | No       | `""`                                 |
+| `OPM_ARGS`                  | An array of arguments to pass directly to the `opm` command (e.g., `['alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']`).                    | `array`  | Yes      | `[]`                       |
+| `OPM_OUTPUT_PATH`           | The relative path for the `opm` command's output file (e.g., `'v4.18/catalog/example-operator/catalog.json'`). Relative to the root directory of the source code. | `string` | Yes      |                                      |
+| `IDMS_PATH`                 | Path to an `ImageDigestMirrorSet` file (e.g., `.tekton/images-mirror-set.yaml`). Used to replace related image pullspecs in the catalog.           | `string` | No       | `.tekton/images-mirror-set.yaml` |
 
 ---
 
 ## Results
 
-| Result            | Description                                                                                                 |
-| :---------------- | :---------------------------------------------------------------------------------------------------------- |
+| Result            | Description                                                                                                                     |
+| :---------------- | :------------------------------------------------------------------------------------------------------------------------------ |
 | `SOURCE_ARTIFACT` | The Trusted Artifact URI pointing to the artifact with the application source code, now including the generated file-based catalog. |
-

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -9,35 +9,37 @@ metadata:
     app.kubernetes.io/version: "0.1"
 spec:
   description: This task runs an OPM command with user-specified arguments, passed as an array.
+    It can optionally replace pullspecs in a catalog-template file before running the command.
   params:
     - name: SOURCE_ARTIFACT
-      description: The Trusted Artifact URI pointing to the artifact with
-        the application source code.
       type: string
+      description: The Trusted Artifact URI pointing to the artifact with the application source code.
     - name: ociStorage
-      description: The OCI repository where the Trusted Artifacts are stored.
       type: string
+      description: The OCI repository where the Trusted Artifacts are stored.
     - name: ociArtifactExpiresAfter
       type: string
-      description: >-
-        Expiration date for the trusted artifacts created in the OCI repository. An empty string means
-        the artifacts do not expire.
+      description: Expiration date for the trusted artifacts. Empty string means no expiration.
+    - name: FILE_TO_UPDATE_PULLSPEC
+      type: string
+      description: Optional. Relative path to a file (e.g., catalog-template.yml) in which pullspecs should be updated before running opm.
+      default: ""
     - name: OPM_ARGS
-      description: The array of arguments to pass to the 'opm' command
-        (e.g., [ 'alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']).
       type: array
+      description: The array of arguments to pass to the 'opm' command. (e.g., [ 'alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']).
+      default: []
     - name: OPM_OUTPUT_PATH
+      type: string
       description: Relative path for the opm command's output file (e.g. 'v4.18/catalog/example-operator/catalog.json').
         Relative to the root directory of given source code (Git repository).
-      type: string
     - name: IDMS_PATH
-      description: Optional, path for ImageDigestMirrorSet file. It defaults to .tekton/images-mirror-set.yaml`
       type: string
+      description: Optional, path for ImageDigestMirrorSet file. It defaults to '.tekton/images-mirror-set.yaml'
       default: ".tekton/images-mirror-set.yaml"
   results:
     - name: SOURCE_ARTIFACT
-      description: The Trusted Artifact URI pointing to the artifact with
-        the application source code with generated file-based catalog from catalog-template.yml.
+      description: The Trusted Artifact URI pointing to the artifact with the application source code with generated
+        file-based catalog from catalog-template.yml.
   volumes:
     - name: workdir
       emptyDir: {}
@@ -46,69 +48,59 @@ spec:
       - mountPath: /var/workdir
         name: workdir
   steps:
-    - name: check-and-skip-if-needed
-      image: registry.access.redhat.com/ubi9/ubi-minimal:latest
-      results:
-        - name: valid_params
-          description: True or False depending if all required parameters were set.
-      env:
-        - name: OPM_OUTPUT_PATH_PARAM
-          value: $(params.OPM_OUTPUT_PATH)
-        - name: SOURCE_ARTIFACT_PARAM
-          value: $(params.SOURCE_ARTIFACT)
-      command: ["/bin/bash", "-c"]
-      args:
-        - |
-          #!/bin/bash
-          # shellcheck source=/dev/null
-          set -e
-
-          if [[ $# -eq 0 || -z "${OPM_OUTPUT_PATH_PARAM}" ]]; then
-            if [[ $# -eq 0 ]]; then
-              echo "Parameter 'OPM_ARGS' is empty. Skipping OPM execution."
-            else
-              echo "Parameter 'OPM_OUTPUT_PATH' is empty. Skipping OPM execution."
-            fi
-
-            echo "Returning SOURCE_ARTIFACT from previous task."
-            echo -n "${SOURCE_ARTIFACT_PARAM}" | tee "$(results.SOURCE_ARTIFACT.path)"
-
-            echo -n "false" > "$(step.results.valid_params.path)"
-            exit 0
-          fi
-
-          echo -n "true" > "$(step.results.valid_params.path)"
-        - "bash"
-        - $(params.OPM_ARGS[*])
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:635a890e9f0211b4eb5b8c811d6f06b3ed9ff7da952ebad236fbfe52ba36dbf7
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: replace-related-images-pullspec-in-file
+      image: quay.io/konflux-ci/konflux-test:v1.4.33@sha256:f1e256d52ec62f8927106659d65fc842e330d3cfed791775c1ef4fedf270dbc8
+      workingDir: /var/workdir/source
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: IDMS_PATH_PARAM
+          value: $(params.IDMS_PATH)
+        - name: FILE_TO_UPDATE_PULLSPEC_PATH
+          value: $(params.FILE_TO_UPDATE_PULLSPEC)
       when:
-        - input: "$(steps.check-and-skip-if-needed.results.valid_params)"
-          operator: in
-          values: ["true"]
+        - input: "$(params.FILE_TO_UPDATE_PULLSPEC)"
+          operator: notin
+          values: [""]
+        - input: "$(params.IDMS_PATH)"
+          operator: notin
+          values: [""]
+      script: |
+          #!/bin/bash
+          set -euo pipefail
+
+          # shellcheck source=/dev/null
+          source /utils.sh
+          if [[ ! -f "${IDMS_PATH_PARAM}" ]]; then
+              echo "Warning: IDMS file '${IDMS_PATH_PARAM}' not found. Skipping replacement."
+              exit 0
+          fi
+          if [[ ! -f "${FILE_TO_UPDATE_PULLSPEC_PATH}" ]]; then
+              echo "Warning: File to update '${FILE_TO_UPDATE_PULLSPEC_PATH}' not found. Skipping replacement."
+              exit 0
+          fi
+
+          echo "Replacing pullspecs in '${FILE_TO_UPDATE_PULLSPEC_PATH}' using '${IDMS_PATH_PARAM}'."
+          replace_mirror_pullspec_with_source "${IDMS_PATH_PARAM}" "${FILE_TO_UPDATE_PULLSPEC_PATH}"
     - name: run-opm-with-user-args
       image: quay.io/konflux-ci/operator-sdk-builder:latest@sha256:e7cfe742ef5be036478408e98094f49109474418521970f739a6c1ff6faa4267
       workingDir: /var/workdir/source
-      when:
-        - input: "$(steps.check-and-skip-if-needed.results.valid_params)"
-          operator: in
-          values: ["true"]
       results:
-        - name: skip_replace
-          description: "True if the IDMS file does not exist, false otherwise."
+        - name: skip_create_trusted_artifact
+          description: Set to 'true' if the create-trusted-artifact step should be skipped.
       env:
         - name: OPM_OUTPUT_PATH_PARAM
           value: $(params.OPM_OUTPUT_PATH)
-        - name: IDMS_PATH_PARAM
-          value: $(params.IDMS_PATH)
+        - name: SOURCE_ARTIFACT_PARAM
+          value: $(params.SOURCE_ARTIFACT)
       securityContext:
         runAsUser: 0
-      command:
-        - "/bin/bash"
-        - "-c"
+      command: ["/bin/bash", "-c"]
       args:
         - |
           #!/bin/bash
@@ -118,15 +110,20 @@ spec:
           printf "OPM Argument received: '%s'\n" "$@"
 
           # Ensure OPM_OUTPUT_PATH_PARAM is provided
-          if [[ -z "${OPM_OUTPUT_PATH_PARAM}" ]]; then
-            echo "Error: OPM_OUTPUT_PATH is a mandatory parameter and cannot be empty."
-            exit 1
+          if [[ $# -eq 0 || -z "${OPM_OUTPUT_PATH_PARAM}" ]]; then
+            echo "Parameter 'OPM_ARGS' or 'OPM_OUTPUT_PATH' is empty. Skipping OPM execution."
+
+            echo "Returning SOURCE_ARTIFACT from previous task."
+            echo -n "${SOURCE_ARTIFACT_PARAM}" | tee "$(results.SOURCE_ARTIFACT.path)"
+
+            echo -n "true" > "$(step.results.skip_create_trusted_artifact.path)"
+            exit 0
           fi
 
           # Validate that the path is not absolute
           if [[ "${OPM_OUTPUT_PATH_PARAM}" == /* ]]; then
             echo "Error: OPM_OUTPUT_PATH must be a relative path, but got '${OPM_OUTPUT_PATH_PARAM}'."
-            exit 1
+            exit 2
           fi
 
           # Get the directory part of the path
@@ -138,69 +135,19 @@ spec:
             mkdir -p "${OUTPUT_DIR}"
           fi
 
-          echo "Running OPM command and writing the output to file: $(pwd)/${OPM_OUTPUT_PATH_PARAM}"
-
-          # Execute the opm command and redirect its output
+          echo "Running opm $* > ${OPM_OUTPUT_PATH_PARAM}"
           opm "$@" > "${OPM_OUTPUT_PATH_PARAM}"
+          echo "OPM command finished."
 
-          echo "OPM command finished"
-
-          # Check for IDMS file existence
-          # this check need to be here since this is the first step with access to the source code
-          if [[ -n "${IDMS_PATH_PARAM}" && -f "${IDMS_PATH_PARAM}" ]]; then
-              echo -n "false" > "$(step.results.skip_replace.path)"
-          else
-              if [[ -n "${IDMS_PATH_PARAM}" ]]; then
-                echo "IDMS file '${IDMS_PATH_PARAM}' not found."
-              fi
-              echo "Step replace-related-images-pullspec-in-catalog will be skipped."
-
-              echo -n "true" > "$(step.results.skip_replace.path)"
-          fi
+          echo -n "false" > "$(step.results.skip_create_trusted_artifact.path)"
         - "bash"
         - $(params.OPM_ARGS[*])
-      computeResources:
-        limits:
-          memory: 4Gi
-        requests:
-          cpu: 1
-          memory: 4Gi
-    - name: replace-related-images-pullspec-in-catalog
-      image: quay.io/konflux-ci/konflux-test:v1.4.33@sha256:f1e256d52ec62f8927106659d65fc842e330d3cfed791775c1ef4fedf270dbc8
-      workingDir: /var/workdir/source
-      securityContext:
-        runAsUser: 0
-      env:
-        - name: IDMS_PATH
-          value: $(params.IDMS_PATH)
-        - name: OPM_OUTPUT_PATH
-          value: $(params.OPM_OUTPUT_PATH)
-      when:
-        - input: "$(steps.run-opm-with-user-args.results.skip_replace)"
-          operator: in
-          values: ["false"]
-        - input: "$(steps.check-and-skip-if-needed.results.valid_params)"
-          operator: in
-          values: ["true"]
-        - input: "$(params.IDMS_PATH)"
-          operator: notin
-          values: ["", "null"]
-      script: |
-          #!/bin/bash
-          set -euo pipefail
-
-          # shellcheck source=/dev/null
-          source /utils.sh
-
-          replace_mirror_pullspec_with_source "${IDMS_PATH}" "${OPM_OUTPUT_PATH}"
-      computeResources:
-        limits:
-          memory: 2Gi
-        requests:
-          cpu: 1
-          memory: 2Gi
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:edd8e3affc389320b15b9de8a5aedbf7b0463211b77c981563a2cfa20076b0c0
+      when:
+        - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
+          operator: in
+          values: ["false"]
       env:
       - name: IMAGE_EXPIRES_AFTER
         value: $(params.ociArtifactExpiresAfter)
@@ -209,13 +156,3 @@ spec:
         - --store
         - $(params.ociStorage)
         - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
-      when:
-        - input: "$(steps.check-and-skip-if-needed.results.valid_params)"
-          operator: in
-          values: ["true"]
-      computeResources:
-        limits:
-          memory: 3Gi
-        requests:
-          cpu: "1"
-          memory: 3Gi


### PR DESCRIPTION
Fixing bug in run-opm-command-oci-ta. We need to replace pull spec in catalog-template before we run `opm alpha render-template`.

[CLOUDDST-28855]
[KONFLUX-5311]

Assisted-by: Gemini
