### PR TITLE
chore(CI): install pmt into CI

### DIFF
--- a/.github/workflows/check-task-migration.yaml
+++ b/.github/workflows/check-task-migration.yaml
@@ -35,6 +35,8 @@ jobs:
           sudo apt-get install -y --no-install-recommends \
               tzdata python3-ruamel.yaml
 
+          pip install git+https://github.com/konflux-ci/pipeline-migration-tool --user
+
           kubectl get all -n tekton-pipelines
           # Require name main
           git branch main origin/main


### PR DESCRIPTION
pmt tool is the new way how to do the migrations. It must be avaialble in CI

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
