### PR TITLE
Add "redhat" versioning template for Mobster

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -321,7 +321,8 @@
         "image: (?<depName>quay\\.io/konflux-ci/mobster[^:]*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "autoReplaceStringTemplate": "image: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
-      "datasourceTemplate": "docker"
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "redhat"
     }
   ]
 }


### PR DESCRIPTION
Mobster is released using Konflux and is produced with "{version}-{suffix}" tags. By default renovate detect a suffix as a platform. This causes that updates are done only if matching platform is found. Since our suffix is part of version (release) it is dynamic and never stay the same. With non-redhat versioning renovate always skip the update of Mobster images.

This commit fixes the issue with not updating Mobster images using renovate.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
