### PR TITLE
fix: syft image was not multi-arch

### DIFF
--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -969,7 +969,7 @@ spec:
       name: trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28
+  - image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:15ed82f0b5311a570ccb8ea02135d9776c6d61e545c51b256b3fc5b5db20ba67
     name: sbom-syft-generate
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -1036,7 +1036,7 @@ spec:
             - SETFCAP
         runAsUser: 0
     - name: sbom-syft-generate
-      image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28
+      image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:15ed82f0b5311a570ccb8ea02135d9776c6d61e545c51b256b3fc5b5db20ba67
       workingDir: /var/workdir/source
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -1177,7 +1177,7 @@ spec:
       readOnly: true
     workingDir: /var/workdir
   - computeResources: {}
-    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:15ed82f0b5311a570ccb8ea02135d9776c6d61e545c51b256b3fc5b5db20ba67
     name: sbom-syft-generate
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -1149,7 +1149,7 @@ spec:
       readOnly: true
     workingDir: $(workspaces.source.path)
   - computeResources: {}
-    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:15ed82f0b5311a570ccb8ea02135d9776c6d61e545c51b256b3fc5b5db20ba67
     name: sbom-syft-generate
     script: |
       #!/bin/bash

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -960,7 +960,7 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: sbom-syft-generate
-    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:dc0da6b4448428e625271b542cc029ab03de92f75ea50d6d63b1d088d20bbd28
+    image: registry.access.redhat.com/rh-syft-tech-preview/syft-rhel9:1.29.0@sha256:15ed82f0b5311a570ccb8ea02135d9776c6d61e545c51b256b3fc5b5db20ba67
     # Respect Syft configuration if the user has it in the root of their repository
     # (need to set the workdir, see https://github.com/anchore/syft/issues/2465)
     workingDir: $(workspaces.source.path)/source


### PR DESCRIPTION
Changing the Syft image used to be multi-arch. The tag itself is pushed with a multi-arch image index but the digest was pinned to a specific image manifest. When the change was made to the original image, Renovate will not update to an image index. Instead, it will update the digest to digest of the matching image manifest.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
