### PR TITLE
chore((KONFLUX-11519)): disable sast tasks update from task folder in renavate.json

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -66,6 +66,8 @@
 /external-task/sast-snyk-check-oci-ta                @konflux-ci/integration-service-maintainers @sfowl
 /external-task/sast-unicode-check                    @konflux-ci/integration-service-maintainers @sfowl
 /external-task/sast-unicode-check-oci-ta             @konflux-ci/integration-service-maintainers @sfowl
+
+# maintained by konflux-sast-tasks, should be ignored by renovate
 /task/coverity-availability-check           @konflux-ci/integration-service-maintainers @sfowl
 /task/sast-coverity-check                   @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @sfowl
 /task/sast-coverity-check-oci-ta            @konflux-ci/integration-service-maintainers @konflux-ci/build-maintainers @sfowl

--- a/renovate.json
+++ b/renovate.json
@@ -93,7 +93,6 @@
         "stepactions/fips-operator-check-step-action/**",
         "task/clair-scan/**",
         "task/clamav-scan/**",
-        "task/coverity-availability-check/**",
         "task/deprecated-image-check/**",
         "task/fbc-fips-check-oci-ta/**",
         "task/fbc-fips-check/**",
@@ -102,14 +101,6 @@
         "task/fips-operator-bundle-check/**",
         "task/github-sarif-upload/**",
         "task/run-opm-command-oci-ta/**",
-        "task/sast-coverity-check-oci-ta/**",
-        "task/sast-coverity-check/**",
-        "task/sast-shell-check-oci-ta/**",
-        "task/sast-shell-check/**",
-        "task/sast-snyk-check-oci-ta/**",
-        "task/sast-snyk-check/**",
-        "task/sast-unicode-check-oci-ta/**",
-        "task/sast-unicode-check/**",
         "task/sbom-json-check/**",
         "task/validate-fbc/**"
       ]
@@ -201,6 +192,22 @@
         "task/opm-get-bundle-version/**",
         "task/opm-render-bundles/**"
       ]
+    },
+    {
+      "groupName": "konflux-sast-tasks",
+      "description": "Updated and verified in konflux-sast-tasks so should be ignored here",
+      "matchFileNames": [
+        "task/coverity-availability-check/**",
+        "task/sast-coverity-check-oci-ta/**",
+        "task/sast-coverity-check/**",
+        "task/sast-shell-check-oci-ta/**",
+        "task/sast-shell-check/**",
+        "task/sast-snyk-check-oci-ta/**",
+        "task/sast-snyk-check/**",
+        "task/sast-unicode-check-oci-ta/**",
+        "task/sast-unicode-check/**"
+      ],
+      "enabled": false
     },
     {
       "groupName": "tekton-tools-tasks",


### PR DESCRIPTION
* since sast tasks have been maintainerd by konflux-sast-tasks repo so let's remove sast task from renovate.json to stop the mintmaker PR to update the these file

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
