### PR TITLE
Updating operator-sdk-builder image in run-opm-command task

### DIFF
--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -88,7 +88,7 @@ spec:
           echo "Replacing pullspecs in '${FILE_TO_UPDATE_PULLSPEC_PATH}' using '${IDMS_PATH_PARAM}'."
           replace_mirror_pullspec_with_source "${IDMS_PATH_PARAM}" "${FILE_TO_UPDATE_PULLSPEC_PATH}"
     - name: run-opm-with-user-args
-      image: quay.io/konflux-ci/operator-sdk-builder:latest@sha256:e7cfe742ef5be036478408e98094f49109474418521970f739a6c1ff6faa4267
+      image: quay.io/konflux-ci/operator-sdk-builder:latest@sha256:e08de236089a3756535b5be1abacc3f465b1f5771efd8a40c7a2dae4febd67d7
       workingDir: /var/workdir/source
       results:
         - name: skip_create_trusted_artifact


### PR DESCRIPTION
This new `operator-sdk-builder` image contains fix for accepting signed images when running opm.

[KFLUXSPRT-5013]
