### PR TITLE
Isv 6411 + ISV-6412: Stop scanning source dir using Syft and make it configurable

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -80,6 +80,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
+|SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| | |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -77,6 +77,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
+|SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| | |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -76,6 +76,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
+|SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| | |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -78,6 +78,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
+|SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| | |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |

--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -154,6 +154,13 @@ spec:
       about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection'
     name: SBOM_SYFT_SELECT_CATALOGERS
     type: string
+  - default: "true"
+    description: Flag to enable or disable SBOM generation from source code. The scanner
+      of the source code is enabled only for non-hermetic builds and can be disabled
+      if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false
+      positives on source code scanning.
+    name: SBOM_SOURCE_SCAN_ENABLED
+    type: string
   - default: oci
     description: The format for the resulting image's mediaType. Valid values are
       oci (default) or docker.
@@ -269,6 +276,8 @@ spec:
       value: $(params.SBOM_TYPE)
     - name: SBOM_SYFT_SELECT_CATALOGERS
       value: $(params.SBOM_SYFT_SELECT_CATALOGERS)
+    - name: SBOM_SOURCE_SCAN_ENABLED
+      value: $(params.SBOM_SOURCE_SCAN_ENABLED)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
     - name: WORKINGDIR_MOUNT
@@ -985,17 +994,28 @@ spec:
 
       OCI_DIR="$(cat /shared/container_path)"
 
-      syft_args=(
+      syft_oci_args=(
         oci-dir:"${OCI_DIR}"
         --output "$syft_sbom_type=$(workspaces.source.path)/sbom-image.json"
       )
+      syft_source_args=(
+        dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT"
+        --output "$syft_sbom_type=$(workspaces.source.path)/sbom-source.json"
+      )
 
       if [ "${SBOM_SYFT_SELECT_CATALOGERS}" != "" ]; then
-        syft_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+        syft_oci_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+        syft_source_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
       fi
 
       echo "Running syft on the image"
-      syft "${syft_args[@]}"
+      syft "${syft_oci_args[@]}"
+      if [[ "${HERMETIC}" == "false" && "${SBOM_SOURCE_SCAN_ENABLED}" == "true" ]]; then
+        echo "Running syft on the source code"
+        syft "${syft_source_args[@]}"
+      else
+        echo "Skipping syft on source code."
+      fi
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:
@@ -1060,6 +1080,10 @@ spec:
         --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
         --base-image-digest-file "/shared/base_images_digests"
       )
+
+      if [ -f "$(workspaces.source.path)/sbom-source.json" ]; then
+        mobster_args+=(--from-syft "$(workspaces.source.path)/sbom-source.json")
+      fi
 
       if [ -f "$(workspaces.source.path)/sbom-prefetch.json" ]; then
         mobster_args+=(--from-hermeto "$(workspaces.source.path)/sbom-prefetch.json")

--- a/task/buildah-oci-ta/0.6/README.md
+++ b/task/buildah-oci-ta/0.6/README.md
@@ -35,6 +35,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|
 |PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
 |PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|proxy-ca-bundle|false|
+|SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -145,6 +145,13 @@ spec:
         from.
       type: string
       default: proxy-ca-bundle
+    - name: SBOM_SOURCE_SCAN_ENABLED
+      description: Flag to enable or disable SBOM generation from source code.
+        The scanner of the source code is enabled only for non-hermetic builds
+        and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn
+        off catalogers that cause false positives on source code scanning.
+      type: string
+      default: "true"
     - name: SBOM_SYFT_SELECT_CATALOGERS
       description: 'Extra option to customize Syft''s default catalogers when
         generating SBOMs. The value corresponds to Syft''s CLI flag --select-catalogers.
@@ -301,6 +308,8 @@ spec:
         value: $(params.INHERIT_BASE_IMAGE_LABELS)
       - name: PRIVILEGED_NESTED
         value: $(params.PRIVILEGED_NESTED)
+      - name: SBOM_SOURCE_SCAN_ENABLED
+        value: $(params.SBOM_SOURCE_SCAN_ENABLED)
       - name: SBOM_SYFT_SELECT_CATALOGERS
         value: $(params.SBOM_SYFT_SELECT_CATALOGERS)
       - name: SBOM_TYPE
@@ -1063,17 +1072,28 @@ spec:
 
         OCI_DIR="$(cat /shared/container_path)"
 
-        syft_args=(
+        syft_oci_args=(
           oci-dir:"${OCI_DIR}"
           --output "$syft_sbom_type=/var/workdir/sbom-image.json"
         )
+        syft_source_args=(
+          dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT"
+          --output "$syft_sbom_type=/var/workdir/sbom-source.json"
+        )
 
         if [ "${SBOM_SYFT_SELECT_CATALOGERS}" != "" ]; then
-          syft_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+          syft_oci_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+          syft_source_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
         fi
 
         echo "Running syft on the image"
-        syft "${syft_args[@]}"
+        syft "${syft_oci_args[@]}"
+        if [[ "${HERMETIC}" == "false" && "${SBOM_SOURCE_SCAN_ENABLED}" == "true" ]]; then
+          echo "Running syft on the source code"
+          syft "${syft_source_args[@]}"
+        else
+          echo "Skipping syft on source code."
+        fi
 
         echo "[$(date --utc -Ins)] End sbom-syft-generate"
     - name: prepare-sboms
@@ -1126,6 +1146,10 @@ spec:
           --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
           --base-image-digest-file "/shared/base_images_digests"
         )
+
+        if [ -f "/var/workdir/sbom-source.json" ]; then
+          mobster_args+=(--from-syft "/var/workdir/sbom-source.json")
+        fi
 
         if [ -f "/var/workdir/sbom-prefetch.json" ]; then
           mobster_args+=(--from-hermeto "/var/workdir/sbom-prefetch.json")

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -141,6 +141,13 @@ spec:
     description: The name of the ConfigMap to read proxy CA bundle data from.
     name: PROXY_CA_TRUST_CONFIG_MAP_NAME
     type: string
+  - default: "true"
+    description: Flag to enable or disable SBOM generation from source code. The scanner
+      of the source code is enabled only for non-hermetic builds and can be disabled
+      if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false
+      positives on source code scanning.
+    name: SBOM_SOURCE_SCAN_ENABLED
+    type: string
   - default: ""
     description: 'Extra option to customize Syft''s default catalogers when generating
       SBOMs. The value corresponds to Syft''s CLI flag --select-catalogers. The details
@@ -270,6 +277,8 @@ spec:
       value: $(params.INHERIT_BASE_IMAGE_LABELS)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: SBOM_SOURCE_SCAN_ENABLED
+      value: $(params.SBOM_SOURCE_SCAN_ENABLED)
     - name: SBOM_SYFT_SELECT_CATALOGERS
       value: $(params.SBOM_SYFT_SELECT_CATALOGERS)
     - name: SBOM_TYPE
@@ -1010,6 +1019,7 @@ spec:
           -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
           -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
           -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e SBOM_SOURCE_SCAN_ENABLED="${SBOM_SOURCE_SCAN_ENABLED@Q}" \
           -e SBOM_SYFT_SELECT_CATALOGERS="${SBOM_SYFT_SELECT_CATALOGERS@Q}" \
           -e SBOM_TYPE="${SBOM_TYPE@Q}" \
           -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
@@ -1198,17 +1208,28 @@ spec:
 
       OCI_DIR="$(cat /shared/container_path)"
 
-      syft_args=(
+      syft_oci_args=(
         oci-dir:"${OCI_DIR}"
         --output "$syft_sbom_type=/var/workdir/sbom-image.json"
       )
+      syft_source_args=(
+        dir:"/var/workdir/$SOURCE_CODE_DIR/$CONTEXT"
+        --output "$syft_sbom_type=/var/workdir/sbom-source.json"
+      )
 
       if [ "${SBOM_SYFT_SELECT_CATALOGERS}" != "" ]; then
-        syft_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+        syft_oci_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+        syft_source_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
       fi
 
       echo "Running syft on the image"
-      syft "${syft_args[@]}"
+      syft "${syft_oci_args[@]}"
+      if [[ "${HERMETIC}" == "false" && "${SBOM_SOURCE_SCAN_ENABLED}" == "true" ]]; then
+        echo "Running syft on the source code"
+        syft "${syft_source_args[@]}"
+      else
+        echo "Skipping syft on source code."
+      fi
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:
@@ -1280,6 +1301,10 @@ spec:
         --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
         --base-image-digest-file "/shared/base_images_digests"
       )
+
+      if [ -f "/var/workdir/sbom-source.json" ]; then
+        mobster_args+=(--from-syft "/var/workdir/sbom-source.json")
+      fi
 
       if [ -f "/var/workdir/sbom-prefetch.json" ]; then
         mobster_args+=(--from-hermeto "/var/workdir/sbom-prefetch.json")

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -154,6 +154,13 @@ spec:
       about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection'
     name: SBOM_SYFT_SELECT_CATALOGERS
     type: string
+  - default: "true"
+    description: Flag to enable or disable SBOM generation from source code. The scanner
+      of the source code is enabled only for non-hermetic builds and can be disabled
+      if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false
+      positives on source code scanning.
+    name: SBOM_SOURCE_SCAN_ENABLED
+    type: string
   - default: oci
     description: The format for the resulting image's mediaType. Valid values are
       oci (default) or docker.
@@ -277,6 +284,8 @@ spec:
       value: $(params.SBOM_TYPE)
     - name: SBOM_SYFT_SELECT_CATALOGERS
       value: $(params.SBOM_SYFT_SELECT_CATALOGERS)
+    - name: SBOM_SOURCE_SCAN_ENABLED
+      value: $(params.SBOM_SOURCE_SCAN_ENABLED)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
     - name: WORKINGDIR_MOUNT
@@ -988,6 +997,7 @@ spec:
           -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
           -e SBOM_TYPE="${SBOM_TYPE@Q}" \
           -e SBOM_SYFT_SELECT_CATALOGERS="${SBOM_SYFT_SELECT_CATALOGERS@Q}" \
+          -e SBOM_SOURCE_SCAN_ENABLED="${SBOM_SOURCE_SCAN_ENABLED@Q}" \
           -e ANNOTATIONS_FILE="${ANNOTATIONS_FILE@Q}" \
           -e WORKINGDIR_MOUNT="${WORKINGDIR_MOUNT@Q}" \
           -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
@@ -1168,17 +1178,28 @@ spec:
 
       OCI_DIR="$(cat /shared/container_path)"
 
-      syft_args=(
+      syft_oci_args=(
         oci-dir:"${OCI_DIR}"
         --output "$syft_sbom_type=$(workspaces.source.path)/sbom-image.json"
       )
+      syft_source_args=(
+        dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT"
+        --output "$syft_sbom_type=$(workspaces.source.path)/sbom-source.json"
+      )
 
       if [ "${SBOM_SYFT_SELECT_CATALOGERS}" != "" ]; then
-        syft_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+        syft_oci_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+        syft_source_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
       fi
 
       echo "Running syft on the image"
-      syft "${syft_args[@]}"
+      syft "${syft_oci_args[@]}"
+      if [[ "${HERMETIC}" == "false" && "${SBOM_SOURCE_SCAN_ENABLED}" == "true" ]]; then
+        echo "Running syft on the source code"
+        syft "${syft_source_args[@]}"
+      else
+        echo "Skipping syft on source code."
+      fi
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:
@@ -1247,6 +1268,10 @@ spec:
         --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
         --base-image-digest-file "/shared/base_images_digests"
       )
+
+      if [ -f "$(workspaces.source.path)/sbom-source.json" ]; then
+        mobster_args+=(--from-syft "$(workspaces.source.path)/sbom-source.json")
+      fi
 
       if [ -f "$(workspaces.source.path)/sbom-prefetch.json" ]; then
         mobster_args+=(--from-hermeto "$(workspaces.source.path)/sbom-prefetch.json")

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -140,6 +140,14 @@ spec:
       https://github.com/anchore/syft/wiki/Package-Cataloger-Selection
     type: string
     default: ""
+  - name: SBOM_SOURCE_SCAN_ENABLED
+    description: >-
+      Flag to enable or disable SBOM generation from source code. The scanner
+      of the source code is enabled only for non-hermetic builds and can be disabled if
+      the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false
+      positives on source code scanning.
+    type: string
+    default: "true"
   - name: BUILDAH_FORMAT
     description: The format for the resulting image's mediaType. Valid values are oci (default) or docker.
     type: string
@@ -255,6 +263,8 @@ spec:
       value: $(params.SBOM_TYPE)
     - name: SBOM_SYFT_SELECT_CATALOGERS
       value: $(params.SBOM_SYFT_SELECT_CATALOGERS)
+    - name: SBOM_SOURCE_SCAN_ENABLED
+      value: $(params.SBOM_SOURCE_SCAN_ENABLED)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
     - name: WORKINGDIR_MOUNT
@@ -977,17 +987,28 @@ spec:
 
       OCI_DIR="$(cat /shared/container_path)"
 
-      syft_args=(
+      syft_oci_args=(
         oci-dir:"${OCI_DIR}"
         --output "$syft_sbom_type=$(workspaces.source.path)/sbom-image.json"
       )
+      syft_source_args=(
+        dir:"$(workspaces.source.path)/$SOURCE_CODE_DIR/$CONTEXT"
+        --output "$syft_sbom_type=$(workspaces.source.path)/sbom-source.json"
+      )
 
       if [ "${SBOM_SYFT_SELECT_CATALOGERS}" != "" ]; then
-        syft_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+        syft_oci_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
+        syft_source_args+=(--select-catalogers "${SBOM_SYFT_SELECT_CATALOGERS}")
       fi
 
       echo "Running syft on the image"
-      syft "${syft_args[@]}"
+      syft "${syft_oci_args[@]}"
+      if [[ "${HERMETIC}" == "false" && "${SBOM_SOURCE_SCAN_ENABLED}" == "true" ]]; then
+        echo "Running syft on the source code"
+        syft "${syft_source_args[@]}"
+      else
+        echo "Skipping syft on source code."
+      fi
 
       echo "[$(date --utc -Ins)] End sbom-syft-generate"
     volumeMounts:
@@ -1052,6 +1073,10 @@ spec:
         --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
         --base-image-digest-file "/shared/base_images_digests"
       )
+
+      if [ -f "$(workspaces.source.path)/sbom-source.json" ]; then
+        mobster_args+=(--from-syft "$(workspaces.source.path)/sbom-source.json")
+      fi
 
       if [ -f "$(workspaces.source.path)/sbom-prefetch.json" ]; then
         mobster_args+=(--from-hermeto "$(workspaces.source.path)/sbom-prefetch.json")


### PR DESCRIPTION
This pull request combines 2 separate jiras but since they are interconnected, I am opening one PR for both.

feat([ISV-6412](https://issues.redhat.com//browse/ISV-6412)): Stop scanning source code using Syft
    
Based on the agreement with ProdSec we are removing the Syft scan of the
source directory. Scanning a source code (git repo) leads to SBOMs with
packages that are not in the product/image itself. It produces a lot of
false positives in the CVE remediation and makes SBOMs bigger than
needed.

feat([ISV-6411](https://issues.redhat.com//browse/ISV-6411)): Add task param to customize Syft catalogers

For subset of the product team the default set of Syft catalogers is not
optimal and brings more false positives. This change make the Syft
catalogers cofigurable.

JIRA: [ISV-6411](https://issues.redhat.com//browse/ISV-6411) [ISV-6412](https://issues.redhat.com//browse/ISV-6412)
