### PR TITLE
feat(KONFLUX-6945): update fips stepaction to use new get_image_mirror_list function

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -69,23 +69,26 @@ spec:
         echo "Could not inspect original pullspec $related_image. Checking if there's a mirror present"
         if [ -n "${image_mirror_map}" ]; then
           reg_and_repo=$(get_image_registry_and_repository "${related_image}")
-          mapfile -t mirrors < <(echo "${image_mirror_map}" | jq -r --arg image "${reg_and_repo}" '.[$image][]')
-          echo "Mirrors for $reg_and_repo are:"
-          printf "%s\n" "${mirrors[@]}"
+          mapfile -t mirrors < <(get_image_mirror_list "${reg_and_repo}" "${image_mirror_map}")
+          if [[ -z "${mirrors[0]}" ]]; then
+            echo "No mirrors found in image mirror map for ${reg_and_repo}"
+          else
+            echo "Mirrors for $reg_and_repo are:"
+            printf "%s\n" "${mirrors[@]}"
 
-          for mirror in "${mirrors[@]}"; do
-            echo "Attempting to use mirror ${mirror}"
-            replaced_image=$(replace_image_pullspec "$related_image" "$mirror")
-            if ! image_labels=$(get_image_labels "$replaced_image"); then
-              echo "Mirror $mirror is inaccessible."
-              continue
-            fi
-            image_accessible=1
-            echo "Replacing $related_image with $replaced_image"
-            related_image="$replaced_image"
-            break
-          done
-
+            for mirror in "${mirrors[@]}"; do
+              echo "Attempting to use mirror ${mirror}"
+              replaced_image=$(replace_image_pullspec "$related_image" "$mirror")
+              if ! image_labels=$(get_image_labels "$replaced_image"); then
+                echo "Mirror $mirror is inaccessible."
+                continue
+              fi
+              image_accessible=1
+              echo "Replacing $related_image with $replaced_image"
+              related_image="$replaced_image"
+              break
+            done
+          fi
         fi
       else
         image_accessible=1


### PR DESCRIPTION
Updated `fips-operator-check-step-action` to use the new [konflux-test/utils function](https://github.com/konflux-ci/konflux-test/pull/643) for returning entries from an ImageDigestMirrorSet. 

This update is just for the StepAction. A follow-up PR will be opened to update the fips tasks themselves.
