### PR TITLE
sast-shell-check: don't fail task when KFP unreachable

### DIFF
--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -133,7 +133,7 @@ spec:
           PROJECT_NAME=${COMPONENT_LABEL}
         fi
 
-        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+        echo "INFO: The PROJECT_NAME used is: ${PROJECT_NAME}"
 
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
         if [ -f "$ca_bundle" ]; then
@@ -207,27 +207,35 @@ spec:
         fi
 
         if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
-          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
-          echo -n "Probing ${PROBE_URL}... "
+          KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
+        fi
+        PROBE_URL="${KFP_GIT_URL%.git}" # trims '.git' suffix
+
+        # create the KFP clone directory regardless
+        KFP_DIR="known-false-positives"
+        KFP_CLONED="0"
+        mkdir "${KFP_DIR}"
+
+        # We check if the KFP_GIT_URL variable is set to clone and apply the filters or not
+        if [[ -n "${KFP_GIT_URL}" ]]; then
+          # Default location only reachable from internal Konflux instances, check reachable first
+          echo -n "INFO: Probing ${PROBE_URL}... "
           if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
-            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-            KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-          else
-            echo "Setting KFP_GIT_URL to empty string"
-            KFP_GIT_URL=
+            echo "INFO: Trying to clone known-false-positives.."
+            git clone "${KFP_GIT_URL}" "${KFP_DIR}" && KFP_CLONED="1"
           fi
         fi
 
-        # Filter known false positives if KFP_GIT_URL is set
-        if [ -n "${KFP_GIT_URL}" ]; then
-          echo "Filtering known false positives using ${KFP_GIT_URL}"
+        if [[ "${KFP_CLONED}" -eq "0" ]]; then
+          echo "WARN: Failed to clone known-false-positives at ${KFP_GIT_URL}, scan results will not be filtered"
+        else
+          echo "INFO: Filtering false positives in results files using csfilter-kfp..."
 
           # build initial csfilter-kfp command
           csfilter_kfp_cmd=(
             csfilter-kfp
             --verbose
-            --kfp-git-url="${KFP_GIT_URL}"
+            --kfp-dir="${KFP_DIR}"
             --project-nvr="${PROJECT_NAME}"
           )
 
@@ -236,19 +244,16 @@ spec:
           fi
 
           # Execute the command and capture any errors
-          if ! "${csfilter_kfp_cmd[@]}" "${OUTPUT_FILE}" >"${OUTPUT_FILE}.filtered" 2>"${OUTPUT_FILE}.error"; then
-            echo "Error occurred while filtering known false positives:"
-            cat "${OUTPUT_FILE}.error"
-            note="Task $(context.task.name) failed: For details, check Tekton task log."
-            ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
-            echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-            exit 1
+          set +e
+          "${csfilter_kfp_cmd[@]}" "${OUTPUT_FILE}" >"${OUTPUT_FILE}.filtered" 2>"${OUTPUT_FILE}.error"
+          status=$?
+          set -e
+          if [ "$status" -ne 0 ]; then
+            echo "WARN: failed to filter known false positives" >&2
           else
             mv "${OUTPUT_FILE}.filtered" "$OUTPUT_FILE"
-            echo "Filtered results saved back to $OUTPUT_FILE"
+            echo "INFO: Succeeded filtering known false positives" >&2
           fi
-        else
-          echo "KFP_GIT_URL is not set. Skipping false positive filtering."
         fi
 
         echo "ShellCheck results have been saved to $OUTPUT_FILE"

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -113,7 +113,7 @@ spec:
             PROJECT_NAME=${COMPONENT_LABEL}
         fi
 
-        echo "The PROJECT_NAME used is: ${PROJECT_NAME}"
+        echo "INFO: The PROJECT_NAME used is: ${PROJECT_NAME}"
 
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
         if [ -f "$ca_bundle" ]; then
@@ -187,27 +187,35 @@ spec:
         fi
 
         if [[ "${KFP_GIT_URL}" == "SITE_DEFAULT" ]]; then
-          # Set KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git for internal Konflux instances
-          PROBE_URL="https://gitlab.cee.redhat.com/osh/known-false-positives"
-          echo -n "Probing ${PROBE_URL}... "
-          if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
-            echo "Setting KFP_GIT_URL to https://gitlab.cee.redhat.com/osh/known-false-positives.git"
             KFP_GIT_URL="https://gitlab.cee.redhat.com/osh/known-false-positives.git"
-          else
-            echo "Setting KFP_GIT_URL to empty string"
-            KFP_GIT_URL=
-          fi
+        fi
+        PROBE_URL="${KFP_GIT_URL%.git}" # trims '.git' suffix
+
+        # create the KFP clone directory regardless
+        KFP_DIR="known-false-positives"
+        KFP_CLONED="0"
+        mkdir "${KFP_DIR}"
+
+        # We check if the KFP_GIT_URL variable is set to clone and apply the filters or not
+        if [[ -n "${KFP_GIT_URL}" ]]; then
+            # Default location only reachable from internal Konflux instances, check reachable first
+            echo -n "INFO: Probing ${PROBE_URL}... "
+            if curl --fail --head --max-time 60 --no-progress-meter "${PROBE_URL}" > >(head -1); then
+                echo "INFO: Trying to clone known-false-positives.."
+                git clone "${KFP_GIT_URL}" "${KFP_DIR}" && KFP_CLONED="1"
+            fi
         fi
 
-        # Filter known false positives if KFP_GIT_URL is set
-        if [ -n "${KFP_GIT_URL}" ]; then
-            echo "Filtering known false positives using ${KFP_GIT_URL}"
+        if [[ "${KFP_CLONED}" -eq "0" ]]; then
+            echo "WARN: Failed to clone known-false-positives at ${KFP_GIT_URL}, scan results will not be filtered"
+        else
+            echo "INFO: Filtering false positives in results files using csfilter-kfp..."
 
             # build initial csfilter-kfp command
             csfilter_kfp_cmd=(
                 csfilter-kfp
                 --verbose
-                --kfp-git-url="${KFP_GIT_URL}"
+                --kfp-dir="${KFP_DIR}"
                 --project-nvr="${PROJECT_NAME}"
             )
 
@@ -216,19 +224,16 @@ spec:
             fi
 
             # Execute the command and capture any errors
-            if ! "${csfilter_kfp_cmd[@]}" "${OUTPUT_FILE}" > "${OUTPUT_FILE}.filtered" 2> "${OUTPUT_FILE}.error"; then
-                echo "Error occurred while filtering known false positives:"
-                cat "${OUTPUT_FILE}.error"
-                note="Task $(context.task.name) failed: For details, check Tekton task log."
-                ERROR_OUTPUT=$(make_result_json -r ERROR -t "$note")
-                echo "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
-                exit 1
+            set +e
+            "${csfilter_kfp_cmd[@]}" "${OUTPUT_FILE}" > "${OUTPUT_FILE}.filtered" 2> "${OUTPUT_FILE}.error"
+            status=$?
+            set -e
+            if [ "$status" -ne 0 ]; then
+                echo "WARN: failed to filter known false positives" >&2
             else
                 mv "${OUTPUT_FILE}.filtered" "$OUTPUT_FILE"
-                echo "Filtered results saved back to $OUTPUT_FILE"
+                echo "INFO: Succeeded filtering known false positives" >&2
             fi
-        else
-            echo "KFP_GIT_URL is not set. Skipping false positive filtering."
         fi
 
         echo "ShellCheck results have been saved to $OUTPUT_FILE"

--- a/task/sast-shell-check/0.1/tests/test-sast-shell-check-bad-kfp-repo.yaml
+++ b/task/sast-shell-check/0.1/tests/test-sast-shell-check-bad-kfp-repo.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-sast-shell-check-bad-kfp-rep
+spec:
+  description: |
+    Test the sast-shell-check task succeeds even if the KFP repo is unreachable
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: init
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/init/0.2/init.yaml
+      params:
+        - name: image-url
+          value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"
+    - name: clone-repository
+      runAfter:
+        - init
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/test-data-sast
+        - name: revision
+          value: main
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/git-clone/0.1/git-clone.yaml
+    - name: scan-with-shellcheck
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      runAfter:
+        - clone-repository
+      taskRef:
+        name: sast-shell-check
+      params:
+        - name: image-url
+          value: "quay.io/redhat-user-workloads/sast-tests-tenant/tests/tests-sast-shell-check:latest"
+          # Test using a non-existent KFP repo does not cause task failure
+        - name: KFP_GIT_URL
+          value: https://gitlab.com/bad/repo/url.git
+    - name: check-result
+      runAfter:
+        - scan-with-shellcheck
+      workspaces:
+        - name: workspace
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/konflux-test:v1.4.28@sha256:4a5423e125fc28db800421422d9933290dc4b62a22401d74cd3348c03107a5d9
+            script: |
+              #!/usr/bin/env bash
+              set -eu
+              echo "Check-result"
+              # Extract findings stats from the resulting SARIF data
+              ls -la "$(workspaces.workspace.path)"/hacbs/
+              cat "$(workspaces.workspace.path)"/hacbs/sast-shell-check/shellcheck-results.sarif
+              output=$(csgrep --mode=evtstat "$(workspaces.workspace.path)"/hacbs/sast-shell-check/shellcheck-results.sarif | tr -d '\n')
+              expected="      8	SHELLCHECK_WARNING                              	warning[SC1083]      2	SHELLCHECK_WARNING                              	warning[SC2069]"
+              # Compare output with expected string
+              if [[ "$output" == "$expected" ]]; then
+                echo "Test passed!"
+              else
+                echo "Test failed!"
+                echo "Actual output: [$output]"
+                echo "Expected output: [$expected]"
+                return 1
+              fi


### PR DESCRIPTION
Applies same logic as in 14dbc6b04b20f60fdbb3a37a56b70d4a2681f806 for sast-snyk-check task.

A new test is added because, unlike the snyk task, no secret is required to run the shellcheck task.

[PSSECAUT-1386](https://issues.redhat.com/browse/PSSECAUT-1386)