### PR TITLE
Fix external-task CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -84,6 +84,7 @@
 /task/verify-signed-rpms    @amisstea @avi-biton @gbenhaim @yftacherzog
 
 # renovate groupName=vanguard
+/external-task/rpms-signature-scan          @amisstea @avi-biton @gbenhaim @yftacherzog
 /task/build-helm-chart                      @amisstea @avi-biton @gbenhaim @yftacherzog
 /task/build-helm-chart-oci-ta               @amisstea @avi-biton @gbenhaim @yftacherzog
 /pipelines/tekton-bundle-builder            @konflux-ci/ec @amisstea @avi-biton @gbenhaim @yftacherzog

--- a/hack/check-task-owners.sh
+++ b/hack/check-task-owners.sh
@@ -13,7 +13,7 @@ trap 'rm "$temp_gitignore"' EXIT
 codeowners_to_gitignore CODEOWNERS > "$temp_gitignore"
 
 important_dirs=$(
-    for f in task/* stepactions/*; do
+    for f in task/* external-task/* stepactions/*; do
         if [[ -d "$f" ]]; then
             echo "$f"
         fi

--- a/renovate.json
+++ b/renovate.json
@@ -227,6 +227,7 @@
     {
       "groupName": "vanguard",
       "matchFileNames": [
+        "external-task/rpms-signature-scan/**",
         "pipelines/tekton-bundle-builder-oci-ta/**",
         "pipelines/tekton-bundle-builder/**",
         "task/build-helm-chart-oci-ta/**",


### PR DESCRIPTION
Add missing CODEOWNERS for external-task/rpms-signature-scan

Check external-task/* owners in CI