### PR TITLE
feat(ISV-6503): Enable contextual SBOM for non-hermetic build

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -64,7 +64,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| ""| '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
-|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| false| |
+|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -63,7 +63,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| ""| '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
-|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| false| |
+|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -62,7 +62,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.| ""| |
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
-|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| false| |
+|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -62,7 +62,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| ""| '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
-|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| false| |
+|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|

--- a/task/buildah-min/0.6/buildah-min.yaml
+++ b/task/buildah-min/0.6/buildah-min.yaml
@@ -209,7 +209,7 @@ spec:
     description: The image is built from this URL.
     name: SOURCE_URL
     type: string
-  - default: "false"
+  - default: "true"
     description: Determines if SBOM will be contextualized.
     name: CONTEXTUALIZE_SBOM
     type: string
@@ -1093,7 +1093,7 @@ spec:
       requests:
         cpu: 10m
         memory: 128Mi
-    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
+    image: quay.io/konflux-ci/mobster:1.1.0-1763042639@sha256:028dfcf2ac8b0404141550de17364bf049b0ddb35f45a24a075bc1f485a56c80
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta/0.6/README.md
+++ b/task/buildah-oci-ta/0.6/README.md
@@ -20,7 +20,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
 |COMMIT_SHA|The image is built from this commit.|""|false|
 |CONTEXT|Path to the directory to use as context.|.|false|
-|CONTEXTUALIZE_SBOM|Determines if SBOM will be contextualized.|false|false|
+|CONTEXTUALIZE_SBOM|Determines if SBOM will be contextualized.|true|false|
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |HERMETIC|Determines if build will be executed without network access.|false|false|

--- a/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.6/buildah-oci-ta.yaml
@@ -78,7 +78,7 @@ spec:
     - name: CONTEXTUALIZE_SBOM
       description: Determines if SBOM will be contextualized.
       type: string
-      default: "false"
+      default: "true"
     - name: DOCKERFILE
       description: Path to the Dockerfile to build.
       type: string
@@ -1156,7 +1156,7 @@ spec:
 
         echo "[$(date --utc -Ins)] End sbom-syft-generate"
     - name: prepare-sboms
-      image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
+      image: quay.io/konflux-ci/mobster:1.1.0-1763042639@sha256:028dfcf2ac8b0404141550de17364bf049b0ddb35f45a24a075bc1f485a56c80
       args:
         - --additional-base-images
         - $(params.ADDITIONAL_BASE_IMAGES[*])

--- a/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.6/buildah-remote-oci-ta.yaml
@@ -74,7 +74,7 @@ spec:
     description: Path to the directory to use as context.
     name: CONTEXT
     type: string
-  - default: "false"
+  - default: "true"
     description: Determines if SBOM will be contextualized.
     name: CONTEXTUALIZE_SBOM
     type: string
@@ -1312,7 +1312,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
+    image: quay.io/konflux-ci/mobster:1.1.0-1763042639@sha256:028dfcf2ac8b0404141550de17364bf049b0ddb35f45a24a075bc1f485a56c80
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.6/buildah-remote.yaml
+++ b/task/buildah-remote/0.6/buildah-remote.yaml
@@ -209,7 +209,7 @@ spec:
     description: The image is built from this URL.
     name: SOURCE_URL
     type: string
-  - default: "false"
+  - default: "true"
     description: Determines if SBOM will be contextualized.
     name: CONTEXTUALIZE_SBOM
     type: string
@@ -1282,7 +1282,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
+    image: quay.io/konflux-ci/mobster:1.1.0-1763042639@sha256:028dfcf2ac8b0404141550de17364bf049b0ddb35f45a24a075bc1f485a56c80
     name: prepare-sboms
     script: |
       #!/bin/bash

--- a/task/buildah/0.6/buildah.yaml
+++ b/task/buildah/0.6/buildah.yaml
@@ -198,7 +198,7 @@ spec:
   - name: CONTEXTUALIZE_SBOM
     description: Determines if SBOM will be contextualized.
     type: string
-    default: "false"
+    default: "true"
   - name: SBOM_SKIP_VALIDATION
     description: Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.
     type: string
@@ -1079,7 +1079,7 @@ spec:
       subPath: ca-bundle.crt
 
   - name: prepare-sboms
-    image: quay.io/konflux-ci/mobster:1.1.0-1762282332@sha256:17d208056137237e0c9619216a93c111b97a3d2214bf7ab7907856c344beac65
+    image: quay.io/konflux-ci/mobster:1.1.0-1763042639@sha256:028dfcf2ac8b0404141550de17364bf049b0ddb35f45a24a075bc1f485a56c80
     computeResources:
       limits:
         memory: 512Mi


### PR DESCRIPTION
Contextual SBOM is re-enabled for non-hermetic build (it is generated by default again). Konflux is now
referencing mobster image with improved performance and logging (displaying timing & data for the qualitative assesment of the produced Contextual SBOM) of the Contextual SBOM workflow.
