### PR TITLE
Add logs to show parameters passed to olot

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -188,7 +188,7 @@ spec:
         echo REMOVE_ORIGINALS_ARG "${REMOVE_ORIGINALS_ARG[@]}"
         echo MODELCARD_PATH "$MODELCARD_PATH"
         echo TARGET_OCI "$TARGET_OCI"
-        echo models/*
+        echo Models: models/*
 
         olot "${REMOVE_ORIGINALS_ARG[@]}" -m "$MODELCARD_PATH" "$TARGET_OCI" models/*
 


### PR DESCRIPTION
Logged environment variables so it will be possible to reproduce the exact `olot` command executed