### PR TITLE
fix(verify-source): return results without trailing newlines

### DIFF
--- a/task/verify-source/0.1/tests/test-verify-source-no-vsa.yaml
+++ b/task/verify-source/0.1/tests/test-verify-source-no-vsa.yaml
@@ -37,9 +37,9 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              # Strip trailing newlines from results
-              LEVEL=$(echo "$SLSA_LEVEL_ACHIEVED" | tr -d '\n')
-              OUTPUT=$(echo "$TEST_OUTPUT" | tr -d '\n')
+              # Task should return results without trailing newlines
+              LEVEL="$SLSA_LEVEL_ACHIEVED"
+              OUTPUT="$TEST_OUTPUT"
 
               echo "SLSA_SOURCE_LEVEL_ACHIEVED: $LEVEL"
               echo "TEST_OUTPUT: $OUTPUT"

--- a/task/verify-source/0.1/tests/test-verify-source-with-vsa.yaml
+++ b/task/verify-source/0.1/tests/test-verify-source-with-vsa.yaml
@@ -37,9 +37,9 @@ spec:
               #!/usr/bin/env sh
               set -eux
 
-              # Strip trailing newlines from results
-              LEVEL=$(echo "$SLSA_LEVEL_ACHIEVED" | tr -d '\n')
-              OUTPUT=$(echo "$TEST_OUTPUT" | tr -d '\n')
+              # Task should return results without trailing newlines
+              LEVEL="$SLSA_LEVEL_ACHIEVED"
+              OUTPUT="$TEST_OUTPUT"
 
               echo "SLSA_SOURCE_LEVEL_ACHIEVED: $LEVEL"
               echo "TEST_OUTPUT: $OUTPUT"

--- a/task/verify-source/0.1/verify-source.yaml
+++ b/task/verify-source/0.1/verify-source.yaml
@@ -175,9 +175,9 @@ spec:
         EOF
         )
 
-        # Write results
-        echo "$ACHIEVED_LEVEL" >"$(results.SLSA_SOURCE_LEVEL_ACHIEVED.path)"
-        echo "$TEST_OUTPUT" >"$(results.TEST_OUTPUT.path)"
+        # Write results (without trailing newlines)
+        printf '%s' "$ACHIEVED_LEVEL" >"$(results.SLSA_SOURCE_LEVEL_ACHIEVED.path)"
+        printf '%s' "$TEST_OUTPUT" >"$(results.TEST_OUTPUT.path)"
 
         echo "=== SLSA Verification Summary ==="
         echo "Result: $VERIFICATION_RESULT"


### PR DESCRIPTION
## Summary

Addresses the review comment from PR #2867: "Consider not removing the newline here - I think we want the Task to return results without trailing newlines and the test should verify that"

This PR modifies the `verify-source` task to write results without trailing newlines and updates both test files to expect this behavior.

## Changes

1. **Task (`verify-source.yaml`)**: Changed from `echo` to `printf '%s'` when writing results to avoid appending trailing newlines
2. **Tests**: Removed the `tr -d '\n'` logic that was stripping newlines, since the Task now returns clean results
3. Updated both test files:
   - `test-verify-source-with-vsa.yaml`
   - `test-verify-source-no-vsa.yaml`

## Testing

- ✅ YAML syntax validated with yamllint
- CI tests will validate Tekton task execution

## Related

- Follows up on review comment in #2867

---

Generated with assistance from Claude Code