### PR TITLE
Bump up Mobster references to 1.1.0

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -216,7 +216,7 @@ spec:
         add:
           - SETFCAP
 
-  - image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
+  - image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
     name: create-sbom
     computeResources:
       limits:

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -219,7 +219,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
+    image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
     name: create-sbom
     script: |
       #!/bin/bash

--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -174,7 +174,7 @@ spec:
           add:
             - SETFCAP
     - name: save-sbom
-      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
+      image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/build-maven-zip/0.1/build-maven-zip.yaml
+++ b/task/build-maven-zip/0.1/build-maven-zip.yaml
@@ -146,7 +146,7 @@ spec:
       mountPath: /mnt/trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
+  - image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
     name: save-sbom
     computeResources:
       limits:

--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -998,7 +998,7 @@ spec:
       requests:
         cpu: 10m
         memory: 128Mi
-    image: quay.io/konflux-ci/mobster:1.0.0-1760010717@sha256:213269cdde962187fef52532c5794589a9bd309962333d150e46b5dfe8e50461
+    image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -1058,7 +1058,7 @@ spec:
 
         echo "[$(date --utc -Ins)] End sbom-syft-generate"
     - name: prepare-sboms
-      image: quay.io/konflux-ci/mobster:1.0.0-1760010717@sha256:213269cdde962187fef52532c5794589a9bd309962333d150e46b5dfe8e50461
+      image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
       args:
         - --additional-base-images
         - $(params.ADDITIONAL_BASE_IMAGES[*])

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -1212,7 +1212,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:1.0.0-1760010717@sha256:213269cdde962187fef52532c5794589a9bd309962333d150e46b5dfe8e50461
+    image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -1182,7 +1182,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:1.0.0-1760010717@sha256:213269cdde962187fef52532c5794589a9bd309962333d150e46b5dfe8e50461
+    image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -980,7 +980,7 @@ spec:
       subPath: ca-bundle.crt
 
   - name: prepare-sboms
-    image: quay.io/konflux-ci/mobster:1.0.0-1760010717@sha256:213269cdde962187fef52532c5794589a9bd309962333d150e46b5dfe8e50461
+    image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
     computeResources:
       limits:
         memory: 512Mi

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -222,7 +222,7 @@ spec:
         echo -n "${IMAGE}@${RESULTING_DIGEST}" > "$(results.IMAGE_REF.path)"
 
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
+      image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
       workingDir: /var/workdir
       script: |
         #!/bin/bash

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -100,7 +100,7 @@ spec:
         - name: SOURCE_ARTIFACT
           value: $(tasks.mock-trusted-artifact.results.SOURCE_ARTIFACT)
         - name: BASE_IMAGE
-          value: "registry.access.redhat.com/ubi9/ubi:latest"
+          value: "registry.access.redhat.com/ubi9/ubi:9.6-1758184894"
         - name: PLATFORM
           value: linux/s390x
         - name: MODEL_IMAGE

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -324,7 +324,7 @@ spec:
           add:
             - SETFCAP
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
+      image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
       workingDir: /var/workdir
       script: |
         #!/bin/bash

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -309,7 +309,7 @@ spec:
           name: varlibcontainers
       workingDir: $(workspaces.source.path)
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster:0.6.0-1755613650@sha256:41e877cac3bda4ae5b8a59bbb8241e6f56dc18750476e6ce979264de161516dc
+      image: quay.io/konflux-ci/mobster:1.1.0-1761130945@sha256:c2624a94a0da0974cc02a22d056d43a9af2b5b4aa5ccb160dc3c715f93c95a9f
       script: |
         #!/bin/bash
         set -euo pipefail


### PR DESCRIPTION
A new release of Mobster is available and replaces all previous version.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
