### PR TITLE
fix(init): hotfix for migration 0.2.1

### DIFF
--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.2.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/init/0.2/migrations/0.2.2.sh
+++ b/task/init/0.2/migrations/0.2.2.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: init@0.2.2
+# Creation time: 2025-09-29T15:00:03Z
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+
+# Fixing migration from 0.2.1, where old FBC pipelines has been accidentally migrated to docker
+
+if yq -e '.spec.params[] | select(.name == "buildah-format")' "$pipeline_file" >/dev/null; then
+    # migration happened
+    if yq -e '.spec.tasks[] | select(.taskRef.params[] | (.name == "name" and .value == "validate-fbc"))' "$pipeline_file" >/dev/null; then
+       # it's older FBC pipeline with migration, switch to oci
+       yq -i '(select( .spec.params[] | .name == "buildah-format")).default = "oci"' "$pipeline_file"
+       echo "Switching FBC pipeline back to OCI"
+    fi
+fi
+


### PR DESCRIPTION
Older FBC pipelines without run-opm-command has been accidentally migrated to docker format. Fix this by changing default to oci.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
