### PR TITLE
feat(KONFLUX-6945): enhance idms handling for run opm task

### DIFF
--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -277,7 +277,7 @@ spec:
         load_utils
         convert_tags_to_digests
     - name: replace-related-images-pullspec-in-file
-      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:2b1e6e5e9b28f17770476039d1c3e68166b61fefcf0d4a6359f30d044b149b65
+      image: quay.io/konflux-ci/konflux-test:v1.4.44@sha256:00d5ba3ac4fadb315da2199e931c1167f2b45884d2990de39104dfa9b78117d4
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0


### PR DESCRIPTION
Updated run-opm-cmd task to use konflux-test v1.4.44 which calls an enhanced `replace_mirror_pullspec_with_source()`. 

See [this corresponding konflux-test pull request](https://github.com/konflux-ci/konflux-test/pull/675). 
