### PR TITLE
Set "memory.requests=memory.limits" for Steps BUILD and POSTPROCESS in task "sast-coverity-check"

### DIFF
--- a/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -288,7 +288,7 @@ spec:
   stepTemplate:
     computeResources:
       limits:
-        memory: 4Gi
+        memory: 16Gi
       requests:
         cpu: "1"
         memory: 1Gi
@@ -1005,7 +1005,7 @@ spec:
           memory: 16Gi
         requests:
           cpu: "4"
-          memory: 4Gi
+          memory: 16Gi
       securityContext:
         capabilities:
           add:
@@ -1218,4 +1218,4 @@ spec:
           memory: 16Gi
         requests:
           cpu: "4"
-          memory: 4Gi
+          memory: 16Gi

--- a/task/sast-coverity-check/0.3/sast-coverity-check.yaml
+++ b/task/sast-coverity-check/0.3/sast-coverity-check.yaml
@@ -233,7 +233,7 @@ spec:
   stepTemplate:
     computeResources:
       limits:
-        memory: 4Gi
+        memory: 16Gi
       requests:
         cpu: "1"
         memory: 1Gi
@@ -449,7 +449,7 @@ spec:
         memory: 16Gi
       requests:
         cpu: 4
-        memory: 4Gi
+        memory: 16Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
@@ -940,7 +940,7 @@ spec:
         memory: 16Gi
       requests:
         cpu: 4
-        memory: 4Gi
+        memory: 16Gi
     env:
     - name: IMAGE_URL
       value: $(params.image-url)


### PR DESCRIPTION
As per '[https://issues.redhat.com/browse/KONFLUX-6712]' we are supposed to define resources for steps within a task in such a way that the resources those steps are actually consuming in real clusters can be guaranteed. This makes sure that resources needed by other core system services (as mentioned in '[https://issues.redhat.com/browse/OHSS-48388]') can be guaranteed too.

For the existing task "sast-coverity-check" spec definition, we see that memory.requests=4Gi while memory.limits=16Gi. However as reported in '[https://issues.redhat.com/browse/KONFLUX-10047]' we see that the steps BUILD and POSTPROCESS is consuming memory consistently more than they request, but keeping within their limit.

This PR intends to set "memory.requests=memory.limits" for both steps 'BUILD' and 'POSTPROCESS' in task "sast-coverity-check"