### PR TITLE
Set desirable resource consumption limits for all steps of task: "buildah"

### DIFF
--- a/task/buildah/0.7/buildah.yaml
+++ b/task/buildah/0.7/buildah.yaml
@@ -237,9 +237,9 @@ spec:
   stepTemplate:
     computeResources:
       limits:
-        memory: 256Mi
+        memory: 128Mi
       requests:
-        memory: 256Mi
+        memory: 128Mi
         cpu: '1'
     volumeMounts:
     - mountPath: /shared
@@ -1221,9 +1221,9 @@ spec:
       echo "[$(date --utc -Ins)] End upload-sbom"
     computeResources:
       limits:
-        memory: 512Mi
+        memory: 128Mi
       requests:
-        memory: 512Mi
+        memory: 128Mi
         cpu: 100m
     volumeMounts:
     - name: trusted-ca


### PR DESCRIPTION
As requested by @sfowl in this PR (https://github.com/konflux-ci/konflux-sast-tasks/pull/47) to check on `buildah` task first, here are the results (using tool from https://github.com/redhat-appstudio/perfscale/pull/15) for various memory consumption statistics of the task:`buildah` for the last 7 days on various clusters (data could be extracted only for the following clusters):
```
cluster_name="kflux-prd-rh02", task_name="buildah", step_name="step-build", Max_mem="8192 MB", 95_Pctl_Mem="8192 MB", 90_Pctl_Mem="8192 MB", Median_Mem="6636 MB"
cluster_name="kflux-prd-rh03", task_name="buildah", step_name="step-build", Max_mem="2219 MB", 95_Pctl_Mem="1780 MB", 90_Pctl_Mem="1780 MB", Median_Mem="220 MB"
cluster_name="kflux-rhel-p01", task_name="buildah", step_name="step-build", Max_mem="656 MB", 95_Pctl_Mem="656 MB", 90_Pctl_Mem="656 MB", Median_Mem="34 MB"
cluster_name="stone-prd-rh01", task_name="buildah", step_name="step-build", Max_mem="8192 MB", 95_Pctl_Mem="8192 MB", 90_Pctl_Mem="8192 MB", Median_Mem="8192 MB"
cluster_name="stone-stg-rh01", task_name="buildah", step_name="step-build", Max_mem="402 MB", 95_Pctl_Mem="402 MB", 90_Pctl_Mem="35 MB", Median_Mem="35 MB"

cluster_name="kflux-prd-rh02", task_name="buildah", step_name="step-push", Max_mem="530 MB", 95_Pctl_Mem="32 MB", 90_Pctl_Mem="11 MB", Median_Mem="8 MB"
cluster_name="kflux-prd-rh03", task_name="buildah", step_name="step-push", Max_mem="32 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="9 MB", Median_Mem="7 MB"
cluster_name="kflux-rhel-p01", task_name="buildah", step_name="step-push", Max_mem="10 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="10 MB"
cluster_name="stone-prd-rh01", task_name="buildah", step_name="step-push", Max_mem="4096 MB", 95_Pctl_Mem="4096 MB", 90_Pctl_Mem="4096 MB", Median_Mem="12 MB"
cluster_name="stone-stg-rh01", task_name="buildah", step_name="step-push", Max_mem="425 MB", 95_Pctl_Mem="425 MB", 90_Pctl_Mem="33 MB", Median_Mem="6 MB"

cluster_name="kflux-prd-rh02", task_name="buildah", step_name="step-sbom-syft-generate", Max_mem="404 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="8 MB"
cluster_name="kflux-prd-rh03", task_name="buildah", step_name="step-sbom-syft-generate", Max_mem="10 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="8 MB"
cluster_name="kflux-rhel-p01", task_name="buildah", step_name="step-sbom-syft-generate", Max_mem="8 MB", 95_Pctl_Mem="8 MB", 90_Pctl_Mem="8 MB", Median_Mem="8 MB"
cluster_name="stone-prd-rh01", task_name="buildah", step_name="step-sbom-syft-generate", Max_mem="4096 MB", 95_Pctl_Mem="4096 MB", 90_Pctl_Mem="4096 MB", Median_Mem="10 MB"
cluster_name="stone-stg-rh01", task_name="buildah", step_name="step-sbom-syft-generate", Max_mem="10 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="8 MB"

cluster_name="kflux-prd-rh02", task_name="buildah", step_name="step-prepare-sboms", Max_mem="190 MB", 95_Pctl_Mem="88 MB", 90_Pctl_Mem="87 MB", Median_Mem="8 MB"
cluster_name="kflux-prd-rh03", task_name="buildah", step_name="step-prepare-sboms", Max_mem="10 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="9 MB", Median_Mem="7 MB"
cluster_name="kflux-rhel-p01", task_name="buildah", step_name="step-prepare-sboms", Max_mem="87 MB", 95_Pctl_Mem="87 MB", 90_Pctl_Mem="10 MB", Median_Mem="10 MB"
cluster_name="stone-prd-rh01", task_name="buildah", step_name="step-prepare-sboms", Max_mem="180 MB", 95_Pctl_Mem="88 MB", 90_Pctl_Mem="11 MB", Median_Mem="10 MB"
cluster_name="stone-stg-rh01", task_name="buildah", step_name="step-prepare-sboms", Max_mem="11 MB", 95_Pctl_Mem="11 MB", 90_Pctl_Mem="8 MB", Median_Mem="5 MB"

cluster_name="kflux-prd-rh02", task_name="buildah", step_name="step-upload-sbom", Max_mem="12 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="8 MB"
cluster_name="kflux-prd-rh03", task_name="buildah", step_name="step-upload-sbom", Max_mem="10 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="10 MB", Median_Mem="8 MB"
cluster_name="kflux-rhel-p01", task_name="buildah", step_name="step-upload-sbom", Max_mem="10 MB", 95_Pctl_Mem="10 MB", 90_Pctl_Mem="8 MB", Median_Mem="7 MB"
cluster_name="stone-prd-rh01", task_name="buildah", step_name="step-upload-sbom", Max_mem="36 MB", 95_Pctl_Mem="12 MB", 90_Pctl_Mem="12 MB", Median_Mem="10 MB"
cluster_name="stone-stg-rh01", task_name="buildah", step_name="step-upload-sbom", Max_mem="9 MB", 95_Pctl_Mem="9 MB", 90_Pctl_Mem="8 MB", Median_Mem="8 MB"
```

We see that `stepTemplate` (default for every step/container) is set for 4GB each for request & limits, which is not necessary at all. Reserving memory when all steps/containers are not going to use that much (as seen via data above) is not needed. So, we made the following changes:

1. Reduce mem request/limit for `stepTemplate` down to 128M from 4G since we see that steps `step-prepare-sboms` and `upload-sbom` are hardly using 4G
2. We see that steps `push` & `sbom-syft-generate` are consistently using 4G of memory, so we are adding a new definition for them. Earlier they used to fall back to 4G of `stepTemplate`
3. Step `upload-sbom` from 512M to 128M since we see that max mem used is 12Mb
4. Keeping other resource definitions for other step(s) (e.g: `build` & `prepare-sboms`) unchanged

With the above changes, earlier the overall Memory consumption for a single `buildah` task POD would be actually reduced 384Mb.

Cc: @jhutar 