### PR TITLE
fix(OCPBUGS-60987): change default mediaType from oci to docker

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -146,6 +146,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker (default).
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -252,6 +257,8 @@ spec:
       - $(params.build-args[*])
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:

--- a/pipelines/core-services/patch.yaml
+++ b/pipelines/core-services/patch.yaml
@@ -81,13 +81,18 @@
 #      9  image-expires-after
 #     10  build-source-image
 #     11  build-image-index
-#     12  build-args
-#     13  build-args-file
-#     14  privileged-nested
+#     12  buildah-format
+#     13  build-args
+#     14  build-args-file
+#     15  privileged-nested
 
 # Remove privilege-nested pipeline param
 - op: remove
-  path: /spec/params/14
+  path: /spec/params/15
+# We want to always build OCI images by default
+- op: replace
+  path: /spec/params/12/default  # buildah-format
+  value: "oci"
 # We want to always build the image index by default
 - op: replace
   path: /spec/params/11/default  # build-image-index

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -12,6 +12,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| build-images:0.4:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.4:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
@@ -37,7 +38,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-images.results.IMAGE_REF[*])']'|
@@ -53,7 +54,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| '$(params.buildah-format)'|
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch| | |

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -64,6 +64,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: docker
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker (default).
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -175,6 +180,8 @@ spec:
       value: $(params.build-args-file)
     - name: PRIVILEGED_NESTED
       value: $(params.privileged-nested)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -11,6 +11,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.3:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| build-container:0.4:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
@@ -36,7 +37,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
@@ -52,7 +53,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| '$(params.buildah-format)'|
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch| | |

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -64,6 +64,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: docker
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker (default).
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -164,6 +169,8 @@ spec:
       value: $(params.build-args-file)
     - name: PRIVILEGED_NESTED
       value: $(params.privileged-nested)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -22,7 +22,10 @@
 #      9  image-expires-after
 #     10  build-source-image
 #     11  build-image-index
+#     12  buildah-format
 
+- op: remove
+  path: /spec/params/12  # buildah-format
 - op: remove
   path: /spec/params/11  # build-image-index
 - op: remove

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -11,6 +11,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.4:BUILD_ARGS_FILE ; sast-coverity-check:0.3:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| build-container:0.4:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.4:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.4:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
@@ -36,7 +37,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
@@ -52,7 +53,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| '$(params.buildah-format)'|
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch| | |

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -80,6 +80,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: docker
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker (default).
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -174,6 +179,8 @@ spec:
       value: $(params.build-args-file)
     - name: PRIVILEGED_NESTED
       value: $(params.privileged-nested)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -89,6 +89,8 @@
     value: "$(params.build-args-file)"
   - name: PRIVILEGED_NESTED
     value: "$(params.privileged-nested)"
+  - name: BUILDAH_FORMAT
+    value: "$(params.buildah-format)"
 
 # FIXME: duplicate the "add" operations for sast-coverity-check, which is based on build-container
 - op: test

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -12,6 +12,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| build-images:0.4:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.4:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| true| build-images:0.4:HERMETIC|
@@ -36,7 +37,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-images.results.IMAGE_REF[*])']'|
@@ -52,7 +53,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| '$(params.buildah-format)'|
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch| | |

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -64,6 +64,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: docker
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker (default).
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -187,6 +192,8 @@ spec:
       - $(params.build-args[*])
     - name: BUILD_ARGS_FILE
       value: $(params.build-args-file)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -29,14 +29,15 @@
 #      9  image-expires-after
 #     10  build-source-image
 #     11  build-image-index
-#     12  build-args
-#     13  build-args-file
-#     14  privileged-nested
-#     15  build-platforms
+#     12  buildah-format
+#     13  build-args
+#     14  build-args-file
+#     15  privileged-nested
+#     16  build-platforms
 - op: remove
-  path: /spec/params/14
+  path: /spec/params/15  # privileged-nested
 - op: replace
-  path: /spec/params/7/default
+  path: /spec/params/7/default  # hermetic
   value: "true"
 - op: add
   path: /spec/tasks/2

--- a/pipelines/maven-zip-build/patch.yaml
+++ b/pipelines/maven-zip-build/patch.yaml
@@ -29,7 +29,10 @@
 #      9  image-expires-after
 #     10  build-source-image
 #     11  build-image-index
+#     12  buildah-format
 
+- op: remove
+  path: /spec/params/12  # buildah-format
 - op: remove
   path: /spec/params/11  # build-image-index
 - op: remove

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -5,6 +5,7 @@
 |---|---|---|---|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker (default).| oci| build-container:0.2:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
@@ -29,7 +30,7 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -73,6 +73,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker (default).
+    name: buildah-format
+    type: string
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -147,6 +152,8 @@ spec:
       value: $(params.git-url)
     - name: REVISION
       value: $(params.revision)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     runAfter:

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -5,6 +5,7 @@
 |---|---|---|---|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker (default).| oci| build-container:0.2:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
@@ -29,7 +30,7 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci or docker (default).| docker| |
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|

--- a/pipelines/tekton-bundle-builder/patch.yaml
+++ b/pipelines/tekton-bundle-builder/patch.yaml
@@ -32,6 +32,20 @@
 # Order of finally tasks from the base template:
 # kustomize build pipelines/template-build/ | yq ".spec.finally.[].name" | nl -v 0
 #      0  show-summary
+# $ kustomize build pipelines/template-build/ | yq ".spec.params.[].name" | nl -v 0
+#      0  git-url
+#      1  revision
+#      2  output-image
+#      3  path-context
+#      4  dockerfile
+#      5  rebuild
+#      6  skip-checks
+#      7  hermetic
+#      8  prefetch-input
+#      9  image-expires-after
+#     10  build-source-image
+#     11  build-image-index
+#     12  buildah-format
 - op: add
   path: /spec/tasks/3/params
   value:
@@ -43,6 +57,8 @@
     value: $(params.git-url)
   - name: REVISION
     value: $(params.revision)
+  - name: BUILDAH_FORMAT
+    value: $(params.buildah-format)
 # Remove tasks that assume a binary image
 - op: remove
   path: /spec/tasks/17  # rpms-signature-scan
@@ -64,3 +80,7 @@
   path: /spec/tasks/6   # deprecated-base-image-check
 - op: remove
   path: /spec/tasks/5   # build-source-image
+
+- op: replace
+  path: /spec/params/12/default  # buildah-format
+  value: "oci"

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -75,6 +75,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker (default).
+    name: buildah-format
+    type: string
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -143,6 +148,8 @@ spec:
       value: $(params.git-url)
     - name: REVISION
       value: $(params.revision)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -57,6 +57,11 @@ spec:
       description: Add built image into an OCI image index
       type: string
       default: "false"
+    - name: buildah-format
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker (default).
+      type: string
+      default: "docker"
   tasks:
     - name: init
       params:

--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -39,9 +39,9 @@ spec:
     type: string
     default: vfs
   - name: BUILDAH_FORMAT
-    description: The format for the resulting image's mediaType. Valid values are oci (default) or docker.
+    description: The format for the resulting image's mediaType. Valid values are oci or docker (default).
     type: string
-    default: oci
+    default: docker
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -44,9 +44,9 @@ spec:
     description: Storage driver to configure for buildah
     name: STORAGE_DRIVER
     type: string
-  - default: oci
+  - default: docker
     description: The format for the resulting image's mediaType. Valid values are
-      oci (default) or docker.
+      oci or docker (default).
     name: BUILDAH_FORMAT
     type: string
   results:

--- a/task/buildah-min/0.4/buildah-min.yaml
+++ b/task/buildah-min/0.4/buildah-min.yaml
@@ -148,9 +148,9 @@ spec:
       format.'
     name: SBOM_TYPE
     type: string
-  - default: oci
+  - default: docker
     description: The format for the resulting image's mediaType. Valid values are
-      oci (default) or docker.
+      oci or docker (default).
     name: BUILDAH_FORMAT
     type: string
   - default: []

--- a/task/buildah-oci-ta/0.4/README.md
+++ b/task/buildah-oci-ta/0.4/README.md
@@ -13,7 +13,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
-|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
+|BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci or docker (default).|docker|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |BUILD_ARGS_FILE|Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file|""|false|
 |BUILD_TIMESTAMP|Defines the single build time for all buildah builds in seconds since UNIX epoch|""|false|

--- a/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.4/buildah-oci-ta.yaml
@@ -46,9 +46,9 @@ spec:
       default: ""
     - name: BUILDAH_FORMAT
       description: The format for the resulting image's mediaType. Valid values
-        are oci (default) or docker.
+        are oci or docker (default).
       type: string
-      default: oci
+      default: docker
     - name: BUILD_ARGS
       description: Array of --build-arg values ("arg=value" strings)
       type: array

--- a/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.4/buildah-remote-oci-ta.yaml
@@ -43,9 +43,9 @@ spec:
       be applied to the image
     name: ANNOTATIONS_FILE
     type: string
-  - default: oci
+  - default: docker
     description: The format for the resulting image's mediaType. Valid values are
-      oci (default) or docker.
+      oci or docker (default).
     name: BUILDAH_FORMAT
     type: string
   - default: []

--- a/task/buildah-remote/0.4/buildah-remote.yaml
+++ b/task/buildah-remote/0.4/buildah-remote.yaml
@@ -148,9 +148,9 @@ spec:
       format.'
     name: SBOM_TYPE
     type: string
-  - default: oci
+  - default: docker
     description: The format for the resulting image's mediaType. Valid values are
-      oci (default) or docker.
+      oci or docker (default).
     name: BUILDAH_FORMAT
     type: string
   - default: []

--- a/task/buildah/0.4/buildah.yaml
+++ b/task/buildah/0.4/buildah.yaml
@@ -133,9 +133,9 @@ spec:
     type: string
     default: spdx
   - name: BUILDAH_FORMAT
-    description: The format for the resulting image's mediaType. Valid values are oci (default) or docker.
+    description: The format for the resulting image's mediaType. Valid values are oci or docker (default).
     type: string
-    default: oci
+    default: docker
   - name: ADDITIONAL_BASE_IMAGES
     description: |-
       Additional base image references to include to the SBOM. Array of image_reference_with_digest strings


### PR DESCRIPTION
OpenShift's documentation indicates that disconnected clusters can use any container registry that supports Docker v2-2. This means that disconnected mirroring will fail if the registry doesn't support OCI.

https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/disconnected_environments/connected-to-disconnected

In order to have the easiest default support for all images produced, we should just change the default mediaType. If any users want OCI specific mediaTypes, they can still enable that.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
