### PR TITLE
feat(ISV-6451): added SBOM_SKIP_VALIDATION to mobster-related tasks

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -43,6 +43,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-images.results.IMAGE_REF[*])']'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |
@@ -82,6 +83,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -42,6 +42,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |
@@ -79,6 +80,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -42,6 +42,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |
@@ -78,6 +79,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -41,6 +41,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-images.results.IMAGE_REF[*])']'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |
@@ -80,6 +81,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |

--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -39,6 +39,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -24,6 +24,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| Reference of the OCI-Artifact this build task will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
 |PREFETCH_ROOT| The root directory of the artifacts under the prefetched directory. Will be kept in the maven zip as the top directory for all artifacts.| maven-repository| |
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 ### coverity-availability-check:0.2 task parameters

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -23,6 +23,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| Reference of the OCI-Artifact this build task will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
 |PREFETCH_ROOT| The root directory of the artifacts under the prefetched directory. Will be kept in the maven zip as the top directory for all artifacts.| maven-repository| |
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 ### coverity-availability-check:0.2 task parameters

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -34,6 +34,7 @@
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -34,6 +34,7 @@
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time resulting in garbage collection of the digest. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| vfs| |
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |

--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -42,6 +42,10 @@ spec:
     description: The format for the resulting image's mediaType. Valid values are oci (default) or docker.
     type: string
     default: oci
+  - name: SBOM_SKIP_VALIDATION
+    description: Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.
+    type: string
+    default: "false"
   - name: caTrustConfigMapName
     type: string
     description: The name of the ConfigMap to read CA bundle data from
@@ -225,7 +229,7 @@ spec:
         add:
           - SETFCAP
 
-  - image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+  - image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
     name: create-sbom
     computeResources:
       limits:
@@ -246,12 +250,20 @@ spec:
       IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
       IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
       echo "Creating SBOM result file..."
-      mobster generate \
-        --output /index-build-data/index.spdx.json \
-        oci-index \
-        --index-image-pullspec "$IMAGE_URL" \
-        --index-image-digest "$IMAGE_DIGEST" \
-        --index-manifest-path "$MANIFEST_DATA_FILE" \
+      mobster_args=(generate --output /index-build-data/index.spdx.json)
+
+      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+        echo "Skipping SBOM validation"
+        mobster_args+=(--skip-validation)
+      fi
+
+      mobster_args+=(
+        oci-index
+        --index-image-pullspec "$IMAGE_URL"
+        --index-image-digest "$IMAGE_DIGEST"
+        --index-manifest-path "$MANIFEST_DATA_FILE"
+      )
+      mobster "${mobster_args[@]}"
 
   - name: upload-sbom
     image: quay.io/konflux-ci/appstudio-utils:latest@sha256:b7bb649b8bec2cd59ab92e0a633ade7e80e08dc8a62f9577bd0ad8847e52a26d

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -49,6 +49,11 @@ spec:
       oci (default) or docker.
     name: BUILDAH_FORMAT
     type: string
+  - default: "false"
+    description: Flag to enable or disable SBOM validation before save. Validation
+      is optional - use this if you are experiencing performance issues.
+    name: SBOM_SKIP_VALIDATION
+    type: string
   - default: trusted-ca
     description: The name of the ConfigMap to read CA bundle data from
     name: caTrustConfigMapName
@@ -228,7 +233,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
     name: create-sbom
     script: |
       #!/bin/bash
@@ -243,12 +248,20 @@ spec:
       IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
       IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
       echo "Creating SBOM result file..."
-      mobster generate \
-        --output /index-build-data/index.spdx.json \
-        oci-index \
-        --index-image-pullspec "$IMAGE_URL" \
-        --index-image-digest "$IMAGE_DIGEST" \
-        --index-manifest-path "$MANIFEST_DATA_FILE" \
+      mobster_args=(generate --output /index-build-data/index.spdx.json)
+
+      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+        echo "Skipping SBOM validation"
+        mobster_args+=(--skip-validation)
+      fi
+
+      mobster_args+=(
+        oci-index
+        --index-image-pullspec "$IMAGE_URL"
+        --index-image-digest "$IMAGE_DIGEST"
+        --index-manifest-path "$MANIFEST_DATA_FILE"
+      )
+      mobster "${mobster_args[@]}"
   - computeResources:
       limits:
         memory: 512Mi

--- a/task/build-maven-zip-oci-ta/0.1/README.md
+++ b/task/build-maven-zip-oci-ta/0.1/README.md
@@ -12,6 +12,7 @@ Note that this task needs the output of prefetch-dependencies task. If it is not
 |IMAGE|Reference of the OCI-Artifact this build task will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |PREFETCH_ROOT|The root directory of the artifacts under the prefetched directory. Will be kept in the maven zip as the top directory for all artifacts.|maven-repository|false|
+|SBOM_SKIP_VALIDATION|Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.|false|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 

--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -39,6 +39,12 @@ spec:
         all artifacts.
       type: string
       default: maven-repository
+    - name: SBOM_SKIP_VALIDATION
+      description: Flag to enable or disable SBOM validation before save.
+        Validation is optional - use this if you are experiencing performance
+        issues.
+      type: string
+      default: "false"
     - name: caTrustConfigMapKey
       description: The name of the key in the ConfigMap that contains the
         CA bundle data.
@@ -82,6 +88,8 @@ spec:
         value: $(params.IMAGE_EXPIRES_AFTER)
       - name: PKG_ROOT
         value: $(params.PREFETCH_ROOT)
+      - name: SBOM_SKIP_VALIDATION
+        value: $(params.SBOM_SKIP_VALIDATION)
     volumeMounts:
       - mountPath: /shared
         name: shared
@@ -174,7 +182,7 @@ spec:
           add:
             - SETFCAP
     - name: save-sbom
-      image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+      image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca
@@ -189,12 +197,18 @@ spec:
 
         # Use Mobster to generate maven-zip SBOM file using the Hermeto (Cachi2) output
         if [ -f "/var/workdir/cachi2/output/bom.json" ]; then
-          mobster generate \
-            --output sbom.json \
-            oci-image \
-            --from-hermeto "/var/workdir/cachi2/output/bom.json" \
-            --image-pullspec "$IMAGE_URL" \
+          mobster_args=(generate --output sbom.json)
+          if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+            echo "Skipping SBOM validation"
+            mobster_args+=(--skip-validation)
+          fi
+          mobster_args+=(
+            oci-image
+            --from-hermeto "/var/workdir/cachi2/output/bom.json"
+            --image-pullspec "$IMAGE_URL"
             --image-digest "$IMAGE_DIGEST"
+          )
+          mobster "${mobster_args[@]}"
         else
           echo "The SBOM file for fetched artifacts is not found!"
           exit 1

--- a/task/build-maven-zip/0.1/build-maven-zip.yaml
+++ b/task/build-maven-zip/0.1/build-maven-zip.yaml
@@ -37,7 +37,10 @@ spec:
     type: string
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
-
+  - name: SBOM_SKIP_VALIDATION
+    description: Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.
+    type: string
+    default: "false"
   results:
   - description: Digest of the OCI-Artifact just built
     name: IMAGE_DIGEST
@@ -58,6 +61,8 @@ spec:
       value: $(params.FILE_NAME)
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.IMAGE_EXPIRES_AFTER)
+    - name: SBOM_SKIP_VALIDATION
+      value: $(params.SBOM_SKIP_VALIDATION)
     volumeMounts:
       - mountPath: /shared
         name: shared
@@ -146,7 +151,7 @@ spec:
       mountPath: /mnt/trusted-ca
       readOnly: true
     workingDir: $(workspaces.source.path)
-  - image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+  - image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
     name: save-sbom
     computeResources:
       limits:
@@ -163,12 +168,18 @@ spec:
 
       # Use Mobster to generate maven-zip SBOM file using the Hermeto (Cachi2) output
       if [ -f "$(workspaces.source.path)/cachi2/output/bom.json" ]; then
-        mobster generate \
-                --output sbom.json \
-                oci-image \
-                --from-hermeto "$(workspaces.source.path)/cachi2/output/bom.json" \
-                --image-pullspec "$IMAGE_URL" \
-                --image-digest "$IMAGE_DIGEST"
+        mobster_args=(generate --output sbom.json)
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          echo "Skipping SBOM validation"
+          mobster_args+=(--skip-validation)
+        fi
+        mobster_args+=(
+          oci-image
+          --from-hermeto "$(workspaces.source.path)/cachi2/output/bom.json"
+          --image-pullspec "$IMAGE_URL"
+          --image-digest "$IMAGE_DIGEST"
+        )
+        mobster "${mobster_args[@]}"
       else
         echo "The SBOM file for fetched artifacts is not found!"
         exit 1

--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -213,6 +213,11 @@ spec:
     description: Determines if SBOM will be contextualized.
     name: CONTEXTUALIZE_SBOM
     type: string
+  - default: "true"
+    description: Flag to enable or disable SBOM validation before save. Validation
+      is optional - use this if you are experiencing performance issues.
+    name: SBOM_SKIP_VALIDATION
+    type: string
   - default: "false"
     description: Omit build history information from the resulting image. Improves
       reproducibility by excluding timestamps and layer metadata.
@@ -308,6 +313,8 @@ spec:
       value: $(params.BUILD_TIMESTAMP)
     - name: CONTEXTUALIZE_SBOM
       value: $(params.CONTEXTUALIZE_SBOM)
+    - name: SBOM_SKIP_VALIDATION
+      value: $(params.SBOM_SKIP_VALIDATION)
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
     imagePullPolicy: IfNotPresent
@@ -1086,7 +1093,7 @@ spec:
       requests:
         cpu: 10m
         memory: 128Mi
-    image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
     name: prepare-sboms
     script: |
       #!/bin/bash
@@ -1122,6 +1129,16 @@ spec:
       mobster_args=(
         generate
         --output sbom.json
+      )
+
+      # Validation is a flag for `generate`, not `oci-image`, so we need to
+      # handle it before the oci-image arguments
+      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+        echo "Skipping SBOM validation"
+        mobster_args+=(--skip-validation)
+      fi
+
+      mobster_args+=(
         oci-image
         --from-syft "$(workspaces.source.path)/sbom-image.json"
         --image-pullspec "$IMAGE_URL"

--- a/task/buildah-oci-ta/0.6/README.md
+++ b/task/buildah-oci-ta/0.6/README.md
@@ -37,6 +37,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
 |PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|proxy-ca-bundle|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
+|SBOM_SKIP_VALIDATION|Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.|true|false|
 |SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -155,6 +155,12 @@ spec:
         Does nothing if SOURCE_DATE_EPOCH is not defined.
       type: string
       default: "false"
+    - name: SBOM_SKIP_VALIDATION
+      description: Flag to enable or disable SBOM validation before save.
+        Validation is optional - use this if you are experiencing performance
+        issues.
+      type: string
+      default: "true"
     - name: SBOM_SOURCE_SCAN_ENABLED
       description: Flag to enable or disable SBOM generation from source code.
         The scanner of the source code is enabled only for non-hermetic builds
@@ -330,6 +336,8 @@ spec:
         value: $(params.INHERIT_BASE_IMAGE_LABELS)
       - name: PRIVILEGED_NESTED
         value: $(params.PRIVILEGED_NESTED)
+      - name: SBOM_SKIP_VALIDATION
+        value: $(params.SBOM_SKIP_VALIDATION)
       - name: SBOM_SOURCE_SCAN_ENABLED
         value: $(params.SBOM_SOURCE_SCAN_ENABLED)
       - name: SBOM_SYFT_SELECT_CATALOGERS
@@ -1148,7 +1156,7 @@ spec:
 
         echo "[$(date --utc -Ins)] End sbom-syft-generate"
     - name: prepare-sboms
-      image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+      image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
       args:
         - --additional-base-images
         - $(params.ADDITIONAL_BASE_IMAGES[*])
@@ -1190,6 +1198,16 @@ spec:
         mobster_args=(
           generate
           --output sbom.json
+        )
+
+        # Validation is a flag for `generate`, not `oci-image`, so we need to
+        # handle it before the oci-image arguments
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          echo "Skipping SBOM validation"
+          mobster_args+=(--skip-validation)
+        fi
+
+        mobster_args+=(
           oci-image
           --from-syft "/var/workdir/sbom-image.json"
           --image-pullspec "$IMAGE_URL"

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -152,6 +152,11 @@ spec:
     name: REWRITE_TIMESTAMP
     type: string
   - default: "true"
+    description: Flag to enable or disable SBOM validation before save. Validation
+      is optional - use this if you are experiencing performance issues.
+    name: SBOM_SKIP_VALIDATION
+    type: string
+  - default: "true"
     description: Flag to enable or disable SBOM generation from source code. The scanner
       of the source code is enabled only for non-hermetic builds and can be disabled
       if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false
@@ -297,6 +302,8 @@ spec:
       value: $(params.INHERIT_BASE_IMAGE_LABELS)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: SBOM_SKIP_VALIDATION
+      value: $(params.SBOM_SKIP_VALIDATION)
     - name: SBOM_SOURCE_SCAN_ENABLED
       value: $(params.SBOM_SOURCE_SCAN_ENABLED)
     - name: SBOM_SYFT_SELECT_CATALOGERS
@@ -1068,6 +1075,7 @@ spec:
           -e IMAGE_EXPIRES_AFTER="${IMAGE_EXPIRES_AFTER@Q}" \
           -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
           -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e SBOM_SKIP_VALIDATION="${SBOM_SKIP_VALIDATION@Q}" \
           -e SBOM_SOURCE_SCAN_ENABLED="${SBOM_SOURCE_SCAN_ENABLED@Q}" \
           -e SBOM_SYFT_SELECT_CATALOGERS="${SBOM_SYFT_SELECT_CATALOGERS@Q}" \
           -e SBOM_TYPE="${SBOM_TYPE@Q}" \
@@ -1304,7 +1312,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
     name: prepare-sboms
     script: |
       #!/bin/bash
@@ -1347,6 +1355,16 @@ spec:
       mobster_args=(
         generate
         --output sbom.json
+      )
+
+      # Validation is a flag for `generate`, not `oci-image`, so we need to
+      # handle it before the oci-image arguments
+      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+        echo "Skipping SBOM validation"
+        mobster_args+=(--skip-validation)
+      fi
+
+      mobster_args+=(
         oci-image
         --from-syft "/var/workdir/sbom-image.json"
         --image-pullspec "$IMAGE_URL"

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -213,6 +213,11 @@ spec:
     description: Determines if SBOM will be contextualized.
     name: CONTEXTUALIZE_SBOM
     type: string
+  - default: "true"
+    description: Flag to enable or disable SBOM validation before save. Validation
+      is optional - use this if you are experiencing performance issues.
+    name: SBOM_SKIP_VALIDATION
+    type: string
   - default: "false"
     description: Omit build history information from the resulting image. Improves
       reproducibility by excluding timestamps and layer metadata.
@@ -316,6 +321,8 @@ spec:
       value: $(params.BUILD_TIMESTAMP)
     - name: CONTEXTUALIZE_SBOM
       value: $(params.CONTEXTUALIZE_SBOM)
+    - name: SBOM_SKIP_VALIDATION
+      value: $(params.SBOM_SKIP_VALIDATION)
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
     - name: BUILDER_IMAGE
@@ -1052,6 +1059,7 @@ spec:
           -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
           -e BUILD_TIMESTAMP="${BUILD_TIMESTAMP@Q}" \
           -e CONTEXTUALIZE_SBOM="${CONTEXTUALIZE_SBOM@Q}" \
+          -e SBOM_SKIP_VALIDATION="${SBOM_SKIP_VALIDATION@Q}" \
           -e SKIP_INJECTIONS="${SKIP_INJECTIONS@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e SOURCE_URL="${SOURCE_URL@Q}" \
@@ -1274,7 +1282,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
     name: prepare-sboms
     script: |
       #!/bin/bash
@@ -1314,6 +1322,16 @@ spec:
       mobster_args=(
         generate
         --output sbom.json
+      )
+
+      # Validation is a flag for `generate`, not `oci-image`, so we need to
+      # handle it before the oci-image arguments
+      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+        echo "Skipping SBOM validation"
+        mobster_args+=(--skip-validation)
+      fi
+
+      mobster_args+=(
         oci-image
         --from-syft "$(workspaces.source.path)/sbom-image.json"
         --image-pullspec "$IMAGE_URL"

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -199,6 +199,10 @@ spec:
     description: Determines if SBOM will be contextualized.
     type: string
     default: "false"
+  - name: SBOM_SKIP_VALIDATION
+    description: Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.
+    type: string
+    default: "true"
   - name: OMIT_HISTORY
     description: Omit build history information from the resulting image. Improves
       reproducibility by excluding timestamps and layer metadata.
@@ -297,6 +301,8 @@ spec:
       value: $(params.BUILD_TIMESTAMP)
     - name: CONTEXTUALIZE_SBOM
       value: $(params.CONTEXTUALIZE_SBOM)
+    - name: SBOM_SKIP_VALIDATION
+      value: $(params.SBOM_SKIP_VALIDATION)
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
     imagePullPolicy: IfNotPresent
@@ -1073,7 +1079,7 @@ spec:
       subPath: ca-bundle.crt
 
   - name: prepare-sboms
-    image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
     computeResources:
       limits:
         memory: 512Mi
@@ -1117,6 +1123,16 @@ spec:
       mobster_args=(
         generate
         --output sbom.json
+      )
+
+      # Validation is a flag for `generate`, not `oci-image`, so we need to
+      # handle it before the oci-image arguments
+      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+        echo "Skipping SBOM validation"
+        mobster_args+=(--skip-validation)
+      fi
+
+      mobster_args+=(
         oci-image
         --from-syft "$(workspaces.source.path)/sbom-image.json"
         --image-pullspec "$IMAGE_URL"

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -222,7 +222,7 @@ spec:
         echo -n "${IMAGE}@${RESULTING_DIGEST}" > "$(results.IMAGE_REF.path)"
 
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+      image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
       workingDir: /var/workdir
       script: |
         #!/bin/bash

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -324,7 +324,7 @@ spec:
           add:
             - SETFCAP
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+      image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
       workingDir: /var/workdir
       script: |
         #!/bin/bash

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -309,7 +309,7 @@ spec:
           name: varlibcontainers
       workingDir: $(workspaces.source.path)
     - name: sbom-generate
-      image: quay.io/konflux-ci/mobster:1.1.0-1761230566@sha256:8c8044c24042e991ee246c75544380652ee50e1f684055d4fd7c3433a3b839e2
+      image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
       script: |
         #!/bin/bash
         set -euo pipefail


### PR DESCRIPTION
Hey, first PR here. I am still working out the local dev/testing process, so this may take me a bit to get right.

This updates mobster to the latest Quay tag & adds the ability to add the new `--skip-validation` argument to `mobster generate` commands using `SBOM_SKIP_VALIDATION` in relevant tasks where we do that. I think this is primarily to avoid performance bottlenecks with the contextual SBOM.

Some minor refactors to how we were calling mobster in the tasks had to happen here as the new flag has to be after `generate` rather than the subcommand, mind the big changes to the tasks to use arrays for arguments.

The ticket specified skipping validation is only a default on the `buildah` task (& derivatives).