### PR TITLE
Fix ko pipeline to use oci buildah format and push multiple tags.

### DIFF
--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -34,7 +34,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ALWAYS_BUILD_INDEX| Build an image index even if IMAGES is of length 1. Default true. If the image index generation is skipped, the task will forward values for params.IMAGES[0] to results.IMAGE_*. In order to properly set all results, use the repository:tag@sha256:digest format for the IMAGES parameter.| true| 'true'|
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| 'docker'|
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| 'oci'|
 |COMMIT_SHA| The commit the image is built from.| ""| '$(tasks.clone-repository.results.commit)'|
 |IMAGE| The target image and tag where the image will be pushed to.| None| '$(params.output-image)'|
 |IMAGES| List of Image Manifests to be referenced by the Image Index| None| '['$(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)']'|

--- a/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
+++ b/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
@@ -170,7 +170,7 @@ spec:
       value:
       - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
     - name: BUILDAH_FORMAT
-      value: docker
+      value: oci
     runAfter:
     - build-container
     taskRef:

--- a/pipelines/ko-build-oci-ta/patch.yaml
+++ b/pipelines/ko-build-oci-ta/patch.yaml
@@ -167,7 +167,7 @@
   value: "true"
 - op: replace
   path: /spec/tasks/4/params/5/value
-  value: docker
+  value: oci
 
 # build-source-image
 - op: replace

--- a/task/ko-oci-ta/0.1/ko-oci-ta.yaml
+++ b/task/ko-oci-ta/0.1/ko-oci-ta.yaml
@@ -121,6 +121,8 @@ spec:
           value: $(params.KO_DOCKER_REPO)
         - name: TAG
           value: $(params.TAG)
+        - name: TASKRUN_NAME
+          value: $(context.taskRun.name)
       script: |
         #!/bin/bash
         set -euo pipefail
@@ -136,7 +138,7 @@ spec:
         [ -n "${COMMIT_SHA}" ] && labels+=",vcs-ref=${COMMIT_SHA}"
         [ -n "${IMAGE_EXPIRES_AFTER}" ] && labels+=",quay.expires-after=${IMAGE_EXPIRES_AFTER})"
 
-        args=("${IMAGE_NAMING_STRATEGY}" --image-label "${labels}" --sbom spdx --sbom-dir /tmp)
+        args=("${IMAGE_NAMING_STRATEGY}" -t "${TASKRUN_NAME}" --image-label "${labels}" --sbom spdx --sbom-dir /tmp)
         [ -n "${TAG}" ] && args+=(-t "${TAG}")
 
         ko build "${args[@]}" "${IMPORT_PATH}" 2>&1 | tee /tmp/build.log
@@ -147,7 +149,7 @@ spec:
         sbom_url=$(grep 'Published SBOM' /tmp/build.log | awk '{print $5}')
         sbom_file=$(grep 'Writing SBOM to' /tmp/build.log | awk '{print $6}')
 
-        cosign attach sbom --type=spdx --input-format=json --sbom="${sbom_file}" "${url}@${digest}"
+        cosign attach sbom --type=spdx --input-format=json --sbom="${sbom_file}" "${ref}"
 
         echo "IMAGE_DIGEST=${digest}"
         echo "IMAGE_REF=${ref}"
@@ -155,7 +157,7 @@ spec:
         echo "SBOM_BLOB_URL=${sbom_url}"
 
         echo -n "${digest}" >"$(results.IMAGE_DIGEST.path)"
-        echo -n "${url}@${digest}" >"$(results.IMAGE_REF.path)"
+        echo -n "${ref}" >"$(results.IMAGE_REF.path)"
         echo -n "${url}" >"$(results.IMAGE_URL.path)"
         echo -n "${sbom_url}" >"$(results.SBOM_BLOB_URL.path)"
         echo "Completed."


### PR DESCRIPTION
# Before you complete this pull request ...
Fix the following in the `ko` task and pipeline:

- Change the buildah format to be `oci`.
- Add an additional tag to the image pushed by `ko`.
