### PR TITLE
fix: use mounted CA trust in build-image-index steps

### DIFF
--- a/task/build-image-index/0.1/build-image-index.yaml
+++ b/task/build-image-index/0.1/build-image-index.yaml
@@ -114,6 +114,15 @@ spec:
 
       sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
 
+      echo "[$(date --utc -Ins)] Update CA trust"
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
       if [[ $# -ne 1 && "$ALWAYS_BUILD_INDEX" != "true" ]]; then
         echo "Skipping image index generation while supplying multiple image inputs is unsupported."
         exit 2
@@ -249,6 +258,15 @@ spec:
     script: |
       #!/bin/bash
       set -e
+
+      echo "[$(date --utc -Ins)] Update CA trust"
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
 
       SBOM_RESULT_FILE="/index-build-data/index.spdx.json"
       if [ ! -f "$SBOM_RESULT_FILE" ]; then

--- a/task/build-image-manifest/0.1/build-image-manifest.yaml
+++ b/task/build-image-manifest/0.1/build-image-manifest.yaml
@@ -112,6 +112,15 @@ spec:
 
       sed -i 's/^\s*short-name-mode\s*=\s*.*/short-name-mode = "disabled"/' /etc/containers/registries.conf
 
+      echo "[$(date --utc -Ins)] Update CA trust"
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
+
       if [[ $# -ne 1 && "$ALWAYS_BUILD_INDEX" != "true" ]]; then
         echo "Skipping image index generation while supplying multiple image inputs is unsupported."
         exit 2
@@ -251,6 +260,15 @@ spec:
     script: |
       #!/bin/bash
       set -e
+
+      echo "[$(date --utc -Ins)] Update CA trust"
+
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        cp -vf $ca_bundle /etc/pki/ca-trust/source/anchors
+        update-ca-trust
+      fi
 
       SBOM_RESULT_FILE="/index-build-data/index.spdx.json"
       if [ ! -f "$SBOM_RESULT_FILE" ]; then


### PR DESCRIPTION
## Description

PR #2889 added CA trust parameters to the `build-image-index` task but didn't actually install the certificates in the steps that need them. This causes TLS verification failures when pushing to registries with self-signed certificates (e.g., KinD registries).

## Changes

- Add CA trust installation to the `build` step (for buildah manifest operations)
- Add CA trust installation to the `upload-sbom` step (for cosign attach operations)

Both steps now check for the mounted CA bundle and install it before performing registry operations.

## Testing

Tested with KinD registry using self-signed certificates. Without this fix, both steps fail with:
```
tls: failed to verify certificate: x509: certificate signed by unknown authority
```

With this fix, both steps successfully trust the registry certificate.

## Related

- Fixes the implementation from PR #2889
- Resolves TLS verification failures in self-signed certificate environments