### PR TITLE
fix(KONFLUX-11519): add clair-scan 0.3 digest to external-task

### DIFF
--- a/external-task/clair-scan/0.3/clair-scan.yaml
+++ b/external-task/clair-scan/0.3/clair-scan.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:a5fa66ed5b8c107e7bc29cb084edcc07e394f818cc59ef2db2f9dcb0cd1fa3dc


### PR DESCRIPTION
* add clair-scan 0.3 task bundle to external-task since it has been moved to and released via github.comkonflux-ci/konflux-test-tasks repo

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
