### PR TITLE
task/buildah: add SKIP_INJECTIONS parameter

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -85,6 +85,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| | |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
+|SKIP_INJECTIONS| Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.| false| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -82,6 +82,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| | |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
+|SKIP_INJECTIONS| Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.| false| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -81,6 +81,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| | |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
+|SKIP_INJECTIONS| Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.| false| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| | |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -83,6 +83,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| | |
 |SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
+|SKIP_INJECTIONS| Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.| false| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|

--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -228,6 +228,11 @@ spec:
       if SOURCE_DATE_EPOCH is not defined.
     name: REWRITE_TIMESTAMP
     type: string
+  - default: "false"
+    description: Don't inject a content-sets.json or a labels.json file. This requires
+      that the canonical Containerfile takes care of this itself.
+    name: SKIP_INJECTIONS
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -303,6 +308,8 @@ spec:
       value: $(params.BUILD_TIMESTAMP)
     - name: CONTEXTUALIZE_SBOM
       value: $(params.CONTEXTUALIZE_SBOM)
+    - name: SKIP_INJECTIONS
+      value: $(params.SKIP_INJECTIONS)
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - mountPath: /shared
@@ -445,7 +452,9 @@ spec:
       if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
         icm_opts+=(-c)
       fi
-      inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+      if [ "${SKIP_INJECTIONS}" = "false" ]; then
+        inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+      fi
 
       echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
@@ -736,12 +745,14 @@ spec:
 
       jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
-      echo "" >>"$dockerfile_copy"
-      # Always write labels.json to the new standard location
-      echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
-      # Conditionally write to the old location for backward compatibility
-      if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
-        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      if [ "${SKIP_INJECTIONS}" = "false" ]; then
+        echo "" >>"$dockerfile_copy"
+        # Always write labels.json to the new standard location
+        echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+        # Conditionally write to the old location for backward compatibility
+        if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+          echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+        fi
       fi
 
       # Make sure our labels.json file isn't filtered out

--- a/task/buildah-oci-ta/0.6/README.md
+++ b/task/buildah-oci-ta/0.6/README.md
@@ -40,6 +40,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.|spdx|false|
+|SKIP_INJECTIONS|Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.|false|false|
 |SKIP_SBOM_GENERATION|Skip SBOM-related operations. This will likely cause EC policies to fail if enabled|false|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -174,6 +174,12 @@ spec:
         - must be in the same format.'
       type: string
       default: spdx
+    - name: SKIP_INJECTIONS
+      description: Don't inject a content-sets.json or a labels.json file.
+        This requires that the canonical Containerfile takes care of this
+        itself.
+      type: string
+      default: "false"
     - name: SKIP_SBOM_GENERATION
       description: Skip SBOM-related operations. This will likely cause EC
         policies to fail if enabled
@@ -330,6 +336,8 @@ spec:
         value: $(params.SBOM_SYFT_SELECT_CATALOGERS)
       - name: SBOM_TYPE
         value: $(params.SBOM_TYPE)
+      - name: SKIP_INJECTIONS
+        value: $(params.SKIP_INJECTIONS)
       - name: SKIP_SBOM_GENERATION
         value: $(params.SKIP_SBOM_GENERATION)
       - name: SKIP_UNUSED_STAGES
@@ -517,7 +525,9 @@ spec:
         if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
           icm_opts+=(-c)
         fi
-        inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+        if [ "${SKIP_INJECTIONS}" = "false" ]; then
+          inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+        fi
 
         echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
@@ -816,12 +826,14 @@ spec:
 
         jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
-        echo "" >>"$dockerfile_copy"
-        # Always write labels.json to the new standard location
-        echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
-        # Conditionally write to the old location for backward compatibility
-        if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
-          echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+        if [ "${SKIP_INJECTIONS}" = "false" ]; then
+          echo "" >>"$dockerfile_copy"
+          # Always write labels.json to the new standard location
+          echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+          # Conditionally write to the old location for backward compatibility
+          if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+            echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+          fi
         fi
 
         # Make sure our labels.json file isn't filtered out

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -171,6 +171,11 @@ spec:
     name: SBOM_TYPE
     type: string
   - default: "false"
+    description: Don't inject a content-sets.json or a labels.json file. This requires
+      that the canonical Containerfile takes care of this itself.
+    name: SKIP_INJECTIONS
+    type: string
+  - default: "false"
     description: Skip SBOM-related operations. This will likely cause EC policies
       to fail if enabled
     name: SKIP_SBOM_GENERATION
@@ -298,6 +303,8 @@ spec:
       value: $(params.SBOM_SYFT_SELECT_CATALOGERS)
     - name: SBOM_TYPE
       value: $(params.SBOM_TYPE)
+    - name: SKIP_INJECTIONS
+      value: $(params.SKIP_INJECTIONS)
     - name: SKIP_SBOM_GENERATION
       value: $(params.SKIP_SBOM_GENERATION)
     - name: SKIP_UNUSED_STAGES
@@ -550,7 +557,9 @@ spec:
       if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
         icm_opts+=(-c)
       fi
-      inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+      if [ "${SKIP_INJECTIONS}" = "false" ]; then
+        inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+      fi
 
       echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
@@ -849,12 +858,14 @@ spec:
 
       jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
-      echo "" >>"$dockerfile_copy"
-      # Always write labels.json to the new standard location
-      echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
-      # Conditionally write to the old location for backward compatibility
-      if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
-        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      if [ "${SKIP_INJECTIONS}" = "false" ]; then
+        echo "" >>"$dockerfile_copy"
+        # Always write labels.json to the new standard location
+        echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+        # Conditionally write to the old location for backward compatibility
+        if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+          echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+        fi
       fi
 
       # Make sure our labels.json file isn't filtered out
@@ -1060,6 +1071,7 @@ spec:
           -e SBOM_SOURCE_SCAN_ENABLED="${SBOM_SOURCE_SCAN_ENABLED@Q}" \
           -e SBOM_SYFT_SELECT_CATALOGERS="${SBOM_SYFT_SELECT_CATALOGERS@Q}" \
           -e SBOM_TYPE="${SBOM_TYPE@Q}" \
+          -e SKIP_INJECTIONS="${SKIP_INJECTIONS@Q}" \
           -e SKIP_SBOM_GENERATION="${SKIP_SBOM_GENERATION@Q}" \
           -e SKIP_UNUSED_STAGES="${SKIP_UNUSED_STAGES@Q}" \
           -e SOURCE_CODE_DIR="${SOURCE_CODE_DIR@Q}" \

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -228,6 +228,11 @@ spec:
       if SOURCE_DATE_EPOCH is not defined.
     name: REWRITE_TIMESTAMP
     type: string
+  - default: "false"
+    description: Don't inject a content-sets.json or a labels.json file. This requires
+      that the canonical Containerfile takes care of this itself.
+    name: SKIP_INJECTIONS
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -311,6 +316,8 @@ spec:
       value: $(params.BUILD_TIMESTAMP)
     - name: CONTEXTUALIZE_SBOM
       value: $(params.CONTEXTUALIZE_SBOM)
+    - name: SKIP_INJECTIONS
+      value: $(params.SKIP_INJECTIONS)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/buildah-task:latest@sha256:c711eeac025a5f829d5d7bb281d7e0df380969d1e37e5329d0cb7740ff0aa301
     - name: PLATFORM
@@ -527,7 +534,9 @@ spec:
       if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
         icm_opts+=(-c)
       fi
-      inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+      if [ "${SKIP_INJECTIONS}" = "false" ]; then
+        inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+      fi
 
       echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
@@ -818,12 +827,14 @@ spec:
 
       jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
-      echo "" >>"$dockerfile_copy"
-      # Always write labels.json to the new standard location
-      echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
-      # Conditionally write to the old location for backward compatibility
-      if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
-        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      if [ "${SKIP_INJECTIONS}" = "false" ]; then
+        echo "" >>"$dockerfile_copy"
+        # Always write labels.json to the new standard location
+        echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+        # Conditionally write to the old location for backward compatibility
+        if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+          echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+        fi
       fi
 
       # Make sure our labels.json file isn't filtered out
@@ -1041,6 +1052,7 @@ spec:
           -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
           -e BUILD_TIMESTAMP="${BUILD_TIMESTAMP@Q}" \
           -e CONTEXTUALIZE_SBOM="${CONTEXTUALIZE_SBOM@Q}" \
+          -e SKIP_INJECTIONS="${SKIP_INJECTIONS@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e SOURCE_URL="${SOURCE_URL@Q}" \
           -e DOCKERFILE="${DOCKERFILE@Q}" \

--- a/task/buildah/0.6/README.md
+++ b/task/buildah/0.6/README.md
@@ -49,6 +49,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |OMIT_HISTORY|Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.|false|false|
 |SOURCE_DATE_EPOCH|Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and clamps file mtimes to ensure consistent digests.|""|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
+|SKIP_INJECTIONS|Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -215,6 +215,11 @@ spec:
       nothing if SOURCE_DATE_EPOCH is not defined.
     type: string
     default: "false"
+  - name: SKIP_INJECTIONS
+    description: Don't inject a content-sets.json or a labels.json file. This
+      requires that the canonical Containerfile takes care of this itself.
+    type: string
+    default: "false"
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -292,6 +297,8 @@ spec:
       value: $(params.BUILD_TIMESTAMP)
     - name: CONTEXTUALIZE_SBOM
       value: $(params.CONTEXTUALIZE_SBOM)
+    - name: SKIP_INJECTIONS
+      value: $(params.SKIP_INJECTIONS)
     imagePullPolicy: IfNotPresent
   steps:
   - image: quay.io/konflux-ci/buildah-task:latest@sha256:c711eeac025a5f829d5d7bb281d7e0df380969d1e37e5329d0cb7740ff0aa301
@@ -434,7 +441,9 @@ spec:
       if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
         icm_opts+=(-c)
       fi
-      inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+      if [ "${SKIP_INJECTIONS}" = "false" ]; then
+        inject-icm-to-containerfile "${icm_opts[@]}" "$dockerfile_copy" "/var/workdir/cachi2/output/bom.json" "$SOURCE_CODE_DIR/$CONTEXT"
+      fi
 
       echo "[$(date --utc -Ins)] Prepare system (architecture: $(uname -m))"
 
@@ -725,12 +734,14 @@ spec:
 
       jq '.' "$SOURCE_CODE_DIR/$CONTEXT/labels.json"
 
-      echo "" >>"$dockerfile_copy"
-      # Always write labels.json to the new standard location
-      echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
-      # Conditionally write to the old location for backward compatibility
-      if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
-        echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+      if [ "${SKIP_INJECTIONS}" = "false" ]; then
+        echo "" >>"$dockerfile_copy"
+        # Always write labels.json to the new standard location
+        echo 'COPY labels.json /usr/share/buildinfo/labels.json' >>"$dockerfile_copy"
+        # Conditionally write to the old location for backward compatibility
+        if [ "${ICM_KEEP_COMPAT_LOCATION}" = "true" ]; then
+          echo 'COPY labels.json /root/buildinfo/labels.json' >>"$dockerfile_copy"
+        fi
       fi
 
       # Make sure our labels.json file isn't filtered out


### PR DESCRIPTION
Today, the buildah task automatically adds `COPY` directives into the Containerfile to inject dynamically-generated files (`content-sets.json` and `labels.json`). This kind of dynamic mutation of the build process makes it very hard to reproduce the build outside of Konflux (especially `labels.json`, which requires parsing the Containerfile).

Really, all the information in those files already lives in the upstream repo, and it's not hard for a project to take over that resposibility.

Add a new SKIP_INJECTIONS parameter which when set to `true` skips all those mutations.

To reiterate more explicitly: all our images should have these files. They are consumed by scanners like Clair. The goal is NOT to ship images without them, but simply to allow projects to take over that responsibility. We will eventually have checks in place that verify the presence and contents of these files. This will block anyone using this parameter without the necessary work upstream to add them.