### PR TITLE
fix: restore old external task versions

### DIFF
--- a/external-task/clair-scan/0.1/clair-scan.yaml
+++ b/external-task/clair-scan/0.1/clair-scan.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.1@sha256:bd5ec7081ead5bc28dce14defa6821fc61a8d52700c512dc6b0d071fa98d929b

--- a/external-task/clair-scan/0.2/clair-scan.yaml
+++ b/external-task/clair-scan/0.2/clair-scan.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a7cc183967f89c4ac100d04ab8f81e54733beee60a0528208107c9a22d3c43af
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.2@sha256:076d5cde62b55bbfcdda2b4782392256bbda5ad38f839013b4330b3aba70a973

--- a/external-task/clamav-scan/0.1/clamav-scan.yaml
+++ b/external-task/clamav-scan/0.1/clamav-scan.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:b0bd59748cda4a7abf311e4f448e6c1d00c6b6d8c0ecc1c2eb33e08dc0e0b802
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:a01f94db2bdf6f9a86e1e9cc256e1b7c26cb4d0253e67579196bd8ffbc33a7ca

--- a/external-task/deprecated-image-check/0.1/deprecated-image-check.yaml
+++ b/external-task/deprecated-image-check/0.1/deprecated-image-check.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.1@sha256:f0655def0168c69c9dc9f2005ff18c42b897500fc958e34426dd369944031b49

--- a/external-task/deprecated-image-check/0.2/deprecated-image-check.yaml
+++ b/external-task/deprecated-image-check/0.2/deprecated-image-check.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.2@sha256:d4e255786075b8ddc2a2a6ec7f4b66e17e952f4cb1d6f4116f99aeeaa9b15176

--- a/external-task/deprecated-image-check/0.3/deprecated-image-check.yaml
+++ b/external-task/deprecated-image-check/0.3/deprecated-image-check.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.3@sha256:bc5dd8b791b6d7f1bdce3d589e1962d8bdccaef84ad0ac46de2f1df60f0f6070

--- a/external-task/deprecated-image-check/0.4/deprecated-image-check.yaml
+++ b/external-task/deprecated-image-check/0.4/deprecated-image-check.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.4@sha256:febec4cf37d92c1623cdd61c2e4b1647dc13d1ff75f44b8cb24569eb215b583d


### PR DESCRIPTION
* The old versions of the external tasks were updated to the newest tags, this restores the old tags/digests

Signed-off-by: dirgim <kpavic@redhat.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
