### PR TITLE
Increase memory limits for FIPS tasks

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -263,10 +263,11 @@ spec:
         echo "${images_processed_template/\[%s]/[$digests_processed_string]}" >"/tekton/home/images_processed.txt"
       computeResources:
         limits:
-          memory: 8Gi
+          cpu: "1"
+          memory: 12Gi
         requests:
           cpu: "1"
-          memory: 8Gi
+          memory: 12Gi
       securityContext:
         capabilities:
           add:
@@ -274,10 +275,11 @@ spec:
     - name: fips-operator-check-step-action
       computeResources:
         limits:
-          memory: 8Gi
+          cpu: "1"
+          memory: 12Gi
         requests:
-          cpu: 500m
-          memory: 8Gi
+          cpu: "1"
+          memory: 12Gi
       ref:
         params:
           - name: url

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -31,9 +31,10 @@ spec:
       image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:89cdc9d251e15d07018548137b4034669df8e9e2b171a188c8b8201d3638cb17
       computeResources:
         limits:
-          memory: 8Gi
+          memory: 12Gi
+          cpu: '1'
         requests:
-          memory: 8Gi
+          memory: 12Gi
           cpu: '1'
       env:
         - name: IMAGE_URL
@@ -259,10 +260,11 @@ spec:
     - name: fips-operator-check-step-action
       computeResources:
         limits:
-          memory: 8Gi
+          memory: 12Gi
+          cpu: '1'
         requests:
-          memory: 8Gi
-          cpu: 500m
+          memory: 12Gi
+          cpu: '1'
       ref:
         resolver: git
         params:

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -140,10 +140,11 @@ spec:
         echo "${images_processed_template/\[%s]/[$digests_processed_string]}" >/tekton/home/images_processed.txt
       computeResources:
         limits:
-          memory: 8Gi
+          cpu: "1"
+          memory: 12Gi
         requests:
-          cpu: 500m
-          memory: 8Gi
+          cpu: "1"
+          memory: 12Gi
       securityContext:
         capabilities:
           add:
@@ -151,10 +152,11 @@ spec:
     - name: fips-operator-check-step-action
       computeResources:
         limits:
-          memory: 8Gi
+          cpu: "1"
+          memory: 12Gi
         requests:
-          cpu: 500m
-          memory: 8Gi
+          cpu: "1"
+          memory: 12Gi
       ref:
         params:
           - name: url

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -29,10 +29,11 @@ spec:
       image: quay.io/konflux-ci/konflux-test:v1.4.34@sha256:62a7bf68015c711e0eb0698c10d203d0393a8e0efa09306f1fce543dea383f3c
       computeResources:
         limits:
-          memory: 8Gi
+          memory: 12Gi
+          cpu: '1'
         requests:
-          memory: 8Gi
-          cpu: 500m
+          memory: 12Gi
+          cpu: '1'
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -124,10 +125,11 @@ spec:
     - name: fips-operator-check-step-action
       computeResources:
         limits:
-          memory: 8Gi
+          memory: 12Gi
+          cpu: '1'
         requests:
-          memory: 8Gi
-          cpu: 500m
+          memory: 12Gi
+          cpu: '1'
       ref:
         resolver: git
         params:


### PR DESCRIPTION
This commit increases the limits and requests for the FIPS tasks to keep up with the increasing size of the index images.

Refers to [KFLUXSPRT-5429](https://issues.redhat.com//browse/KFLUXSPRT-5429)

