### PR TITLE
Add package-operator package build task

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -133,6 +133,10 @@
 # renovate groupName=ko-builder
 /task/ko-oci-ta @ggallen @vdemeester @arewm @skoved @rh-hemartin @maruiz93
 
+# renovate groupName=package-operator
+/task/package-operator-package        @eqrx @erdii
+/task/package-operator-package-oci-ta @eqrx @erdii
+
 # These are auto-generated and often require changes when tasks change.
 # Allow anyone with write access to approve the changes.
 /pipelines/*/README.md

--- a/pipelines/package-operator-package/README.md
+++ b/pipelines/package-operator-package/README.md
@@ -1,0 +1,13 @@
+# package-operator-package pipeline
+
+Given a git repository, a reference (as in, tag or commit) and a path within the repository this pipeline will create a package-operator package.
+
+The process of how a pko package is defined and packaged is documented [here](https://package-operator.run/docs/guides/packaging-an-application/). This task expects the package definition, will build it using `kubectl-package` and push the created package to the given OCI registry destination.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|--|
+|SRC_REPO_URL|URL of the git repo containing the package definition||true|
+|SRC_REF|Git ref (branch, tag, commit) to use on the given src repo||true|
+|SRC_PATH|Path within the check out src repo containing the package definition||true|
+|DST_URL|URL where to push the generated pko package to||true|

--- a/pipelines/package-operator-package/kustomization.yaml
+++ b/pipelines/package-operator-package/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../template-build
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Pipeline

--- a/pipelines/package-operator-package/package-operator-package.yaml
+++ b/pipelines/package-operator-package/package-operator-package.yaml
@@ -1,0 +1,380 @@
+# WARNING: This is an auto generated file, do not modify this file directly
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  labels:
+    pipelines.openshift.io/runtime: ""
+    pipelines.openshift.io/strategy: ""
+    pipelines.openshift.io/used-by: ""
+  name: package-operator-package
+spec:
+  description: |
+    Given a git repository, a reference (as in, tag or commit) and a path within the repository this pipeline will create a package-operator package.
+
+    The process of how a pko package is defined and packaged is documented [here](https://package-operator.run/docs/guides/packaging-an-application/). This task expects the package definition, will build it using `kubectl-package` and push the created package to the given OCI registry destination.
+  finally: []
+  params:
+  - description: Source Repository URL
+    name: git-url
+    type: string
+  - default: ""
+    description: Revision of the Source Repository
+    name: revision
+    type: string
+  - description: Fully Qualified Output Image
+    name: output-image
+    type: string
+  - default: .
+    description: Path to the source code of an application's component from where
+      to build image.
+    name: path-context
+    type: string
+  - default: "false"
+    description: Force rebuild image
+    name: rebuild
+    type: string
+  - default: "false"
+    description: Skip checks against built image
+    name: skip-checks
+    type: string
+  - default: "false"
+    description: Execute the build with network isolation
+    name: hermetic
+    type: string
+  - default: ""
+    description: Build dependencies to be prefetched
+    name: prefetch-input
+    type: string
+  - default: ""
+    description: Image tag expiration time, time values could be something like 1h,
+      2d, 3w for hours, days, and weeks, respectively.
+    name: image-expires-after
+    type: string
+  - default: "false"
+    description: Build a source image.
+    name: build-source-image
+    type: string
+  - default: "false"
+    description: Add built image into an OCI image index
+    name: build-image-index
+    type: string
+  - default: docker
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker.
+    name: buildah-format
+    type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
+  results:
+  - name: IMAGE_URL
+    value: $(tasks.build-image-index.results.IMAGE_URL)
+  - name: IMAGE_DIGEST
+    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+  - name: CHAINS-GIT_URL
+    value: $(tasks.clone-repository.results.url)
+  - name: CHAINS-GIT_COMMIT
+    value: $(tasks.clone-repository.results.commit)
+  tasks:
+  - name: init
+    params:
+    - name: image-url
+      value: $(params.output-image)
+    - name: rebuild
+      value: $(params.rebuild)
+    - name: skip-checks
+      value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
+    taskRef:
+      name: init
+      version: "0.2"
+  - name: clone-repository
+    params:
+    - name: url
+      value: $(params.git-url)
+    - name: revision
+      value: $(params.revision)
+    runAfter:
+    - init
+    taskRef:
+      name: git-clone
+      version: "0.1"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: output
+      workspace: workspace
+    - name: basic-auth
+      workspace: git-auth
+  - name: prefetch-dependencies
+    params:
+    - name: input
+      value: $(params.prefetch-input)
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: prefetch-dependencies
+      version: "0.2"
+    workspaces:
+    - name: source
+      workspace: workspace
+    - name: git-basic-auth
+      workspace: git-auth
+    - name: netrc
+      workspace: netrc
+  - name: build-container
+    params:
+    - name: SRC_PATH
+      value: $(params.path-context)
+    - name: DST_URL
+      value: $(params.output-image)
+    runAfter:
+    - prefetch-dependencies
+    taskRef:
+      name: package-operator-package
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: package
+      workspace: workspace
+  - name: build-image-index
+    params:
+    - name: IMAGE
+      value: $(params.output-image)
+    - name: COMMIT_SHA
+      value: $(tasks.clone-repository.results.commit)
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.image-expires-after)
+    - name: ALWAYS_BUILD_INDEX
+      value: $(params.build-image-index)
+    - name: IMAGES
+      value:
+      - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
+    runAfter:
+    - build-container
+    taskRef:
+      name: build-image-index
+      version: "0.2"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+  - name: build-source-image
+    params:
+    - name: BINARY_IMAGE
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: BINARY_IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: source-build
+      version: "0.3"
+    when:
+    - input: $(tasks.init.results.build)
+      operator: in
+      values:
+      - "true"
+    - input: $(params.build-source-image)
+      operator: in
+      values:
+      - "true"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: deprecated-base-image-check
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: deprecated-image-check
+      version: "0.5"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: clair-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clair-scan
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: ecosystem-cert-preflight-checks
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: ecosystem-cert-preflight-checks
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-snyk-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-snyk-check
+      version: "0.4"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: clamav-scan
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: clamav-scan
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-coverity-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - coverity-availability-check
+    taskRef:
+      name: sast-coverity-check
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    - input: $(tasks.coverity-availability-check.results.STATUS)
+      operator: in
+      values:
+      - success
+    workspaces:
+    - name: source
+      workspace: workspace
+  - name: coverity-availability-check
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: coverity-availability-check
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  - name: sast-shell-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-shell-check
+      version: "0.1"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: sast-unicode-check
+    params:
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: sast-unicode-check
+      version: "0.3"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+    workspaces:
+    - name: workspace
+      workspace: workspace
+  - name: apply-tags
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: apply-tags
+      version: "0.2"
+  - name: rpms-signature-scan
+    params:
+    - name: image-url
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: image-digest
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    runAfter:
+    - build-image-index
+    taskRef:
+      name: rpms-signature-scan
+      version: "0.2"
+    when:
+    - input: $(params.skip-checks)
+      operator: in
+      values:
+      - "false"
+  workspaces:
+  - name: workspace
+  - name: git-auth
+    optional: true
+  - name: netrc
+    optional: true

--- a/pipelines/package-operator-package/patch.yaml
+++ b/pipelines/package-operator-package/patch.yaml
@@ -1,0 +1,29 @@
+---
+- op: add
+  path: /spec/description
+  value: |
+    Given a git repository, a reference (as in, tag or commit) and a path within the repository this pipeline will create a package-operator package.
+
+    The process of how a pko package is defined and packaged is documented [here](https://package-operator.run/docs/guides/packaging-an-application/). This task expects the package definition, will build it using `kubectl-package` and push the created package to the given OCI registry destination.
+- op: replace
+  path: /metadata/name
+  value: package-operator-package
+- op: replace
+  path: /spec/tasks/3/taskRef/name
+  value: package-operator-package
+- op: add
+  path: /spec/tasks/3/params
+  value:
+  - name: SRC_PATH
+    value: $(params.path-context)
+  - name: DST_URL
+    value: $(params.output-image)
+- op: replace
+  path: /spec/tasks/3/workspaces
+  value:
+  - name: package
+    workspace: workspace
+- op: remove
+  path: /spec/params/4 # dockerfile
+- op: remove
+  path: /spec/tasks/16 # push-dockerfile

--- a/renovate.json
+++ b/renovate.json
@@ -262,6 +262,13 @@
       "matchFileNames": [
         "task/ko-oci-ta/**"
       ]
+    },
+    {
+      "groupName": "package-operator",
+      "matchFileNames": [
+        "task/package-operator-package-oci-ta/**",
+        "task/package-operator-package/**"
+      ]
     }
   ],
   "postUpdateOptions": [

--- a/task/package-operator-package-oci-ta/0.1/README.md
+++ b/task/package-operator-package-oci-ta/0.1/README.md
@@ -1,0 +1,25 @@
+# package-operator-package-oci-ta task
+
+Given a git repository, a reference (as in, tag or commit) and a path within the
+repository this task will create a package-operator package.    The process of how a pko package is defined and packaged is documented
+[here](https://package-operator.run/docs/guides/packaging-an-application/).
+This task expects the package definition, will build it using `kubectl-package`
+and push the created package to the given OCI registry destination.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|DST_URL|URL where to push the generated pko package to.||true|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|SRC_PATH|Path of the directory within the repository that contains package manifest.||true|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the package just built|
+|IMAGE_REF|Image reference of the built package|
+|IMAGE_URL|Image repository and tag where the built package was pushed|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+
+
+## Additional info

--- a/task/package-operator-package-oci-ta/0.1/package-operator-package-oci-ta.yaml
+++ b/task/package-operator-package-oci-ta/0.1/package-operator-package-oci-ta.yaml
@@ -1,0 +1,131 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: package-operator-package-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.21.1
+    tekton.dev/platforms: linux/amd64
+    tekton.dev/tags: package-operator
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: package-operator-package
+spec:
+  description: |-
+    Given a git repository, a reference (as in, tag or commit) and a path within the
+    repository this task will create a package-operator package.    The process of how a pko package is defined and packaged is documented
+    [here](https://package-operator.run/docs/guides/packaging-an-application/).
+    This task expects the package definition, will build it using `kubectl-package`
+    and push the created package to the given OCI registry destination.
+  params:
+    - name: DST_URL
+      description: URL where to push the generated pko package to.
+      type: string
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: SRC_PATH
+      description: Path of the directory within the repository that contains
+        package manifest.
+      type: string
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the package just built
+    - name: IMAGE_REF
+      description: Image reference of the built package
+    - name: IMAGE_URL
+      description: Image repository and tag where the built package was pushed
+    - name: SBOM_BLOB_URL
+      description: Reference of SBOM blob digest to enable digest-based verification
+        from provenance
+      type: string
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: ca-bundle.crt
+            path: ca-bundle.crt
+        name: trusted-ca
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    volumeMounts:
+      - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        name: trusted-ca
+        readOnly: true
+        subPath: ca-bundle.crt
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:43d997ac61bef77eaee0413fe50c29b66eb4d0d32066f5bd4a83f39e4b2d9457
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: build-pkg
+      image: quay.io/redhat-services-prod/mos-lpsre-tenant/package-operator-internal/kubectl-package-internal:a003501@sha256:2acd8331cf101ba16a2905e38ac6767275988f64851374ddbe33f037450c9e90
+      workingDir: /var/workdir/source
+      env:
+        - name: DST_URL
+          value: $(params.DST_URL)
+        - name: SRC_PATH
+          value: $(params.SRC_PATH)
+      script: |
+        #!/bin/bash
+        set -eu -o pipefail
+
+        cd "$SRC_PATH"
+
+        digest=$(kubectl-package build --tag "$DST_URL" --push . --output-format digest)
+        echo -n "$digest" >"$(results.IMAGE_DIGEST.path)"
+        echo -n "$DST_URL" >"$(results.IMAGE_URL.path)"
+        echo -n "$DST_URL@$digest" >"$(results.IMAGE_REF.path)"
+    - name: build-sbom
+      image: quay.io/konflux-ci/mobster:1.0.0-1761030771@sha256:f751b8fb47409eeef7c3235f201a5a9c137a5014cf7f1474340298101c7b1a0f
+      workingDir: /var/workdir
+      env:
+        - name: SRC_PATH
+          value: $(params.SRC_PATH)
+      script: |
+        #!/bin/bash
+        set -eu -o pipefail
+
+        cd source
+        git config --global --add safe.directory .
+
+        src_ref="$(git rev-parse --verify HEAD)"
+        src_repo_url="$(git remote get-url origin)"
+        cd -
+
+        url="$src_repo_url#ref=$src_ref&path=$SRC_PATH"
+
+        mobster generate --output sbom.json pko-package --sbom-type spdx \
+          --url "$url" --package-pullspec "$(cat "$(results.IMAGE_REF.path)")" --package-digest "$(cat "$(results.IMAGE_DIGEST.path)")"
+    - name: push-sbom
+      image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+      workingDir: /var/workdir
+      env:
+        - name: DST_URL
+          value: $(params.DST_URL)
+      script: |
+        #!/bin/bash
+        set -eu -o pipefail
+
+        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+        mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" >/tmp/auth/config.json
+        export DOCKER_CONFIG=/tmp/auth
+        echo "Pushing sbom to registry"
+        if ! retry cosign attach sbom --sbom sbom.json --type spdx "$(cat "$(results.IMAGE_REF.path)")"; then
+          echo "Failed to push sbom to registry"
+          exit 1
+        fi
+
+        IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+        # Remove tag from IMAGE while allowing registry to contain a port number.
+        sbom_repo=sbom_repo="${IMAGE_URL%:*}"
+        sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+
+        # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+        echo -n "${sbom_repo}@sha256:${sbom_digest}" >"$(results.SBOM_BLOB_URL.path)"
+        cosign attach sbom --sbom sbom.json --type spdx "$DST_URL"

--- a/task/package-operator-package-oci-ta/0.1/recipe.yaml
+++ b/task/package-operator-package-oci-ta/0.1/recipe.yaml
@@ -1,0 +1,11 @@
+---
+base: ../../package-operator-package/0.1/package-operator-package.yaml
+add:
+  - use-source
+removeWorkspaces:
+  - source
+preferStepTemplate: true
+replacements:
+  workspaces.source.path: /var/workdir
+regexReplacements:
+  "/workspace(/.*)": /var/workdir$1

--- a/task/package-operator-package/0.1/README.md
+++ b/task/package-operator-package/0.1/README.md
@@ -1,0 +1,12 @@
+# package-operator-package task
+
+Given a git repository, a reference (as in, tag or commit) and a path within the repository this task will create a package-operator package.
+
+The process of how a pko package is defined and packaged is documented [here](https://package-operator.run/docs/guides/packaging-an-application/). This task expects the package definition, will build it using `kubectl-package` and push the created package to the given OCI registry destination.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|--|
+|PACKAGE_PATH|File path the package manifest is in||true|
+|SBOM_SRC|Source that is being specified in the SBOM pushed alongside the package||true|
+|DST_URL|URL where to push the generated pko package to||true|

--- a/task/package-operator-package/0.1/package-operator-package.yaml
+++ b/task/package-operator-package/0.1/package-operator-package.yaml
@@ -1,0 +1,119 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.21.1"
+    tekton.dev/tags: package-operator
+    tekton.dev/platforms: linux/amd64
+  labels:
+    app.kubernetes.io/version: "0.1"
+    build.appstudio.redhat.com/build_type: package-operator-package
+  name: package-operator-package
+spec:
+  description: |-
+    Given a git repository, a reference (as in, tag or commit) and a path within the
+    repository this task will create a package-operator package.    The process of how a pko package is defined and packaged is documented
+    [here](https://package-operator.run/docs/guides/packaging-an-application/).
+    This task expects the package definition, will build it using `kubectl-package`
+    and push the created package to the given OCI registry destination.
+  params:
+    - name: SRC_PATH
+      description: Path of the directory within the repository that contains package manifest.
+      type: string
+    - name: DST_URL
+      description: URL where to push the generated pko package to.
+      type: string
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the package just built
+    - name: IMAGE_URL
+      description: Image repository and tag where the built package was pushed
+    - name: IMAGE_REF
+      description: Image reference of the built package
+    - name: SBOM_BLOB_URL
+      description: Reference of SBOM blob digest to enable digest-based verification from provenance
+      type: string
+  workspaces:
+    - name: source
+      description: Workspace containing the source code to build.
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: ca-bundle.crt
+            path: ca-bundle.crt
+        name: trusted-ca
+  stepTemplate:
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        subPath: ca-bundle.crt
+        readOnly: true
+  steps:
+  - name: build-pkg
+    image: quay.io/redhat-services-prod/mos-lpsre-tenant/package-operator-internal/kubectl-package-internal:a003501@sha256:2acd8331cf101ba16a2905e38ac6767275988f64851374ddbe33f037450c9e90
+    env:
+      - name: DST_URL
+        value: $(params.DST_URL)
+      - name: SRC_PATH
+        value: $(params.SRC_PATH)
+    script: |
+      #!/bin/bash
+      set -eu -o pipefail
+
+      cd "$SRC_PATH"
+
+      digest=$(kubectl-package build --tag "$DST_URL" --push . --output-format digest)
+      echo -n "$digest" > "$(results.IMAGE_DIGEST.path)"
+      echo -n "$DST_URL" > "$(results.IMAGE_URL.path)"
+      echo -n "$DST_URL@$digest" > "$(results.IMAGE_REF.path)"
+    workingDir: $(workspaces.source.path)/source
+  - name: build-sbom
+    workingDir: $(workspaces.source.path)
+    image: quay.io/konflux-ci/mobster:1.0.0-1761030771@sha256:f751b8fb47409eeef7c3235f201a5a9c137a5014cf7f1474340298101c7b1a0f
+    env:
+      - name: SRC_PATH
+        value: $(params.SRC_PATH)
+    script: |
+      #!/bin/bash
+      set -eu -o pipefail
+
+      cd source
+      git config --global --add safe.directory .
+
+      src_ref="$(git rev-parse --verify HEAD)"
+      src_repo_url="$(git remote get-url origin)"
+      cd -
+
+      url="$src_repo_url#ref=$src_ref&path=$SRC_PATH"
+
+      mobster generate --output sbom.json pko-package --sbom-type spdx \
+        --url "$url" --package-pullspec "$(cat "$(results.IMAGE_REF.path)")" --package-digest "$(cat "$(results.IMAGE_DIGEST.path)")"
+  - name: push-sbom
+    workingDir: $(workspaces.source.path)
+    image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+    env:
+      - name: DST_URL
+        value: $(params.DST_URL)
+    script: |
+      #!/bin/bash
+      set -eu -o pipefail
+
+      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+      mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" > /tmp/auth/config.json
+      export DOCKER_CONFIG=/tmp/auth
+      echo "Pushing sbom to registry"
+      if ! retry cosign attach sbom --sbom sbom.json --type spdx "$(cat "$(results.IMAGE_REF.path)")"
+      then
+          echo "Failed to push sbom to registry"
+          exit 1
+      fi
+
+      IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+      # Remove tag from IMAGE while allowing registry to contain a port number.
+      sbom_repo=sbom_repo="${IMAGE_URL%:*}"
+      sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+
+      # The SBOM_BLOB_URL is created by `cosign attach sbom`.
+      echo -n "${sbom_repo}@sha256:${sbom_digest}" > "$(results.SBOM_BLOB_URL.path)"
+      cosign attach sbom --sbom sbom.json --type spdx "$DST_URL"

--- a/task/package-operator-package/0.1/tests/test-package-operator-package-happy-path.yaml
+++ b/task/package-operator-package/0.1/tests/test-package-operator-package-happy-path.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-package-operator-package
+spec:
+  description: |
+    Test the package-operator-package by building a stub package and pushing it somewhere.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: clone-package-repository
+      params:
+      - name: url
+        value: https://github.com/package-operator/package-operator.git
+      - name: revision
+        value: dbcfde1e37c6773ec51ff3620f1a9d2c3d07a99d
+      - name: subdirectory
+        value: source
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+    - name: run-package-operator-package
+      taskRef:
+        name: package-operator-package
+      params:
+        - name: SRC_PATH
+          value: "config/packages/test-stub"
+        - name: DST_URL
+          value: registry-service.kind-registry/test-stub:latest
+      workspaces:
+        - name: source
+          workspace: tests-workspace
+      runAfter:
+        - clone-package-repository
+    - name: verify-package-operator-package-result
+      params:
+        - name: DST_URL
+          value: registry-service.kind-registry/test-stub:latest
+      taskSpec:
+        params:
+          - name: DST_URL
+        volumes:
+          - name: trusted-ca
+            configMap:
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              name: trusted-ca
+        stepTemplate:
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+        steps:
+          - name: run-package-operator-package-test
+            image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              mkdir image
+              cd image
+              oc image extract "$(params.DST_URL)"
+              [ -f package/manifest.yaml ]
+              echo "pass"
+      runAfter:
+        - run-package-operator-package


### PR DESCRIPTION
This PR adds a task that allows users to build package-operator packages.

The documentation of package-operator is [here](https://package-operator.run), the documentation on how to pack packages for it is [here](https://package-operator.run/docs/guides/packaging-an-application/).

Design is tracked by tickets [KONFLUX-7390](https://issues.redhat.com/browse/KONFLUX-7390) and [PKO-283](https://issues.redhat.com/browse/PKO-283).