### PR TITLE
Remove set -e option for git-clone task

### DIFF
--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -213,7 +213,7 @@ spec:
           value: /var/workdir/source
       script: |
         #!/usr/bin/env sh
-        set -eu
+        set -u
 
         if [ "${PARAM_VERBOSE}" = "true" ]; then
           set -x

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -180,7 +180,7 @@ spec:
         readOnly: true
     script: |
       #!/usr/bin/env sh
-      set -eu
+      set -u
 
       if [ "${PARAM_VERBOSE}" = "true" ] ; then
         set -x


### PR DESCRIPTION
There's lots of error handling code in this task that is all skipped because of this flag. Remove it, so we can handle errors more explicitly.

Fixes https://github.com/konflux-ci/build-definitions/issues/2788
