### PR TITLE
chore: update external konflux task references

### DIFF
--- a/external-task/coverity-availability-check/0.2/coverity-availability-check.yaml
+++ b/external-task/coverity-availability-check/0.2/coverity-availability-check.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:5623e48314ffd583e9cab383011dc0763b6c92b09c4f427b8bfcca885394a21c
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:36400873d3031df128c55aa71ee11d322c3e55fd8f13dc5779098fbc117c0aa3

--- a/external-task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/external-task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:f59175d9a0a60411738228dfe568af4684af4aa5e7e05c832927cb917801d489
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:462baed733dfc38aca5395499e92f19b6f13a74c2e88fe5d86c3cffa2f899b57

--- a/external-task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
+++ b/external-task/sast-coverity-check-oci-ta/0.3/sast-coverity-check-oci-ta.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:ae62d14c999fd93246fef4e57d28570fa5200c3266b9a3263a39965e5a5b02d7
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:78f5244a8cfd28c890ed62db7e4ff1fc97ff39876d37fb19f1b0c2c286a4002c

--- a/external-task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/external-task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:1f0fcba24ebc447d9f8a2ea2e8f262fa435d6c523ca6b0346cd67261551fc9ed
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:d44336d7bcbd1f7cedee639357a493bd1f661e2859e49e11a34644bdf6819c4e

--- a/external-task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
+++ b/external-task/sast-snyk-check-oci-ta/0.4/sast-snyk-check-oci-ta.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:60f2dac41844d222086ff7f477e51f3563716b183d87db89f603d6f604c21760
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:8ad28b7783837a24acbc9a8494c935e796e591ce476085ad5899bebd7e53f077

--- a/external-task/sast-unicode-check-oci-ta/0.3/sast-unicode-check-oci-ta.yaml
+++ b/external-task/sast-unicode-check-oci-ta/0.3/sast-unicode-check-oci-ta.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:1833c618170ab9deb8455667f220df8e88d16ccd630a2361366f594e2bdcb712
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.3@sha256:e5a8d3e8e7be7246a1460385b95c084ea6e8fe7520d40fe4389deb90f1bf5176


### PR DESCRIPTION
  - Update coverity-availability-check/0.2
  - Update deprecated-image-check/0.5
  - Update sast-coverity-check-oci-ta/0.3
  - Update sast-shell-check-oci-ta/0.1
  - Update sast-snyk-check-oci-ta/0.4
  - Update sast-unicode-check-oci-ta/0.3

[KFLUXSPRT-6265](https://issues.redhat.com/browse/KFLUXSPRT-6265)
These tasks are all failing EC. 

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
