### PR TITLE
chore(KFLUXVNGD-520): cluster level proxy configuration

### DIFF
--- a/task/init/0.2/MIGRATION.md
+++ b/task/init/0.2/MIGRATION.md
@@ -63,3 +63,14 @@ The migration script failed to detect variations of buildah task and therefore d
 ## Action from users
 
 No action required. The migration script automatically handles all necessary changes.
+
+# Migration from 0.2.5 to 0.2.6
+
+The init task now initializes the parameters for caching.
+It fetches the parameters from `cluster-config` configmap and updates
+`enable-cache-proxy`, `no-proxy` and `http-proxy` accordingly
+
+
+## Action from users
+
+No action required.

--- a/task/init/0.2/init.yaml
+++ b/task/init/0.2/init.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.5"
+    app.kubernetes.io/version: "0.2.6"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"
@@ -32,7 +32,7 @@ spec:
 
   steps:
     - name: init
-      image: registry.access.redhat.com/ubi9/skopeo:9.7-1764822892@sha256:1a8ec73cad58afc794233833408e2d719dd52ebc8ccc066a2e3781d8441f6d31
+      image: quay.io/konflux-ci/task-runner:0.2.0@sha256:ba65585f5c8b0a74dc51590e95961765322427d1d62ccd4eb742ff0442291985
       computeResources:
         limits:
           memory: 256Mi
@@ -55,6 +55,9 @@ spec:
 
         skopeo_retries=3
 
+        default_http_proxy="squid.caching.svc.cluster.local:3128"
+        default_no_proxy="brew.registry.redhat.io,docker.io,gcr.io,ghcr.io,images.paas.redhat.com,mirror.gcr.io,nvcr.io,quay.io,registry-proxy.engineering.redhat.com,registry.access.redhat.com,registry.ci.openshift.org,registry.fedoraproject.org,registry.redhat.io,registry.stage.redhat.io,vault.habana.ai"
+
         echo "Determine if Image Already Exists"
         # Build the image when rebuild is set to true or image does not exist
         # The image check comes last to avoid unnecessary, slow API calls
@@ -64,10 +67,40 @@ spec:
           echo -n "false" > "$(results.build.path)"
         fi
 
-        # Set cache proxy configuration if enabled
-        if [ "$ENABLE_CACHE_PROXY" == "true" ]; then
-          echo -n "squid.caching.svc.cluster.local:3128" > "$(results.http-proxy.path)"
+        # Fetch cluster-config from konflux-info namespace
+        echo "Fetching cluster-config from konflux-info namespace..."
+        if config_map=$(oc get configmap cluster-config -n konflux-info -o json 2>/dev/null); then
+          # ConfigMap exists
+          allow_cache=$(echo "$config_map" | jq -r '.data["allow-cache-proxy"] // "true"')
+          if [ "$allow_cache" == "true" ]; then
+             http_proxy=$(echo "$config_map" | jq -r --arg default_http "$default_http_proxy" '.data["http-proxy"] // $default_http')
+             no_proxy=$(echo "$config_map" | jq -r --arg default_no "$default_no_proxy" '.data["no-proxy"] // $default_no')
+          else
+             # allow-cache-proxy is false (or any other value != true)
+             http_proxy=""
+             no_proxy=""
+          fi
         else
-          echo -n "" > "$(results.http-proxy.path)"
+          # ConfigMap missing, use defaults
+          echo "Warning: Failed to fetch cluster-config ConfigMap. Proceeding with defaults."
+          allow_cache="true"
+          http_proxy="$default_http_proxy"
+          no_proxy="$default_no_proxy"
         fi
-        echo -n "" > "$(results.no-proxy.path)"
+
+        # Apply ENABLE_CACHE_PROXY check (from task param) ONLY if cluster allows it
+        if [ "$allow_cache" == "true" ] && [ "$ENABLE_CACHE_PROXY" == "true" ]; then
+           # Use the resolved values
+           echo "Cache proxy enabled (cluster-enabled: $allow_cache, task-enable: $ENABLE_CACHE_PROXY)"
+        else
+           # Task param disabled OR cluster disabled
+           echo "Cache proxy disabled (cluster-enabled: $allow_cache, task-enable: $ENABLE_CACHE_PROXY)"
+           http_proxy=""
+           no_proxy=""
+        fi
+
+        echo "Setting HTTP_PROXY to $http_proxy"
+        echo -n "$http_proxy" > "$(results.http-proxy.path)"
+
+        echo "Setting NO_PROXY to $no_proxy"
+        echo -n "$no_proxy" > "$(results.no-proxy.path)"


### PR DESCRIPTION
The init task now initializes the parameters for caching. It fetches the parameters from `cluster-config` configmap and updates `enable-cache-proxy`, `no-proxy` and `http-proxy` accordingly

bump to version 0.2.6

Assisted-by: Cursor with Gemini-3-pro