### PR TITLE
fix: change image used in  apply-tags task

### DIFF
--- a/task/apply-tags/0.2/apply-tags.yaml
+++ b/task/apply-tags/0.2/apply-tags.yaml
@@ -43,7 +43,7 @@ spec:
         requests:
           cpu: 100m
           memory: 256Mi
-      image: registry.access.redhat.com/ubi9/skopeo:9.6-1754871306@sha256:e59e2cb3fd8d7613798738fb06aad5aab61f32c18aed595df16a46a8e078dfa6
+      image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
       args:
         - $(params.ADDITIONAL_TAGS[*])
       env:
@@ -71,7 +71,7 @@ spec:
         requests:
           memory: 256Mi
           cpu: 100m
-      image: registry.access.redhat.com/ubi9/skopeo:9.6-1754871306@sha256:e59e2cb3fd8d7613798738fb06aad5aab61f32c18aed595df16a46a8e078dfa6
+      image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
       env:
       - name: IMAGE_URL
         value: $(params.IMAGE_URL)


### PR DESCRIPTION
Use `appstudio-utils` image which contains both `skopeo` and `jq`
Fixes: https://github.com/konflux-ci/build-definitions/issues/2719
