### PR TITLE
pko pipeline: add missing task version

### DIFF
--- a/pipelines/package-operator-package/package-operator-package.yaml
+++ b/pipelines/package-operator-package/package-operator-package.yaml
@@ -136,6 +136,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: package-operator-package
+      version: "0.1"
     when:
     - input: $(tasks.init.results.build)
       operator: in

--- a/pipelines/package-operator-package/patch.yaml
+++ b/pipelines/package-operator-package/patch.yaml
@@ -9,8 +9,10 @@
   path: /metadata/name
   value: package-operator-package
 - op: replace
-  path: /spec/tasks/3/taskRef/name
-  value: package-operator-package
+  path: /spec/tasks/3/taskRef
+  value:
+    name: package-operator-package
+    version: "0.1"
 - op: add
   path: /spec/tasks/3/params
   value:


### PR DESCRIPTION
Due to the missing 'version' attribute in the pipeline yaml, the build process didn't resolve the taskRef for the package-operator-package Task to a real bundle reference but instead kept just the task name.

    taskRef
      name: package-operator-package

This causes the pipeline to fail, because it expects a Task called package-operator-package to already exist on the cluster.

Add the version attribute to solve that.
