### PR TITLE
fix(git-clone): bump git image version to support retries

### DIFF
--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -159,7 +159,7 @@ spec:
       optional: true
   steps:
     - name: clone
-      image: quay.io/konflux-ci/git-clone@sha256:89beb91dde5b4f2d3fd941b9a305e90420c65bb006c0c65f30f19c9e0c6350fa
+      image: quay.io/konflux-ci/git-clone@sha256:d8b6f4276e35d7de23123de8eae14f56f830a5f92c73f260020fb3c7853f65e5
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
@@ -326,7 +326,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: symlink-check
-      image: quay.io/konflux-ci/git-clone@sha256:89beb91dde5b4f2d3fd941b9a305e90420c65bb006c0c65f30f19c9e0c6350fa
+      image: quay.io/konflux-ci/git-clone@sha256:d8b6f4276e35d7de23123de8eae14f56f830a5f92c73f260020fb3c7853f65e5
       volumeMounts:
         - mountPath: /var/workdir
           name: workdir

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -170,7 +170,7 @@ spec:
       value: $(workspaces.basic-auth.bound)
     - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
       value: $(workspaces.basic-auth.path)
-    image: quay.io/konflux-ci/git-clone@sha256:89beb91dde5b4f2d3fd941b9a305e90420c65bb006c0c65f30f19c9e0c6350fa
+    image: quay.io/konflux-ci/git-clone@sha256:d8b6f4276e35d7de23123de8eae14f56f830a5f92c73f260020fb3c7853f65e5
     computeResources: {}
     securityContext:
       runAsUser: 0
@@ -317,7 +317,7 @@ spec:
       fi
 
   - name: symlink-check
-    image: quay.io/konflux-ci/git-clone@sha256:89beb91dde5b4f2d3fd941b9a305e90420c65bb006c0c65f30f19c9e0c6350fa
+    image: quay.io/konflux-ci/git-clone@sha256:d8b6f4276e35d7de23123de8eae14f56f830a5f92c73f260020fb3c7853f65e5
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     env:

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -193,7 +193,7 @@ spec:
       value: $(workspaces.basic-auth.path)
     - name: CHECKOUT_DIR
       value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:89beb91dde5b4f2d3fd941b9a305e90420c65bb006c0c65f30f19c9e0c6350fa
+    image: quay.io/konflux-ci/git-clone@sha256:d8b6f4276e35d7de23123de8eae14f56f830a5f92c73f260020fb3c7853f65e5
     name: clone
     script: |
       #!/usr/bin/env sh
@@ -320,7 +320,7 @@ spec:
       value: $(params.enableSymlinkCheck)
     - name: CHECKOUT_DIR
       value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:89beb91dde5b4f2d3fd941b9a305e90420c65bb006c0c65f30f19c9e0c6350fa
+    image: quay.io/konflux-ci/git-clone@sha256:d8b6f4276e35d7de23123de8eae14f56f830a5f92c73f260020fb3c7853f65e5
     name: symlink-check
     script: |
       #!/usr/bin/env bash


### PR DESCRIPTION
Bumping to image version which contains the fix for retries.

Fix: https://github.com/tektoncd-catalog/git-clone/commit/828ece013ff71e0a7156fd0379ed661f650300ce

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
