### PR TITLE
Add content-sets.json to .containerignore

### DIFF
--- a/task/buildah-min/0.5/buildah-min.yaml
+++ b/task/buildah-min/0.5/buildah-min.yaml
@@ -687,9 +687,11 @@ spec:
       if [ -n "$containerignore" ]; then
         ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
         cp "$containerignore" "$ignorefile_copy"
-
-        echo "" >> "$ignorefile_copy"
-        echo "!/labels.json" >> "$ignorefile_copy"
+        {
+          echo ""
+          echo "!/labels.json"
+          echo "!/content-sets.json"
+        } >> "$ignorefile_copy"
         BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
       fi
 

--- a/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml
@@ -766,9 +766,11 @@ spec:
         if [ -n "$containerignore" ]; then
           ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
           cp "$containerignore" "$ignorefile_copy"
-
-          echo "" >>"$ignorefile_copy"
-          echo "!/labels.json" >>"$ignorefile_copy"
+          {
+            echo ""
+            echo "!/labels.json"
+            echo "!/content-sets.json"
+          } >>"$ignorefile_copy"
           BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
         fi
 

--- a/task/buildah-remote-oci-ta/0.5/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.5/buildah-remote-oci-ta.yaml
@@ -800,9 +800,11 @@ spec:
       if [ -n "$containerignore" ]; then
         ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
         cp "$containerignore" "$ignorefile_copy"
-
-        echo "" >>"$ignorefile_copy"
-        echo "!/labels.json" >>"$ignorefile_copy"
+        {
+          echo ""
+          echo "!/labels.json"
+          echo "!/content-sets.json"
+        } >>"$ignorefile_copy"
         BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
       fi
 

--- a/task/buildah-remote/0.5/buildah-remote.yaml
+++ b/task/buildah-remote/0.5/buildah-remote.yaml
@@ -769,9 +769,11 @@ spec:
       if [ -n "$containerignore" ]; then
         ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
         cp "$containerignore" "$ignorefile_copy"
-
-        echo "" >> "$ignorefile_copy"
-        echo "!/labels.json" >> "$ignorefile_copy"
+        {
+          echo ""
+          echo "!/labels.json"
+          echo "!/content-sets.json"
+        } >> "$ignorefile_copy"
         BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
       fi
 

--- a/task/buildah/0.5/buildah.yaml
+++ b/task/buildah/0.5/buildah.yaml
@@ -673,9 +673,11 @@ spec:
       if [ -n "$containerignore" ]; then
         ignorefile_copy=$(mktemp --tmpdir "$(basename "$containerignore").XXXXXX")
         cp "$containerignore" "$ignorefile_copy"
-
-        echo "" >> "$ignorefile_copy"
-        echo "!/labels.json" >> "$ignorefile_copy"
+        {
+          echo ""
+          echo "!/labels.json"
+          echo "!/content-sets.json"
+        } >> "$ignorefile_copy"
         BUILDAH_ARGS+=(--ignorefile "$ignorefile_copy")
       fi
 


### PR DESCRIPTION
If a repository that includes an allow-list .containerignore is being built on Konflux, files generated at build time that are injected into the final image can not be copied.

This has been recently fixed for labels.json, do the same for content-sets.json which is also being injected into the image.
