### PR TITLE
Revert to the latest release

### DIFF
--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -107,7 +107,7 @@ spec:
           cat "/var/workdir/vars/$filename"
         done
     - name: oci-copy
-      image: quay.io/konflux-ci/oras:latest@sha256:e52de03c78ea65bf806cebee6892f054e2ae7b554d302e4a83ef28ec5010b2ee
+      image: quay.io/konflux-ci/oras:latest@sha256:720ad83b2b7f9239b0f04fabbeea568611dd07c18ad99f79b98ad0e5aa76331c
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -87,7 +87,7 @@ spec:
         done
       workingDir: $(workspaces.source.path)
     - name: oci-copy
-      image: quay.io/konflux-ci/oras:latest@sha256:e52de03c78ea65bf806cebee6892f054e2ae7b554d302e4a83ef28ec5010b2ee
+      image: quay.io/konflux-ci/oras:latest@sha256:720ad83b2b7f9239b0f04fabbeea568611dd07c18ad99f79b98ad0e5aa76331c
       computeResources:
         limits:
           memory: 1Gi


### PR DESCRIPTION
This PR:
https://github.com/konflux-ci/build-definitions/pull/2675
Upgraded the  oras version to  1.3.0-beta.4+1.24.6
However, the oras 1.3.0-beta.3 version introduced the following breaking change:
• “BREAKING CHANGE Remove the global --no-tty flag
The --no-tty flag is kept for TTY-capable commands”
As a result the oci-copy-ta command fails when executing:
oras manifest push --no-tty --registry-config auth.json
