### PR TITLE
CI: fix repo creation script

### DIFF
--- a/.tekton/scripts/create-task-pipeline-bundle-repos.sh
+++ b/.tekton/scripts/create-task-pipeline-bundle-repos.sh
@@ -78,7 +78,7 @@ do
     fi
 
     locate_in_all_namespaces task "$task_name"
-done < <(find task/*/*/ -maxdepth 0 -type d -print0)
+done < <(find task -mindepth 2 -maxdepth 2 -type d -print0)
 
 echo
 echo "Checking existence of pipeline bundle repositories..."


### PR DESCRIPTION
Previously, the script would list all task directories including the ones that are symlinks to archived tasks. Some of the archived tasks are now broken, causing the script to fail.

Adjust the 'find' call to exclude symlinks.
