### PR TITLE
Add an image-append-platform option to modelcar task

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -56,6 +56,10 @@ spec:
       description: add --remove-originals param to olot
       type: string
       default: "false"
+    - name: IMAGE_APPEND_PLATFORM
+      description: Whether to append a sanitized platform architecture on the IMAGE tag
+      type: string
+      default: "false"
   results:
     - name: IMAGE_DIGEST
       description: Digest of the artifact just pushed
@@ -100,6 +104,8 @@ spec:
         value: $(params.MODEL_IMAGE)
       - name: PLATFORM
         value: $(params.PLATFORM)
+      - name: IMAGE_APPEND_PLATFORM
+        value: $(params.IMAGE_APPEND_PLATFORM)
       - name: TARGET_OCI
         value: "/var/workdir/modelcar-oci"
     volumeMounts:
@@ -189,6 +195,11 @@ spec:
         set -eu
         set -o pipefail
 
+        if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+          IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+          export IMAGE
+        fi
+
         select-oci-auth "$IMAGE" >auth.json
 
         echo "Pushing complete artifact manifest to ${IMAGE}"
@@ -251,6 +262,10 @@ spec:
       workingDir: /var/workdir
       script: |
         #!/bin/bash
+        if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+          IMAGE="${IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+          export IMAGE
+        fi
         REPO=${IMAGE%:*}
         echo "Found that ${REPO} is the repository for ${IMAGE}"
         SBOM_DIGEST=$(sha256sum sbom.json | awk '{ print $1 }')

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -103,6 +103,8 @@ spec:
           value: "registry.access.redhat.com/ubi9/ubi:latest@sha256:b68c21b2dd3e72abcf2f8dcfc77580e4030564d1243bfcb7cd64ccc5aa3e0a25"
         - name: PLATFORM
           value: linux/s390x
+        - name: IMAGE_APPEND_PLATFORM
+          value: "true"
         - name: MODEL_IMAGE
           value: $(tasks.mock-trusted-artifact.results.MODEL_PATH)
         - name: IMAGE
@@ -167,17 +169,17 @@ spec:
               #!/usr/bin/env bash
               set -eu
 
-              echo "Confirm we can inspect the image"
-              skopeo inspect "docker://${IMAGE_REF//:latest/}"
+              echo "Confirm we can inspect the image with an archful tag"
+              skopeo inspect "docker://${IMAGE_REF//:latest-linux-s390x/}"
 
               echo "Confirm the image is single-arch; multiarch not supported"
-              mediaType=$(skopeo inspect --raw "docker://${IMAGE_REF//:latest/}" | jq -r .mediaType)
+              mediaType=$(skopeo inspect --raw "docker://${IMAGE_REF//:latest-linux-s390x/}" | jq -r .mediaType)
               if [ "$mediaType" != "application/vnd.oci.image.manifest.v1+json" ]; then
                   echo "Image is not single-arch." && exit 1
               fi
 
               echo "Confirm the image is s390x - the one we asked for"
-              mediaType=$(skopeo inspect "docker://${IMAGE_REF//:latest/}" | jq -r .Architecture)
+              mediaType=$(skopeo inspect "docker://${IMAGE_REF//:latest-linux-s390x/}" | jq -r .Architecture)
               if [ "$mediaType" != "s390x" ]; then
                   echo "Image is not s390x." && exit 1
               fi


### PR DESCRIPTION
Without this, then two different arches will race to claim the same floating tag. The loser will get garbage collected by quay.

The `IMAGE_APPEND_PLATFORM` param uses the same form and pattern as in `task/buildah-remote-oci-ta/`, for consistency.