### PR TITLE
fix(KONFLUX-9780): SBOM generation fails if img name contains underscores

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -185,7 +185,7 @@ spec:
         add:
           - SETFCAP
 
-  - image: quay.io/konflux-ci/mobster@sha256:0e924f70c0998fac59dc513f5b482f0779c1e0457ebb56e1b8294e4f65fb0ecb
+  - image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
     name: create-sbom
     computeResources:
       limits:

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -194,7 +194,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster@sha256:0e924f70c0998fac59dc513f5b482f0779c1e0457ebb56e1b8294e4f65fb0ecb
+    image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
     name: create-sbom
     script: |
       #!/bin/bash

--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -174,7 +174,7 @@ spec:
           add:
             - SETFCAP
     - name: save-sbom
-      image: quay.io/konflux-ci/mobster:0.6.0-1753174420@sha256:c7002b4f892f62881838607fb4d6e46ab82b9d6bf49c72304138c18308b9af33
+      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/build-maven-zip/0.1/build-maven-zip.yaml
+++ b/task/build-maven-zip/0.1/build-maven-zip.yaml
@@ -146,7 +146,7 @@ spec:
       mountPath: /mnt/trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - image: quay.io/konflux-ci/mobster:0.6.0-1753174420@sha256:c7002b4f892f62881838607fb4d6e46ab82b9d6bf49c72304138c18308b9af33
+  - image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
     name: save-sbom
     computeResources:
       limits:

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -179,7 +179,7 @@ spec:
         echo -n "${IMAGE}@${RESULTING_DIGEST}" > "$(results.IMAGE_REF.path)"
 
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster@sha256:1298794cb6c6bc3aa42a2f1206e8ec1497e9a105675a663648f31236a2dc605d
+      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
       workingDir: /var/workdir
       script: |
         #!/bin/bash

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -316,7 +316,7 @@ spec:
           add:
             - SETFCAP
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster@sha256:3603ad3858f87c0071563b4830b359333e14de09aeed445c074177ae936870f2
+      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
       workingDir: /var/workdir
       script: |
         #!/bin/bash

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -301,7 +301,7 @@ spec:
           name: varlibcontainers
       workingDir: $(workspaces.source.path)
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster@sha256:3603ad3858f87c0071563b4830b359333e14de09aeed445c074177ae936870f2
+      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
       script: |
         #!/bin/bash
         set -euo pipefail


### PR DESCRIPTION
This is an addendum to #2686, we need this fix everywhere because every task may be impacted by the issue.