### PR TITLE
Remove --no-tty flag from oras manifest push command since it's depre…

### DIFF
--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -293,7 +293,7 @@ spec:
         done
 
         echo "Pushing complete artifact manifest to ${IMAGE}"
-        if ! retry oras manifest push --no-tty --registry-config auth.json "${IMAGE}" artifact-manifest.json; then
+        if ! retry oras manifest push --registry-config auth.json "${IMAGE}" artifact-manifest.json; then
           echo "Failed to push complete artifact manifest to ${IMAGE}"
           exit 1
         fi

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -282,7 +282,7 @@ spec:
         done
 
         echo "Pushing complete artifact manifest to ${IMAGE}"
-        if ! retry oras manifest push --no-tty --registry-config auth.json "${IMAGE}" artifact-manifest.json
+        if ! retry oras manifest push --registry-config auth.json "${IMAGE}" artifact-manifest.json
         then
           echo "Failed to push complete artifact manifest to ${IMAGE}"
           exit 1


### PR DESCRIPTION
This PR:
oras has introduceted in 1.3.0-beta.3 version the following breaking change:
• “BREAKING CHANGE Remove the global --no-tty flag
The --no-tty flag is kept for TTY-capable commands”

As a result the oci-copy-ta command fails when executing:
oras manifest push --no-tty --registry-config auth.json

This PR removed the deprecated flag from unsupported oras commands. 
Keep in mind that `oras attach --no-tty` remains as is since it works fine. 