### PR TITLE
prefetch-dependencies: Use correct GitHub links for Hermeto

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -158,7 +158,7 @@ spec:
         if [ -n "${CONFIG_FILE_CONTENT}" ]; then
           # we need to drop 'goproxy_url' for safety reasons until the CLI prefetch tool upstream
           # decides what the SBOM impact of this configuration option will be:
-          # https://github.com/containerbuildsystem/hermeto/issues/577
+          # https://github.com/hermetoproject/hermeto/issues/577
           yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}" >/mnt/config/config.yaml
         fi
     - name: prefetch-dependencies

--- a/task/prefetch-dependencies/0.2/README.md
+++ b/task/prefetch-dependencies/0.2/README.md
@@ -1,7 +1,7 @@
 # prefetch-dependencies task
 
 Task that uses a prefetch CLI tool to prefetch build dependencies.
-See docs at https://github.com/containerbuildsystem/cachi2#basic-usage.
+See docs at https://github.com/hermetoproject/hermeto#basic-usage.
 
 ## Configuration
 
@@ -19,7 +19,7 @@ params:
       subprocess_timeout: 3600
 ```
 
-[available configuration parameters]: https://github.com/containerbuildsystem/cachi2?tab=readme-ov-file#available-configuration-parameters
+[available configuration parameters]: https://github.com/hermetoproject/hermeto?tab=readme-ov-file#available-configuration-parameters
 
 ## Parameters
 |name|description|default value|required|

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   description: |-
     Task that uses a prefetch CLI tool to prefetch build dependencies.
-    See docs at https://github.com/containerbuildsystem/hermeto#basic-usage.
+    See docs at https://github.com/hermetoproject/hermeto#basic-usage.
 
     ## Configuration
 
@@ -28,7 +28,7 @@ spec:
           subprocess_timeout: 3600
     ```
 
-    [available configuration parameters]: https://github.com/containerbuildsystem/hermeto?tab=readme-ov-file#available-configuration-parameters
+    [available configuration parameters]: https://github.com/hermetoproject/hermeto?tab=readme-ov-file#available-configuration-parameters
   params:
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
@@ -78,7 +78,7 @@ spec:
       then
         # we need to drop 'goproxy_url' for safety reasons until the CLI prefetch tool upstream
         # decides what the SBOM impact of this configuration option will be:
-        # https://github.com/containerbuildsystem/hermeto/issues/577
+        # https://github.com/hermetoproject/hermeto/issues/577
         yq 'del(.goproxy_url)' <<< "${CONFIG_FILE_CONTENT}" > /mnt/config/config.yaml
       fi
 


### PR DESCRIPTION
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
