### PR TITLE
feat: git-clone, git-clone-oci-ta: support merging target branch from different repo

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -156,6 +156,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| ""| '$(params.image-expires-after)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -153,6 +153,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| ""| '$(params.image-expires-after)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -153,6 +153,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |gitInitImage| Deprecated. Has no effect. Will be removed in the future.| ""| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |refspec| Refspec to fetch before checking out revision.| ""| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -136,6 +136,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| ""| '$(params.image-expires-after)'|

--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -92,6 +92,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| ""| '$(params.image-expires-after)'|

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -43,6 +43,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| ""| '$(params.image-expires-after)'|

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -44,6 +44,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |gitInitImage| Deprecated. Has no effect. Will be removed in the future.| ""| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |refspec| Refspec to fetch before checking out revision.| ""| |

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -50,6 +50,8 @@
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| ""| '$(params.image-expires-after)'|

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -52,6 +52,8 @@
 |gitInitImage| Deprecated. Has no effect. Will be removed in the future.| ""| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
+|mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
 |noProxy| Opt out of proxying HTTP/HTTPS requests.| ""| |
 |refspec| Refspec to fetch before checking out revision.| ""| |

--- a/task/git-clone-oci-ta/0.1/README.md
+++ b/task/git-clone-oci-ta/0.1/README.md
@@ -12,6 +12,8 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |fetchTags|Fetch all tags for the repo.|false|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. |""|false|
+|mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. |""|false|
 |mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
 |noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
 |ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -46,6 +46,18 @@ spec:
       description: HTTPS proxy server for SSL requests.
       type: string
       default: ""
+    - name: mergeSourceDepth
+      description: |
+        Perform a shallow fetch of the target branch, fetching only the most recent N commits.
+        If empty, fetches the full history of the target branch.
+      type: string
+      default: ""
+    - name: mergeSourceRepoUrl
+      description: |
+        URL of the repository to fetch the target branch from when mergeTargetBranch is true.
+        If empty, uses the same repository (origin). This allows merging a branch from a different repository.
+      type: string
+      default: ""
     - name: mergeTargetBranch
       description: Set to "true" to merge the targetBranch into the checked-out
         revision.
@@ -209,6 +221,10 @@ spec:
           value: $(params.mergeTargetBranch)
         - name: PARAM_TARGET_BRANCH
           value: $(params.targetBranch)
+        - name: PARAM_MERGE_SOURCE_REPO_URL
+          value: $(params.mergeSourceRepoUrl)
+        - name: PARAM_MERGE_SOURCE_DEPTH
+          value: $(params.mergeSourceDepth)
         - name: WORKSPACE_SSH_DIRECTORY_BOUND
           value: $(workspaces.ssh-directory.bound)
         - name: WORKSPACE_SSH_DIRECTORY_PATH
@@ -281,17 +297,55 @@ spec:
         fi
         if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
           echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
-          echo "Fetching target branch '${PARAM_TARGET_BRANCH}'..."
-          retry git fetch origin "${PARAM_TARGET_BRANCH}"
+
+          if [ "${PARAM_DEPTH}" = "1" ]; then
+            echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
+          fi
+
+          if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
+            echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
+          fi
+
+          # Determine if merging from a different repository or the same one
+          if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
+            # Normalize URLs for comparison (remove trailing slashes and .git suffix)
+            normalize_url() {
+              echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
+            }
+
+            NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
+            NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
+
+            if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
+              echo "Merge source URL is the same as origin. Using existing 'origin' remote."
+              MERGE_REMOTE="origin"
+            else
+              echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
+              echo "Adding remote 'merge-source'..."
+              git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
+              MERGE_REMOTE="merge-source"
+            fi
+          else
+            echo "Merging from the same repository (origin)"
+            MERGE_REMOTE="origin"
+          fi
+
+          echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
+          if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
+            retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+          else
+            retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+          fi
           FETCH_EXIT_CODE="$?"
           if [ "${FETCH_EXIT_CODE}" != "0" ]; then
-            echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}'." >&2
+            echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}." >&2
             exit "${FETCH_EXIT_CODE}"
           fi
-          echo "Merging origin/${PARAM_TARGET_BRANCH} into current HEAD..."
+
+          echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
           git config --global user.email "tekton-git-clone@tekton.dev"
           git config --global user.name "Tekton Git Clone Task"
-          git merge "origin/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
+          git merge "${MERGE_REMOTE}/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
           MERGE_CHECK_EXIT_CODE="$?"
           if [ "${MERGE_CHECK_EXIT_CODE}" != "0" ]; then
             echo "ERROR: Merge conflict detected or merge failed before commit." >&2
@@ -305,7 +359,7 @@ spec:
               echo "No diff was found, skipping merge..." >&2
             else
               echo "Merge successful (no conflicts found), committing..."
-              git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+              git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"
               COMMIT_EXIT_CODE="$?"
               if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
                 echo "ERROR: Failed to commit merge." >&2

--- a/task/git-clone/0.1/README.md
+++ b/task/git-clone/0.1/README.md
@@ -28,6 +28,8 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
 |targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
+|mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository.|""|false|
+|mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch.|""|false|
 
 ## Results
 |name|description|

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -108,6 +108,18 @@ spec:
     description: The target branch to merge into the revision (if mergeTargetBranch is true).
     type: string
     default: "main"
+  - name: mergeSourceRepoUrl
+    description: |
+      URL of the repository to fetch the target branch from when mergeTargetBranch is true.
+      If empty, uses the same repository (origin). This allows merging a branch from a different repository.
+    type: string
+    default: ""
+  - name: mergeSourceDepth
+    description: |
+      Perform a shallow fetch of the target branch, fetching only the most recent N commits.
+      If empty, fetches the full history of the target branch.
+    type: string
+    default: ""
   results:
   - description: The precise commit SHA that was fetched by this Task.
     name: commit
@@ -168,6 +180,10 @@ spec:
       value: $(params.mergeTargetBranch)
     - name: PARAM_TARGET_BRANCH
       value: $(params.targetBranch)
+    - name: PARAM_MERGE_SOURCE_REPO_URL
+      value: $(params.mergeSourceRepoUrl)
+    - name: PARAM_MERGE_SOURCE_DEPTH
+      value: $(params.mergeSourceDepth)
     - name: WORKSPACE_OUTPUT_PATH
       value: $(workspaces.output.path)
     - name: WORKSPACE_SSH_DIRECTORY_BOUND
@@ -273,17 +289,55 @@ spec:
       fi
       if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
         echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
-        echo "Fetching target branch '${PARAM_TARGET_BRANCH}'..."
-        retry git fetch origin "${PARAM_TARGET_BRANCH}"
+
+        if [ "${PARAM_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        # Determine if merging from a different repository or the same one
+        if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
+          # Normalize URLs for comparison (remove trailing slashes and .git suffix)
+          normalize_url() {
+            echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
+          }
+
+          NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
+          NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
+
+          if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
+            echo "Merge source URL is the same as origin. Using existing 'origin' remote."
+            MERGE_REMOTE="origin"
+          else
+            echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
+            echo "Adding remote 'merge-source'..."
+            git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
+            MERGE_REMOTE="merge-source"
+          fi
+        else
+          echo "Merging from the same repository (origin)"
+          MERGE_REMOTE="origin"
+        fi
+
+        echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
+        if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
+          retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        else
+          retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        fi
         FETCH_EXIT_CODE="$?"
         if [ "${FETCH_EXIT_CODE}" != "0" ]; then
-          echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}'." >&2
+          echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}." >&2
           exit "${FETCH_EXIT_CODE}"
         fi
-        echo "Merging origin/${PARAM_TARGET_BRANCH} into current HEAD..."
+
+        echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
         git config --global user.email "tekton-git-clone@tekton.dev"
         git config --global user.name "Tekton Git Clone Task"
-        git merge "origin/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
+        git merge "${MERGE_REMOTE}/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
         MERGE_CHECK_EXIT_CODE="$?"
         if [ "${MERGE_CHECK_EXIT_CODE}" != "0" ] ; then
           echo "ERROR: Merge conflict detected or merge failed before commit." >&2
@@ -297,7 +351,7 @@ spec:
             echo "No diff was found, skipping merge..." >&2
           else
             echo "Merge successful (no conflicts found), committing..."
-            git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+            git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"
             COMMIT_EXIT_CODE="$?"
             if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
               echo "ERROR: Failed to commit merge." >&2

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -49,6 +49,18 @@ spec:
     description: HTTPS proxy server for SSL requests.
     name: httpsProxy
     type: string
+  - default: ""
+    description: |
+      Perform a shallow fetch of the target branch, fetching only the most recent N commits.
+      If empty, fetches the full history of the target branch.
+    name: mergeSourceDepth
+    type: string
+  - default: ""
+    description: |
+      URL of the repository to fetch the target branch from when mergeTargetBranch is true.
+      If empty, uses the same repository (origin). This allows merging a branch from a different repository.
+    name: mergeSourceRepoUrl
+    type: string
   - default: "false"
     description: Set to "true" to merge the targetBranch into the checked-out revision.
     name: mergeTargetBranch
@@ -191,6 +203,10 @@ spec:
       value: $(params.mergeTargetBranch)
     - name: PARAM_TARGET_BRANCH
       value: $(params.targetBranch)
+    - name: PARAM_MERGE_SOURCE_REPO_URL
+      value: $(params.mergeSourceRepoUrl)
+    - name: PARAM_MERGE_SOURCE_DEPTH
+      value: $(params.mergeSourceDepth)
     - name: WORKSPACE_SSH_DIRECTORY_BOUND
       value: $(workspaces.ssh-directory.bound)
     - name: WORKSPACE_SSH_DIRECTORY_PATH
@@ -265,17 +281,55 @@ spec:
       fi
       if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
         echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
-        echo "Fetching target branch '${PARAM_TARGET_BRANCH}'..."
-        retry git fetch origin "${PARAM_TARGET_BRANCH}"
+
+        if [ "${PARAM_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        # Determine if merging from a different repository or the same one
+        if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
+          # Normalize URLs for comparison (remove trailing slashes and .git suffix)
+          normalize_url() {
+            echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
+          }
+
+          NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
+          NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
+
+          if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
+            echo "Merge source URL is the same as origin. Using existing 'origin' remote."
+            MERGE_REMOTE="origin"
+          else
+            echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
+            echo "Adding remote 'merge-source'..."
+            git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
+            MERGE_REMOTE="merge-source"
+          fi
+        else
+          echo "Merging from the same repository (origin)"
+          MERGE_REMOTE="origin"
+        fi
+
+        echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
+        if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
+          retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        else
+          retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        fi
         FETCH_EXIT_CODE="$?"
         if [ "${FETCH_EXIT_CODE}" != "0" ]; then
-          echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}'." >&2
+          echo "ERROR: Failed to fetch target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}." >&2
           exit "${FETCH_EXIT_CODE}"
         fi
-        echo "Merging origin/${PARAM_TARGET_BRANCH} into current HEAD..."
+
+        echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
         git config --global user.email "tekton-git-clone@tekton.dev"
         git config --global user.name "Tekton Git Clone Task"
-        git merge "origin/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
+        git merge "${MERGE_REMOTE}/${PARAM_TARGET_BRANCH}" --no-commit --no-ff --allow-unrelated-histories
         MERGE_CHECK_EXIT_CODE="$?"
         if [ "${MERGE_CHECK_EXIT_CODE}" != "0" ]; then
           echo "ERROR: Merge conflict detected or merge failed before commit." >&2
@@ -289,7 +343,7 @@ spec:
             echo "No diff was found, skipping merge..." >&2
           else
             echo "Merge successful (no conflicts found), committing..."
-            git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' into ${RESULT_SHA}"
+            git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"
             COMMIT_EXIT_CODE="$?"
             if [ "${COMMIT_EXIT_CODE}" != "0" ]; then
               echo "ERROR: Failed to commit merge." >&2


### PR DESCRIPTION
Add ability to merge target branch from a different repository when using mergeTargetBranch parameter.

New parameters:
- mergeSourceRepoUrl: URL of repo to fetch target branch from
- mergeSourceDepth: shallow fetch depth for target branch

The task normalizes URLs to detect when mergeSourceRepoUrl matches the cloned repo, avoiding duplicate remotes. Includes warnings when using shallow clones with merge operations.

Changes are backward-compatible, and behavior is unchanged if mergeSourceRepoUrl is not provided.

Assisted-by: Claude <noreply@anthropic.com>
