### PR TITLE
Set memory request equal to memory limit for fbc-builder tasks

### DIFF
--- a/task/build-image-index/0.2/build-image-index.yaml
+++ b/task/build-image-index/0.2/build-image-index.yaml
@@ -106,7 +106,7 @@ spec:
       limits:
         memory: 4Gi
       requests:
-        memory: 512Mi
+        memory: 4Gi
         cpu: 250m
     args: ["$(params.IMAGES[*])"]
     script: |
@@ -242,7 +242,7 @@ spec:
       limits:
         memory: 512Mi
       requests:
-        memory: 256Mi
+        memory: 512Mi
         cpu: 100m
     script: |
       #!/bin/bash
@@ -313,5 +313,5 @@ spec:
       limits:
         memory: 512Mi
       requests:
-        memory: 256Mi
+        memory: 512Mi
         cpu: 100m

--- a/task/buildah-oci-ta/0.7/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.7/buildah-oci-ta.yaml
@@ -306,7 +306,7 @@ spec:
         memory: 4Gi
       requests:
         cpu: "1"
-        memory: 1Gi
+        memory: 4Gi
     env:
       - name: ACTIVATION_KEY
         value: $(params.ACTIVATION_KEY)
@@ -1011,7 +1011,7 @@ spec:
           memory: 8Gi
         requests:
           cpu: "1"
-          memory: 2Gi
+          memory: 8Gi
       securityContext:
         capabilities:
           add:
@@ -1247,7 +1247,7 @@ spec:
           memory: 512Mi
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 512Mi
       securityContext:
         runAsUser: 0
     - name: upload-sbom
@@ -1297,4 +1297,4 @@ spec:
           memory: 512Mi
         requests:
           cpu: 100m
-          memory: 256Mi
+          memory: 512Mi

--- a/task/buildah-remote-oci-ta/0.7/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.7/buildah-remote-oci-ta.yaml
@@ -272,7 +272,7 @@ spec:
         memory: 4Gi
       requests:
         cpu: "1"
-        memory: 1Gi
+        memory: 4Gi
     env:
     - name: ACTIVATION_KEY
       value: $(params.ACTIVATION_KEY)
@@ -371,7 +371,7 @@ spec:
         memory: 8Gi
       requests:
         cpu: "1"
-        memory: 2Gi
+        memory: 8Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
@@ -1314,7 +1314,7 @@ spec:
         memory: 512Mi
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 512Mi
     image: quay.io/konflux-ci/mobster:1.1.0-1763042639@sha256:028dfcf2ac8b0404141550de17364bf049b0ddb35f45a24a075bc1f485a56c80
     name: prepare-sboms
     script: |
@@ -1407,7 +1407,7 @@ spec:
         memory: 512Mi
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 512Mi
     image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2b004dc4b55529823e8994e33df0d80e3d1de610e116f830e2b6d5d6e5539186
     name: upload-sbom
     script: |

--- a/task/buildah-remote/0.7/buildah-remote.yaml
+++ b/task/buildah-remote/0.7/buildah-remote.yaml
@@ -263,7 +263,7 @@ spec:
         memory: 4Gi
       requests:
         cpu: "1"
-        memory: 1Gi
+        memory: 4Gi
     env:
     - name: STORAGE_DRIVER
       value: $(params.STORAGE_DRIVER)
@@ -348,7 +348,7 @@ spec:
         memory: 8Gi
       requests:
         cpu: "1"
-        memory: 2Gi
+        memory: 8Gi
     env:
     - name: COMMIT_SHA
       value: $(params.COMMIT_SHA)
@@ -1284,7 +1284,7 @@ spec:
         memory: 512Mi
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 512Mi
     image: quay.io/konflux-ci/mobster:1.1.0-1763042639@sha256:028dfcf2ac8b0404141550de17364bf049b0ddb35f45a24a075bc1f485a56c80
     name: prepare-sboms
     script: |
@@ -1374,7 +1374,7 @@ spec:
         memory: 512Mi
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 512Mi
     image: quay.io/konflux-ci/appstudio-utils:latest@sha256:2b004dc4b55529823e8994e33df0d80e3d1de610e116f830e2b6d5d6e5539186
     name: upload-sbom
     script: |

--- a/task/buildah/0.7/buildah.yaml
+++ b/task/buildah/0.7/buildah.yaml
@@ -239,7 +239,7 @@ spec:
       limits:
         memory: 4Gi
       requests:
-        memory: 1Gi
+        memory: 4Gi
         cpu: '1'
     volumeMounts:
     - mountPath: /shared
@@ -313,7 +313,7 @@ spec:
       limits:
         memory: 8Gi
       requests:
-        memory: 2Gi
+        memory: 8Gi
         cpu: '1'
     env:
     - name: COMMIT_SHA
@@ -1087,7 +1087,7 @@ spec:
       limits:
         memory: 512Mi
       requests:
-        memory: 256Mi
+        memory: 512Mi
         cpu: 100m
     args:
     - --additional-base-images
@@ -1214,7 +1214,7 @@ spec:
       limits:
         memory: 512Mi
       requests:
-        memory: 256Mi
+        memory: 512Mi
         cpu: 100m
     volumeMounts:
     - name: trusted-ca


### PR DESCRIPTION
Refers to [KONFLUX-11444](https://issues.redhat.com//browse/KONFLUX-11444)

Reference: https://home.robusta.dev/blog/kubernetes-memory-limit
