### PR TITLE
fix: appstudio-utils image was not multi-arch in buildah

### DIFF
--- a/task/apply-tags/0.2/apply-tags.yaml
+++ b/task/apply-tags/0.2/apply-tags.yaml
@@ -43,7 +43,7 @@ spec:
         requests:
           cpu: 100m
           memory: 256Mi
-      image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+      image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
       args:
         - $(params.ADDITIONAL_TAGS[*])
       env:
@@ -71,7 +71,7 @@ spec:
         requests:
           memory: 256Mi
           cpu: 100m
-      image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+      image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
       env:
       - name: IMAGE_URL
         value: $(params.IMAGE_URL)

--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -245,7 +245,7 @@ spec:
         --index-manifest-path "$MANIFEST_DATA_FILE" \
 
   - name: upload-sbom
-    image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+    image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
     script: |
       #!/bin/bash
       set -e

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -246,7 +246,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+    image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
     name: upload-sbom
     script: |
       #!/bin/bash

--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -1113,7 +1113,7 @@ spec:
       requests:
         cpu: 100m
         memory: 512Mi
-    image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+    image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
     name: upload-sbom
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -1179,7 +1179,7 @@ spec:
       securityContext:
         runAsUser: 0
     - name: upload-sbom
-      image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+      image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -1334,7 +1334,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+    image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
     name: upload-sbom
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -1301,7 +1301,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+    image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
     name: upload-sbom
     script: |
       #!/bin/bash

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -1102,7 +1102,7 @@ spec:
       runAsUser: 0
 
   - name: upload-sbom
-    image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+    image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2a2bc3c3492b83114f350fd35d4c7ee076be13a2c1f1f243ef44c515b4615332
     script: |
       #!/bin/bash
       set -euo pipefail


### PR DESCRIPTION
The appstudio-utils image was pinned to an old digest which was not multi-arch. I updated the image to the latest digest and pinned it to an image index digest in the buildah tasks.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
