### PR TITLE
chore(KFLUXVNGD-556): update rpms-signature-scan ref

### DIFF
--- a/external-task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
+++ b/external-task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/konflux-vanguard/task-rpms-signature-scan:0.2@sha256:7a7a2f0b6d0ffc590530289d3b8bad3b45c59ef338cb3c8d350038e7537f405f
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7a7a2f0b6d0ffc590530289d3b8bad3b45c59ef338cb3c8d350038e7537f405f


### PR DESCRIPTION
Update rpms-signature-scan task bundle to use tekton-catalog repository

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
