### PR TITLE
prefetch-dependencies: Drop git fetch --tags workaround

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -412,15 +412,6 @@ spec:
 
         INPUT=$(inject_rpm_summary_flag "$INPUT")
 
-        # Some repos with go submodules would fail during prefetch dependencies task
-        # Forcing fetching tags serves as a workaround
-        export RETRY_MAX_TRIES=2
-        WORKSPACE_SOURCE="/var/workdir/source"
-        if ! (cd "$WORKSPACE_SOURCE" && retry git fetch --tags); then
-          exit 1
-        fi
-        unset RETRY_MAX_TRIES
-
         hermeto --log-level="$LOG_LEVEL" --mode="$MODE" $config_flag fetch-deps \
           $dev_pacman_flag \
           --source="/var/workdir/source" \

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -345,15 +345,6 @@ spec:
 
       INPUT=$(inject_rpm_summary_flag "$INPUT")
 
-      # Some repos with go submodules would fail during prefetch dependencies task
-      # Forcing fetching tags serves as a workaround
-      export RETRY_MAX_TRIES=2
-      WORKSPACE_SOURCE="$(workspaces.source.path)/source"
-      if ! (cd "$WORKSPACE_SOURCE" && retry git fetch --tags); then
-        exit 1
-      fi
-      unset RETRY_MAX_TRIES
-
       hermeto --log-level="$LOG_LEVEL" --mode="$MODE" $config_flag fetch-deps \
       $dev_pacman_flag \
       --source="$(workspaces.source.path)/source" \


### PR DESCRIPTION
The root cause of occasional error when fetching git tags was somewhere else, which means this workaround is no longer necessary.

Related piece of work:
Tekton PR: https://github.com/tektoncd-catalog/git-clone/pull/79
Hermeto PR: https://github.com/hermetoproject/hermeto/pull/1174

JIRA: https://issues.redhat.com/browse/STONEBLD-4062

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
