### PR TITLE
Update deprecated task path

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -349,7 +349,7 @@ spec:
             - name: revision
               value: main
             - name: pathInRepo
-              value: common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+              value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
         params:
           - name: test-name
             value: "$(context.pipelineRun.name)"


### PR DESCRIPTION
Updates the deprecated "common/tasks/" path to "tasks/". Path should be updated before 31/10/25 to avoid breaking changes.