### PR TITLE
buildah: append labels.json to containerignore

### DIFF
--- a/task/buildah-min/0.5/buildah-min.yaml
+++ b/task/buildah-min/0.5/buildah-min.yaml
@@ -675,6 +675,23 @@ spec:
       echo "" >>"$dockerfile_copy"
       echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
 
+      # Make sure our labels.json file isn't filtered out
+      containerignore=""
+      if [ -f "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore" ]; then
+        containerignore="$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+      elif [ -f "$SOURCE_CODE_DIR/$CONTEXT/.containerignore" ]; then
+        containerignore="$SOURCE_CODE_DIR/$CONTEXT/.containerignore"
+      fi
+
+      if [ -n "$containerignore" ]; then
+        ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
+        cp "$containerignore" "$ignorefile_copy"
+
+        echo "" >> "$ignorefile_copy"
+        echo "!/labels.json" >> "$ignorefile_copy"
+        BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
+      fi
+
       echo "[$(date --utc -Ins)] Register sub-man"
 
       ACTIVATION_KEY_PATH="/activation-key"

--- a/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml
@@ -754,6 +754,23 @@ spec:
         echo "" >>"$dockerfile_copy"
         echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
 
+        # Make sure our labels.json file isn't filtered out
+        containerignore=""
+        if [ -f "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore" ]; then
+          containerignore="$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+        elif [ -f "$SOURCE_CODE_DIR/$CONTEXT/.containerignore" ]; then
+          containerignore="$SOURCE_CODE_DIR/$CONTEXT/.containerignore"
+        fi
+
+        if [ -n "$containerignore" ]; then
+          ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
+          cp "$containerignore" "$ignorefile_copy"
+
+          echo "" >>"$ignorefile_copy"
+          echo "!/labels.json" >>"$ignorefile_copy"
+          BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
+        fi
+
         echo "[$(date --utc -Ins)] Register sub-man"
 
         ACTIVATION_KEY_PATH="/activation-key"

--- a/task/buildah-remote-oci-ta/0.5/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.5/buildah-remote-oci-ta.yaml
@@ -788,6 +788,23 @@ spec:
       echo "" >>"$dockerfile_copy"
       echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
 
+      # Make sure our labels.json file isn't filtered out
+      containerignore=""
+      if [ -f "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore" ]; then
+        containerignore="$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+      elif [ -f "$SOURCE_CODE_DIR/$CONTEXT/.containerignore" ]; then
+        containerignore="$SOURCE_CODE_DIR/$CONTEXT/.containerignore"
+      fi
+
+      if [ -n "$containerignore" ]; then
+        ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
+        cp "$containerignore" "$ignorefile_copy"
+
+        echo "" >>"$ignorefile_copy"
+        echo "!/labels.json" >>"$ignorefile_copy"
+        BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
+      fi
+
       echo "[$(date --utc -Ins)] Register sub-man"
 
       ACTIVATION_KEY_PATH="/activation-key"

--- a/task/buildah-remote/0.5/buildah-remote.yaml
+++ b/task/buildah-remote/0.5/buildah-remote.yaml
@@ -757,6 +757,23 @@ spec:
       echo "" >>"$dockerfile_copy"
       echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
 
+      # Make sure our labels.json file isn't filtered out
+      containerignore=""
+      if [ -f "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore" ]; then
+        containerignore="$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+      elif [ -f "$SOURCE_CODE_DIR/$CONTEXT/.containerignore" ]; then
+        containerignore="$SOURCE_CODE_DIR/$CONTEXT/.containerignore"
+      fi
+
+      if [ -n "$containerignore" ]; then
+        ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
+        cp "$containerignore" "$ignorefile_copy"
+
+        echo "" >> "$ignorefile_copy"
+        echo "!/labels.json" >> "$ignorefile_copy"
+        BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
+      fi
+
       echo "[$(date --utc -Ins)] Register sub-man"
 
       ACTIVATION_KEY_PATH="/activation-key"

--- a/task/buildah/0.5/buildah.yaml
+++ b/task/buildah/0.5/buildah.yaml
@@ -662,6 +662,23 @@ spec:
       echo "" >>"$dockerfile_copy"
       echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
 
+      # Make sure our labels.json file isn't filtered out
+      containerignore=""
+      if [ -f "$SOURCE_CODE_DIR/$CONTEXT/.dockerignore" ]; then
+        containerignore="$SOURCE_CODE_DIR/$CONTEXT/.dockerignore"
+      elif [ -f "$SOURCE_CODE_DIR/$CONTEXT/.containerignore" ]; then
+        containerignore="$SOURCE_CODE_DIR/$CONTEXT/.containerignore"
+      fi
+
+      if [ -n "$containerignore" ]; then
+        ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
+        cp "$containerignore" "$ignorefile_copy"
+
+        echo "" >> "$ignorefile_copy"
+        echo "!/labels.json" >> "$ignorefile_copy"
+        BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
+      fi
+
       echo "[$(date --utc -Ins)] Register sub-man"
 
       ACTIVATION_KEY_PATH="/activation-key"


### PR DESCRIPTION
In [1] we added a labels.json to the image to help with vulnerability scanning.
Make sure to allow this file in the `containerignore` in case projects use it in an allow-list pattern.

[1] https://github.com/konflux-ci/build-definitions/pull/2598/files#diff-8ececcbe0dae0061a00d374353e73b4c75b606c645b90e1546ea1dcff69bb748

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
