### PR TITLE
sast-coverity: pin base buildah task dep to specific commit

### DIFF
--- a/task/sast-coverity-check/0.3/kustomization.yaml
+++ b/task/sast-coverity-check/0.3/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../buildah/0.4
+  # Pin base buildah task to specific commit to reduce churn
+  - https://github.com/konflux-ci/build-definitions/raw/2b07ac561f8e79d8103fffb62859af60ad3a358f/task/buildah/0.4/buildah.yaml
 
 patches:
 - path: patch.yaml


### PR DESCRIPTION
This is to reduce churn so that changes to buildah task don't require updating the coverity task at the same time. This should prioritize stability for the coverity task, and prevent cases when buildah task updates introduces changes that rely on recent buildah image versions, that may not yet also be in the coverity image.

