### PR TITLE
ensure correct digests are returned after format conversion

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -178,26 +178,39 @@ spec:
           exit 1
       fi
 
+      # Remove local cache to force remote 'inspect'.
+      # When 'buildah push' converts formats (e.g., OCI->Docker), it creates new
+      # digests in the registry, but the local cache becomes stale (retains old digests).
+      # This ensures we 'inspect' the correct post-conversion digests for SBOMs.
+      echo "Removing local manifest list: $IMAGE"
+      buildah manifest rm "$IMAGE"
+
       INDEX_REPOSITORY="$(echo "$IMAGE" | cut -d@ -f1 | cut -d: -f1)"
-      MANIFEST_DIGESTS=$(buildah manifest inspect "$IMAGE" | jq -er ".manifests[].digest")
+      PUSHED_INDEX_DIGEST=$(cat image-digest)
+      IMMUTABLE_INDEX_REF="${INDEX_REPOSITORY}@${PUSHED_INDEX_DIGEST}"
+      INSPECT_FILE="/index-build-data/manifest_data.json"
+
+      echo "Inspecting remote manifest index at: $IMMUTABLE_INDEX_REF"
+
+      if ! retry buildah manifest inspect "$IMMUTABLE_INDEX_REF" > "$INSPECT_FILE"
+      then
+          echo "Failed to inspect remote manifest index: $IMMUTABLE_INDEX_REF"
+          exit 1
+      fi
+
+      echo "Successfully inspected remote index, saved to $INSPECT_FILE"
+
+      MANIFEST_DIGESTS=$(jq -er ".manifests[].digest" "$INSPECT_FILE")
       image_manifests=""
       for i in $MANIFEST_DIGESTS
       do
         image_manifests="${image_manifests} ${INDEX_REPOSITORY}@${i},"
       done
 
-      cat image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$PUSHED_INDEX_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
       echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
-      {
-        echo -n "${IMAGE}@"
-        cat "image-digest"
-      } > "$(results.IMAGE_REF.path)"
+      echo -n "${IMMUTABLE_INDEX_REF}" > "$(results.IMAGE_REF.path)"
       echo -n "${image_manifests:1:-1}" > "$(results.IMAGES.path)"
-
-      # buildah manifest inspect will always give precedence to the local image.
-      # Since we built this image in the same place as we are inspecting it, we can
-      # just inspect it instead of finding the digest and inspecting the remote image.
-      buildah manifest inspect "$IMAGE" > /index-build-data/manifest_data.json
     securityContext:
       capabilities:
         add:

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -176,26 +176,39 @@ spec:
           exit 1
       fi
 
+      # Remove local cache to force remote 'inspect'.
+      # When 'buildah push' converts formats (e.g., OCI->Docker), it creates new
+      # digests in the registry, but the local cache becomes stale (retains old digests).
+      # This ensures we 'inspect' the correct post-conversion digests for SBOMs.
+      echo "Removing local manifest list: $IMAGE"
+      buildah manifest rm "$IMAGE"
+
       INDEX_REPOSITORY="$(echo "$IMAGE" | cut -d@ -f1 | cut -d: -f1)"
-      MANIFEST_DIGESTS=$(buildah manifest inspect "$IMAGE" | jq -er ".manifests[].digest")
+      PUSHED_INDEX_DIGEST=$(cat image-digest)
+      IMMUTABLE_INDEX_REF="${INDEX_REPOSITORY}@${PUSHED_INDEX_DIGEST}"
+      INSPECT_FILE="/index-build-data/manifest_data.json"
+
+      echo "Inspecting remote manifest index at: $IMMUTABLE_INDEX_REF"
+
+      if ! retry buildah manifest inspect "$IMMUTABLE_INDEX_REF" > "$INSPECT_FILE"
+      then
+          echo "Failed to inspect remote manifest index: $IMMUTABLE_INDEX_REF"
+          exit 1
+      fi
+
+      echo "Successfully inspected remote index, saved to $INSPECT_FILE"
+
+      MANIFEST_DIGESTS=$(jq -er ".manifests[].digest" "$INSPECT_FILE")
       image_manifests=""
       for i in $MANIFEST_DIGESTS
       do
         image_manifests="${image_manifests} ${INDEX_REPOSITORY}@${i},"
       done
 
-      cat image-digest | tee $(results.IMAGE_DIGEST.path)
+      echo -n "$PUSHED_INDEX_DIGEST" | tee "$(results.IMAGE_DIGEST.path)"
       echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
-      {
-        echo -n "${IMAGE}@"
-        cat "image-digest"
-      } > "$(results.IMAGE_REF.path)"
+      echo -n "${IMMUTABLE_INDEX_REF}" > "$(results.IMAGE_REF.path)"
       echo -n "${image_manifests:1:-1}" > "$(results.IMAGES.path)"
-
-      # buildah manifest inspect will always give precedence to the local image.
-      # Since we built this image in the same place as we are inspecting it, we can
-      # just inspect it instead of finding the digest and inspecting the remote image.
-      buildah manifest inspect "$IMAGE" > /index-build-data/manifest_data.json
     securityContext:
       capabilities:
         add:


### PR DESCRIPTION
When buildah push converts formats (e.g., OCI to Docker), it creates new remote digests. However, the task was inspecting a stale local cache and a floating tag, causing it to output the old digests. This broke downstream attestations, which targeted the wrong, pre-conversion manifests.

This commit fixes this by:
  - Clearing the local cache (buildah manifest rm) to force a remote lookup.
  - Inspecting the immutable digest-based reference (repo@sha256:...) from the image-digest file to avoid race conditions.

## Testing

I've tested the new task in [this PR](https://github.com/fmudry-konflux/devfile-sample-hello-world/pull/19) (see only `the last 2 commits`).
Commits:
  - First commit (second from last): the `new task` implementation
  - Second commit (last): Failed on ec as expected (see [the comment](https://github.com/fmudry-konflux/devfile-sample-hello-world/pull/19#issuecomment-3451514416))