### PR TITLE
chore: update fips-operator-check-step-action ref

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -291,7 +291,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: a308fe2078cdb1ded8dac223da217f83e73421a5
+            value: ac78bc7b6ea4d34781a4cff44ae9647745e2e65d
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -277,7 +277,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: a308fe2078cdb1ded8dac223da217f83e73421a5
+            value: ac78bc7b6ea4d34781a4cff44ae9647745e2e65d
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -168,7 +168,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: a308fe2078cdb1ded8dac223da217f83e73421a5
+            value: ac78bc7b6ea4d34781a4cff44ae9647745e2e65d
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -142,7 +142,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: a308fe2078cdb1ded8dac223da217f83e73421a5
+            value: ac78bc7b6ea4d34781a4cff44ae9647745e2e65d
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 


### PR DESCRIPTION
Update stepaction reference to ac78bc7b6ea4d34781a4cff44ae9647745e2e65d in all tasks to include the file collision fix.
