### PR TITLE
sast-coverity: pin base buildah task in 0.2 to specific commit

### DIFF
--- a/archived-tasks/sast-coverity-check/0.2/kustomization.yaml
+++ b/archived-tasks/sast-coverity-check/0.2/kustomization.yaml
@@ -2,7 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - ../../../task/buildah/0.4
+  # Pin base buildah task to specific commit to reduce churn
+  - https://github.com/konflux-ci/build-definitions/raw/2b07ac561f8e79d8103fffb62859af60ad3a358f/task/buildah/0.4/buildah.yaml
 
 patches:
 - path: patch.yaml


### PR DESCRIPTION
Previously done for sast-coverity 0.3 version in 6d7eee3b4b0d65755d26097aa550930d1be23262.
