### PR TITLE
fix(git-clone): set limit to 10 retries for git-init

### DIFF
--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -261,7 +261,8 @@ spec:
           -sslVerify="${PARAM_SSL_VERIFY}" \
           -submodules="${PARAM_SUBMODULES}" \
           -depth="${PARAM_DEPTH}" \
-          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
+          -retryMaxAttempts=10
         cd "${CHECKOUT_DIR}"
         RESULT_SHA="$(git rev-parse HEAD)"
         RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -253,7 +253,8 @@ spec:
         -sslVerify="${PARAM_SSL_VERIFY}" \
         -submodules="${PARAM_SUBMODULES}" \
         -depth="${PARAM_DEPTH}" \
-        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
+        -retryMaxAttempts=10
       cd "${CHECKOUT_DIR}"
       RESULT_SHA="$(git rev-parse HEAD)"
       RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -245,7 +245,8 @@ spec:
         -sslVerify="${PARAM_SSL_VERIFY}" \
         -submodules="${PARAM_SUBMODULES}" \
         -depth="${PARAM_DEPTH}" \
-        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
+        -retryMaxAttempts=10
       cd "${CHECKOUT_DIR}"
       RESULT_SHA="$(git rev-parse HEAD)"
       RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"


### PR DESCRIPTION
Default is no retries, we must explicitly set retries.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
