### PR TITLE
Add convert-image-tasks-to-digests in run-opm-command-oci-ta task

### DIFF
--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -178,11 +178,14 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### run-opm-command-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|CONVERT_TAGS_TO_DIGESTS| Optional. Convert all image tags in the catalog output to sha256 digests. Enabled by default. Set to 'false' to disable.| true| |
 |FILE_TO_UPDATE_PULLSPEC| Optional. Relative path to a file (e.g., catalog-template.yml) in which pullspecs should be updated before running opm.| ""| |
 |IDMS_PATH| Optional, path for ImageDigestMirrorSet file. It defaults to '.tekton/images-mirror-set.yaml'| .tekton/images-mirror-set.yaml| |
 |OPM_ARGS| The array of arguments to pass to the 'opm' command. (e.g., [ 'alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']).| []| []|
 |OPM_OUTPUT_PATH| Relative path for the opm command's output file (e.g. 'v4.18/catalog/example-operator/catalog.json'). Relative to the root directory of given source code (Git repository).| None| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
+|caTrustConfigMapKey| The key in the ConfigMap containing the CA bundle.| ca-bundle.crt| |
+|caTrustConfigMapName| The name of the ConfigMap containing the CA bundle for TLS verification.| trusted-ca| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts. Empty string means no expiration.| None| '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).opm'|
 ### validate-fbc:0.1 task parameters

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -36,6 +36,18 @@ spec:
       type: string
       description: Optional, path for ImageDigestMirrorSet file. It defaults to '.tekton/images-mirror-set.yaml'
       default: ".tekton/images-mirror-set.yaml"
+    - name: CONVERT_TAGS_TO_DIGESTS
+      type: string
+      description: Optional. Convert all image tags in the catalog output to sha256 digests. Enabled by default. Set to 'false' to disable.
+      default: "true"
+    - name: caTrustConfigMapName
+      type: string
+      description: The name of the ConfigMap containing the CA bundle for TLS verification.
+      default: trusted-ca
+    - name: caTrustConfigMapKey
+      type: string
+      description: The key in the ConfigMap containing the CA bundle.
+      default: ca-bundle.crt
   results:
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with the application source code with generated
@@ -43,10 +55,21 @@ spec:
   volumes:
     - name: workdir
       emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
   stepTemplate:
     volumeMounts:
       - mountPath: /var/workdir
         name: workdir
+      - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        name: trusted-ca
+        readOnly: true
+        subPath: ca-bundle.crt
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:aa601d847eafa87747894b770eff43b47cffe2cc39059bb345ee58b378473b8f
@@ -108,6 +131,151 @@ spec:
           echo -n "false" > "$(step.results.skip_create_trusted_artifact.path)"
         - "bash"
         - $(params.OPM_ARGS[*])
+    - name: convert-image-tags-to-digests
+      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:2b1e6e5e9b28f17770476039d1c3e68166b61fefcf0d4a6359f30d044b149b65
+      workingDir: /var/workdir/source
+      securityContext:
+        runAsUser: 0
+      env:
+        - name: OPM_OUTPUT_PATH_PARAM
+          value: $(params.OPM_OUTPUT_PATH)
+      when:
+        - input: "$(params.CONVERT_TAGS_TO_DIGESTS)"
+          operator: in
+          values: ["true"]
+        - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
+          operator: in
+          values: ["false"]
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        load_utils() {
+          # shellcheck source=/dev/null
+          source /utils.sh
+        }
+
+        # Main conversion function
+        convert_tags_to_digests() {
+          local -r catalog_file="${OPM_OUTPUT_PATH_PARAM}"
+
+          echo "Converting image tags to sha256 digests in '${catalog_file}'."
+
+          if [[ ! -f "${catalog_file}" ]]; then
+            echo "Error: Catalog file '${catalog_file}' not found." >&2
+            return 1
+          fi
+
+          # Extract image references from specific OLM catalog paths only:
+          # - .image (root level bundle image)
+          # - .relatedImages[].image (related images array)
+          echo "Extracting image references from catalog..."
+          local -a images=()
+          mapfile -t images < <(jq -r '.image, .relatedImages[]?.image | select(. != null)' "${catalog_file}" | sort -u)
+
+          if [[ ${#images[@]} -eq 0 ]]; then
+            echo "No images found in catalog. Nothing to convert."
+            return 0
+          fi
+
+          echo "Found ${#images[@]} unique image reference(s)."
+
+          # Map: key=original_image, value=digest_image
+          local -A image_digests_map=()
+
+          # Process each image and get its digest
+          for image in "${images[@]}"; do
+            # Fail on empty image references - indicates malformed catalog
+            if [[ -z "${image}" ]]; then
+              echo "Error: Found empty image reference in catalog. This indicates a malformed catalog entry." >&2
+              return 1
+            fi
+
+            # Parse the image URL using parse_image_url (utils.sh function)
+            local parsed_image parsed_digest parsed_tag parsed_registry_repository
+            parsed_image=$(parse_image_url "${image}")
+            parsed_digest=$(echo "$parsed_image" | jq -r '.digest')
+            parsed_tag=$(echo "$parsed_image" | jq -r '.tag')
+            parsed_registry_repository=$(echo "$parsed_image" | jq -r '.registry_repository')
+
+            # Skip images that already use digest format
+            if [[ -n "${parsed_digest}" ]]; then
+              echo "Image '${image}' already uses digest format. Skipping."
+              continue
+            fi
+
+            # Fail if image doesn't have a tag
+            # Untagged images are ambiguous and defeat the purpose of digest conversion
+            if [[ -z "${parsed_tag}" ]]; then
+              echo "Error: Image '${image}' has no tag. Cannot convert to digest." >&2
+              return 1
+            fi
+
+            echo "Processing image: ${image}"
+
+            # Get the digest using skopeo with retry wrapper
+            local digest
+            if ! digest=$(retry skopeo inspect --no-tags --format='{{.Digest}}' "docker://${image}"); then
+              echo "Error: Failed to get digest for image '${image}'." >&2
+              return 1
+            fi
+
+            if [[ -z "${digest}" ]]; then
+              echo "Error: Empty digest returned for image '${image}'." >&2
+              return 1
+            fi
+
+            # Construct the digest-based image reference
+            local image_with_digest="${parsed_registry_repository}@${digest}"
+
+            image_digests_map["${image}"]="${image_with_digest}"
+          done
+
+          # Apply all replacements
+          if [[ ${#image_digests_map[@]} -gt 0 ]]; then
+            echo ""
+            echo "Applying ${#image_digests_map[@]} replacement(s) to catalog file:"
+            for img in "${!image_digests_map[@]}"; do
+              echo "  ${img} -> ${image_digests_map[${img}]}"
+            done
+            echo ""
+
+            # Create temporary file for the catalog replacements
+            local tmp_file
+            tmp_file=$(mktemp)
+            trap 'rm -f "${tmp_file}"' RETURN
+
+            # Iterate over the map and replace each image reference
+            local old_image
+            for old_image in "${!image_digests_map[@]}"; do
+              local new_image="${image_digests_map[${old_image}]}"
+
+              # Replace in specific OLM catalog paths only:
+              # - .image (root level)
+              # - .relatedImages[].image (related images array)
+              if ! jq --arg old "${old_image}" --arg new "${new_image}" \
+                   '(if .image == $old then .image = $new else . end) |
+                    (if .relatedImages then .relatedImages = [.relatedImages[] | if .image == $old then .image = $new else . end] else . end)' \
+                   "${catalog_file}" > "${tmp_file}"; then
+                echo "Error: Failed to replace image '${old_image}' in catalog." >&2
+                return 1
+              fi
+
+              if ! mv "${tmp_file}" "${catalog_file}"; then
+                echo "Error: Failed to update catalog file." >&2
+                return 1
+              fi
+            done
+
+            echo "Successfully converted ${#image_digests_map[@]} image reference(s) to digest format."
+          else
+            echo "No images needed conversion."
+          fi
+        }
+
+        # Load utilities and run the conversion
+        load_utils
+        convert_tags_to_digests
     - name: replace-related-images-pullspec-in-file
       image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:2b1e6e5e9b28f17770476039d1c3e68166b61fefcf0d4a6359f30d044b149b65
       workingDir: /var/workdir/source

--- a/task/run-opm-command-oci-ta/0.1/spec/convert_tags_to_digests_spec.sh
+++ b/task/run-opm-command-oci-ta/0.1/spec/convert_tags_to_digests_spec.sh
@@ -1,0 +1,246 @@
+#!/bin/env bash
+
+set -o errexit
+set -o pipefail
+set -o nounset
+
+# Check if shellspec is available
+if ! command -v shellspec &> /dev/null; then
+  echo "ERROR: shellspec is not installed or not in PATH." >&2
+  echo "Install it with: curl -fsSL https://git.io/shellspec | sh" >&2
+  echo "Or see: https://github.com/shellspec/shellspec#installation" >&2
+  exit 1
+fi
+
+eval "$(shellspec - -c) exit 1"
+
+task_path=run-opm-command-oci-ta.yaml
+
+if [[ -f "../${task_path}" ]]; then
+    task_path="../${task_path}"
+fi
+
+extract_script() {
+  local script_dir
+  script_dir="$(mktemp -d)"
+  local script="${script_dir}/$1.sh"
+
+  if ! yq -r ".spec.steps[] | select(.name == \"$1\").script" "${task_path}" > "${script}"; then
+    echo "ERROR: Failed to extract script for step '$1' from ${task_path}" >&2
+    exit 1
+  fi
+
+  # Verify script was extracted (not empty)
+  if [[ ! -s "${script}" ]]; then
+    echo "ERROR: Extracted script is empty. Step '$1' may not exist in ${task_path}" >&2
+    exit 1
+  fi
+
+  # Fetch real utils.sh from konflux-test repository for accurate testing
+  local utils_url="https://raw.githubusercontent.com/konflux-ci/konflux-test/main/test/utils.sh"
+  local utils_file="${script_dir}/utils.sh"
+  
+  if ! curl -sSfL "${utils_url}" -o "${utils_file}" 2>/dev/null; then
+    echo "ERROR: Failed to fetch utils.sh from ${utils_url}" >&2
+    exit 1
+  fi
+  
+  # Verify we got actual shell script content, not an error page
+  if ! file "${utils_file}" | grep -qi "shell script"; then
+    echo "ERROR: Downloaded file is not a valid shell script (might be an error page)" >&2
+    echo "File type: $(file "${utils_file}")" >&2
+    exit 1
+  fi
+  
+  # Override load_utils to source the fetched utils.sh
+  sed -i "s|load_utils() {|load_utils() { source ${utils_file}; return; # original: |g" "${script}"
+
+  chmod +x "${script}"
+  echo "${script}"
+}
+
+# array containing files/directories to remove on test exit
+cleanup=()
+trap 'rm -rf "${cleanup[@]}"' EXIT
+
+# Extract the convert-image-tags-to-digests Step script so we can test it
+convert_script="$(extract_script convert-image-tags-to-digests)"
+cleanup+=("$(dirname "${convert_script}")")
+
+testdir() {
+    testdir="$(mktemp -d)" && cleanup+=("${testdir}") && cd "${testdir}"
+    AfterEach "rm -rf \"\$testdir\""
+}
+
+# Helper to create a sample catalog JSON with images
+create_catalog_with_images() {
+    cat > catalog.json << 'EOF'
+{
+  "schema": "olm.bundle",
+  "name": "test-operator.v1.0.0",
+  "image": "registry.redhat.io/test/operator-bundle:v1.0.0",
+  "relatedImages": [
+    {
+      "name": "operator",
+      "image": "registry.redhat.io/test/operator:v1.0.0"
+    },
+    {
+      "name": "already-digested",
+      "image": "quay.io/test/image@sha256:abc123def456"
+    }
+  ]
+}
+EOF
+}
+
+# Helper to create catalog with only digest-based images
+create_catalog_with_digests_only() {
+    cat > catalog.json << 'EOF'
+{
+  "schema": "olm.bundle",
+  "name": "test-operator.v1.0.0",
+  "image": "quay.io/test/bundle@sha256:abc123",
+  "relatedImages": [
+    {
+      "name": "operator",
+      "image": "quay.io/test/operator@sha256:def456"
+    }
+  ]
+}
+EOF
+}
+
+Describe "convert-image-tags-to-digests"
+    BeforeEach testdir
+
+    export OPM_OUTPUT_PATH_PARAM="catalog.json"
+    export CONVERT_TAGS_TO_DIGESTS_PARAM="true"
+
+    It "handles missing catalog file gracefully"
+        # Don't create catalog.json
+
+        When call "${convert_script}"
+        The status should eq 1
+        The output should include "Converting image tags"
+        The stderr should include "Catalog file"
+        The stderr should include "not found"
+    End
+
+    It "handles empty catalog (no images)"
+        cat > catalog.json << 'EOF'
+{
+  "schema": "olm.package",
+  "name": "test-operator"
+}
+EOF
+
+        When call "${convert_script}"
+        The status should eq 0
+        The output should include "No images found"
+    End
+
+    It "fails on empty image reference"
+        cat > catalog.json << 'EOF'
+{
+  "schema": "olm.bundle",
+  "image": ""
+}
+EOF
+
+        When call "${convert_script}"
+        The status should eq 1
+        The output should include "Found 1 unique image"
+        The stderr should include "empty image reference"
+    End
+
+    It "skips images that already have digests"
+        create_catalog_with_digests_only
+
+        # Mock skopeo - should not be called for digest images
+        Mock skopeo
+            echo "ERROR: skopeo should not be called for digest images" >&2
+            exit 1
+        End
+
+        When call "${convert_script}"
+        The status should eq 0
+        The output should include "digest format"
+        The output should include "No images needed conversion"
+    End
+
+    It "processes tagged images and calls skopeo"
+        create_catalog_with_images
+
+        # Mock skopeo to return digests
+        Mock skopeo
+            case "$*" in
+                *"registry.redhat.io/test/operator-bundle:v1.0.0"*)
+                    echo "sha256:bundledigest123"
+                    ;;
+                *"registry.redhat.io/test/operator:v1.0.0"*)
+                    echo "sha256:operatordigest456"
+                    ;;
+                *)
+                    echo "sha256:unknowndigest"
+                    ;;
+            esac
+        End
+
+        When call "${convert_script}"
+        The status should eq 0
+        The output should include "Found 3 unique image"
+        The output should include "digest format"
+        The output should include "Processing image:"
+        The output should include "@sha256:bundledigest123"
+        The output should include "@sha256:operatordigest456"
+        The output should include "Successfully converted 2"
+    End
+
+    It "fails when skopeo cannot get digest"
+        create_catalog_with_images
+
+        # Mock skopeo - fail for bundle
+        Mock skopeo
+            echo "Error: transient network error" >&2
+            exit 1
+        End
+
+        # Mock sleep to speed up tests
+        Mock sleep
+            :
+        End
+
+        When call "${convert_script}"
+        The status should eq 1
+        The output should include "Processing image:"
+        The stderr should include "Failed to get digest"
+    End
+
+    It "fails when skopeo returns empty digest"
+        create_catalog_with_images
+
+        # Mock skopeo - return empty digest
+        Mock skopeo
+            echo ""
+        End
+
+        When call "${convert_script}"
+        The status should eq 1
+        The output should include "Processing image:"
+        The stderr should include "Empty digest"
+    End
+
+    It "fails on images without tags"
+        cat > catalog.json << 'EOF'
+{
+  "schema": "olm.bundle",
+  "image": "registry.example.com/image-without-tag"
+}
+EOF
+
+        When call "${convert_script}"
+        The status should eq 1
+        The output should include "Found 1 unique image"
+        The stderr should include "has no tag"
+    End
+End

--- a/task/run-opm-command-oci-ta/0.1/tests/pre-apply-task-hook.sh
+++ b/task/run-opm-command-oci-ta/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script is called before applying the task to set up required resources
+# No special resources needed - the CI environment provides:
+# - trusted-ca ConfigMap (injected by cert-manager trust-manager)
+# - Registry access via kind-registry
+
+echo "Pre-requirements setup complete for run-opm-command-oci-ta task"

--- a/task/run-opm-command-oci-ta/0.1/tests/test-convert-tags-already-digested.yaml
+++ b/task/run-opm-command-oci-ta/0.1/tests/test-convert-tags-already-digested.yaml
@@ -1,0 +1,175 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-convert-tags-to-digests-already-digested
+spec:
+  description: |
+    Tests the convert_tags_to_digests step with images that already have digests.
+    Verifies that the step completes successfully without needing registry access.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: create-source-artifact
+      params:
+        - name: ociStorage
+          value: registry-service.kind-registry/oci-ta:test-already-digested
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+      taskSpec:
+        results:
+          - name: SOURCE_ARTIFACT
+            type: string
+        params:
+          - name: ociStorage
+          - name: caTrustConfigMapName
+          - name: caTrustConfigMapKey
+        workspaces:
+          - name: tests-workspace
+        volumes:
+          - name: trusted-ca
+            configMap:
+              items:
+                - key: $(params.caTrustConfigMapKey)
+                  path: ca-bundle.crt
+              name: $(params.caTrustConfigMapName)
+        stepTemplate:
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+        steps:
+          - name: create-catalog-with-digests
+            image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              # Create source directory structure
+              mkdir -p "$(workspaces.tests-workspace.path)/source/.konflux/catalog/test-operator"
+
+              # Create a catalog with images that already have digests
+              # No registry access needed - conversion step will skip these
+              cat > "$(workspaces.tests-workspace.path)/source/.konflux/catalog/test-operator/catalog.json" << 'EOF'
+              {
+                "schema": "olm.bundle",
+                "name": "test-operator.v1.0.0",
+                "image": "registry.example.com/test/operator-bundle@sha256:abc123def456789",
+                "relatedImages": [
+                  {
+                    "name": "operator",
+                    "image": "registry.example.com/test/operator@sha256:def456abc789123"
+                  }
+                ]
+              }
+              EOF
+
+              echo "Created catalog with digest-based images:"
+              cat "$(workspaces.tests-workspace.path)/source/.konflux/catalog/test-operator/catalog.json"
+          - name: create-trusted-artifact
+            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:aa601d847eafa87747894b770eff43b47cffe2cc39059bb345ee58b378473b8f
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.SOURCE_ARTIFACT.path)=$(workspaces.tests-workspace.path)/source
+      workspaces:
+        - name: tests-workspace
+          workspace: tests-workspace
+    - name: run-task-with-conversion-enabled
+      taskRef:
+        name: run-opm-command-oci-ta
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.create-source-artifact.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: registry-service.kind-registry/oci-ta:test-already-digested-output
+        - name: ociArtifactExpiresAfter
+          value: ""
+        - name: OPM_ARGS
+          value: []
+        - name: OPM_OUTPUT_PATH
+          value: ".konflux/catalog/test-operator/catalog.json"
+        - name: CONVERT_TAGS_TO_DIGESTS
+          value: "true"
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+      runAfter:
+        - create-source-artifact
+    - name: verify-digests-preserved
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.run-task-with-conversion-enabled.results.SOURCE_ARTIFACT)
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+      taskSpec:
+        params:
+          - name: SOURCE_ARTIFACT
+          - name: caTrustConfigMapName
+          - name: caTrustConfigMapKey
+        workspaces:
+          - name: tests-workspace
+        volumes:
+          - name: trusted-ca
+            configMap:
+              items:
+                - key: $(params.caTrustConfigMapKey)
+                  path: ca-bundle.crt
+              name: $(params.caTrustConfigMapName)
+        stepTemplate:
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+        steps:
+          - name: fetch-artifact
+            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:aa601d847eafa87747894b770eff43b47cffe2cc39059bb345ee58b378473b8f
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=$(workspaces.tests-workspace.path)/output
+          - name: verify-images-still-digested
+            image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              CATALOG_FILE="$(workspaces.tests-workspace.path)/output/.konflux/catalog/test-operator/catalog.json"
+
+              echo "Verifying catalog file..."
+              if [[ ! -f "${CATALOG_FILE}" ]]; then
+                echo "❌ Catalog file not found"
+                exit 1
+              fi
+
+              echo "Catalog content:"
+              cat "${CATALOG_FILE}"
+
+              # Define expected images as JSON array
+              EXPECTED='["registry.example.com/test/operator-bundle@sha256:abc123def456789","registry.example.com/test/operator@sha256:def456abc789123"]'
+
+              # Extract actual images and compare with expected (order-independent)
+              ACTUAL=$(jq -c '[.. | objects | select(has("image")) | .image] | sort' "${CATALOG_FILE}")
+              EXPECTED_SORTED=$(echo "${EXPECTED}" | jq -c 'sort')
+
+              echo "Expected images: ${EXPECTED_SORTED}"
+              echo "Actual images:   ${ACTUAL}"
+
+              if [[ "${ACTUAL}" == "${EXPECTED_SORTED}" ]]; then
+                echo "✅ All images match exactly"
+              else
+                echo "❌ Images do not match"
+                exit 1
+              fi
+      workspaces:
+        - name: tests-workspace
+          workspace: tests-workspace
+      runAfter:
+        - run-task-with-conversion-enabled

--- a/task/run-opm-command-oci-ta/0.1/tests/test-convert-tags-disabled.yaml
+++ b/task/run-opm-command-oci-ta/0.1/tests/test-convert-tags-disabled.yaml
@@ -1,0 +1,175 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-convert-tags-to-digests-disabled
+spec:
+  description: |
+    Tests the convert_tags_to_digests step when CONVERT_TAGS_TO_DIGESTS is disabled.
+    Verifies that image tags are preserved (not converted) when the feature is off.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: create-source-artifact
+      params:
+        - name: ociStorage
+          value: registry-service.kind-registry/oci-ta:test-convert-disabled
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+      taskSpec:
+        results:
+          - name: SOURCE_ARTIFACT
+            type: string
+        params:
+          - name: ociStorage
+          - name: caTrustConfigMapName
+          - name: caTrustConfigMapKey
+        workspaces:
+          - name: tests-workspace
+        volumes:
+          - name: trusted-ca
+            configMap:
+              items:
+                - key: $(params.caTrustConfigMapKey)
+                  path: ca-bundle.crt
+              name: $(params.caTrustConfigMapName)
+        stepTemplate:
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+        steps:
+          - name: create-catalog-with-tags
+            image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              # Create source directory structure
+              mkdir -p "$(workspaces.tests-workspace.path)/source/.konflux/catalog/test-operator"
+
+              # Create a catalog with tagged images (not digests)
+              # These are intentionally fake images - we're testing the skip logic
+              cat > "$(workspaces.tests-workspace.path)/source/.konflux/catalog/test-operator/catalog.json" << 'EOF'
+              {
+                "schema": "olm.bundle",
+                "name": "test-operator.v1.0.0",
+                "image": "registry.example.com/test/operator-bundle:v1.0.0",
+                "relatedImages": [
+                  {
+                    "name": "operator",
+                    "image": "registry.example.com/test/operator:v1.0.0"
+                  }
+                ]
+              }
+              EOF
+
+              echo "Created catalog with tagged images:"
+              cat "$(workspaces.tests-workspace.path)/source/.konflux/catalog/test-operator/catalog.json"
+          - name: create-trusted-artifact
+            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:aa601d847eafa87747894b770eff43b47cffe2cc39059bb345ee58b378473b8f
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.SOURCE_ARTIFACT.path)=$(workspaces.tests-workspace.path)/source
+      workspaces:
+        - name: tests-workspace
+          workspace: tests-workspace
+    - name: run-task-with-conversion-disabled
+      taskRef:
+        name: run-opm-command-oci-ta
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.create-source-artifact.results.SOURCE_ARTIFACT)
+        - name: ociStorage
+          value: registry-service.kind-registry/oci-ta:test-convert-disabled-output
+        - name: ociArtifactExpiresAfter
+          value: ""
+        - name: OPM_ARGS
+          value: []
+        - name: OPM_OUTPUT_PATH
+          value: ".konflux/catalog/test-operator/catalog.json"
+        - name: CONVERT_TAGS_TO_DIGESTS
+          value: "false"
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+      runAfter:
+        - create-source-artifact
+    - name: verify-tags-preserved
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.run-task-with-conversion-disabled.results.SOURCE_ARTIFACT)
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+      taskSpec:
+        params:
+          - name: SOURCE_ARTIFACT
+          - name: caTrustConfigMapName
+          - name: caTrustConfigMapKey
+        workspaces:
+          - name: tests-workspace
+        volumes:
+          - name: trusted-ca
+            configMap:
+              items:
+                - key: $(params.caTrustConfigMapKey)
+                  path: ca-bundle.crt
+              name: $(params.caTrustConfigMapName)
+        stepTemplate:
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+        steps:
+          - name: fetch-artifact
+            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:aa601d847eafa87747894b770eff43b47cffe2cc39059bb345ee58b378473b8f
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=$(workspaces.tests-workspace.path)/output
+          - name: verify-images-still-tagged
+            image: quay.io/konflux-ci/appstudio-utils:1610c1fc4cfc9c9053dbefc1146904a4df6659ef@sha256:90ac97b811073cb99a23232c15a08082b586c702b85da6200cf54ef505e3c50c
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              CATALOG_FILE="$(workspaces.tests-workspace.path)/output/.konflux/catalog/test-operator/catalog.json"
+
+              echo "Verifying catalog file..."
+              if [[ ! -f "${CATALOG_FILE}" ]]; then
+                echo "❌ Catalog file not found"
+                exit 1
+              fi
+
+              echo "Catalog content:"
+              cat "${CATALOG_FILE}"
+
+              # Define expected images as JSON array (tagged, not digests)
+              EXPECTED='["registry.example.com/test/operator-bundle:v1.0.0","registry.example.com/test/operator:v1.0.0"]'
+
+              # Extract actual images and compare with expected (order-independent)
+              ACTUAL=$(jq -c '[.. | objects | select(has("image")) | .image] | sort' "${CATALOG_FILE}")
+              EXPECTED_SORTED=$(echo "${EXPECTED}" | jq -c 'sort')
+
+              echo "Expected images: ${EXPECTED_SORTED}"
+              echo "Actual images:   ${ACTUAL}"
+
+              if [[ "${ACTUAL}" == "${EXPECTED_SORTED}" ]]; then
+                echo "✅ All images match exactly - tags preserved, no digests added"
+              else
+                echo "❌ Images do not match - conversion may have occurred or images modified"
+                exit 1
+              fi
+      workspaces:
+        - name: tests-workspace
+          workspace: tests-workspace
+      runAfter:
+        - run-task-with-conversion-disabled


### PR DESCRIPTION
**Why these changes?**

When building olm fbc catalogs, image references might be generated with tags (e.g., `registry.redhat.io/my-bundle:v1.0`) if the corresponding catalog template was based on tags too. Exclusive tags based catalog templates for released bundle images are a powerful development pattern when combined with the nudge mechanism: should all the bundle images include tags but the unreleased bundle (digest), we can automatically streamline the corresponding catalog build, without leveraging any extra logic, just the bundle nudge for the unreleased bundle image.

Telco operators want to leverage that pattern in our fbc pipelines and it will require a final digest mapping for the tags based images, which has been implemented as an extra step, `convert-image-tags-to-digests`, in `run-opm-command-oci-ta` task. The final catalog generated will be entirely based on digests.

**Implementation Details**

- `task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml` : added new `convert-image-tags-to-digests` step with `CONVERT_TAGS_TO_DIGESTS` parameter (default: `true`). Leverages skopeo for the tag to digest mapping.

-  `task/run-opm-command-oci-ta/0.1/README.md` : updated documentation with new parameter and functionality description.