### PR TITLE
fix: pin versions of k8s.io/api and k8s.io/apimachinery

### DIFF
--- a/task-generator/trusted-artifacts/go.mod
+++ b/task-generator/trusted-artifacts/go.mod
@@ -17,6 +17,11 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
+replace (
+	k8s.io/api v0.34.1 => k8s.io/api v0.32.8
+	k8s.io/apimachinery v0.34.1 => k8s.io/apimachinery v0.32.8
+)
+
 require (
 	cel.dev/expr v0.24.0 // indirect
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect


### PR DESCRIPTION
Use the same versions as what tektoncd/pipeline uses.

This is a fix for https://github.com/konflux-ci/build-definitions/pull/2729#issuecomment-3240289095. k8s.io/api v0.34.1 does not have package `k8s.io/api/networking/v1alpha1`.