### PR TITLE
chore(workflows): use releases for actions

### DIFF
--- a/.github/workflows/check-buildah-remote.yaml
+++ b/.github/workflows/check-buildah-remote.yaml
@@ -9,9 +9,9 @@ jobs:
     name: Check Buildah Remote
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8   # v5
+      - uses: actions/checkout@v5.0.0
       - name: Install Go
-        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00   # v6
+        uses: actions/setup-go@v6.0.0
         with:
           go-version-file: './task-generator/remote/go.mod'
       - name: Check buildah remote

--- a/.github/workflows/go-ci.yaml
+++ b/.github/workflows/go-ci.yaml
@@ -14,13 +14,13 @@ jobs:
           - task-generator/remote
           - task-generator/trusted-artifacts
     steps:
-      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
-      - uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version-file: './${{matrix.path}}/go.mod'
           cache-dependency-path: ./${{matrix.path}}/go.sum
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@b002b6ecfcabe6ac0e2c6cba1bcc779eb34ac51f
+        uses: golangci/golangci-lint-action@v8.0.0
         with:
           working-directory: ${{matrix.path}}
           args: "--timeout=10m --build-tags='normal periodic'"
@@ -33,9 +33,9 @@ jobs:
           - task-generator/remote
           - task-generator/trusted-artifacts
     steps:
-      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
+      - uses: actions/checkout@v5.0.0
       - name: Install Go
-        uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
+        uses: actions/setup-go@v6.0.0
         with:
           go-version-file: './${{matrix.path}}/go.mod'
           cache-dependency-path: ./${{matrix.path}}/go.sum
@@ -77,19 +77,19 @@ jobs:
           - task-generator/remote
           - task-generator/trusted-artifacts
     steps:
-      - uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
-      - uses: actions/setup-go@c0137caad775660c0844396c52da96e560aba63d
+      - uses: actions/checkout@v5.0.0
+      - uses: actions/setup-go@v6.0.0
         with:
           go-version-file: './${{matrix.path}}/go.mod'
           cache-dependency-path: ./${{matrix.path}}/go.sum
       # https://github.com/securego/gosec/blob/12be14859bc7d4b956b71bef0b443694aa519d8a/README.md#integrating-with-code-scanning
       - name: Run Gosec Security Scanner
-        uses: securego/gosec@master
+        uses: securego/gosec@v2.22.10
         with:
           # we let the report trigger content trigger a failure using the GitHub Security features.
           args: '-tags normal,periodic -no-fail -fmt sarif -out results.sarif ${{matrix.path}}/...'
       - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@9b0ac1cc3b2985145e276933b2b96f423f56e68b
+        uses: github/codeql-action/upload-sarif@v4.31.2
         with:
           # Path to SARIF file relative to the root of the repository
           sarif_file: results.sarif

--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -21,7 +21,7 @@ jobs:
 
       - name: Get all changed files in the PR from task directory
         id: changed-dirs
-        uses: tj-actions/changed-files@d03a93c0dbfac6d6dd6a0d8a5e7daff992b07449
+        uses: tj-actions/changed-files@v47
         with:
           files: |
             # Any task yaml or script (including its tests) is changed


### PR DESCRIPTION
Instead of random commit that could lead into broken action and generates daily updates from renovate, use the official releases.

It may also provide changelog in this way

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
