### PR TITLE
chore(deps): bump git-clone image

### DIFF
--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -159,7 +159,7 @@ spec:
       optional: true
   steps:
     - name: clone
-      image: quay.io/konflux-ci/git-clone@sha256:9baece0395f7b08540f8bfcfcc396533ef0e5bcb8b43f6a2c8fe98fd595c8b85
+      image: quay.io/konflux-ci/git-clone@sha256:6d95e6001e28a59f64a51c35a1ca5d383f9fe3833c6d563650bbf83643edd8d9
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
@@ -324,7 +324,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: symlink-check
-      image: quay.io/konflux-ci/git-clone@sha256:9baece0395f7b08540f8bfcfcc396533ef0e5bcb8b43f6a2c8fe98fd595c8b85
+      image: quay.io/konflux-ci/git-clone@sha256:6d95e6001e28a59f64a51c35a1ca5d383f9fe3833c6d563650bbf83643edd8d9
       volumeMounts:
         - mountPath: /var/workdir
           name: workdir

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -170,7 +170,7 @@ spec:
       value: $(workspaces.basic-auth.bound)
     - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
       value: $(workspaces.basic-auth.path)
-    image: quay.io/konflux-ci/git-clone@sha256:9baece0395f7b08540f8bfcfcc396533ef0e5bcb8b43f6a2c8fe98fd595c8b85
+    image: quay.io/konflux-ci/git-clone@sha256:6d95e6001e28a59f64a51c35a1ca5d383f9fe3833c6d563650bbf83643edd8d9
     computeResources: {}
     securityContext:
       runAsUser: 0
@@ -315,7 +315,7 @@ spec:
       fi
 
   - name: symlink-check
-    image: quay.io/konflux-ci/git-clone@sha256:9baece0395f7b08540f8bfcfcc396533ef0e5bcb8b43f6a2c8fe98fd595c8b85
+    image: quay.io/konflux-ci/git-clone@sha256:6d95e6001e28a59f64a51c35a1ca5d383f9fe3833c6d563650bbf83643edd8d9
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     env:

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -193,7 +193,7 @@ spec:
       value: $(workspaces.basic-auth.path)
     - name: CHECKOUT_DIR
       value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:9baece0395f7b08540f8bfcfcc396533ef0e5bcb8b43f6a2c8fe98fd595c8b85
+    image: quay.io/konflux-ci/git-clone@sha256:6d95e6001e28a59f64a51c35a1ca5d383f9fe3833c6d563650bbf83643edd8d9
     name: clone
     script: |
       #!/usr/bin/env sh
@@ -318,7 +318,7 @@ spec:
       value: $(params.enableSymlinkCheck)
     - name: CHECKOUT_DIR
       value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:9baece0395f7b08540f8bfcfcc396533ef0e5bcb8b43f6a2c8fe98fd595c8b85
+    image: quay.io/konflux-ci/git-clone@sha256:6d95e6001e28a59f64a51c35a1ca5d383f9fe3833c6d563650bbf83643edd8d9
     name: symlink-check
     script: |
       #!/usr/bin/env bash


### PR DESCRIPTION
New git clone image contains fix to correctly clone submodules when retries happen.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
