### PR TITLE
Update buildah-task bundle reference

### DIFF
--- a/appstudio-utils/Dockerfile
+++ b/appstudio-utils/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/enterprise-contract/cli:latest AS ec-image
 RUN ARCH=$(uname -m) && \
     if [ "$ARCH" = "x86_64" ]; then ARCH="amd64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="arm64"; fi && \
     cp /usr/local/bin/ec_linux_${ARCH}.gz /tmp/ec.gz
-FROM quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458 AS buildah-task-image
+FROM quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d AS buildah-task-image
 FROM registry.access.redhat.com/ubi9/ubi
 
 COPY --from=ec-image /tmp/ec.gz /usr/bin/ec.gz

--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -76,7 +76,7 @@ spec:
       - name: shared-dir
         mountPath: /index-build-data
   steps:
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -89,7 +89,7 @@ spec:
       requests:
         cpu: 250m
         memory: 512Mi
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     name: build
     script: |
       #!/bin/bash

--- a/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
+++ b/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
@@ -137,7 +137,7 @@ spec:
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - args:
         - "$(params.BUILD_ARGS[*])"
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
       name: "run-script"
       script: |-
         #!/usr/bin/env bash
@@ -454,7 +454,7 @@ spec:
         requests:
           cpu: "1"
           memory: 1Gi
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
       name: inject-sbom-and-push
       env:
         - name: TASKRUN_NAME

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -124,7 +124,7 @@ spec:
         echo "declare TAGGED_AS=${TAGGED_AS}" >> /var/workdir/vars
 
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
       computeResources:
         limits:
           memory: 512Mi

--- a/task/buildah-min/0.5/buildah-min.yaml
+++ b/task/buildah-min/0.5/buildah-min.yaml
@@ -296,7 +296,7 @@ spec:
       value: $(params.NO_PROXY)
     - name: ICM_KEEP_COMPAT_LOCATION
       value: $(params.ICM_KEEP_COMPAT_LOCATION)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     name: build
     script: |
       #!/bin/bash
@@ -859,7 +859,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml
@@ -332,7 +332,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -923,7 +923,7 @@ spec:
           add:
             - SETFCAP
     - name: push
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-remote-oci-ta/0.5/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.5/buildah-remote-oci-ta.yaml
@@ -283,7 +283,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -333,7 +333,7 @@ spec:
       value: $(params.NO_PROXY)
     - name: ICM_KEEP_COMPAT_LOCATION
       value: $(params.ICM_KEEP_COMPAT_LOCATION)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     name: build
     script: |-
       #!/bin/bash
@@ -1061,7 +1061,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.5/buildah-remote.yaml
+++ b/task/buildah-remote/0.5/buildah-remote.yaml
@@ -274,7 +274,7 @@ spec:
     - name: BUILD_TIMESTAMP
       value: $(params.BUILD_TIMESTAMP)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+      value: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -310,7 +310,7 @@ spec:
       value: $(params.NO_PROXY)
     - name: ICM_KEEP_COMPAT_LOCATION
       value: $(params.ICM_KEEP_COMPAT_LOCATION)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     name: build
     script: |-
       #!/bin/bash
@@ -1031,7 +1031,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah/0.5/buildah.yaml
+++ b/task/buildah/0.5/buildah.yaml
@@ -253,7 +253,7 @@ spec:
       value: $(params.BUILD_TIMESTAMP)
     imagePullPolicy: IfNotPresent
   steps:
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+  - image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     name: build
     computeResources:
       limits:
@@ -842,7 +842,7 @@ spec:
       readOnly: true
     workingDir: $(workspaces.source.path)
   - name: push
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+    image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
     env:
     - name: BUILDAH_FORMAT
       value: $(params.BUILDAH_FORMAT)

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -119,7 +119,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: run-script
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:1e686fc8fe41f985d9871d80f22bef4b58e6b2df3237385ee43113907231b458
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca


### PR DESCRIPTION
Updating buildah-task bundle to apply quick fix for `Signature for identity "<user's-base-image>" is not accepted;` problem.
