### PR TITLE
Add volume mount to sast-snyk-check-oci-ta.

### DIFF
--- a/task/sast-snyk-check-oci-ta/0.4/recipe.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/recipe.yaml
@@ -10,3 +10,4 @@ replacements:
   workspaces.workspace.path: /var/workdir
 regexReplacements:
   hacbs/\$\(context.task.name\): source
+useTAVolumeMount: true

--- a/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -105,6 +105,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
     - name: sast-snyk-check
       image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
       workingDir: /var/workdir/source


### PR DESCRIPTION
Add volume mount to sast-snyk-check.

I am running Konflux locally on a kind cluster on my laptop. When running my pipeline, the ecosystem-cert-preflight-checks task fails with TLS errors. This is rectified by adding `useTAVolumeMount: true` to the recipe.yaml files which will add the volume mounts for the certificates in the task when it is generated.