### PR TITLE
feat(KONFLUX-1486): Add IMAGE_NAMING_STRATEGY parameter to ko builder.

### DIFF
--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -116,6 +116,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |COMMIT_SHA| The image is built from this commit.| | '$(tasks.clone-repository.results.commit)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | '$(params.image-expires-after)'|
+|IMAGE_NAMING_STRATEGY| One of --base-import-paths, --bare, or --preserve-import-paths| --base-import-paths| |
 |IMPORT_PATH| import path of package main| .| '$(params.import-path)'|
 |KO_DEFAULTBASEIMAGE| base image for ko build| | '$(params.default-base-image)'|
 |KO_DOCKER_REPO| Container repository where to push images built with ko| | '$(params.ko-docker-repo)'|

--- a/task/ko-oci-ta/0.1/ko-oci-ta.yaml
+++ b/task/ko-oci-ta/0.1/ko-oci-ta.yaml
@@ -25,6 +25,9 @@ spec:
         hours, days, and weeks, respectively.
       type: string
       default: ""
+    - name: IMAGE_NAMING_STRATEGY
+      description: One of --base-import-paths, --bare, or --preserve-import-paths
+      default: --base-import-paths
     - name: IMPORT_PATH
       description: import path of package main
       default: .
@@ -120,13 +123,18 @@ spec:
         #!/bin/bash
         set -euo pipefail
 
+        if [ "${IMAGE_NAMING_STRATEGY}" != "--base-import-paths" ] && [ "${IMAGE_NAMING_STRATEGY}" != "--bare" ] && [ "${IMAGE_NAMING_STRATEGY}" != "--preserve-import-paths" ]; then
+            echo "Invalid value specified for IMAGE_NAMING_STRATEGY: ${IMAGE_NAMING_STRATEGY}"
+            exit 1
+        fi
+
         [ -n "${DEFAULT_BASEIMAGE}" ] && KO_DEFAULTBASEIMAGE="${DEFAULT_BASEIMAGE}" && export KO_DEFAULTBASEIMAGE
 
         labels="architecture=$(uname -m),vcs-type=git,build-date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
         [ -n "${COMMIT_SHA}" ] && labels+=",vcs-ref=${COMMIT_SHA}"
         [ -n "${IMAGE_EXPIRES_AFTER}" ] && labels+=",quay.expires-after=${IMAGE_EXPIRES_AFTER})"
 
-        args=(--base-import-paths --image-label "${labels}")
+        args=("${IMAGE_NAMING_STRATEGY}" --image-label "${labels}")
         [ -n "${TAG}" ] && args+=(-t "${TAG}")
 
         ko build "${args[@]}" "${IMPORT_PATH}" 2>&1 | tee /tmp/build.log


### PR DESCRIPTION
Allow the user to specify the image naming strategy for a `ko` build. If not specified, the default value (--base-import-paths) is used which results in the task behaving the same as before this change.

Note that this change is backward compatible.