### PR TITLE
fix(KONFLUX-10577): rebuilt task-fbc-target-index-pruning-check

### DIFF
--- a/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
+++ b/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
@@ -250,5 +250,6 @@ spec:
         if [[ "${digests_processed[*]}" != *"$IMAGE_DIGEST"* ]]; then
           digests_processed+=("\"$IMAGE_DIGEST\"")
         fi
+
         digests_processed_string=$(IFS=,; echo "${digests_processed[*]}")
         echo "${images_processed_template/\[%s]/[$digests_processed_string]}" | tee "$(results.IMAGES_PROCESSED.path)"


### PR DESCRIPTION
* task quay.io/konflux-ci/tekton-catalog/task-fbc-target-index-pruning-check@sha256:cd86fe953ff59f0bebd1180669d83ca89b46cf6af4edce5794807e488ca661ef suggested and trusted by EC is generated from https://github.com/konflux-ci/konflux-operator-tasks/tree/94cb1b07755e71e509f18f829e94faa006f88c5d and it is not added to external_task so that it is not added to fbc-builder pipeline
* make dummy change to rebuild task-fbc-target-index-pruning-chec to update task-fbc-target-index-pruning-check digest in fbc-builder pipeline

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
