### PR TITLE
fix(OCPBUGS-60987): change default mediaType from oci to docker

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -130,6 +130,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: oci
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker.
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -238,6 +243,8 @@ spec:
       value: $(params.build-args-file)
     - name: SOURCE_URL
       value: $(tasks.clone-repository.results.url)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:
@@ -266,6 +273,8 @@ spec:
     - name: IMAGES
       value:
       - $(tasks.build-images.results.IMAGE_REF[*])
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     runAfter:
     - build-images
     taskRef:

--- a/pipelines/core-services/patch.yaml
+++ b/pipelines/core-services/patch.yaml
@@ -81,13 +81,18 @@
 #      9  image-expires-after
 #     10  build-source-image
 #     11  build-image-index
-#     12  build-args
-#     13  build-args-file
-#     14  privileged-nested
+#     12  buildah-format
+#     13  build-args
+#     14  build-args-file
+#     15  privileged-nested
 
 # Remove privilege-nested pipeline param
 - op: remove
-  path: /spec/params/14
+  path: /spec/params/15
+# We want to always build OCI images by default
+- op: replace
+  path: /spec/params/12/default  # buildah-format
+  value: "oci"
 # We want to always build the image index by default
 - op: replace
   path: /spec/params/11/default  # build-image-index

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -12,6 +12,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-images:0.5:BUILDAH_FORMAT ; build-image-index:0.1:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.5:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.5:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
@@ -37,7 +38,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-images.results.IMAGE_REF[*])']'|
@@ -53,7 +54,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch| | |

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -64,6 +64,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: docker
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker.
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -177,6 +182,8 @@ spec:
       value: $(params.privileged-nested)
     - name: SOURCE_URL
       value: $(tasks.clone-repository.results.url)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -207,6 +214,8 @@ spec:
     - name: IMAGES
       value:
       - $(tasks.build-images.results.IMAGE_REF[*])
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     runAfter:
     - build-images
     taskRef:

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -11,6 +11,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.5:BUILD_ARGS_FILE ; sast-coverity-check:0.3:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-container:0.5:BUILDAH_FORMAT ; build-image-index:0.1:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.5:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.5:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
@@ -36,7 +37,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
@@ -52,7 +53,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch| | |

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -64,6 +64,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: docker
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker.
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -166,6 +171,8 @@ spec:
       value: $(params.privileged-nested)
     - name: SOURCE_URL
       value: $(tasks.clone-repository.results.url)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -194,6 +201,8 @@ spec:
     - name: IMAGES
       value:
       - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     runAfter:
     - build-container
     taskRef:

--- a/pipelines/docker-build-rhtap/patch.yaml
+++ b/pipelines/docker-build-rhtap/patch.yaml
@@ -22,7 +22,10 @@
 #      9  image-expires-after
 #     10  build-source-image
 #     11  build-image-index
+#     12  buildah-format
 
+- op: remove
+  path: /spec/params/12  # buildah-format
 - op: remove
   path: /spec/params/11  # build-image-index
 - op: remove

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -11,6 +11,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-container:0.5:BUILD_ARGS_FILE ; sast-coverity-check:0.3:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.1:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
+|buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-container:0.5:BUILDAH_FORMAT ; build-image-index:0.1:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.5:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.5:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
@@ -36,7 +37,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| '$(params.build-image-index)'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|
 |COMMIT_SHA| The commit the image is built from.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
@@ -52,7 +53,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| | |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| | |
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|
 |BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| | '$(params.build-args-file)'|
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch| | |

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -64,6 +64,11 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: docker
+    description: The format for the resulting image's mediaType. Valid values are
+      oci or docker.
+    name: buildah-format
+    type: string
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -160,6 +165,8 @@ spec:
       value: $(params.privileged-nested)
     - name: SOURCE_URL
       value: $(tasks.clone-repository.results.url)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     runAfter:
     - prefetch-dependencies
     taskRef:
@@ -186,6 +193,8 @@ spec:
     - name: IMAGES
       value:
       - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+    - name: BUILDAH_FORMAT
+      value: $(params.buildah-format)
     runAfter:
     - build-container
     taskRef:

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -91,6 +91,8 @@
     value: "$(params.privileged-nested)"
   - name: SOURCE_URL
     value: "$(tasks.clone-repository.results.url)"
+  - name: BUILDAH_FORMAT
+    value: "$(params.buildah-format)"
 
 # FIXME: duplicate the "add" operations for sast-coverity-check, which is based on build-container
 - op: test

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -29,15 +29,95 @@
 #      9  image-expires-after
 #     10  build-source-image
 #     11  build-image-index
-#     12  build-args
-#     13  build-args-file
-#     14  privileged-nested
-#     15  build-platforms
+#     12  buildah-format
+#     13  build-args
+#     14  build-args-file
+#     15  privileged-nested
+#     16  build-platforms
 - op: remove
-  path: /spec/params/14
+  path: /spec/params/15  # privileged-nested
+- op: remove
+  path: /spec/params/12  # buildah-format - FBC is always OCI
 - op: replace
-  path: /spec/params/7/default
+  path: /spec/params/7/default  # hermetic
   value: "true"
+
+# Remove params
+# $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.3.params.[].name" | nl -v 0
+#  0	IMAGE
+#  1	DOCKERFILE
+#  2	CONTEXT
+#  3	HERMETIC
+#  4	PREFETCH_INPUT
+#  5	IMAGE_EXPIRES_AFTER
+#  6	COMMIT_SHA
+#  7	BUILD_ARGS
+#  8	BUILD_ARGS_FILE
+#  9	PRIVILEGED_NESTED
+# 10	SOURCE_URL
+# 11	BUILDAH_FORMAT
+# 12	SOURCE_ARTIFACT
+# 13	CACHI2_ARTIFACT
+# 14	IMAGE_APPEND_PLATFORM
+- op: remove
+  path: /spec/tasks/3/params/11  # BUILDAH_FORMAT - FBC is always OCI
+- op: remove
+  path: /spec/tasks/3/params/9  # PRIVILEGED_NESTED
+# Remove tasks
+# $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.[].name" | nl -v 0 
+#      0	init
+#      1	clone-repository
+#      2	prefetch-dependencies
+#      3	build-images
+#      4	build-image-index
+#      5	build-source-image
+#      6	deprecated-base-image-check
+#      7	clair-scan
+#      8	ecosystem-cert-preflight-checks
+#      9	sast-snyk-check
+#     10	clamav-scan
+#     11	sast-coverity-check
+#     12	coverity-availability-check
+#     13	sast-shell-check
+#     14	sast-unicode-check
+#     15	apply-tags
+#     16	push-dockerfile
+#     17	rpms-signature-scan
+- op: remove
+  path: /spec/tasks/17  # rpms-signature-scan
+- op: remove
+  path: /spec/tasks/16  # push-dockerfile
+- op: remove
+  path: /spec/tasks/14  # sast-unicode-scan
+- op: remove
+  path: /spec/tasks/13  # sast-shell-scan
+- op: remove
+  path: /spec/tasks/12  # coverity-availability-check
+- op: remove
+  path: /spec/tasks/11  # sast-coverity-check
+- op: remove
+  path: /spec/tasks/10  # clamav-scan
+- op: remove
+  path: /spec/tasks/9  # sast-snyk-check
+- op: remove
+  path: /spec/tasks/8  # ecosystem-cert-preflight-checks
+- op: remove
+  path: /spec/tasks/7  # clair-scan
+- op: remove
+  path: /spec/tasks/5  # build-source-image
+# Remove build-image-index task params
+# $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.4.params.[].name" | nl -v 0
+#  0	IMAGE
+#  1	COMMIT_SHA
+#  2	IMAGE_EXPIRES_AFTER
+#  3	ALWAYS_BUILD_INDEX
+#  4	IMAGES
+#  5	BUILDAH_FORMAT
+- op: remove
+  path: /spec/tasks/4/params/5  # BUILDAH_FORMAT - FBC is always OCI
+
+
+# KEEP removal operations before adding operations, otherwise you will die from counting correct index numbers
 - op: add
   path: /spec/tasks/2
   value:
@@ -69,45 +149,6 @@
 - op: replace
   path: /spec/tasks/4/runAfter/0
   value: clone-repository
-# Remove params
-# $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.3.params.[].name" | nl -v 0
-#      0	IMAGE
-#      1	DOCKERFILE
-#      2	CONTEXT
-#      3	HERMETIC
-#      4	PREFETCH_INPUT
-#      5	IMAGE_EXPIRES_AFTER
-#      6	COMMIT_SHA
-#      7	BUILD_ARGS
-#      8	BUILD_ARGS_FILE
-#      9	PRIVILEGED_NESTED
-#     10	SOURCE_ARTIFACT
-#     11	CACHI2_ARTIFACT
-#     12	IMAGE_APPEND_PLATFORM
-- op: remove
-  path: /spec/tasks/4/params/9
-- op: remove
-  path: /spec/tasks/18  # rpms-signature-scan
-- op: remove
-  path: /spec/tasks/17  # push-dockerfile
-- op: remove
-  path: /spec/tasks/15  # sast-unicode-scan
-- op: remove
-  path: /spec/tasks/14  # sast-shell-scan
-- op: remove
-  path: /spec/tasks/13  # coverity-availability-check
-- op: remove
-  path: /spec/tasks/12  # sast-coverity-check
-- op: remove
-  path: /spec/tasks/11  # clamav-scan
-- op: remove
-  path: /spec/tasks/10  # sast-snyk-check
-- op: remove
-  path: /spec/tasks/9  # ecosystem-cert-preflight-checks
-- op: remove
-  path: /spec/tasks/8  # clair-scan
-- op: remove
-  path: /spec/tasks/6  # build-source-image
 - op: add
   path: /spec/tasks/-
   value:

--- a/pipelines/maven-zip-build/patch.yaml
+++ b/pipelines/maven-zip-build/patch.yaml
@@ -29,7 +29,10 @@
 #      9  image-expires-after
 #     10  build-source-image
 #     11  build-image-index
+#     12  buildah-format
 
+- op: remove
+  path: /spec/params/12  # buildah-format
 - op: remove
   path: /spec/params/11  # build-image-index
 - op: remove

--- a/pipelines/tekton-bundle-builder/patch.yaml
+++ b/pipelines/tekton-bundle-builder/patch.yaml
@@ -61,3 +61,31 @@
   path: /spec/tasks/6   # deprecated-base-image-check
 - op: remove
   path: /spec/tasks/5   # build-source-image
+
+# Remove buildah format, it's not applicable for tekton-bundles
+# $ kustomize build pipelines/template-build/ | yq ".spec.params.[].name" | nl -v 0
+#      0  git-url
+#      1  revision
+#      2  output-image
+#      3  path-context
+#      4  dockerfile
+#      5  rebuild
+#      6  skip-checks
+#      7  hermetic
+#      8  prefetch-input
+#      9  image-expires-after
+#     10  build-source-image
+#     11  build-image-index
+#     12  buildah-format
+- op: remove
+  path: /spec/params/12  # buildah-format
+# Remove build-index-image task params
+# $ yq ".spec.tasks.4.params.[].name" pipelines/template-build/template-build.yaml | nl -v 0
+#      0	IMAGE
+#      1	COMMIT_SHA
+#      2	IMAGE_EXPIRES_AFTER
+#      3	ALWAYS_BUILD_INDEX
+#      4	IMAGES
+#      5	BUILDAH_FORMAT
+- op: remove
+  path: /spec/tasks/4/params/5  # BUILDAH_FORMAT

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -57,6 +57,11 @@ spec:
       description: Add built image into an OCI image index
       type: string
       default: "false"
+    - name: buildah-format
+      description: The format for the resulting image's mediaType. Valid values are
+        oci or docker.
+      type: string
+      default: "docker"
   tasks:
     - name: init
       params:
@@ -140,6 +145,8 @@ spec:
       - name: IMAGES
         value:
         - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+      - name: BUILDAH_FORMAT
+        value: "$(params.buildah-format)"
     - name: build-source-image
       when:
         - input: $(tasks.init.results.build)

--- a/task/init/0.2/MIGRATION.md
+++ b/task/init/0.2/MIGRATION.md
@@ -7,3 +7,22 @@ The parameters `skip-optional`, `pipelinerun-name` and ` pipelinerun-uid` used b
 Update files in Pull-Request created by RHTAP bot:
 - Search for the task named `init`
 - Remove the `skip-optional`, `pipelinerun-name` and ` pipelinerun-uid` parameters from the params section
+
+
+# Migration from 0.2 to 0.2.1
+
+OpenShift's documentation indicates that disconnected clusters can
+use any container registry that supports Docker v2-2. This means that
+disconnected mirroring will fail if the registry doesn't support OCI.
+
+https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/disconnected_environments/connected-to-disconnected
+
+Thus, to support old workflows, we are migrating globally back to docker format, and then project by project should decide when to use OCI again.
+
+FBC builds should continue using `oci` format.
+
+## Action from users
+
+Change `BUILDAH_FORMAT` param value to `docker` in build related tasks: build-images, build-container, build-image-index (build-image-manifest eventually).
+
+If your project require OCI, you don't need to do change (However, check automatic migration if it didn't migrate you to docker format).

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/init/0.2/migrations/0.2.1.sh
+++ b/task/init/0.2/migrations/0.2.1.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: init@0.2.1
+# Creation time: 2025-09-19T10:00:53Z
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+
+buildah_format="docker"
+
+# Check if the run-opm-command task exists, FBC pipeline must be OCI by default
+if yq -e '.spec.tasks[] | select(.name == "run-opm-command")' "$pipeline_file" >/dev/null; then
+    echo "FBC pipeline detected, skipping"
+    exit 0
+fi
+
+# Tekton bundle build pipeline must be OCI by default
+if yq -e '.spec.tasks[] | select(.taskRef.params[] | (.name == "name" and (.value == "tkn-bundle" or .value == "tkn-bundle-oci-ta")))' "$pipeline_file" >/dev/null; then
+    echo "Tekton bundle build pipeline detected, skipping"
+    exit 0
+fi
+
+
+buildah_format_tasks=( \
+  "buildah-min" "buildah" "buildah-oci-ta" \
+  "buildah-remote" "buildah-remote-oci-ta" \
+  "build-image-index" "build-image-manifest" \
+  # sast tasks have BUILDAH_FORMAT param, but we can ignore them, as image is ephemeral for testing only
+  # "sast-coverity-check" "sast-coverity-check-oci-ta" \
+)
+# Determine all tasks which should be updated
+tasks_to_be_updated=()
+
+# lookup for tasks by references, not by names as we need exactly these tasks, to avoid name colision
+for task_refname in "${buildah_format_tasks[@]}"; do
+    if yq -e ".spec.tasks[] | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))" "$pipeline_file" >/dev/null; then
+        tasks_to_be_updated+=( "$(yq -e ".spec.tasks[] | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\")).name" "${pipeline_file}")" )
+    fi
+done
+
+if [ ${#tasks_to_be_updated[@]} -eq 0 ]; then
+    echo "No tasks marked for update"
+    exit 0
+fi
+
+
+if yq -e '.spec.params[] | select(.name == "buildah-format")' "$pipeline_file" >/dev/null; then
+    echo "Pipeline param buildah-format already exist, skipping migration"
+    exit 0
+fi
+
+for build_taskname_value in "${tasks_to_be_updated[@]}"; do
+    # Check if the task already has the BUILDAH_FORMAT parameter
+    if yq -e ".spec.tasks[] | select(.name == \"$build_taskname_value\").params[] | select(.name == \"BUILDAH_FORMAT\")" "$pipeline_file" >/dev/null; then
+        echo "BUILDAH_FORMAT parameter already exists in $build_taskname_value task. Skipping migration"
+        exit 0
+    fi
+done
+
+# Update all relevant tasks
+echo "Adding buildah-format pipeline param"
+yq -i ".spec.params += [{\
+    \"name\": \"buildah-format\",\
+    \"default\": \"${buildah_format}\",\
+    \"type\": \"string\",\
+    \"description\": \"The format for the resulting image's mediaType. Valid values are oci or docker.\"\
+}]" "$pipeline_file"
+
+for build_taskname_value in "${tasks_to_be_updated[@]}"; do
+    echo "Adding BUILDAH_PARAM into task ${build_taskname_value}"
+    yq -i "(.spec.tasks[] | select(.name == \"$build_taskname_value\")).params += [{\"name\": \"BUILDAH_FORMAT\", \"value\": \"\$(params.buildah-format)\"}]" "$pipeline_file"
+done


### PR DESCRIPTION
OpenShift's documentation indicates that disconnected clusters can use any container registry that supports Docker v2-2. This means that disconnected mirroring will fail if the registry doesn't support OCI.

https://docs.redhat.com/en/documentation/openshift_container_platform/4.19/html/disconnected_environments/connected-to-disconnected

In order to have the easiest default support for all images produced, we should just change the default mediaType. If any users want OCI specific mediaTypes, they can still enable that.

FBC build must continue to use OCI format.

Migration script is created to add BUILDAH_FORMAT param if doesn't exist with value "docker" (or "oci" for FBC build).

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
