### PR TITLE
fix(KONFLUX-9780): SBOM generation fails if img name contains underscores

### DIFF
--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -877,7 +877,7 @@ spec:
       requests:
         cpu: 10m
         memory: 128Mi
-    image: quay.io/konflux-ci/mobster:0.6.0-1754562950@sha256:8a1afd0a1f30a823827e4ed41e5245a947627dce18032931e0c74974392f9440
+    image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -937,7 +937,7 @@ spec:
 
         echo "[$(date --utc -Ins)] End sbom-syft-generate"
     - name: prepare-sboms
-      image: quay.io/konflux-ci/mobster:0.6.0-1754562950@sha256:8a1afd0a1f30a823827e4ed41e5245a947627dce18032931e0c74974392f9440
+      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
       args:
         - --additional-base-images
         - $(params.ADDITIONAL_BASE_IMAGES[*])

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -1083,7 +1083,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:0.6.0-1754562950@sha256:8a1afd0a1f30a823827e4ed41e5245a947627dce18032931e0c74974392f9440
+    image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -1053,7 +1053,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:0.6.0-1754562950@sha256:8a1afd0a1f30a823827e4ed41e5245a947627dce18032931e0c74974392f9440
+    image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -862,7 +862,7 @@ spec:
       subPath: ca-bundle.crt
 
   - name: prepare-sboms
-    image: quay.io/konflux-ci/mobster:0.6.0-1754562950@sha256:8a1afd0a1f30a823827e4ed41e5245a947627dce18032931e0c74974392f9440
+    image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
     computeResources:
       limits:
         memory: 512Mi


### PR DESCRIPTION
Use newer mobster version with fixed spdx id normalization.
[Mobster PR](https://github.com/konflux-ci/mobster/pull/158)
https://issues.redhat.com/browse/KONFLUX-9780