### PR TITLE
Fix missing proxy config during buildah pull

### DIFF
--- a/task/buildah-min/0.5/buildah-min.yaml
+++ b/task/buildah-min/0.5/buildah-min.yaml
@@ -641,7 +641,9 @@ spec:
             tr -d "'"
         )
         if [[ -n "$FINAL_BASE_IMAGE" ]]; then
+          set_proxy
           buildah pull "$FINAL_BASE_IMAGE" >/dev/null` `
+          unset_proxy
           buildah inspect "$FINAL_BASE_IMAGE" | jq '.OCIv1.config.Labels' >"base_images_labels.json"
         fi
       fi

--- a/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.5/buildah-oci-ta.yaml
@@ -720,7 +720,9 @@ spec:
               tr -d "'"
           )
           if [[ -n "$FINAL_BASE_IMAGE" ]]; then
+            set_proxy
             buildah pull "$FINAL_BASE_IMAGE" >/dev/null$()
+            unset_proxy
             buildah inspect "$FINAL_BASE_IMAGE" | jq '.OCIv1.config.Labels' >"base_images_labels.json"
           fi
         fi

--- a/task/buildah-remote-oci-ta/0.5/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.5/buildah-remote-oci-ta.yaml
@@ -754,7 +754,9 @@ spec:
             tr -d "'"
         )
         if [[ -n "$FINAL_BASE_IMAGE" ]]; then
+          set_proxy
           buildah pull "$FINAL_BASE_IMAGE" >/dev/null$()
+          unset_proxy
           buildah inspect "$FINAL_BASE_IMAGE" | jq '.OCIv1.config.Labels' >"base_images_labels.json"
         fi
       fi

--- a/task/buildah-remote/0.5/buildah-remote.yaml
+++ b/task/buildah-remote/0.5/buildah-remote.yaml
@@ -723,7 +723,9 @@ spec:
             tr -d "'"
         )
         if [[ -n "$FINAL_BASE_IMAGE" ]]; then
+          set_proxy
           buildah pull "$FINAL_BASE_IMAGE" >/dev/null` `
+          unset_proxy
           buildah inspect "$FINAL_BASE_IMAGE" | jq '.OCIv1.config.Labels' >"base_images_labels.json"
         fi
       fi

--- a/task/buildah/0.5/buildah.yaml
+++ b/task/buildah/0.5/buildah.yaml
@@ -627,7 +627,9 @@ spec:
             tr -d "'"
         )
         if [[ -n "$FINAL_BASE_IMAGE" ]]; then
+          set_proxy
           buildah pull "$FINAL_BASE_IMAGE" >/dev/null` `
+          unset_proxy
           buildah inspect "$FINAL_BASE_IMAGE" | jq '.OCIv1.config.Labels' >"base_images_labels.json"
         fi
       fi


### PR DESCRIPTION
All buildah pull/build commands should use the proxy, if provided.