### PR TITLE
feat(KONFLUX-10642): increase memory limit fbc-target-index-pruning-check

### DIFF
--- a/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
+++ b/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
@@ -82,7 +82,7 @@ spec:
             - SETFCAP
       computeResources:
         limits:
-          memory: 6Gi
+          memory: 10Gi
         requests:
           memory: 6Gi
       script: |


### PR DESCRIPTION
* increase memory limit fbc-target-index-pruning-check to 10G to resolve OOMKilled

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
