### PR TITLE
chore(KFLUXVNGD-518): update init task to include enable-cache-proxy parameter

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -135,6 +135,9 @@ spec:
       oci or docker.
     name: buildah-format
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -175,6 +178,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"
@@ -245,6 +250,10 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: HTTP_PROXY
+      value: $(tasks.init.results.http-proxy)
+    - name: NO_PROXY
+      value: $(tasks.init.results.no-proxy)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:

--- a/pipelines/core-services/patch.yaml
+++ b/pipelines/core-services/patch.yaml
@@ -82,13 +82,14 @@
 #     10  build-source-image
 #     11  build-image-index
 #     12  buildah-format
-#     13  build-args
-#     14  build-args-file
-#     15  privileged-nested
+#     13  enable-cache-proxy
+#     14  build-args
+#     15  build-args-file
+#     16  privileged-nested
 
 # Remove privilege-nested pipeline param
 - op: remove
-  path: /spec/params/15
+  path: /spec/params/16
 # We want to always build OCI images by default
 - op: replace
   path: /spec/params/12/default  # buildah-format

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -14,6 +14,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-images:0.7:BUILDAH_FORMAT ; build-image-index:0.2:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.7:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.7:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.7:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
@@ -68,14 +69,14 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
-|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| |
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_APPEND_PLATFORM| Whether to append a sanitized platform architecture on the IMAGE tag| false| 'true'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
-|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
 |OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
@@ -173,6 +174,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -387,6 +389,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| build-images:0.7:HTTP_PROXY|
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| build-images:0.7:NO_PROXY|
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -69,6 +69,9 @@ spec:
       oci or docker.
     name: buildah-format
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -106,6 +109,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"
@@ -184,6 +189,10 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: HTTP_PROXY
+      value: $(tasks.init.results.http-proxy)
+    - name: NO_PROXY
+      value: $(tasks.init.results.no-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -13,6 +13,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-container:0.7:BUILDAH_FORMAT ; build-image-index:0.2:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.7:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.7:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-container:0.7:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
@@ -67,13 +68,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
-|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| |
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
-|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
 |OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
@@ -170,6 +171,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -384,6 +386,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| build-container:0.7:HTTP_PROXY|
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| build-container:0.7:NO_PROXY|
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -69,6 +69,9 @@ spec:
       oci or docker.
     name: buildah-format
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -100,6 +103,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"
@@ -173,6 +178,10 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: HTTP_PROXY
+      value: $(tasks.init.results.http-proxy)
+    - name: NO_PROXY
+      value: $(tasks.init.results.no-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -13,6 +13,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-container:0.7:BUILDAH_FORMAT ; build-image-index:0.2:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.7:DOCKERFILE ; sast-coverity-check:0.3:DOCKERFILE ; push-dockerfile:0.1:DOCKERFILE|
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.7:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.7:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
@@ -66,13 +67,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
-|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| |
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
-|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
 |OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
@@ -169,6 +170,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -368,6 +370,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| build-container:0.7:HTTP_PROXY|
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| build-container:0.7:NO_PROXY|
 ### push-dockerfile:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -69,6 +69,9 @@ spec:
       oci or docker.
     name: buildah-format
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -100,6 +103,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"
@@ -167,6 +172,10 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: HTTP_PROXY
+      value: $(tasks.init.results.http-proxy)
+    - name: NO_PROXY
+      value: $(tasks.init.results.no-proxy)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -93,6 +93,10 @@
     value: "$(tasks.clone-repository.results.url)"
   - name: BUILDAH_FORMAT
     value: "$(params.buildah-format)"
+  - name: HTTP_PROXY
+    value: "$(tasks.init.results.http-proxy)"
+  - name: NO_PROXY
+    value: "$(tasks.init.results.no-proxy)"
 
 # FIXME: duplicate the "add" operations for sast-coverity-check, which is based on build-container
 - op: test

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -13,6 +13,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.7:DOCKERFILE|
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| true| build-images:0.7:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; run-opm-command:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-images:0.7:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER|
@@ -66,14 +67,14 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
-|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| |
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_APPEND_PLATFORM| Whether to append a sanitized platform architecture on the IMAGE tag| false| 'true'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
-|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
 |OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
@@ -153,6 +154,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -240,6 +242,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| build-images:0.7:HTTP_PROXY|
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| build-images:0.7:NO_PROXY|
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -64,6 +64,9 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -96,6 +99,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"
@@ -189,6 +194,10 @@ spec:
       value: $(params.build-args-file)
     - name: SOURCE_URL
       value: $(tasks.clone-repository.results.url)
+    - name: HTTP_PROXY
+      value: $(tasks.init.results.http-proxy)
+    - name: NO_PROXY
+      value: $(tasks.init.results.no-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -30,12 +30,13 @@
 #     10  build-source-image
 #     11  build-image-index
 #     12  buildah-format
-#     13  build-args
-#     14  build-args-file
-#     15  privileged-nested
-#     16  build-platforms
+#     13  enable-cache-proxy
+#     14  build-args
+#     15  build-args-file
+#     16  privileged-nested
+#     17  build-platforms
 - op: remove
-  path: /spec/params/15  # privileged-nested
+  path: /spec/params/16  # privileged-nested
 - op: remove
   path: /spec/params/12  # buildah-format - FBC is always OCI
 - op: replace
@@ -44,45 +45,47 @@
 
 # Remove params
 # $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.3.params.[].name" | nl -v 0
-#  0	IMAGE
-#  1	DOCKERFILE
-#  2	CONTEXT
-#  3	HERMETIC
-#  4	PREFETCH_INPUT
-#  5	IMAGE_EXPIRES_AFTER
-#  6	COMMIT_SHA
-#  7	BUILD_ARGS
-#  8	BUILD_ARGS_FILE
-#  9	PRIVILEGED_NESTED
-# 10	SOURCE_URL
-# 11	BUILDAH_FORMAT
-# 12	SOURCE_ARTIFACT
-# 13	CACHI2_ARTIFACT
-# 14	IMAGE_APPEND_PLATFORM
+#      0  IMAGE
+#      1  DOCKERFILE
+#      2  CONTEXT
+#      3  HERMETIC
+#      4  PREFETCH_INPUT
+#      5  IMAGE_EXPIRES_AFTER
+#      6  COMMIT_SHA
+#      7  BUILD_ARGS
+#      8  BUILD_ARGS_FILE
+#      9  PRIVILEGED_NESTED
+#     10  SOURCE_URL
+#     11  BUILDAH_FORMAT
+#     12  HTTP_PROXY
+#     13  NO_PROXY
+#     14  SOURCE_ARTIFACT
+#     15  CACHI2_ARTIFACT
+#     16  IMAGE_APPEND_PLATFORM
 - op: remove
   path: /spec/tasks/3/params/11  # BUILDAH_FORMAT - FBC is always OCI
 - op: remove
   path: /spec/tasks/3/params/9  # PRIVILEGED_NESTED
 # Remove tasks
-# $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.[].name" | nl -v 0 
-#      0	init
-#      1	clone-repository
-#      2	prefetch-dependencies
-#      3	build-images
-#      4	build-image-index
-#      5	build-source-image
-#      6	deprecated-base-image-check
-#      7	clair-scan
-#      8	ecosystem-cert-preflight-checks
-#      9	sast-snyk-check
-#     10	clamav-scan
-#     11	sast-coverity-check
-#     12	coverity-availability-check
-#     13	sast-shell-check
-#     14	sast-unicode-check
-#     15	apply-tags
-#     16	push-dockerfile
-#     17	rpms-signature-scan
+# $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.[].name" | nl -v 0
+#      0  init
+#      1  clone-repository
+#      2  prefetch-dependencies
+#      3  build-images
+#      4  build-image-index
+#      5  build-source-image
+#      6  deprecated-base-image-check
+#      7  clair-scan
+#      8  ecosystem-cert-preflight-checks
+#      9  sast-snyk-check
+#     10  clamav-scan
+#     11  sast-coverity-check
+#     12  coverity-availability-check
+#     13  sast-shell-check
+#     14  sast-unicode-check
+#     15  apply-tags
+#     16  push-dockerfile
+#     17  rpms-signature-scan
 - op: remove
   path: /spec/tasks/17  # rpms-signature-scan
 - op: remove
@@ -107,12 +110,12 @@
   path: /spec/tasks/5  # build-source-image
 # Remove build-image-index task params
 # $ kustomize build pipelines/docker-build-multi-platform-oci-ta | yq ".spec.tasks.4.params.[].name" | nl -v 0
-#  0	IMAGE
-#  1	COMMIT_SHA
-#  2	IMAGE_EXPIRES_AFTER
-#  3	ALWAYS_BUILD_INDEX
-#  4	IMAGES
-#  5	BUILDAH_FORMAT
+#      0  IMAGE
+#      1  COMMIT_SHA
+#      2  IMAGE_EXPIRES_AFTER
+#      3  ALWAYS_BUILD_INDEX
+#      4  IMAGES
+#      5  BUILDAH_FORMAT
 - op: remove
   path: /spec/tasks/4/params/5  # BUILDAH_FORMAT - FBC is always OCI
 

--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -9,6 +9,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |build-source-image| Build a source image.| false| |
 |default-base-image| Default base image for ko| | build-container:0.1:KO_DEFAULTBASEIMAGE|
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-container:0.1:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER|
 |import-path| Import path to build| | build-container:0.1:IMPORT_PATH|
@@ -109,6 +110,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -260,6 +262,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| |
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| |
 ### ko-oci-ta:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
+++ b/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
@@ -46,6 +46,9 @@ spec:
     description: Build a source image.
     name: build-source-image
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   - default: ""
     description: Default base image for ko
     name: default-base-image
@@ -84,6 +87,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -7,6 +7,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| init:0.2:image-url ; clone-repository:0.1:ociStorage ; prefetch-dependencies:0.2:ociStorage ; build-oci-artifact:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
@@ -60,6 +61,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -211,6 +213,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| |
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| |
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -42,6 +42,9 @@ spec:
       2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   results:
   - name: IMAGE_URL
     value: $(tasks.build-oci-artifact.results.IMAGE_URL)
@@ -60,6 +63,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -7,6 +7,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| init:0.2:image-url ; build-oci-artifact:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
@@ -60,6 +61,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -199,6 +201,8 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| |
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| |
 ### sast-coverity-check:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -42,6 +42,9 @@ spec:
       2d, 3w for hours, days, and weeks, respectively.
     name: image-expires-after
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   results:
   - name: IMAGE_URL
     value: $(tasks.build-oci-artifact.results.IMAGE_URL)
@@ -60,6 +63,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -6,6 +6,7 @@
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.2:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.2:ociArtifactExpiresAfter ; build-image-index:0.2:IMAGE_EXPIRES_AFTER|
@@ -67,6 +68,7 @@
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -155,6 +157,8 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| |
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| |
 ### prefetch-dependencies-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -59,6 +59,9 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -77,6 +80,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -6,6 +6,7 @@
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.2:ALWAYS_BUILD_INDEX|
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
+|enable-cache-proxy| Enable cache proxy configuration| false| init:0.2:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-image-index:0.2:IMAGE_EXPIRES_AFTER|
@@ -68,6 +69,7 @@
 ### init:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|enable-cache-proxy| Enable cache proxy configuration| false| '$(params.enable-cache-proxy)'|
 |image-url| Image URL for build by PipelineRun| None| '$(params.output-image)'|
 |rebuild| Rebuild the image if exists| false| '$(params.rebuild)'|
 |skip-checks| Skip checks against built image| false| '$(params.skip-checks)'|
@@ -147,6 +149,8 @@
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |build| Defines if the image in param image-url should be built| |
+|http-proxy| HTTP proxy URL for cache proxy (when enable-cache-proxy is true)| |
+|no-proxy| NO_PROXY value for cache proxy (when enable-cache-proxy is true)| |
 ### sast-shell-check:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -59,6 +59,9 @@ spec:
     description: Add built image into an OCI image index
     name: build-image-index
     type: string
+  - default: "false"
+    description: Enable cache proxy configuration
+    name: enable-cache-proxy
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -77,6 +80,8 @@ spec:
       value: $(params.rebuild)
     - name: skip-checks
       value: $(params.skip-checks)
+    - name: enable-cache-proxy
+      value: $(params.enable-cache-proxy)
     taskRef:
       name: init
       version: "0.2"

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -62,6 +62,9 @@ spec:
         oci or docker.
       type: string
       default: "docker"
+    - name: enable-cache-proxy
+      description: Enable cache proxy configuration
+      default: "false"
   tasks:
     - name: init
       params:
@@ -71,6 +74,8 @@ spec:
           value: "$(params.rebuild)"
         - name: skip-checks
           value: "$(params.skip-checks)"
+        - name: enable-cache-proxy
+          value: "$(params.enable-cache-proxy)"
       taskRef:
         name: init
         # A pointer for referencing the correct version of task in the built pipeline bundles.

--- a/task/init/0.2/MIGRATION.md
+++ b/task/init/0.2/MIGRATION.md
@@ -26,3 +26,31 @@ FBC builds should continue using `oci` format.
 Change `BUILDAH_FORMAT` param value to `docker` in build related tasks: build-images, build-container, build-image-index (build-image-manifest eventually).
 
 If your project require OCI, you don't need to do change (However, check automatic migration if it didn't migrate you to docker format).
+
+# Migration from 0.2.3 to 0.2.4
+
+The `init` task now supports cache proxy configuration through a new `enable-cache-proxy` parameter. When enabled, the init task outputs proxy configuration values (`http-proxy` and `no-proxy` results) that can be consumed by build tasks like `buildah`.
+
+This enables builds to use a caching proxy to reduce network traffic and improve build performance.
+
+## Automatic Migration
+
+The migration script (`0.2.4.sh`) automatically performs the following:
+
+1. **Adds `enable-cache-proxy` parameter** to the pipeline with a default value of `"false"` to maintain backward compatibility
+2. **Adds `enable-cache-proxy` parameter** to the `init` task, passing the pipeline parameter value
+3. **Adds `HTTP_PROXY` and `NO_PROXY` parameters** to all buildah-related tasks (including `buildah`, `buildah-remote`, `buildah-oci-ta`, `buildah-remote-oci-ta`, and `buildah-min`) that reference the init task's proxy results:
+   ```yaml
+   - name: HTTP_PROXY
+     value: $(tasks.init.results.http-proxy)
+   - name: NO_PROXY
+     value: $(tasks.init.results.no-proxy)
+   ```
+
+The migration script is idempotent and will skip tasks that already have these parameters configured.
+
+## Action from users
+
+No action required. The migration script automatically handles all necessary changes.
+
+If you want to enable cache proxy for your builds, set the `enable-cache-proxy` parameter to `"true"` in your pipeline configuration. The proxy configuration will then be automatically passed to all buildah tasks.

--- a/task/init/0.2/README.md
+++ b/task/init/0.2/README.md
@@ -8,11 +8,14 @@ Initialize Pipeline Task, include flags for rebuild and auth. Generates image re
 |image-url|Image URL for build by PipelineRun||true|
 |rebuild|Rebuild the image if exists|false|false|
 |skip-checks|Skip checks against built image|false|false|
+|enable-cache-proxy|Enable cache proxy configuration|false|false|
 
 ## Results
 |name|description|
 |---|---|
 |build|Defines if the image in param image-url should be built|
+|http-proxy|HTTP proxy URL for cache proxy (when enable-cache-proxy is true)|
+|no-proxy|NO_PROXY value for cache proxy (when enable-cache-proxy is true)|
 
 
 ## Additional info

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.3"
+    app.kubernetes.io/version: "0.2.4"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"
@@ -19,9 +19,16 @@ spec:
     - name: skip-checks
       description: Skip checks against built image
       default: "false"
+    - name: enable-cache-proxy
+      description: Enable cache proxy configuration
+      default: "false"
   results:
     - name: build
       description: Defines if the image in param image-url should be built
+    - name: http-proxy
+      description: HTTP proxy URL for cache proxy (when enable-cache-proxy is true)
+    - name: no-proxy
+      description: NO_PROXY value for cache proxy (when enable-cache-proxy is true)
 
   steps:
     - name: init
@@ -39,6 +46,8 @@ spec:
           value: $(params.rebuild)
         - name: SKIP_CHECKS
           value: $(params.skip-checks)
+        - name: ENABLE_CACHE_PROXY
+          value: $(params.enable-cache-proxy)
       script: |
         #!/bin/bash
         echo "Build Initialize: $IMAGE_URL"
@@ -50,7 +59,15 @@ spec:
         # Build the image when rebuild is set to true or image does not exist
         # The image check comes last to avoid unnecessary, slow API calls
         if [ "$REBUILD" == "true" ] || [ "$SKIP_CHECKS" == "false" ] || ! skopeo inspect --retry-times "$skopeo_retries" --no-tags --raw "docker://$IMAGE_URL" &>/dev/null; then
-          echo -n "true" > $(results.build.path)
+          echo -n "true" > "$(results.build.path)"
         else
-          echo -n "false" > $(results.build.path)
+          echo -n "false" > "$(results.build.path)"
         fi
+
+        # Set cache proxy configuration if enabled
+        if [ "$ENABLE_CACHE_PROXY" == "true" ]; then
+          echo -n "squid.caching.svc.cluster.local:3128" > "$(results.http-proxy.path)"
+        else
+          echo -n "" > "$(results.http-proxy.path)"
+        fi
+        echo -n "" > "$(results.no-proxy.path)"

--- a/task/init/0.2/migrations/0.2.4.sh
+++ b/task/init/0.2/migrations/0.2.4.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: init@0.2.4
+# Creation time: 2025-11-24T00:00:00Z
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# 1. Check for init task
+# If init task does not exist, exit 0
+if ! yq -e '(.spec.tasks[], .spec.pipelineSpec.tasks[]) | select(.name == "init")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "Pipeline does not use init task, skipping migration"
+    exit 0
+fi
+
+# 2. Pipeline Parameter (enable-cache-proxy)
+# Add enable-cache-proxy parameter if it doesn't exist
+# pmt modify generic insert is not idempotent, we need to check if it exists first
+if ! yq -e '(.spec.params[], .spec.pipelineSpec.params[]) | select(.name == "enable-cache-proxy")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "Adding enable-cache-proxy pipeline param"
+
+    # Determine paths based on whether it is a Pipeline or PipelineRun
+    if yq -e '.spec.pipelineSpec' "$pipeline_file" >/dev/null 2>&1; then
+        # PipelineRun with embedded spec
+        PARAMS_PATH=".spec.pipelineSpec.params"
+        PMT_PARAMS_PATH='["spec", "pipelineSpec", "params"]'
+        PMT_SPEC_PATH='["spec", "pipelineSpec"]'
+    else
+        # Pipeline
+        PARAMS_PATH=".spec.params"
+        PMT_PARAMS_PATH='["spec", "params"]'
+        PMT_SPEC_PATH='["spec"]'
+    fi
+
+    # Check if params exists
+    if yq -e "$PARAMS_PATH" "$pipeline_file" >/dev/null 2>&1; then
+        # params exists, append to it
+        pmt modify -f "$pipeline_file" generic insert \
+            "$PMT_PARAMS_PATH" \
+            '{"name": "enable-cache-proxy", "default": "false", "description": "Enable cache proxy configuration", "type": "string"}'
+    else
+        # params does not exist, create it with the param
+        pmt modify -f "$pipeline_file" generic insert \
+            "$PMT_SPEC_PATH" \
+            '{"params": [{"name": "enable-cache-proxy", "default": "false", "description": "Enable cache proxy configuration", "type": "string"}]}'
+    fi
+else
+    echo "enable-cache-proxy pipeline parameter already exists, checking tasks..."
+fi
+
+# 3. Init Task Parameter (enable-cache-proxy)
+# Add enable-cache-proxy parameter to init task if not present (pmt modify task add-param is idempotent)
+echo "Ensuring enable-cache-proxy parameter exists in init task"
+pmt modify -f "$pipeline_file" task "init" add-param enable-cache-proxy "\$(params.enable-cache-proxy)"
+
+
+# 4. Buildah Task Parameters (HTTP_PROXY, NO_PROXY)
+# List of buildah task variants to look for
+buildah_task_refs=( \
+  "buildah" "buildah-oci-ta" \
+  "buildah-remote" "buildah-remote-oci-ta" \
+  "buildah-min" \
+)
+
+# Combined selector for tasks in both Pipeline and PipelineRun
+TASKS_SELECTOR="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+# Find all task names that use buildah variants
+buildah_task_names=()
+for task_ref in "${buildah_task_refs[@]}"; do
+    # We handle multiple tasks using the same taskRef
+    TASK_FILTER="${TASKS_SELECTOR} | select(.taskRef.name == \"${task_ref}\")"
+
+    if yq -e "$TASK_FILTER" "$pipeline_file" >/dev/null 2>&1; then
+        tasks_found=$(yq -r "$TASK_FILTER | .name" "$pipeline_file")
+        readarray -t -O "${#buildah_task_names[@]}" buildah_task_names <<< "$tasks_found"
+    fi
+done
+
+if [ ${#buildah_task_names[@]} -gt 0 ]; then
+    for task_name in "${buildah_task_names[@]}"; do
+        echo "Processing buildah task: $task_name"
+
+        echo "  Ensuring HTTP_PROXY parameter exists for task $task_name"
+        pmt modify -f "$pipeline_file" task "$task_name" add-param HTTP_PROXY "\$(tasks.init.results.http-proxy)"
+
+        echo "  Ensuring NO_PROXY parameter exists for task $task_name"
+        pmt modify -f "$pipeline_file" task "$task_name" add-param NO_PROXY "\$(tasks.init.results.no-proxy)"
+    done
+else
+    echo "No buildah tasks found in pipeline"
+fi


### PR DESCRIPTION
- Update the `init` task to include a new parameter called `enable-cache-proxy`.
This parameter is optional and used to enable the cache proxy configuration, defaults to false.
- The HTTP_PROXY and NO_PROXY output variables will be defined for the "init" task.
- Update init task version to 0.2.4
- Add migration script

- Update Konflux pipeline templates as follows:
   - The `enable-cache-proxy` pipeline parameter would be defined with default value `false`
   - The values of the output variables will be passed to similarly named parameters on the "buildah" task.

This PR is a part of the https://issues.redhat.com/browse/KFLUXVNGD-526:
Implement the caching feature flag configuration described in the ADR from [PR #274](https://github.com/konflux-ci/architecture/pull/274)

Assisted-by: Cursor (claude-4.5-sonnet)



