### PR TITLE
chore: update external konflux-test-task references

### DIFF
--- a/external-task/clair-scan/0.2/clair-scan.yaml
+++ b/external-task/clair-scan/0.2/clair-scan.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:893ffa3ce26b061e21bb4d8db9ef7ed4ddd4044fe7aa5451ef391034da3ff759
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:076d5cde62b55bbfcdda2b4782392256bbda5ad38f839013b4330b3aba70a973

--- a/external-task/clamav-scan/0.2/clamav-scan.yaml
+++ b/external-task/clamav-scan/0.2/clamav-scan.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:d9e82ed3d71b8dadf301af8db8556ded79edc84039c4ac68707095d0490b367b
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.2@sha256:40555593de346dd3083410c9517d52c3f27e27cb66f447054f4f66fcff56e23f

--- a/external-task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/external-task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:1d07d16810c26713f3d875083924d93697900147364360587ccb5a63f2c31012
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489


### PR DESCRIPTION
* Update clair-scan/0.2
* Update clamav-scan/0.2
* Update deprecated-image-check/0.5

Signed-off-by: dirgim <kpavic@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
