### PR TITLE
switch to oras manifest fetch for image digest lookup in set-outcome

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -372,7 +372,7 @@ spec:
           fi
         done < <(find /artifacts -type f -name "cert-image.json")
 
-        image_digest=$(skopeo inspect "docker://${PARAM_IMAGE_URL}" | jq -r '.Digest')
+        image_digest=$(oras manifest fetch "${PARAM_IMAGE_URL}" | sha256sum | awk '{print "sha256:" $1}')
         if [[ -n "$image_digest" && ! " ${digests_processed[*]} " == *" \"$image_digest\" "* ]]; then
           digests_processed+=("\"$image_digest\"")
         fi


### PR DESCRIPTION
## Motivation
To address the below error, which happens when using an `application/vnd.oci.image.index.v1+json` (or manifest list) is used and the Host OS architecture is not one of the architectures in the list. If this isn't clear, this would happen when the konflux pipeline is configured for `"platform": "linux/s390x"` and the pipeline is running on `linux/amd64`, and an `image.index`, is used over `image manifest`.

Error:
```
STEP-APP-SET-OUTCOME

{"result":"FAILURE","timestamp":"1757076008","note":"Task preflight is a FAILURE: Refer to Tekton task logs for more information","successes":7,"failures":1,"warnings":0}time="2025-09-05T12:40:08Z" level=fatal msg="Error parsing manifest for image: choosing image instance: no image found in image index for architecture \"amd64\", variant \"\", OS \"linux\""
```
- [EET-4877](https://issues.redhat.com//browse/EET-4877)

## Changes
- ~~Updating `app-set-outcome` skopeo logic to not error for `manifest-lists` or `image indexes`~~
- ~~Keeping the logic similar to all other tasks~~
   - ~~Same retry count~~
   - ~~Utilize the `retry` binary available in konflux~~
- ~~Saving off `image-digest` from initial `skopeo` to the results for later steps to consume~~
   - ~~Reduces the `skopeo` calls~~
   - ~~Makes it so we do not care what the media type is in the `app-set-outcome` step~~
- Switch to `oras manifest fetch`
   -  Reduces the `skopeo` calls
   - Ensures that the manifest list digests ends up in the `images-processed`
   - Existing de-duplication logic ensures that no duplicate digests exists
    
 ## Testing
 - Operator bundle (quay.io/opdev/simple-demo-operator-bundle:latest)
 - Standard image manifest of non-host OS (quay.io/yoza/prefighttest:0.0.1)
 - Image Manifest with non-host OS as the only architecture  (quay.io/yoza/prefighttest:0.0.2)
 - Legacy manifest list (quay.io/rh-ee-caxu/test-docker-mediatype-image:latest)