### PR TITLE
fix: quay authentication error in e2e-tests

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -40,7 +40,7 @@ spec:
         secretName: konflux-test-infra
   steps:
     - name: e2e-test
-      image: quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests:fe8a48163ed0cadd99f4f5285590ad9f970d7f30
+      image: quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests:eceb13540ba79f11a41fafe08fc91f8cb86a86ce
       command: ["/konflux-e2e/konflux-e2e.test"]
       # a la infra-deployment updates, when PRs merge in e2e-tests, PRs will be opened
       # against build-definitions to update this tag
@@ -62,7 +62,7 @@ spec:
       - name: COMPONENT_REPO_URLS
         value: "https://github.com/konflux-qe-bd/devfile-sample-python-basic,https://github.com/konflux-qe-bd/devfile-sample-python-basic-clone,https://github.com/konflux-qe-bd/multiarch-sample-repo,https://github.com/konflux-qe-bd/multiarch-sample-repo-clone,https://github.com/konflux-qe-bd/retrodep,https://github.com/konflux-qe-bd/pip-e2e-test,https://github.com/konflux-qe-bd/fbc-sample-repo,https://github.com/konflux-qe-bd/docker-file-from-scratch,https://github.com/konflux-qe-bd/oci-archive-test"
       - name: QUAY_E2E_ORGANIZATION
-        value: konflux-ci
+        value: redhat-appstudio-qe
       - name: E2E_APPLICATIONS_NAMESPACE
         value: "$(params.e2e_test_namespace)"
       - name: GITHUB_TOKEN
@@ -73,8 +73,8 @@ spec:
       - name: QUAY_TOKEN
         valueFrom:
           secretKeyRef:
-            name: quay-push-secret-konflux-ci
-            key: .dockerconfigjson
+            name: e2e-tests-quay-token
+            key: token
       - name: MY_GITHUB_ORG
         value: konflux-qe-bd
       - name: EC_PIPELINES_REPO_URL


### PR DESCRIPTION
This PR will fix the below quay authentication error we are getting in the e2e-tests
```
{
          s: "failed to enable hermetic build in the pipeline bundle with: error when building/pushing a tekton pipeline bundle: error when pushing a bundle quay.io/konflux-ci/test-images:pipeline-bundle-1766038709-qiqn to a container image registry repo: could not push image to registry as \"quay.io/konflux-ci/test-images:pipeline-bundle-1766038709-qiqn\": POST https://quay.io/v2/konflux-ci/test-images/blobs/uploads/: UNAUTHORIZED: access to the requested resource is not authorized; map[]\n",
      }
```
