### PR TITLE
feat: change the core services pipeline to multi-arch

### DIFF
--- a/pipelines/core-services/README.md
+++ b/pipelines/core-services/README.md
@@ -1,1 +1,3 @@
-An extension of build pipelines for Stonesoup core services to allow updating infra-deployments after successful build in CI.
+An extension of build pipelines for Konflux core services to allow updating infra-deployments after successful build in CI.
+
+Since [konflux-ci/konflux-ci](github.com/konflux-ci/konflux-ci) supports running on arm64 and x86, this pipeline will produce a multi-arch image by default as well.

--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -11,10 +11,10 @@ metadata:
   name: docker-build
 spec:
   description: |
-    This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
+    This pipeline is ideal for building container images from a Containerfile that can be used in Konflux deployments.
 
-    _Uses `buildah` to create a container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) if any tasks are added to the pipeline.
-    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-docker-build?tab=tags)_
+    _Uses `buildah` to create a multi-arch container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) if any custom tasks are added to the pipeline.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-core-services-docker-build?tab=tags)_
   finally:
   - name: show-summary
     params:
@@ -142,7 +142,7 @@ spec:
     description: Build a source image.
     name: build-source-image
     type: string
-  - default: "false"
+  - default: "true"
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
@@ -162,6 +162,12 @@ spec:
     name: update-repo-name
   - default: ""
     name: slack-webhook-notification-team
+  - default:
+    - linux/x86_64
+    description: List of platforms to build the container images on. The available
+      set of values is determined by the configuration of the multi-platform-controller.
+    name: build-platforms
+    type: array
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -220,7 +226,12 @@ spec:
       workspace: git-auth
     - name: netrc
       workspace: netrc
-  - name: build-container
+  - matrix:
+      params:
+      - name: PLATFORM
+        value:
+        - $(params.build-platforms)
+    name: build-images
     params:
     - name: IMAGE
       value: $(params.output-image)
@@ -241,10 +252,12 @@ spec:
       - $(params.build-args[*])
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
+    - name: IMAGE_APPEND_PLATFORM
+      value: "true"
     runAfter:
     - prefetch-dependencies
     taskRef:
-      name: buildah
+      name: buildah-remote
       version: "0.4"
     when:
     - input: $(tasks.init.results.build)
@@ -266,9 +279,9 @@ spec:
       value: $(params.build-image-index)
     - name: IMAGES
       value:
-      - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - $(tasks.build-images.results.IMAGE_REF[*])
     runAfter:
-    - build-container
+    - build-images
     taskRef:
       name: build-image-index
       version: "0.1"
@@ -332,7 +345,12 @@ spec:
       operator: in
       values:
       - "false"
-  - name: ecosystem-cert-preflight-checks
+  - matrix:
+      params:
+      - name: platform
+        value:
+        - $(params.build-platforms)
+    name: ecosystem-cert-preflight-checks
     params:
     - name: image-url
       value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -365,7 +383,12 @@ spec:
     workspaces:
     - name: workspace
       workspace: workspace
-  - name: clamav-scan
+  - matrix:
+      params:
+      - name: image-arch
+        value:
+        - $(params.build-platforms)
+    name: clamav-scan
     params:
     - name: image-digest
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/pipelines/core-services/kustomization.yaml
+++ b/pipelines/core-services/kustomization.yaml
@@ -17,11 +17,6 @@ patches:
 - path: slack-notification.yaml
   target:
     kind: Pipeline
-- target:
+- path: patch.yaml
+  target:
     kind: Pipeline
-  # Remove privilege-nested pipeline param and PRIVILEGE_NESTED task param
-  patch: |-
-    - op: remove
-      path: /spec/params/14
-    - op: remove
-      path: /spec/tasks/3/params/9

--- a/pipelines/core-services/patch.yaml
+++ b/pipelines/core-services/patch.yaml
@@ -1,0 +1,110 @@
+- op: add
+  path: /spec/description
+  value: |
+    This pipeline is ideal for building container images from a Containerfile that can be used in Konflux deployments.
+
+    _Uses `buildah` to create a multi-arch container image. It also optionally creates a source image and runs some build-time tests. EC will flag a violation for [`trusted_task.trusted`](https://conforma.dev/docs/policy/packages/release_trusted_task.html#trusted_task__trusted) if any custom tasks are added to the pipeline.
+    This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/repository/konflux-ci/tekton-catalog/pipeline-core-services-docker-build?tab=tags)_
+
+# Order of Tasks from the base docker-build Pipeline:
+# $ kustomize build pipelines/docker-build | yq ".spec.tasks.[].name" | nl -v 0
+#      0  init
+#      1  clone-repository
+#      2  prefetch-dependencies
+#      3  build-container
+#      4  build-image-index
+#      5  build-source-image
+#      6  deprecated-base-image-check
+#      7  clair-scan
+#      8  ecosystem-cert-preflight-checks
+#      9  sast-snyk-check
+#     10  clamav-scan
+#     11  sast-coverity-check
+#     12  coverity-availability-check
+#     13  sast-shell-check
+#     14  sast-unicode-check
+#     15  apply-tags
+#     16  push-dockerfile
+#     17  rpms-signature-scan
+
+# build-container
+- op: replace
+  path: /spec/tasks/3/name
+  value: build-images
+- op: replace
+  path: /spec/tasks/3/taskRef/name
+  value: buildah-remote
+- op: add
+  path: /spec/tasks/3/matrix
+  value:
+    params:
+      - name: PLATFORM
+        value: ["$(params.build-platforms)"]
+- op: add
+  path: /spec/tasks/3/params/-
+  value:
+    name: IMAGE_APPEND_PLATFORM
+    value: "true"
+# Remove PRIVILEGE_NESTED task param
+- op: remove
+  path: /spec/tasks/3/params/9
+
+# build-image-index
+- op: replace
+  path: /spec/tasks/4/params/4/value  # IMAGES
+  value:
+    - $(tasks.build-images.results.IMAGE_REF[*])
+- op: replace
+  path: /spec/tasks/4/runAfter
+  value:
+  - build-images
+
+# ecosystem-cert-preflight-checks
+- op: add
+  path: /spec/tasks/8/matrix
+  value:
+    params:
+      - name: platform
+        value: ["$(params.build-platforms)"]
+
+# Order of pipeline parameters
+# $ kustomize build pipelines/docker-build | yq ".spec.params.[].name" | nl -v 0
+#      0  git-url
+#      1  revision
+#      2  output-image
+#      3  path-context
+#      4  dockerfile
+#      5  rebuild
+#      6  skip-checks
+#      7  hermetic
+#      8  prefetch-input
+#      9  image-expires-after
+#     10  build-source-image
+#     11  build-image-index
+#     12  build-args
+#     13  build-args-file
+#     14  privileged-nested
+
+# Remove privilege-nested pipeline param
+- op: remove
+  path: /spec/params/14
+# We want to always build the image index by default
+- op: replace
+  path: /spec/params/11/default  # build-image-index
+  value: "true"
+
+# Add a pipeline definition parameter to customize the build platforms
+- op: add
+  path: /spec/params/-
+  value:
+    name: build-platforms
+    description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
+    type: array
+    default:
+      - "linux/x86_64"
+- op: add
+  path: /spec/tasks/10/matrix
+  value:
+    params:
+      - name: image-arch
+        value: ["$(params.build-platforms)"]


### PR DESCRIPTION
We have made a concerted effort to ensure that Konflux controllers can run on both amd64 and arm64 hosts. While this is beneficial, none of the pipelines that we produce can currently run on both hosts since the step images are not all being built for both platforms. In order to assist with making all tasks support both architectures, we will make the pipeline which is focused on building Konflux components default to building both architectures.

Use of this pipeline now requires the multi-platform controller to be deployed on the cluster.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
