### PR TITLE
Add certificate volume mount for source-build task.

### DIFF
--- a/task/source-build-oci-ta/0.3/recipe.yaml
+++ b/task/source-build-oci-ta/0.3/recipe.yaml
@@ -13,3 +13,4 @@ regexReplacements:
 preferStepTemplate: true
 replacements:
   workspaces.workspace.path: /var/workdir
+useTAVolumeMount: true

--- a/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
@@ -71,6 +71,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
     - name: get-base-images
       image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
       env:


### PR DESCRIPTION
Add certificate volume mount for source-build task.

This issue was found running Konflux locally.
