### PR TITLE
upgrade Olot version

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -169,7 +169,7 @@ spec:
       workingDir: /var/workdir
       env:
         - name: OLOT_VERSION
-          value: 0.1.7
+          value: 0.1.12
         - name: MODELCARD_PATH
           value: $(params.MODELCARD_PATH)
         - name: REMOVE_ORIGINALS


### PR DESCRIPTION
Explanation:
We’re upgrading the olot version because the new release (v0.1.12) adds support for accessing models that include folder structures during the ModelCar build process. This ensures the pipeline can correctly handle models packaged with directories, which wasn’t fully supported in previous versions.


Olot release version - https://github.com/containers/olot/releases/tag/v0.1.12

Specific fix PR - https://github.com/containers/olot/pull/131