### PR TITLE
Change image digest fetching method to skopeo

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -372,7 +372,7 @@ spec:
           fi
         done < <(find /artifacts -type f -name "cert-image.json")
 
-        image_digest=$(oras manifest fetch "${PARAM_IMAGE_URL}" | sha256sum | awk '{print "sha256:" $1}')
+        image_digest=$(skopeo inspect --raw "docker://${PARAM_IMAGE_URL}" | sha256sum | awk '{print "sha256:" $1}')
         if [[ -n "$image_digest" && ! " ${digests_processed[*]} " == *" \"$image_digest\" "* ]]; then
           digests_processed+=("\"$image_digest\"")
         fi


### PR DESCRIPTION
This step was failing because oras couldn't find the proper authentication. Changing back to skopeo.

resolves: #2862

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
