### PR TITLE
task/buildah*: re-inherit base image labels

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -73,7 +73,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_APPEND_PLATFORM| Whether to append a sanitized platform architecture on the IMAGE tag| false| 'true'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
-|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| false| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
 |OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -71,7 +71,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
-|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| false| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
 |OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -70,7 +70,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
-|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| false| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
 |OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -71,7 +71,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE| Reference of the image buildah will produce.| None| '$(params.output-image)'|
 |IMAGE_APPEND_PLATFORM| Whether to append a sanitized platform architecture on the IMAGE tag| false| 'true'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
-|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| false| |
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
 |OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |

--- a/task/buildah-min/0.7/MIGRATION.md
+++ b/task/buildah-min/0.7/MIGRATION.md
@@ -1,17 +1,21 @@
 # Migration from 0.6 to 0.7
 
-Version 0.7:
+~~Version 0.7:~~
 
-* Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.
-* If you are building on top of a base image like ubi9, and you inherit all
+* ~~Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.~~
+* ~~If you are building on top of a base image like ubi9, and you inherit all
   labels, then your resulting image will bear labels like name=ubi9 and the cpe
   label of ubi9. This makes your image look like it _is_ ubi9, which is not
-  correct.
+  correct.~~
 
-## Action from users
-No specific migration activity is required to absorb this change, however..
+## ~~Action from users~~
+~~No specific migration activity is required to absorb this change, however..~~
 
-For any team that is not explicitly setting the name, cpe, and other required
+~~For any team that is not explicitly setting the name, cpe, and other required
 labels, your images may begin to fail conforma policy checks until those labels
 are explicitly set on your image. You were previously inheriting values
-erroneously from your base image.
+erroneously from your base image.~~
+
+Version 0.7.1:
+
+* Reverts the change from version 0.7. The task now inherits labels by default again.

--- a/task/buildah-min/0.7/buildah-min.yaml
+++ b/task/buildah-min/0.7/buildah-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.7"
+    app.kubernetes.io/version: 0.7.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-min
 spec:
@@ -177,7 +177,7 @@ spec:
       the build (see the CONTEXT param).
     name: WORKINGDIR_MOUNT
     type: string
-  - default: "false"
+  - default: "true"
     description: Determines if the image inherits the base image labels.
     name: INHERIT_BASE_IMAGE_LABELS
     type: string

--- a/task/buildah-oci-ta/0.7/MIGRATION.md
+++ b/task/buildah-oci-ta/0.7/MIGRATION.md
@@ -1,17 +1,21 @@
 # Migration from 0.6 to 0.7
 
-Version 0.7:
+~~Version 0.7:~~
 
-* Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.
-* If you are building on top of a base image like ubi9, and you inherit all
+* ~~Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.~~
+* ~~If you are building on top of a base image like ubi9, and you inherit all
   labels, then your resulting image will bear labels like name=ubi9 and the cpe
   label of ubi9. This makes your image look like it _is_ ubi9, which is not
-  correct.
+  correct.~~
 
-## Action from users
-No specific migration activity is required to absorb this change, however..
+## ~~Action from users~~
+~~No specific migration activity is required to absorb this change, however..~~
 
-For any team that is not explicitly setting the name, cpe, and other required
+~~For any team that is not explicitly setting the name, cpe, and other required
 labels, your images may begin to fail conforma policy checks until those labels
 are explicitly set on your image. You were previously inheriting values
-erroneously from your base image.
+erroneously from your base image.~~
+
+Version 0.7.1:
+
+* Reverts the change from version 0.7. The task now inherits labels by default again.

--- a/task/buildah-oci-ta/0.7/README.md
+++ b/task/buildah-oci-ta/0.7/README.md
@@ -28,7 +28,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |ICM_KEEP_COMPAT_LOCATION|Whether to keep compatibility location at /root/buildinfo/ for ICM injection|true|false|
 |IMAGE|Reference of the image buildah will produce.||true|
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
-|INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|false|false|
+|INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
 |NO_PROXY|Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.|""|false|
 |OMIT_HISTORY|Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.|false|false|

--- a/task/buildah-oci-ta/0.7/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.7/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.7"
+    app.kubernetes.io/version: 0.7.1
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -114,7 +114,7 @@ spec:
     - name: INHERIT_BASE_IMAGE_LABELS
       description: Determines if the image inherits the base image labels.
       type: string
-      default: "false"
+      default: "true"
     - name: LABELS
       description: Additional key=value labels that should be applied to the
         image

--- a/task/buildah-remote-oci-ta/0.7/MIGRATION.md
+++ b/task/buildah-remote-oci-ta/0.7/MIGRATION.md
@@ -1,17 +1,21 @@
 # Migration from 0.6 to 0.7
 
-Version 0.7:
+~~Version 0.7:~~
 
-* Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.
-* If you are building on top of a base image like ubi9, and you inherit all
+* ~~Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.~~
+* ~~If you are building on top of a base image like ubi9, and you inherit all
   labels, then your resulting image will bear labels like name=ubi9 and the cpe
   label of ubi9. This makes your image look like it _is_ ubi9, which is not
-  correct.
+  correct.~~
 
-## Action from users
-No specific migration activity is required to absorb this change, however..
+## ~~Action from users~~
+~~No specific migration activity is required to absorb this change, however..~~
 
-For any team that is not explicitly setting the name, cpe, and other required
+~~For any team that is not explicitly setting the name, cpe, and other required
 labels, your images may begin to fail conforma policy checks until those labels
 are explicitly set on your image. You were previously inheriting values
-erroneously from your base image.
+erroneously from your base image.~~
+
+Version 0.7.1:
+
+* Reverts the change from version 0.7. The task now inherits labels by default again.

--- a/task/buildah-remote-oci-ta/0.7/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.7/buildah-remote-oci-ta.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: "0.7"
+    app.kubernetes.io/version: 0.7.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -109,7 +109,7 @@ spec:
       respectively.
     name: IMAGE_EXPIRES_AFTER
     type: string
-  - default: "false"
+  - default: "true"
     description: Determines if the image inherits the base image labels.
     name: INHERIT_BASE_IMAGE_LABELS
     type: string

--- a/task/buildah-remote/0.7/MIGRATION.md
+++ b/task/buildah-remote/0.7/MIGRATION.md
@@ -1,17 +1,21 @@
 # Migration from 0.6 to 0.7
 
-Version 0.7:
+~~Version 0.7:~~
 
-* Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.
-* If you are building on top of a base image like ubi9, and you inherit all
+* ~~Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.~~
+* ~~If you are building on top of a base image like ubi9, and you inherit all
   labels, then your resulting image will bear labels like name=ubi9 and the cpe
   label of ubi9. This makes your image look like it _is_ ubi9, which is not
-  correct.
+  correct.~~
 
-## Action from users
-No specific migration activity is required to absorb this change, however..
+## ~~Action from users~~
+~~No specific migration activity is required to absorb this change, however..~~
 
-For any team that is not explicitly setting the name, cpe, and other required
+~~For any team that is not explicitly setting the name, cpe, and other required
 labels, your images may begin to fail conforma policy checks until those labels
 are explicitly set on your image. You were previously inheriting values
-erroneously from your base image.
+erroneously from your base image.~~
+
+Version 0.7.1:
+
+* Reverts the change from version 0.7. The task now inherits labels by default again.

--- a/task/buildah-remote/0.7/buildah-remote.yaml
+++ b/task/buildah-remote/0.7/buildah-remote.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: "0.7"
+    app.kubernetes.io/version: 0.7.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -177,7 +177,7 @@ spec:
       the build (see the CONTEXT param).
     name: WORKINGDIR_MOUNT
     type: string
-  - default: "false"
+  - default: "true"
     description: Determines if the image inherits the base image labels.
     name: INHERIT_BASE_IMAGE_LABELS
     type: string

--- a/task/buildah/0.7/MIGRATION.md
+++ b/task/buildah/0.7/MIGRATION.md
@@ -1,17 +1,21 @@
 # Migration from 0.6 to 0.7
 
-Version 0.7:
+~~Version 0.7:~~
 
-* Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.
-* If you are building on top of a base image like ubi9, and you inherit all
+* ~~Changes default value of **INHERIT_BASE_IMAGE_LABELS** from `true` to `false`.~~
+* ~~If you are building on top of a base image like ubi9, and you inherit all
   labels, then your resulting image will bear labels like name=ubi9 and the cpe
   label of ubi9. This makes your image look like it _is_ ubi9, which is not
-  correct.
+  correct.~~
 
-## Action from users
-No specific migration activity is required to absorb this change, however..
+## ~~Action from users~~
+~~No specific migration activity is required to absorb this change, however..~~
 
-For any team that is not explicitly setting the name, cpe, and other required
+~~For any team that is not explicitly setting the name, cpe, and other required
 labels, your images may begin to fail conforma policy checks until those labels
 are explicitly set on your image. You were previously inheriting values
-erroneously from your base image.
+erroneously from your base image.~~
+
+Version 0.7.1:
+
+* Reverts the change from version 0.7. The task now inherits labels by default again.

--- a/task/buildah/0.7/buildah.yaml
+++ b/task/buildah/0.7/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.7"
+    app.kubernetes.io/version: "0.7.1"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -167,7 +167,7 @@ spec:
   - name: INHERIT_BASE_IMAGE_LABELS
     description: Determines if the image inherits the base image labels.
     type: string
-    default: "false"
+    default: "true"
   - name: HTTP_PROXY
     description: >-
       HTTP/HTTPS proxy to use for the buildah pull and build operations.


### PR DESCRIPTION
Effectively reverts b5bf2f390c8dba80a5432de41e83739e4320a575

The change was breaking for more users than expected. Revert it to reduce disruption until we can find a less drastic way to go about it.