### PR TITLE
Temporarily disable FBC e2e test

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -60,7 +60,7 @@ spec:
       - name: APP_SUFFIX
         value: "$(params.app_suffix)"
       - name: COMPONENT_REPO_URLS
-        value: "https://github.com/konflux-qe-bd/devfile-sample-python-basic,https://github.com/konflux-qe-bd/devfile-sample-python-basic-clone,https://github.com/konflux-qe-bd/multiarch-sample-repo,https://github.com/konflux-qe-bd/multiarch-sample-repo-clone,https://github.com/konflux-qe-bd/retrodep,https://github.com/konflux-qe-bd/pip-e2e-test,https://github.com/konflux-qe-bd/fbc-sample-repo,https://github.com/konflux-qe-bd/docker-file-from-scratch,https://github.com/konflux-qe-bd/oci-archive-test"
+        value: "https://github.com/konflux-qe-bd/devfile-sample-python-basic,https://github.com/konflux-qe-bd/devfile-sample-python-basic-clone,https://github.com/konflux-qe-bd/multiarch-sample-repo,https://github.com/konflux-qe-bd/multiarch-sample-repo-clone,https://github.com/konflux-qe-bd/retrodep,https://github.com/konflux-qe-bd/pip-e2e-test,https://github.com/konflux-qe-bd/docker-file-from-scratch,https://github.com/konflux-qe-bd/oci-archive-test"
       - name: QUAY_E2E_ORGANIZATION
         value: konflux-ci
       - name: E2E_APPLICATIONS_NAMESPACE


### PR DESCRIPTION
The repository used for testing FBC builds [1] uses a base image from registry.redhat.io.

To make it possible to pull this base image, the OpenShift namespace where the tests run has a registry.redhat.io pull secret. This pull secret is linked to the 'appstudio-pipeline' Service Account.

The 'appstudio-pipeline' Service Account is no longer used for running the test build pipelines. Until recently, this wasn't a problem, because the build-service operator would link the same secrets to the Service Accounts used today. But, after a recent change [2], build-service doesn't do that anymore so the test is broken.

Disable the test while we work on a fix.

[1]: https://github.com/konflux-qe-bd/fbc-sample-repo
[2]: https://github.com/konflux-ci/build-service/commit/e7349da3fd900eed14130aa0953626faaca150a5