### PR TITLE
Always add org.opencontainers.image.created

### DIFF
--- a/task/buildah-min/0.7/buildah-min.yaml
+++ b/task/buildah-min/0.7/buildah-min.yaml
@@ -680,15 +680,17 @@ spec:
         ANNOTATIONS+=("--annotation" "org.opencontainers.image.source=${SOURCE_URL}")
       fi
       [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
       BUILD_TIMESTAMP_RFC3339=""
       if [ -n "$BUILD_TIMESTAMP" ]; then
         BUILD_TIMESTAMP_RFC3339=$(date -u -d "@$BUILD_TIMESTAMP" +'%Y-%m-%dT%H:%M:%SZ')
-        DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
-        DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
-        ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
       else
-        DEFAULT_LABELS+=("--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')")
+        BUILD_TIMESTAMP_RFC3339=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       fi
+
+      DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
+      DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+      ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
 
       label_pairs=()
       # If INHERIT_BASE_IMAGE_LABELS is true, get the labels from the final base image only
@@ -736,7 +738,7 @@ spec:
       done
 
       # Labels that we explicitly add to the image
-      [ -n "$BUILD_TIMESTAMP_RFC3339" ] && label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+      label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
       label_pairs+=("io.buildah.version=$(buildah version --json | jq -r '.version')")
 
       while IFS= read -r label; do

--- a/task/buildah-oci-ta/0.7/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.7/buildah-oci-ta.yaml
@@ -762,15 +762,17 @@ spec:
           ANNOTATIONS+=("--annotation" "org.opencontainers.image.source=${SOURCE_URL}")
         fi
         [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
         BUILD_TIMESTAMP_RFC3339=""
         if [ -n "$BUILD_TIMESTAMP" ]; then
           BUILD_TIMESTAMP_RFC3339=$(date -u -d "@$BUILD_TIMESTAMP" +'%Y-%m-%dT%H:%M:%SZ')
-          DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
-          DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
-          ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
         else
-          DEFAULT_LABELS+=("--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')")
+          BUILD_TIMESTAMP_RFC3339=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
         fi
+
+        DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
+        DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+        ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
 
         label_pairs=()
         # If INHERIT_BASE_IMAGE_LABELS is true, get the labels from the final base image only
@@ -818,7 +820,7 @@ spec:
         done
 
         # Labels that we explicitly add to the image
-        [ -n "$BUILD_TIMESTAMP_RFC3339" ] && label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+        label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
         label_pairs+=("io.buildah.version=$(buildah version --json | jq -r '.version')")
 
         while IFS= read -r label; do

--- a/task/buildah-remote-oci-ta/0.7/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.7/buildah-remote-oci-ta.yaml
@@ -793,15 +793,17 @@ spec:
         ANNOTATIONS+=("--annotation" "org.opencontainers.image.source=${SOURCE_URL}")
       fi
       [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
       BUILD_TIMESTAMP_RFC3339=""
       if [ -n "$BUILD_TIMESTAMP" ]; then
         BUILD_TIMESTAMP_RFC3339=$(date -u -d "@$BUILD_TIMESTAMP" +'%Y-%m-%dT%H:%M:%SZ')
-        DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
-        DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
-        ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
       else
-        DEFAULT_LABELS+=("--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')")
+        BUILD_TIMESTAMP_RFC3339=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       fi
+
+      DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
+      DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+      ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
 
       label_pairs=()
       # If INHERIT_BASE_IMAGE_LABELS is true, get the labels from the final base image only
@@ -849,7 +851,7 @@ spec:
       done
 
       # Labels that we explicitly add to the image
-      [ -n "$BUILD_TIMESTAMP_RFC3339" ] && label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+      label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
       label_pairs+=("io.buildah.version=$(buildah version --json | jq -r '.version')")
 
       while IFS= read -r label; do

--- a/task/buildah-remote/0.7/buildah-remote.yaml
+++ b/task/buildah-remote/0.7/buildah-remote.yaml
@@ -762,15 +762,17 @@ spec:
         ANNOTATIONS+=("--annotation" "org.opencontainers.image.source=${SOURCE_URL}")
       fi
       [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
       BUILD_TIMESTAMP_RFC3339=""
       if [ -n "$BUILD_TIMESTAMP" ]; then
         BUILD_TIMESTAMP_RFC3339=$(date -u -d "@$BUILD_TIMESTAMP" +'%Y-%m-%dT%H:%M:%SZ')
-        DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
-        DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
-        ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
       else
-        DEFAULT_LABELS+=("--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')")
+        BUILD_TIMESTAMP_RFC3339=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       fi
+
+      DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
+      DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+      ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
 
       label_pairs=()
       # If INHERIT_BASE_IMAGE_LABELS is true, get the labels from the final base image only
@@ -818,7 +820,7 @@ spec:
       done
 
       # Labels that we explicitly add to the image
-      [ -n "$BUILD_TIMESTAMP_RFC3339" ] && label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+      label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
       label_pairs+=("io.buildah.version=$(buildah version --json | jq -r '.version')")
 
       while IFS= read -r label; do

--- a/task/buildah/0.7/buildah.yaml
+++ b/task/buildah/0.7/buildah.yaml
@@ -668,15 +668,17 @@ spec:
         ANNOTATIONS+=("--annotation" "org.opencontainers.image.source=${SOURCE_URL}")
       fi
       [ -n "$IMAGE_EXPIRES_AFTER" ] && DEFAULT_LABELS+=("--label" "quay.expires-after=$IMAGE_EXPIRES_AFTER")
+
       BUILD_TIMESTAMP_RFC3339=""
       if [ -n "$BUILD_TIMESTAMP" ]; then
         BUILD_TIMESTAMP_RFC3339=$(date -u -d "@$BUILD_TIMESTAMP" +'%Y-%m-%dT%H:%M:%SZ')
-        DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
-        DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
-        ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
       else
-        DEFAULT_LABELS+=("--label" "build-date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')")
+        BUILD_TIMESTAMP_RFC3339=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
       fi
+
+      DEFAULT_LABELS+=("--label" "build-date=${BUILD_TIMESTAMP_RFC3339}")
+      DEFAULT_LABELS+=("--label" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+      ANNOTATIONS+=("--annotation" "org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
 
       label_pairs=()
       # If INHERIT_BASE_IMAGE_LABELS is true, get the labels from the final base image only
@@ -724,7 +726,7 @@ spec:
       done
 
       # Labels that we explicitly add to the image
-      [ -n "$BUILD_TIMESTAMP_RFC3339" ] && label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
+      label_pairs+=("org.opencontainers.image.created=${BUILD_TIMESTAMP_RFC3339}")
       label_pairs+=("io.buildah.version=$(buildah version --json | jq -r '.version')")
 
       while IFS= read -r label; do


### PR DESCRIPTION
org.opencontainers.image.created is currently added only when a `BUILD_TIMESTAMP` or `SOURCE_DATA_EPOCH` parameter is provided.

Doing so should help reproducible builds because the timestamp is consistent.
This is different from trying to get the current timestamp in multiple parallel buildah task instances used for multi-arch builds where the timestamp will almost certainly differ.

Hovewer, if the timestamps are not specified, the inconsistency already occurs in multi-arch image indexes anyway in other attributes like `build-date` or `created`

Therefore, it seems better to always include the org.opencontainers.image.created even without parameters for a bit more consistency between builds