### PR TITLE
Make labels.json obey the same ICM compat param as content-sets.json

### DIFF
--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -682,7 +682,12 @@ spec:
       jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
       echo "" >>"$dockerfile_copy"
-      echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      # Always write labels.json to the new standard location
+      echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+      # Conditionally write to the old location for backward compatibility
+      if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      fi
 
       # Make sure our labels.json file isn't filtered out
       containerignore=""

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -761,7 +761,12 @@ spec:
         jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
         echo "" >>"$dockerfile_copy"
-        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+        # Always write labels.json to the new standard location
+        echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+        # Conditionally write to the old location for backward compatibility
+        if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+          echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+        fi
 
         # Make sure our labels.json file isn't filtered out
         containerignore=""

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -795,7 +795,12 @@ spec:
       jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
       echo "" >>"$dockerfile_copy"
-      echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      # Always write labels.json to the new standard location
+      echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+      # Conditionally write to the old location for backward compatibility
+      if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      fi
 
       # Make sure our labels.json file isn't filtered out
       containerignore=""

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -764,7 +764,12 @@ spec:
       jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
       echo "" >>"$dockerfile_copy"
-      echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      # Always write labels.json to the new standard location
+      echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+      # Conditionally write to the old location for backward compatibility
+      if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      fi
 
       # Make sure our labels.json file isn't filtered out
       containerignore=""

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -666,7 +666,12 @@ spec:
       jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
       echo "" >>"$dockerfile_copy"
-      echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      # Always write labels.json to the new standard location
+      echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+      # Conditionally write to the old location for backward compatibility
+      if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      fi
 
       # Make sure our labels.json file isn't filtered out
       containerignore=""


### PR DESCRIPTION
For consistency, and so that labels.json can be present in the right place for bootc.

Related: https://github.com/konflux-ci/build-tasks-dockerfiles/pull/243