### PR TITLE
fix: skip empty user/group IDs in slack notification

### DIFF
--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -99,6 +99,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |shortCommitLength| Length of short commit SHA| 7| |
 |sparseCheckoutDirectories| Define the directory patterns to match or exclude when performing a sparse checkout.| | |
 |sslVerify| Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.| true| |
+|submodulePaths| Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. | | |
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|

--- a/task/slack-webhook-notification-oci-ta/0.1/slack-webhook-notification-oci-ta.yaml
+++ b/task/slack-webhook-notification-oci-ta/0.1/slack-webhook-notification-oci-ta.yaml
@@ -213,13 +213,17 @@ spec:
         # Add user mentions if user-ids are set
         user_mentions=""
         for user_id in "${USER_IDS[@]}"; do
-          user_mentions="${user_mentions}<@${user_id}> "
+          if [ -n "${user_id}" ]; then
+            user_mentions="${user_mentions}<@${user_id}> "
+          fi
         done
 
         # Add group mentions if group-ids are set
         group_mentions=""
         for group_id in "${GROUP_IDS[@]}"; do
-          group_mentions="${group_mentions}<!subteam^${group_id}> "
+          if [ -n "${group_id}" ]; then
+            group_mentions="${group_mentions}<!subteam^${group_id}> "
+          fi
         done
 
         # Prepend mentions to message

--- a/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+++ b/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
@@ -192,13 +192,17 @@ spec:
         # Add user mentions if user-ids are set
         user_mentions=""
         for user_id in "${USER_IDS[@]}"; do
-          user_mentions="${user_mentions}<@${user_id}> "
+          if [ -n "${user_id}" ]; then
+            user_mentions="${user_mentions}<@${user_id}> "
+          fi
         done
 
         # Add group mentions if group-ids are set
         group_mentions=""
         for group_id in "${GROUP_IDS[@]}"; do
-          group_mentions="${group_mentions}<!subteam^${group_id}> "
+          if [ -n "${group_id}" ]; then
+            group_mentions="${group_mentions}<!subteam^${group_id}> "
+          fi
         done
 
         # Prepend mentions to message


### PR DESCRIPTION
Add validation to skip empty strings when constructing user and group mentions for Slack notifications. This prevents malformed mentions like "<@> " from appearing in messages.

Assisted-by: Claude Code <noreply@anthropic.com>

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
