### PR TITLE
Revert "fix: pin versions of k8s.io/api and k8s.io/apimachinery"

### DIFF
--- a/task-generator/trusted-artifacts/go.mod
+++ b/task-generator/trusted-artifacts/go.mod
@@ -17,11 +17,6 @@ require (
 	sigs.k8s.io/yaml v1.6.0
 )
 
-replace (
-	k8s.io/api v0.34.1 => k8s.io/api v0.32.8
-	k8s.io/apimachinery v0.34.1 => k8s.io/apimachinery v0.32.8
-)
-
 require (
 	cel.dev/expr v0.24.0 // indirect
 	contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d // indirect


### PR DESCRIPTION
Due to https://github.com/golang/go/issues/44840, the 'replace' directive causes the trusted-artifacts tool to not be installable.

    go install github.com/konflux-ci/build-definitions/task-generator/trusted-artifacts@latest
        ...
        The go.mod file for the module providing named packages contains one or
        more replace directives. It must not contain directives that would cause
        it to be interpreted differently than if it were the main module.

Removing the replace directive doesn't change anything, the directive has no effect because the current versions of the relevant dependencies are different.

This reverts commit 95784263a9ed6ba60491001a18921af0339514e8.
