### PR TITLE
feat: build appstudio-utils for arm

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -5,7 +5,7 @@ metadata:
   name: build-definitions-pull-request
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || !body.pull_request.draft) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/") && body.head_commit != "null" )
-    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, task/buildah-remote/0.4/buildah-remote.yaml, task/build-image-index/0.1/build-image-index.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.4/sast-snyk-check.yaml, task/sast-unicode-check/0.2/sast-unicode-check.yaml, .tekton/tasks/task-switchboard.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, task/buildah-remote/0.4/buildah-remote.yaml, task/build-image-index/0.1/build-image-index.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.4/sast-snyk-check.yaml, task/sast-unicode-check/0.3/sast-unicode-check.yaml, .tekton/tasks/task-switchboard.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:
@@ -15,6 +15,8 @@ spec:
       value: "{{ revision }}"
     - name: e2e_test_namespace
       value: build-templates-e2e
+    - name: image-target
+      value: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
   pipelineSpec:
     params:
       - name: repo_url
@@ -45,7 +47,7 @@ spec:
             - linux/arm64
         params:
           - name: IMAGE
-            value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+            value: "$(params.image-target)"
           - name: CONTEXT
             value: appstudio-utils
           - name: IMAGE_APPEND_PLATFORM
@@ -61,7 +63,7 @@ spec:
       - name: build-appstudio-utils-index
         params:
           - name: IMAGE
-            value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+            value: "$(params.image-target)"
           - name: IMAGES
             value:
             - $(tasks.build-appstudio-utils.results.IMAGE_REF[*])
@@ -89,9 +91,9 @@ spec:
           name: task-switchboard
         params:
           - name: revision
-            value: $(params.revision)
+            value: "$(params.revision)"
           - name: utils_image
-            value: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
+            value: "$(params.image-target)"
           - name: expressions
             value:
               - tasks := strings.any_prefix_match(input, ["task/", "hack/", ".tekton/"])
@@ -120,6 +122,8 @@ spec:
         params:
           - name: image-digest
             value: "$(tasks.build-appstudio-utils-index.results.IMAGE_DIGEST)"
+          - name: image-url
+            value: "$(tasks.build-appstudio-utils-index.results.IMAGE_URL)"
         taskRef:
           name: sast-unicode-check
         workspaces:
@@ -135,7 +139,7 @@ spec:
         taskSpec:
           steps:
             - name: check-task-structure
-              image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
+              image: $(params.image-target)
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash
@@ -212,7 +216,7 @@ spec:
             description: "custom bundle for fbc-builder pipeline"
           steps:
             - name: build-bundles
-              image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
+              image: $(params.image-target)
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -383,4 +383,4 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 1Gi
+              storage: 5Gi

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -221,6 +221,7 @@ spec:
               script: |
                 #!/usr/bin/env bash
                 set -e
+                git config --global --add safe.directory /workspace/source/source
 
                 QUAY_NAMESPACE=konflux-ci \
                 TEST_REPO_NAME=pull-request-builds \

--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -5,7 +5,7 @@ metadata:
   name: build-definitions-pull-request
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || !body.pull_request.draft) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/") && body.head_commit != "null" )
-    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.4/sast-snyk-check.yaml, task/sast-unicode-check/0.2/sast-unicode-check.yaml, .tekton/tasks/task-switchboard.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, task/buildah-remote/0.4/buildah-remote.yaml, task/build-image-index/0.1/build-image-index.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, task/sast-snyk-check/0.4/sast-snyk-check.yaml, task/sast-unicode-check/0.2/sast-unicode-check.yaml, .tekton/tasks/task-switchboard.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:
@@ -23,7 +23,7 @@ spec:
     workspaces:
       - name: workspace
     tasks:
-      - name: fetch-repository
+      - name: clone-repository
         taskRef:
           name: git-clone
         workspaces:
@@ -37,26 +37,48 @@ spec:
           - name: depth
             value: "0"
       - name: build-appstudio-utils
-        runAfter:
-          - fetch-repository
+        matrix:
+          params:
+          - name: PLATFORM
+            value:
+            - linux/x86_64
+            - linux/arm64
         params:
           - name: IMAGE
-            value: quay.io/konflux-ci/pull-request-builds:appstudio-utils-{{revision}}
+            value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
           - name: CONTEXT
             value: appstudio-utils
+          - name: IMAGE_APPEND_PLATFORM
+            value: "true"
+        runAfter:
+          - clone-repository
         taskRef:
-          name: buildah
+          name: buildah-remote
         workspaces:
           - name: source
             workspace: workspace
+
+      - name: build-appstudio-utils-index
+        params:
+          - name: IMAGE
+            value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+          - name: IMAGES
+            value:
+            - $(tasks.build-appstudio-utils.results.IMAGE_REF[*])
+        runAfter:
+          - build-appstudio-utils
+        taskRef:
+          name: build-image-index
+
       - name: sast-snyk-check
         runAfter:
-          - fetch-repository
+          - clone-repository
+          - build-appstudio-utils-index
         params:
           - name: image-url
-            value: "$(tasks.build-appstudio-utils.results.IMAGE_URL)"
+            value: "$(tasks.build-appstudio-utils-index.results.IMAGE_URL)"
           - name: image-digest
-            value: "$(tasks.build-appstudio-utils.results.IMAGE_DIGEST)"
+            value: "$(tasks.build-appstudio-utils-index.results.IMAGE_DIGEST)"
         taskRef:
           name: sast-snyk-check
         workspaces:
@@ -76,7 +98,7 @@ spec:
               - tasks_pipelines := strings.any_prefix_match(input, ["task/", "pipelines/", "hack/", ".tekton/"])
               - check_partner_tasks := strings.any_prefix_match(input, ["partners/", "hack/", ".tekton/"])
         runAfter:
-          - build-appstudio-utils
+          - build-appstudio-utils-index
         workspaces:
           - name: source
             workspace: workspace
@@ -94,10 +116,10 @@ spec:
             workspace: workspace
       - name: sast-unicode-check
         runAfter:
-          - build-appstudio-utils
+          - build-appstudio-utils-index
         params:
           - name: image-digest
-            value: "$(tasks.build-appstudio-utils.results.IMAGE_DIGEST)"
+            value: "$(tasks.build-appstudio-utils-index.results.IMAGE_DIGEST)"
         taskRef:
           name: sast-unicode-check
         workspaces:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -185,6 +185,7 @@ spec:
               script: |
                 #!/bin/bash
                 set -euo pipefail
+                git config --global --add safe.directory /workspace/source/source
 
                 DATA_BUNDLE_REPO=quay.io/konflux-ci/tekton-catalog/data-acceptable-bundles
                 DATA_BUNDLE_TAG=$(date '+%s')

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -14,6 +14,8 @@ spec:
       value: "{{ repo_url }}"
     - name: revision
       value: "{{ revision }}"
+    - name: image-target
+      value: "quay.io/konflux-ci/appstudio-utils:{{ revision }}"
     - name: slack-webhook-notification-team
       value: "integration-slack-alerts"
   pipelineSpec:
@@ -75,7 +77,7 @@ spec:
             - linux/arm64
         params:
           - name: IMAGE
-            value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+            value: "$(params.image-target)"
           - name: CONTEXT
             value: appstudio-utils
           - name: IMAGE_APPEND_PLATFORM
@@ -91,7 +93,7 @@ spec:
       - name: build-appstudio-utils-index
         params:
           - name: IMAGE
-            value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+            value: "$(params.image-target)"
           - name: IMAGES
             value:
             - $(tasks.build-appstudio-utils.results.IMAGE_REF[*])
@@ -130,7 +132,7 @@ spec:
               type: string
           steps:
             - name: build-bundles-konflux-ci
-              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              image: "$(params.image-target)"
               workingDir: $(workspaces.source.path)/source
               command: ["./hack/build-and-push.sh"]
               env:
@@ -147,7 +149,7 @@ spec:
                 - name: OUTPUT_PIPELINE_BUNDLE_LIST
                   value: $(workspaces.source.path)/pipeline-bundle-list-konflux-ci
             - name: build-bundles-redhat-appstudio
-              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              image: "$(params.image-target)"
               workingDir: $(workspaces.source.path)/source
               command: ["./hack/build-and-push.sh"]
               env:
@@ -168,7 +170,7 @@ spec:
                   subPath: .dockerconfigjson
                   name: quay-secret
             - name: update-acceptable-bundles
-              image: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+              image: "$(params.image-target)"
               workingDir: $(workspaces.source.path)/source
               env:
               - name: REVISION
@@ -214,7 +216,7 @@ spec:
         taskSpec:
           steps:
             - name: run-create-bundle-repos
-              image: quay.io/konflux-ci/appstudio-utils:{{revision}}
+              image: "$(params.image-target)"
               workingDir: $(workspaces.source.path)/source
               script: |
                 #!/usr/bin/env bash

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -258,4 +258,4 @@ spec:
             - ReadWriteOnce
           resources:
             requests:
-              storage: 1Gi
+              storage: 5Gi

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-event: "push"
     pipelinesascode.tekton.dev/on-target-branch: "main"
-    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, .tekton/tasks/buildah.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml, task/apply-tags/0.2/apply-tags.yaml, task/sast-snyk-check/0.4/sast-snyk-check.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, task/buildah-remote/0.4/buildah-remote.yaml, task/build-image-index/0.1/build-image-index.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml, task/apply-tags/0.2/apply-tags.yaml, task/sast-snyk-check/0.4/sast-snyk-check.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:
@@ -47,11 +47,11 @@ spec:
           - name: ARGS
             value: --report --project-name=konflux-ci/build-definitions
           - name: image-url
-            value: $(tasks.build-appstudio-utils.results.IMAGE_URL)
+            value: $(tasks.build-appstudio-utils-index.results.IMAGE_URL)
           - name: image-digest
-            value: $(tasks.build-appstudio-utils.results.IMAGE_DIGEST)
+            value: $(tasks.build-appstudio-utils-index.results.IMAGE_DIGEST)
         runAfter:
-          - build-appstudio-utils
+          - build-appstudio-utils-index
         taskRef:
           name: sast-snyk-check
         workspaces:
@@ -67,29 +67,49 @@ spec:
           - name: source
             workspace: workspace
       - name: build-appstudio-utils
+        matrix:
+          params:
+          - name: PLATFORM
+            value:
+            - linux/x86_64
+            - linux/arm64
         params:
           - name: IMAGE
             value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
           - name: CONTEXT
             value: appstudio-utils
+          - name: IMAGE_APPEND_PLATFORM
+            value: "true"
         runAfter:
           - clone-repository
         taskRef:
-          name: buildah
+          name: buildah-remote
         workspaces:
           - name: source
             workspace: workspace
 
+      - name: build-appstudio-utils-index
+        params:
+          - name: IMAGE
+            value: quay.io/konflux-ci/appstudio-utils:{{ revision }}
+          - name: IMAGES
+            value:
+            - $(tasks.build-appstudio-utils.results.IMAGE_REF[*])
+        runAfter:
+          - build-appstudio-utils
+        taskRef:
+          name: build-image-index
+
       - name: apply-additional-image-tags
         params:
           - name: IMAGE_URL
-            value: $(tasks.build-appstudio-utils.results.IMAGE_URL)
+            value: $(tasks.build-appstudio-utils-index.results.IMAGE_URL)
           - name: IMAGE_DIGEST
-            value: $(tasks.build-appstudio-utils.results.IMAGE_DIGEST)
+            value: $(tasks.build-appstudio-utils-index.results.IMAGE_DIGEST)
           - name: ADDITIONAL_TAGS
             value: ["latest"]
         runAfter:
-          - build-appstudio-utils
+          - build-appstudio-utils-index
         taskRef:
           name: apply-tags
 
@@ -98,7 +118,7 @@ spec:
           - name: revision
             value: "$(params.revision)"
         runAfter:
-          - build-appstudio-utils
+          - build-appstudio-utils-index
           - ec-task-checks
           - create-repositories-if-missing
         workspaces:
@@ -190,7 +210,7 @@ spec:
 
       - name: create-repositories-if-missing
         runAfter:
-          - build-appstudio-utils
+          - build-appstudio-utils-index
         taskSpec:
           steps:
             - name: run-create-bundle-repos

--- a/.tekton/tasks/task-switchboard.yaml
+++ b/.tekton/tasks/task-switchboard.yaml
@@ -41,6 +41,8 @@ spec:
         set -o nounset
         set -o pipefail
 
+        git config --global --add safe.directory /workspace/source/source
+
         rules="$(mktemp -d)"
         trap 'rm -rf "${rules}"' EXIT
         for ((i=1; i<=$#; ++i)); do

--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -1,24 +1,36 @@
 FROM quay.io/enterprise-contract/cli:latest AS ec-image
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
+    cp /usr/local/bin/ec_linux_${ARCH}.gz /tmp/ec.gz
 FROM quay.io/konflux-ci/buildah-task:latest@sha256:b82d465a06c926882d02b721cf8a8476048711332749f39926a01089cf85a3f9 AS buildah-task-image
 FROM registry.access.redhat.com/ubi9/ubi
 
-COPY --from=ec-image /usr/local/bin/ec_linux_amd64.gz /usr/bin/ec.gz
+COPY --from=ec-image /tmp/ec.gz /usr/bin/ec.gz
 RUN gunzip /usr/bin/ec.gz && chmod +x /usr/bin/ec
 COPY --from=buildah-task-image /usr/bin/retry /usr/bin/
 
-RUN curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64 -o /usr/bin/jq && chmod +x /usr/bin/jq
-RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq && chmod +x /usr/bin/yq
-RUN curl -L https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.13/openshift-client-linux.tar.gz | tar -xz -C /usr/bin/
-RUN curl -L https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-amd64 -o /usr/bin/cosign && chmod +x /usr/bin/cosign
-RUN curl -L https://github.com/tektoncd/cli/releases/download/v0.32.2/tkn_0.32.2_Linux_x86_64.tar.gz | tar -xz --no-same-owner -C /usr/bin/ tkn
-RUN curl -L https://github.com/sigstore/rekor/releases/download/v0.5.0/rekor-cli-linux-amd64 -o /usr/bin/rekor-cli && chmod +x /usr/bin/rekor-cli
-RUN curl -L https://github.com/open-policy-agent/conftest/releases/download/v0.32.0/conftest_0.32.0_Linux_x86_64.tar.gz | tar -xz --no-same-owner -C /usr/bin
-RUN curl -L https://github.com/cli/cli/releases/download/v2.60.1/gh_2.60.1_linux_amd64.tar.gz | tar -xz  -C /usr/bin --wildcards "gh_*/bin/gh" --strip-components=2 --no-same-owner
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        GO_ARCH="amd64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        GO_ARCH="arm64"; \
+    fi && \
+    curl -L https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${GO_ARCH} -o /usr/bin/jq && chmod +x /usr/bin/jq && \
+    curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_${GO_ARCH} -o /usr/bin/yq && chmod +x /usr/bin/yq && \
+    curl -L https://mirror.openshift.com/pub/openshift-v4/${ARCH}/clients/ocp/latest-4.13/openshift-client-linux.tar.gz | tar -xz -C /usr/bin/ && \
+    curl -L https://github.com/sigstore/cosign/releases/download/v2.4.1/cosign-linux-${GO_ARCH} -o /usr/bin/cosign && chmod +x /usr/bin/cosign && \
+    curl -L https://github.com/sigstore/rekor/releases/download/v0.5.0/rekor-cli-linux-${GO_ARCH} -o /usr/bin/rekor-cli && chmod +x /usr/bin/rekor-cli && \
+    curl -L https://github.com/cli/cli/releases/download/v2.60.1/gh_2.60.1_linux_${GO_ARCH}.tar.gz | tar -xz  -C /usr/bin --wildcards "gh_*/bin/gh" --strip-components=2 --no-same-owner && \
+    curl -L https://github.com/oras-project/oras/releases/download/v1.2.1/oras_1.2.1_linux_${GO_ARCH}.tar.gz | tar -xz --no-same-owner -C /usr/bin oras
 
-
-# 1.2.0 is the minimum required version
-RUN curl -L https://github.com/oras-project/oras/releases/download/v1.2.1/oras_1.2.1_linux_amd64.tar.gz | \
-    tar -xz --no-same-owner -C /usr/bin oras
+RUN ARCH=$(uname -m) && \
+    if [ "$ARCH" = "x86_64" ]; then \
+        TKN_ARCH="x86_64"; CONFTEST_ARCH="x86_64"; \
+    elif [ "$ARCH" = "aarch64" ]; then \
+        TKN_ARCH="aarch64"; CONFTEST_ARCH="arm64"; \
+    fi && \
+    curl -L https://github.com/tektoncd/cli/releases/download/v0.32.2/tkn_0.32.2_Linux_${TKN_ARCH}.tar.gz | tar -xz --no-same-owner -C /usr/bin/ tkn && \
+    curl -L https://github.com/open-policy-agent/conftest/releases/download/v0.32.0/conftest_0.32.0_Linux_${CONFTEST_ARCH}.tar.gz | tar -xz --no-same-owner -C /usr/bin
 
 RUN dnf -y --setopt=tsflags=nodocs install \
     git \


### PR DESCRIPTION
konflux-ci/konflux-ci can install on arm, but we cannot run our pipelines on arm unless all step images are built for both x86 and arm.

This change starts to build the appstudio-utils image for both architectures.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
