### PR TITLE
fix(ISV-6480): Fix invalid base images digests file.

### DIFF
--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -909,7 +909,8 @@ spec:
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         # Get the image pullspec and filter out a tag if it is not set
-        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
+        # Use head -n 1 to ensure we only get one result even if multiple images match the filter
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image" | head -n 1)
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -990,7 +990,8 @@ spec:
         echo "Recording base image digests used"
         for image in $BASE_IMAGES; do
           # Get the image pullspec and filter out a tag if it is not set
-          base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
+          # Use head -n 1 to ensure we only get one result even if multiple images match the filter
+          base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image" | head -n 1)
           # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
           # if buildah did not use that particular image during build because it was skipped
           if [ -n "$base_image_digest" ]; then

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -1021,7 +1021,8 @@ spec:
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         # Get the image pullspec and filter out a tag if it is not set
-        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
+        # Use head -n 1 to ensure we only get one result even if multiple images match the filter
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image" | head -n 1)
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -991,7 +991,8 @@ spec:
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         # Get the image pullspec and filter out a tag if it is not set
-        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
+        # Use head -n 1 to ensure we only get one result even if multiple images match the filter
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image" | head -n 1)
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -897,7 +897,8 @@ spec:
       echo "Recording base image digests used"
       for image in $BASE_IMAGES; do
         # Get the image pullspec and filter out a tag if it is not set
-        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image")
+        # Use head -n 1 to ensure we only get one result even if multiple images match the filter
+        base_image_digest=$(buildah images --format '{{ .Name }}{{ if ne .Tag "<none>" }}:{{ .Tag }}{{ end }}@{{ .Digest }}' --filter reference="$image" | head -n 1)
         # In some cases, there might be BASE_IMAGES, but not any associated digest. This happens
         # if buildah did not use that particular image during build because it was skipped
         if [ -n "$base_image_digest" ]; then


### PR DESCRIPTION
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.

## Changes to the code

This bug was discovered by [this commit](https://github.com/project-koku/koku-metrics-operator/commit/ee5e94e6c50212f81dbfbda8b6e007d3734ebbcb). At the time, the Dockerfile contained stages referencing `registry.redhat.io/ubi9/ubi-micro:9.6-1754345610` and `registry.redhat.io/ubi9/ubi-micro` (which resolved to `registry.redhat.io/ubi9/ubi-micro:latest`). When the `buildah images` was called with the reference `registry.redhat.io/ubi9/ubi-micro`, two tags with the same digest were returned. This created a corrupted `/shared/base_images_digests` file, where one of the tags appeared on a separate line without any Dockerfile pullspec preceeding it.

To fix this, I just added `| head -n 1` to only fetch a single tag (both of these tags share the same digest, so no information is lost).