### PR TITLE
fix: sanitize relatedImages before conversion to OCI format

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -110,8 +110,18 @@ spec:
         continue
       fi
 
+      # Sanitize the image reference to handle Docker references with both tag and digest
+      sanitized_related_image=$(get_image_registry_repository_digest "${related_image}")
+
+      # If no digest is present, fallback to using tag-based sanitization
+      if [[ "${sanitized_related_image}" != *"@"* ]]; then
+        echo "No digest found in sanitized image, using tag-based sanitization"
+        sanitized_related_image=$(get_image_registry_repository_tag "${related_image}")
+      fi
+      echo "Successfully sanitized image reference: ${sanitized_related_image}. Using sanitized image reference for conversion to OCI format"
+
       # Convert image to OCI format since umoci can only handle the OCI format
-      if ! retry skopeo copy --remove-signatures "docker://${related_image}" "oci:///tekton/home/${component_label}-${version_label}-${release_label}:latest"; then
+      if ! retry skopeo copy --remove-signatures "docker://${sanitized_related_image}" "oci:///tekton/home/${component_label}-${version_label}-${release_label}:latest"; then
         echo -e "Error: Unable to scan image: Could not convert image ${related_image} to OCI format\n"
         error_counter=$((error_counter + 1))
         continue


### PR DESCRIPTION
Image references with tag and digest are not supported when converting the image to OCI format using skopeo. To circumvent that, we need to sanitize it.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
