### PR TITLE
Make it easier to re-run tests locally without creating the namespace

### DIFF
--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -106,6 +106,9 @@ for ITEM in $TEST_ITEMS; do
   
   cp "$TASK_PATH" "$TASK_COPY"
 
+  # Create test namespace
+  ${KUBECTL_CMD} create namespace ${TEST_NS} || echo "Couldn't create namespace"
+
   # run the pre-apply-task-hook.sh if exists
   if [ -f ${TESTS_DIR}/pre-apply-task-hook.sh ]
   then
@@ -113,11 +116,8 @@ for ITEM in $TEST_ITEMS; do
     ${TESTS_DIR}/pre-apply-task-hook.sh "$TASK_COPY"
   fi
 
-  # Create test namespace
-  ${KUBECTL_CMD} create namespace ${TEST_NS}
-
   # Create the service account appstudio-pipeline (konflux spedific requirement)
-  $KUBECTL_CMD create sa appstudio-pipeline -n ${TEST_NS}
+  $KUBECTL_CMD create sa appstudio-pipeline -n ${TEST_NS} || echo "Couldn't create serviceaccount"
 
   # dry-run this YAML to validate and also get formatting side-effects.
   ${KUBECTL_CMD} -n ${TEST_NS} create -f ${TASK_COPY} --dry-run=client -o yaml

--- a/.github/scripts/test_tekton_tasks.sh
+++ b/.github/scripts/test_tekton_tasks.sh
@@ -107,7 +107,9 @@ for ITEM in $TEST_ITEMS; do
   cp "$TASK_PATH" "$TASK_COPY"
 
   # Create test namespace
-  ${KUBECTL_CMD} create namespace ${TEST_NS} || echo "Couldn't create namespace"
+  if ! ${KUBECTL_CMD} get namespace ${TEST_NS}; then
+    ${KUBECTL_CMD} create namespace ${TEST_NS}
+  fi
 
   # run the pre-apply-task-hook.sh if exists
   if [ -f ${TESTS_DIR}/pre-apply-task-hook.sh ]
@@ -117,7 +119,9 @@ for ITEM in $TEST_ITEMS; do
   fi
 
   # Create the service account appstudio-pipeline (konflux spedific requirement)
-  $KUBECTL_CMD create sa appstudio-pipeline -n ${TEST_NS} || echo "Couldn't create serviceaccount"
+  if ! ${KUBECTL_CMD} get sa appstudio-pipeline -n ${TEST_NS}; then
+    ${KUBECTL_CMD} create sa appstudio-pipeline -n ${TEST_NS}
+  fi
 
   # dry-run this YAML to validate and also get formatting side-effects.
   ${KUBECTL_CMD} -n ${TEST_NS} create -f ${TASK_COPY} --dry-run=client -o yaml


### PR DESCRIPTION
I found when running tests locally in a loop that I would have to delete my namespace everytime. This allows me to keep the namespace in place which speeds things up more than you might expect - no waiting for finalizers.

I also moved the namespace creation before the apply hooks call so that I can introduce hooks that create things in the namespace (secrets, configmaps, etc..).