### PR TITLE
feat(clone): allow to specify submodules to clone

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -156,6 +156,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -153,6 +153,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -152,6 +152,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -135,6 +135,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -50,6 +50,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -50,6 +50,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -57,6 +57,7 @@
 |shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -58,6 +58,7 @@
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
 |subdirectory| Subdirectory inside the `output` Workspace to clone the repo into.| source| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -21,6 +21,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |shortCommitLength|Length of short commit SHA|7|false|
 |sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
 |sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
+|submodulePaths|Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. |""|false|
 |submodules|Initialize and fetch git submodules.|true|false|
 |targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
 |url|Repository URL to clone from.||true|

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -86,6 +86,12 @@ spec:
         git remote.
       type: string
       default: "true"
+    - name: submodulePaths
+      description: |
+        Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched.
+        Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable.
+      type: string
+      default: ""
     - name: submodules
       description: Initialize and fetch git submodules.
       type: string
@@ -159,7 +165,7 @@ spec:
       optional: true
   steps:
     - name: clone
-      image: quay.io/konflux-ci/git-clone@sha256:bd303d16e9d9b01622d69deff77c583ebdea36611b15dc243da658d93763e8de
+      image: quay.io/konflux-ci/git-clone@sha256:8398a89bc2c6124dca4ffc66ffb2aa6d8f7acb3af9b1a51580abd3a66918a0ea
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
@@ -177,6 +183,8 @@ spec:
           value: $(params.refspec)
         - name: PARAM_SUBMODULES
           value: $(params.submodules)
+        - name: PARAM_SUBMODULE_PATHS
+          value: $(params.submodulePaths)
         - name: PARAM_DEPTH
           value: $(params.depth)
         - name: PARAM_SHORT_COMMIT_LENGTH
@@ -260,6 +268,7 @@ spec:
           -path="${CHECKOUT_DIR}" \
           -sslVerify="${PARAM_SSL_VERIFY}" \
           -submodules="${PARAM_SUBMODULES}" \
+          -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
           -depth="${PARAM_DEPTH}" \
           -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
           -retryMaxAttempts=10

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -9,6 +9,7 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |revision|Revision to checkout. (branch, tag, sha, ref, etc...)|""|false|
 |refspec|Refspec to fetch before checking out revision.|""|false|
 |submodules|Initialize and fetch git submodules.|true|false|
+|submodulePaths|Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. |""|false|
 |depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
 |shortCommitLength|Length of short commit SHA|7|false|
 |sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -29,6 +29,12 @@ spec:
     description: Initialize and fetch git submodules.
     name: submodules
     type: string
+  - name: submodulePaths
+    description: |
+      Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched.
+      Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable.
+    type: string
+    default: ""
   - default: "1"
     description: Perform a shallow clone, fetching only the most recent N commits.
     name: depth
@@ -130,6 +136,8 @@ spec:
       value: $(params.refspec)
     - name: PARAM_SUBMODULES
       value: $(params.submodules)
+    - name: PARAM_SUBMODULE_PATHS
+      value: $(params.submodulePaths)
     - name: PARAM_DEPTH
       value: $(params.depth)
     - name: PARAM_SHORT_COMMIT_LENGTH
@@ -170,7 +178,7 @@ spec:
       value: $(workspaces.basic-auth.bound)
     - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
       value: $(workspaces.basic-auth.path)
-    image: quay.io/konflux-ci/git-clone@sha256:bd303d16e9d9b01622d69deff77c583ebdea36611b15dc243da658d93763e8de
+    image: quay.io/konflux-ci/git-clone@sha256:8398a89bc2c6124dca4ffc66ffb2aa6d8f7acb3af9b1a51580abd3a66918a0ea
     computeResources: {}
     securityContext:
       runAsUser: 0
@@ -252,6 +260,7 @@ spec:
         -path="${CHECKOUT_DIR}" \
         -sslVerify="${PARAM_SSL_VERIFY}" \
         -submodules="${PARAM_SUBMODULES}" \
+        -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
         -depth="${PARAM_DEPTH}" \
         -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
         -retryMaxAttempts=10

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -87,6 +87,12 @@ spec:
       is not advised unless you are sure that you trust your git remote.
     name: sslVerify
     type: string
+  - default: ""
+    description: |
+      Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched.
+      Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable.
+    name: submodulePaths
+    type: string
   - default: "true"
     description: Initialize and fetch git submodules.
     name: submodules
@@ -159,6 +165,8 @@ spec:
       value: $(params.refspec)
     - name: PARAM_SUBMODULES
       value: $(params.submodules)
+    - name: PARAM_SUBMODULE_PATHS
+      value: $(params.submodulePaths)
     - name: PARAM_DEPTH
       value: $(params.depth)
     - name: PARAM_SHORT_COMMIT_LENGTH
@@ -193,7 +201,7 @@ spec:
       value: $(workspaces.basic-auth.path)
     - name: CHECKOUT_DIR
       value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:bd303d16e9d9b01622d69deff77c583ebdea36611b15dc243da658d93763e8de
+    image: quay.io/konflux-ci/git-clone@sha256:8398a89bc2c6124dca4ffc66ffb2aa6d8f7acb3af9b1a51580abd3a66918a0ea
     name: clone
     script: |
       #!/usr/bin/env sh
@@ -244,6 +252,7 @@ spec:
         -path="${CHECKOUT_DIR}" \
         -sslVerify="${PARAM_SSL_VERIFY}" \
         -submodules="${PARAM_SUBMODULES}" \
+        -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
         -depth="${PARAM_DEPTH}" \
         -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
         -retryMaxAttempts=10


### PR DESCRIPTION
Monorepos may have many submodules and not all of them are needed for every build. Allow users to specify which submodules should be cloned to save resources.

Default is that all submodules are cloned.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
