### PR TITLE
feat(KONFLUX-10515): update tasks to use stepaction with parallel processing

### DIFF
--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -114,6 +114,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### fbc-fips-check-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|MAX_PARALLEL| Maximum number of images to process in parallel| 8| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|

--- a/task/fbc-fips-check-oci-ta/0.1/README.md
+++ b/task/fbc-fips-check-oci-ta/0.1/README.md
@@ -7,6 +7,7 @@ In order to resolve them, this task expects a ImageDigestMirrorSet file located 
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
+|MAX_PARALLEL|Maximum number of images to process in parallel|8|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |image-digest|Image digest to scan.||true|
 |image-url|Image URL.||true|
@@ -19,3 +20,5 @@ In order to resolve them, this task expects a ImageDigestMirrorSet file located 
 
 
 ## Additional info
+### Parallel Processing
+The MAX_PARALLEL parameter controls how many related images are scanned concurrently. The default value is "8", but this can be adjusted based on your resource availability and performance requirements. Increasing this value can speed up the scan for FBC fragments with many related images, but may require more memory and CPU resources.

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -14,6 +14,9 @@ spec:
     This task extracts relatedImages from all unreleased operator bundle images from your FBC fragment and scans them. In the context of FBC fragment, an unreleased operator bundle image is the one that isn't currently present in the Red Hat production Index Image (`registry.redhat.io/redhat/redhat-operator-index`). It is necessary for relatedImages pullspecs to be pullable at build time of the FBC fragment.
     In order to resolve them, this task expects a ImageDigestMirrorSet file located at .tekton/images-mirror-set.yaml of your FBC fragment git repo. It should map unreleased registry.redhat.io pullspecs of relatedImages to their valid quay.io pullspecs. If the ImageDigestMirrorSet is not provided, the task will attempt to process the registry.redhat.io pullspecs as is and might fail.
   params:
+    - name: MAX_PARALLEL
+      description: Maximum number of images to process in parallel
+      default: "8"
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -273,19 +276,22 @@ spec:
           add:
             - SETFCAP
     - name: fips-operator-check-step-action
+      params:
+        - name: MAX_PARALLEL
+          value: $(params.MAX_PARALLEL)
       computeResources:
         limits:
-          cpu: "1"
+          cpu: "8"
           memory: 12Gi
         requests:
-          cpu: "1"
+          cpu: "8"
           memory: 12Gi
       ref:
         params:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 374d67d92cc4d7ac8c0d80876e4e4ca97f07d8b1
+            value: 07cce518c45fe75a9078f5a2f44d49ba711c829e
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fbc-fips-check/0.1/README.md
+++ b/task/fbc-fips-check/0.1/README.md
@@ -7,6 +7,7 @@ The fbc-fips-check task uses the check-payload tool to verify if an unreleased o
 |---|---|---|---|
 |image-digest|Image digest to scan.||true|
 |image-url|Image URL.||true|
+|MAX_PARALLEL|Maximum number of images to process in parallel|"8"|false|
 
 ## Results
 |name|description|
@@ -20,6 +21,10 @@ The fbc-fips-check task uses the check-payload tool to verify if an unreleased o
 |workspace||false|
 
 ## Additional info
+### Parallel Processing
+The MAX_PARALLEL parameter controls how many related images are scanned concurrently. The default value is "8", but this can be adjusted based on your resource availability and performance requirements. Increasing this value can speed up the scan for FBC fragments with many related images, but may require more memory and CPU resources.
+
+### Image Mirror Set
 Here's an example of how the ImageDigestMirrorSet file should look like
 
 ```

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -21,6 +21,9 @@ spec:
       description: Image digest to scan.
     - name: image-url
       description: Image URL.
+    - name: MAX_PARALLEL
+      description: Maximum number of images to process in parallel
+      default: "8"
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.
@@ -261,17 +264,20 @@ spec:
       computeResources:
         limits:
           memory: 12Gi
-          cpu: '1'
+          cpu: '8'
         requests:
           memory: 12Gi
-          cpu: '1'
+          cpu: '8'
+      params:
+        - name: MAX_PARALLEL
+          value: $(params.MAX_PARALLEL)
       ref:
         resolver: git
         params:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 374d67d92cc4d7ac8c0d80876e4e4ca97f07d8b1
+            value: 07cce518c45fe75a9078f5a2f44d49ba711c829e
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 

--- a/task/fips-operator-bundle-check-oci-ta/0.1/README.md
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/README.md
@@ -5,6 +5,7 @@ The fips-operator-bundle-check task uses the check-payload tool to verify if an 
 ## Parameters
 |name|description|default value|required|
 |---|---|---|---|
+|MAX_PARALLEL|Maximum number of images to process in parallel|8|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |image-digest|Image digest to scan.||true|
 |image-url|Image URL.||true|
@@ -17,3 +18,5 @@ The fips-operator-bundle-check task uses the check-payload tool to verify if an 
 
 
 ## Additional info
+### Parallel Processing
+The MAX_PARALLEL parameter controls how many related images are scanned concurrently. The default value is "8", but this can be adjusted based on your resource availability and performance requirements. Increasing this value can speed up the scan for bundles with many related images, but may require more memory and CPU resources.

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -23,6 +23,9 @@ spec:
     It should map unreleased `registry.redhat.io` pullspecs of relatedImages
     to their valid `quay.io` pullspecs.
   params:
+    - name: MAX_PARALLEL
+      description: Maximum number of images to process in parallel
+      default: "8"
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -150,19 +153,22 @@ spec:
           add:
             - SETFCAP
     - name: fips-operator-check-step-action
+      params:
+        - name: MAX_PARALLEL
+          value: $(params.MAX_PARALLEL)
       computeResources:
         limits:
-          cpu: "1"
+          cpu: "8"
           memory: 12Gi
         requests:
-          cpu: "1"
+          cpu: "8"
           memory: 12Gi
       ref:
         params:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 374d67d92cc4d7ac8c0d80876e4e4ca97f07d8b1
+            value: 07cce518c45fe75a9078f5a2f44d49ba711c829e
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fips-operator-bundle-check/0.1/README.md
+++ b/task/fips-operator-bundle-check/0.1/README.md
@@ -7,6 +7,7 @@ The fips-operator-bundle-check task uses the check-payload tool to verify if an 
 |---|---|---|---|
 |image-digest|Image digest to scan.||true|
 |image-url|Image URL.||true|
+|MAX_PARALLEL|Maximum number of images to process in parallel|"8"|false|
 
 ## Results
 |name|description|
@@ -20,6 +21,10 @@ The fips-operator-bundle-check task uses the check-payload tool to verify if an 
 |workspace||false|
 
 ## Additional info
+### Parallel Processing
+The MAX_PARALLEL parameter controls how many related images are scanned concurrently. The default value is "8", but this can be adjusted based on your resource availability and performance requirements. Increasing this value can speed up the scan for bundles with many related images, but may require more memory and CPU resources.
+
+### Image Mirror Set
 Here's an example of how the imageDigestMirrorSet file should look like:
 ```
 ---

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -18,6 +18,9 @@ spec:
       description: Image digest to scan.
     - name: image-url
       description: Image URL.
+    - name: MAX_PARALLEL
+      description: Maximum number of images to process in parallel
+      default: "8"
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.
@@ -126,17 +129,20 @@ spec:
       computeResources:
         limits:
           memory: 12Gi
-          cpu: '1'
+          cpu: '8'
         requests:
           memory: 12Gi
-          cpu: '1'
+          cpu: '8'
+      params:
+        - name: MAX_PARALLEL
+          value: $(params.MAX_PARALLEL)
       ref:
         resolver: git
         params:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 374d67d92cc4d7ac8c0d80876e4e4ca97f07d8b1
+            value: 07cce518c45fe75a9078f5a2f44d49ba711c829e
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 


### PR DESCRIPTION
Update all FIPS check tasks to reference stepaction revision 07cce518c45fe75a9078f5a2f44d49ba711c829e which includes parallel processing improvements.

Changes:
- Add MAX_PARALLEL parameter (default "8") to all tasks
- Update stepaction revision in task references
- Increase CPU limits/requests from 1 to 8 for stepaction since the parallel count is set to 8.
- Update README files with MAX_PARALLEL documentation

Tasks updated:
- fips-operator-bundle-check
- fips-operator-bundle-check-oci-ta
- fbc-fips-check
- fbc-fips-check-oci-ta

Regrading MAX_PARALLEL and computer resources:
- Perf test shows 8 parallels provide the "optimal" improvement, as the gains noticeably decrease beyond that point.
- Increase CPU limits/requests from 1 to 8 for stepaction since the parallel count is set to 8.
- Memory remains unchanged at 12 Gi. As I observed on stone-prod-p02 over the past two weeks, the step (single process) consumes no more than 1.12 Gi across all namespaces, except for `rhoai-tenant`, where the maximum observed is 1.73 Gi. Therefore, 12 Gi should be sufficient in most cases. For `rhoai-tenant`, the memory limit can be increased separately if needed.


