### PR TITLE
Propose 'clair-scan' task resource limits based on actual last 10 days usage data

### DIFF
--- a/task/clair-scan/0.3/clair-scan.yaml
+++ b/task/clair-scan/0.3/clair-scan.yaml
@@ -51,7 +51,8 @@ spec:
       # the clair-in-ci image neither has skopeo or jq installed. Hence, we create an extra step to get the image manifest digests
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 256Mi
+          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m
@@ -92,10 +93,11 @@ spec:
       image: quay.io/konflux-ci/clair-in-ci:6064895  # explicit floating tag, daily updates, per arch call this is exempt for now for use of image digest
       computeResources:
         limits:
-          memory: 6Gi
+          memory: 7Gi
+          cpu: 800m
         requests:
-          memory: 2Gi
-          cpu: 500m
+          memory: 7Gi
+          cpu: 800m
       imagePullPolicy: Always
       env:
         - name: IMAGE_URL
@@ -183,6 +185,13 @@ spec:
         echo "$images_processed" > images-processed.json
     - name: oci-attach-report
       image: quay.io/konflux-ci/oras:latest@sha256:4542f5a2a046ca36653749a8985e46744a5d2d36ee10ca14409be718ce15129e
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
       workingDir: /tekton/home
       env:
         - name: IMAGE_URL
@@ -233,7 +242,8 @@ spec:
       # the cluster will set imagePullPolicy to IfNotPresent
       computeResources:
         limits:
-          memory: 2Gi
+          memory: 256Mi
+          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m


### PR DESCRIPTION
**Summary**:
Update resource limits for clair-scan task based on actual usage data across Konflux clusters. Limits calculated using maximum observed values with 5% safety margin.

**Description**:
This commit updates resource limits (memory and CPU) for all steps in clair-scan task based on comprehensive analysis of actual resource consumption across multiple Konflux clusters.

**The analysis methodology**:
- Uses maximum observed values (not percentile-based) to ensure all workloads fit within limits
- Applies a 5% safety margin on top of maximum values
- Values rounded to standard Kubernetes resource units

**Updated steps include**:
- get-image-manifests: Updated memory limits to 256Mi (from 512Mi), added CPU limits
- get-vulnerabilities: Updated memory limits to 7Gi (from 2Gi requests, 6Gi limits), updated CPU limits to 800m (from 500m)
- oci-attach-report: Added computeResources with 256Mi memory, 100m CPU
- conftest-vulnerabilities: Updated memory limits to 256Mi (from 2Gi), added CPU limits

These limits ensure adequate resources for 100% of observed workloads while optimizing resource allocation based on actual usage patterns.

Assisted-by: Cursor-AI.

- **Full Analysis run with help of tool: https://github.com/redhat-appstudio/perfscale/tree/main/tools/task-mem-and-cpu-usage-scripts**
```
$ time ./analyze_resource_limits.py --file https://github.com/konflux-ci/build-definitions/blob/main/task/clair-scan/0.3/clair-scan.yaml --analyze-again --margin 5 --days 10 --pll-clusters 4 --debug

================================================================================
Checking Cluster Connectivity
================================================================================

Cluster Connectivity Report:
  ✓ kflux-osp-p01: Connected
  ✓ kflux-prd-es01: Connected
  ✓ kflux-prd-rh02: Connected
  ✓ kflux-prd-rh03: Connected
  ✓ kflux-rhel-p01: Connected
  ✓ kflux-stg-es01: Connected
  ✓ stone-prd-rh01: Connected
  ✓ stone-prod-p01: Connected
  ✓ stone-stage-p01: Connected
  ✓ stone-stg-rh01: Connected

✓ All clusters are accessible

================================================================================
CONFIRMATION: Task and Steps Configuration
================================================================================
Source: extracted from YAML file
Task Name: clair-scan
Steps (4):
  1. step-get-image-manifests
  2. step-get-vulnerabilities
  3. step-oci-attach-report
  4. step-conftest-vulnerabilities
================================================================================
Proceed with these values? [y/N]: y

================================================================================
Data Collection Summary
================================================================================
Total clusters processed: 10
Successful: 7
Failed: 3
================================================================================

Warning: 3 cluster(s) had issues:
  • kflux-prd-es01: No data rows (only CSV header - no pods found)
  • kflux-stg-es01: No data rows (only CSV header - no pods found)
  • stone-prd-rh01: Timeout after 1 hour

Note: Cluster failures typically occur when:
  - No pods found for the specified task/steps in the given time period
  - Task/step names don't match what's actually running in that cluster
  - Time period is too short (try increasing --days)

Collected data from 7 cluster(s), total CSV lines: 28

cluster, "task", "step", "pod_max_mem", "namespace_max_mem", "component_max_mem", "application_max_mem", "mem_max_mb", "mem_p95_mb", "mem_p90_mb", "mem_median_mb", "pod_max_cpu", "namespace_max_cpu", "component_max_cpu", "application_max_cpu", "cpu_max", "cpu_p95", "cpu_p90", "cpu_median"
kflux-osp-p01, "clair-scan", "step-get-image-manifests", "openstack-octavia-baa7e60d2389c8222e4e859c758f94df81e9385ff-pod", "openstack-tenant", "openstack-octavia-base-openstack-17-1-rhel-9", "openstack-17-1-rhel-9", "12", "8", "6", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-osp-p01, "clair-scan", "step-get-vulnerabilities", "octavia-amphora-imag608a74073636f3cd6caec53428100dd91c9dc8a-pod", "openstack-tenant", "octavia-amphora-image-openstack-18-0", "openstack-18-0", "3328", "327", "356", "321", "openstack-nova-compu2799dc46fef46b94b152d6e32e748a0722144a7-pod", "openstack-tenant", "openstack-nova-compute-openstack-17-1-rhel-9", "openstack-17-1-rhel-9", "95m", "95m", "68m", "68m"
kflux-osp-p01, "clair-scan", "step-oci-attach-report", "mysqld-exporter-openstack-1cdfe67ebb7d74b23c41bcf2c82019b04-pod", "openstack-tenant", "mysqld-exporter-openstack-18-0", "openstack-18-0", "16", "17", "5", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-osp-p01, "clair-scan", "step-conftest-vulnerabilities", "mariadb-operator-opef739d1d8bd0d56f860cc20c7c0dca715f8ae508-pod", "openstack-tenant", "mariadb-operator-openstack-18-0", "openstack-18-0", "33", "5", "5", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-rhel-p01, "clair-scan", "step-get-image-manifests", "rhelp01cm-app-ymgib-comp-0-on-push-9vn72-clair-scan-2-pod", "jhutar-tenant", "rhelp01cm-app-ymgib-comp-0", "rhelp01cm-app-ymgib", "11", "9", "8", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-rhel-p01, "clair-scan", "step-get-vulnerabilities", "koji-import-utils-on-pull-request-lfhsn-clair-scan-pod", "rhel-on-konflux-tenant", "koji-import-utils", "tooling", "1873", "172", "170", "162", "koji-import-utils-on-pull-request-2t4p7-clair-scan-pod", "rhel-on-konflux-tenant", "koji-import-utils", "tooling", "62m", "62m", "62m", "62m"
kflux-rhel-p01, "clair-scan", "step-oci-attach-report", "rhelp01cm-app-riloo-comp-0-on-push-w4vm2-clair-scan-0-pod", "jhutar-tenant", "rhelp01cm-app-riloo-comp-0", "rhelp01cm-app-riloo", "19", "16", "17", "17", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-rhel-p01, "clair-scan", "step-conftest-vulnerabilities", "rhelp01cm-app-foaqv-comp-0-on-push-djqgc-clair-scan-3-pod", "jhutar-tenant", "rhelp01cm-app-foaqv-comp-0", "rhelp01cm-app-foaqv", "12", "5", "19", "4", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-prod-p01, "clair-scan", "step-get-image-manifests", "prodp01cm-app-klmoo-comp-0-on-push-g9hjb-clair-scan-1-pod", "jhutar-tenant", "prodp01cm-app-klmoo-comp-0", "prodp01cm-app-klmoo", "13", "5", "5", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-prod-p01, "clair-scan", "step-get-vulnerabilities", "prodp01cm-app-zgots-comp-0-on-push-xhs28-clair-scan-1-pod", "jhutar-tenant", "prodp01cm-app-zgots-comp-0", "prodp01cm-app-zgots", "417", "92", "92", "98", "prodp01cm-app-klmoo-comp-0-on-push-g9hjb-clair-scan-1-pod", "jhutar-tenant", "prodp01cm-app-klmoo-comp-0", "prodp01cm-app-klmoo", "21m", "18m", "21m", "18m"
stone-prod-p01, "clair-scan", "step-oci-attach-report", "prodp01cm-app-thpct-comp-0-on-push-c89n4-clair-scan-0-pod", "jhutar-tenant", "prodp01cm-app-thpct-comp-0", "prodp01cm-app-thpct", "18", "5", "12", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-prod-p01, "clair-scan", "step-conftest-vulnerabilities", "prodp01cm-app-urhcy-comp-0-on-push-54jtn-clair-scan-1-pod", "jhutar-tenant", "prodp01cm-app-urhcy-comp-0", "prodp01cm-app-urhcy", "13", "5", "5", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-stage-p01, "clair-scan", "step-get-image-manifests", "undef-app-kpupa-comp-0-on-push-zn76d-clair-scan-3-pod", "jhutar-tenant", "undef-app-kpupa-comp-0", "undef-app-kpupa", "16", "14", "6", "10", "undef-app-ffljx-comp-0-on-push-9gghd-clair-scan-1-pod", "jhutar-tenant", "undef-app-ffljx-comp-0", "undef-app-ffljx", "1m", "1m", "1m", "0m"
stone-stage-p01, "clair-scan", "step-get-vulnerabilities", "undef-app-kabsu-comp-0-on-push-dl85m-clair-scan-3-pod", "jhutar-tenant", "undef-app-kabsu-comp-0", "undef-app-kabsu", "481", "129", "120", "109", "undef-app-rqcmk-comp-0-on-push-vks4m-clair-scan-pod", "jhutar-tenant", "undef-app-rqcmk-comp-0", "undef-app-rqcmk", "27m", "27m", "23m", "27m"
stone-stage-p01, "clair-scan", "step-oci-attach-report", "multi-arch-ta-on-pull-request-z464r-clair-scan-1-pod", "hares-tenant", "multi-arch-ta", "some-project-stg-p01", "18", "17", "17", "17", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-stage-p01, "clair-scan", "step-conftest-vulnerabilities", "undef-app-jzscx-comp-0-on-push-6gj4g-clair-scan-1-pod", "jhutar-tenant", "undef-app-jzscx-comp-0", "undef-app-jzscx", "13", "5", "5", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-prd-rh02, "clair-scan", "step-get-image-manifests", "konflux-test-product2-on-push-5rdzs-clair-scan-pod", "releng-test-product-tenant", "konflux-test-product2", "example-push-artifacts-to-cdn", "46", "8", "38", "38", "single-arch-ta-on-pull-request-b8f2p-clair-scan-pod", "hares-tenant", "single-arch-ta", "some-project-kflux-prd-rh02", "1m", "1m", "1m", "1m"
kflux-prd-rh02, "clair-scan", "step-get-vulnerabilities", "aegis-ai-on-pull-request-nw2px-clair-scan-pod", "aegis-tenant", "aegis-ai", "aegis", "6150", "625", "418", "290", "copr-image-builder-on-pull-request-fc2lj-clair-scan-pod", "fedora-copr-tenant", "copr-image-builder", "fedora-copr-builder", "675m", "691m", "676m", "639m"
kflux-prd-rh02, "clair-scan", "step-oci-attach-report", "prdrh02cm-app-veuee-comp-0-on-push-hdh7r-clair-scan-3-pod", "jhutar-tenant", "prdrh02cm-app-veuee-comp-0", "prdrh02cm-app-veuee", "25", "18", "18", "18", "subctl-0-19-on-pull-request-cqfnb-clair-scan-pod", "submariner-tenant", "subctl-0-19", "submariner-0-19", "1m", "1m", "0m", "1m"
kflux-prd-rh02, "clair-scan", "step-conftest-vulnerabilities", "tektoncd-hub-next-db-migrat1c921a0e497c6bff08802a196f5f8017-pod", "tekton-ecosystem-tenant", "tektoncd-hub-next-db-migration", "openshift-pipelines-core-next", "45", "6", "7", "5", "operator-1-20-operator-on-push-jh7g6-clair-scan-pod", "tekton-ecosystem-tenant", "operator-1-20-operator", "openshift-pipelines-operator-1-20", "3m", "1m", "1m", "3m"
kflux-prd-rh03, "clair-scan", "step-get-image-manifests", "valkey--default--main-on-pull-request-zlltf-clair-scan-0-pod", "hummingbird-tenant", "valkey--default--main", "containers-main", "32", "14", "14", "14", "xcaddy--hatchling--main-on-pull-request-vzcwx-clair-scan-1-pod", "hummingbird-tenant", "xcaddy--hatchling--main", "containers-main", "1m", "1m", "1m", "1m"
kflux-prd-rh03, "clair-scan", "step-get-vulnerabilities", "cuda-rag-on-push-zqgsr-clair-scan-0-pod", "ramalama-tenant", "cuda-rag", "ramalama", "6154", "1556", "1538", "252", "cuda-rag-on-push-jh5r2-clair-scan-0-pod", "ramalama-tenant", "cuda-rag", "ramalama", "459m", "427m", "427m", "427m"
kflux-prd-rh03, "clair-scan", "step-oci-attach-report", "cann-on-push-l57zn-clair-scan-0-pod", "ramalama-tenant", "cann", "ramalama", "20", "16", "16", "16", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-prd-rh03, "clair-scan", "step-conftest-vulnerabilities", "cann-on-push-m2x6c-clair-scan-1-pod", "ramalama-tenant", "cann", "ramalama", "35", "7", "7", "7", "ramalama-on-push-zk98d-clair-scan-0-pod", "ramalama-tenant", "ramalama", "ramalama", "1m", "1m", "1m", "1m"
stone-stg-rh01, "clair-scan", "step-get-image-manifests", "java-quarkus-176731408-on-push-jp5d5-clair-scan-pod", "konflux-ui-automation-tenant", "java-quarkus-176731408", "test-app-176731408", "50", "40", "15", "9", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-stg-rh01, "clair-scan", "step-get-vulnerabilities", "go-component-on-pull-request-qkqsp-clair-scan-pod", "rhtap-integration-tenant", "go-component", "group-snapshot-multi-component", "1693", "250", "264", "250", "go-component-on-pull-request-ttl9p-clair-scan-pod", "rhtap-integration-tenant", "go-component", "group-snapshot-multi-component", "61m", "60m", "60m", "61m"
stone-stg-rh01, "clair-scan", "step-oci-attach-report", "java-quarkus-176515402-on-pull-request-nh9n5-clair-scan-pod", "konflux-ui-automation-tenant", "java-quarkus-176515402", "test-app-176515402", "18", "16", "17", "15", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-stg-rh01, "clair-scan", "step-conftest-vulnerabilities", "collectors-4e2b0465-on-push-vrvkp-clair-scan-1-pod", "dev-release-team-tenant", "collectors-4e2b0465", "e2eapp-4e2b0465", "15", "7", "7", "7", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"

================================================================================
RESOURCE LIMIT RECOMMENDATIONS (Max + 5% Safety Margin)
================================================================================

Step: step-conftest-vulnerabilities
--------------------------------------------------------------------------------
  Memory: 256Mi
    - Base (Max): 256Mi
    - Coverage: 7/7 clusters

  CPU: 100m
    - Base (Max): 100m
    - Coverage: 7/7 clusters

Step: step-get-image-manifests
--------------------------------------------------------------------------------
  Memory: 256Mi
    - Base (Max): 256Mi
    - Coverage: 7/7 clusters

  CPU: 100m
    - Base (Max): 100m
    - Coverage: 7/7 clusters

Step: step-get-vulnerabilities
--------------------------------------------------------------------------------
  Memory: 7Gi
    - Base (Max): 7Gi
    - Coverage: 7/7 clusters

  CPU: 800m
    - Base (Max): 700m
    - Coverage: 7/7 clusters

Step: step-oci-attach-report
--------------------------------------------------------------------------------
  Memory: 256Mi
    - Base (Max): 256Mi
    - Coverage: 7/7 clusters

  CPU: 100m
    - Base (Max): 100m
    - Coverage: 7/7 clusters


====================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
====================================================================================================

Step            Current Requests     Proposed Requests    Current Limits       Proposed Limits     
----------------------------------------------------------------------------------------------------
conftest-vulnerabilities 256Mi / 100m         256Mi / 100m         2Gi / null           256Mi / 100m        
get-image-manifests 256Mi / 100m         256Mi / 100m         512Mi / null         256Mi / 100m        
get-vulnerabilities 2Gi / 500m           7Gi / 800m           6Gi / null           7Gi / 800m          
oci-attach-report null / null          256Mi / 100m         null / null          256Mi / 100m        

Cached recommendations to: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/task-mem-and-cpu-usage-scripts/.analyze_cache/3760e0d53313402c90253b51e90b1c13.json

Recommendations cached. Run with --update to apply changes.

real	61m9.418s
user	22m14.161s
sys	7m33.863s
```

- **Update/create diff from all the recommendations:**
```
$ ./analyze_resource_limits.py --update --file /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/clair-scan/0.3/clair-scan.yaml --debug
Loading recommendations from cache: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/task-mem-and-cpu-usage-scripts/.analyze_cache/3760e0d53313402c90253b51e90b1c13.json
Cache info: original_file=https://github.com/konflux-ci/build-definitions/blob/main/task/clair-scan/0.3/clair-scan.yaml, margin=5%, base=max
Updating local file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/clair-scan/0.3/clair-scan.yaml

====================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
====================================================================================================

Step            Current Requests     Proposed Requests    Current Limits       Proposed Limits     
----------------------------------------------------------------------------------------------------
conftest-vulnerabilities 256Mi / 100m         256Mi / 100m         2Gi / null           256Mi / 100m        
get-image-manifests 256Mi / 100m         256Mi / 100m         512Mi / null         256Mi / 100m        
get-vulnerabilities 2Gi / 500m           7Gi / 800m           6Gi / null           7Gi / 800m          
oci-attach-report null / null          256Mi / 100m         null / null          256Mi / 100m        

DEBUG: Looking for steps: ['conftest-vulnerabilities', 'get-image-manifests', 'get-vulnerabilities', 'oci-attach-report']
DEBUG: Entered steps section at line 48
DEBUG: Left steps section at line 323: volumes:
DEBUG: Processing step 'conftest-vulnerabilities' at line 230
DEBUG: Processing step 'conftest-vulnerabilities', looking for computeResources...
DEBUG: Found computeResources at line 234, indent=6 (step_content_indent=6)
DEBUG: Found limits at line 235, indent=8
DEBUG: Updated memory in limits at line 236: 256Mi
DEBUG: Added cpu to limits at line 237: 100m
DEBUG: Found requests at line 238, indent=8
DEBUG: Updated memory in requests at line 239: 256Mi
DEBUG: Updated cpu in requests at line 240: 100m
Updated step 'conftest-vulnerabilities': memory=256Mi, cpu=100m
DEBUG: Processing step 'oci-attach-report' at line 184
DEBUG: Processing step 'oci-attach-report', looking for computeResources...
DEBUG: Created computeResources for step 'oci-attach-report'
Updated step 'oci-attach-report': memory=256Mi, cpu=100m
DEBUG: Processing step 'get-vulnerabilities' at line 91
DEBUG: Processing step 'get-vulnerabilities', looking for computeResources...
DEBUG: Found computeResources at line 93, indent=6 (step_content_indent=6)
DEBUG: Found limits at line 94, indent=8
DEBUG: Updated memory in limits at line 95: 7Gi
DEBUG: Added cpu to limits at line 96: 800m
DEBUG: Found requests at line 97, indent=8
DEBUG: Updated memory in requests at line 98: 7Gi
DEBUG: Updated cpu in requests at line 99: 800m
Updated step 'get-vulnerabilities': memory=7Gi, cpu=800m
DEBUG: Processing step 'get-image-manifests' at line 49
DEBUG: Processing step 'get-image-manifests', looking for computeResources...
DEBUG: Found computeResources at line 52, indent=6 (step_content_indent=6)
DEBUG: Found limits at line 53, indent=8
DEBUG: Updated memory in limits at line 54: 256Mi
DEBUG: Added cpu to limits at line 55: 100m
DEBUG: Found requests at line 56, indent=8
DEBUG: Updated memory in requests at line 57: 256Mi
DEBUG: Updated cpu in requests at line 58: 100m
Updated step 'get-image-manifests': memory=256Mi, cpu=100m

Updated YAML file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/clair-scan/0.3/clair-scan.yaml
```

- **Running "hack/generate-everything.sh":**
```
bash-5.3$ hack/generate-everything.sh
+++ dirname hack/generate-everything.sh
++ cd hack
++ pwd
+ SCRIPTDIR=/Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/hack
+ cd /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/hack/..
+ yq --version
+ grep -q mikefarah/yq
+ hack/build-manifests.sh
Building task manifest for: sealights-go-oci-ta/0.1
Skip generating manifest for the task: sealights-go-oci-ta/0.1
Building task manifest for: sealights-nodejs-oci-ta/0.1
Skip generating manifest for the task: sealights-nodejs-oci-ta/0.1
Building task manifest for: sealights-python-oci-ta/0.1
Skip generating manifest for the task: sealights-python-oci-ta/0.1
Building task manifest for: buildah-min/0.7
Building task manifest for: buildah-min/0.6
Building task manifest for: pnc-prebuild-git-clone-oci-ta/0.1
Building task manifest for: build-image-manifest/0.1
Building task manifest for: git-clone-oci-ta/0.1
Skip generating manifest for the task: git-clone-oci-ta/0.1
Building task manifest for: build-image-index/0.2
Skip generating manifest for the task: build-image-index/0.2
Building task manifest for: build-image-index/0.1
Skip generating manifest for the task: build-image-index/0.1
Building task manifest for: build-maven-zip/0.1
Skip generating manifest for the task: build-maven-zip/0.1
Building task manifest for: buildah/0.7
Skip generating manifest for the task: buildah/0.7
Building task manifest for: buildah/0.6
Skip generating manifest for the task: buildah/0.6
Building task manifest for: sast-coverity-check/0.3
Building task manifest for: coverity-availability-check/0.2
Skip generating manifest for the task: coverity-availability-check/0.2
Building pipeline manifest for: tekton-bundle-builder
Building pipeline manifest for: tekton-bundle-builder-oci-ta
Building pipeline manifest for: docker-build-oci-ta
Building pipeline manifest for: ko-build-oci-ta
Building pipeline manifest for: fbc-builder
Building pipeline manifest for: package-operator-package
Building pipeline manifest for: core-services
Building pipeline manifest for: maven-zip-build-oci-ta
Building pipeline manifest for: docker-build
Building pipeline manifest for: maven-zip-build
Building pipeline manifest for: docker-build-multi-platform-oci-ta
Building pipeline manifest for: template-build
Skip generating manifest for the pipeline: template-build
+ hack/generate-ta-tasks.sh
+ hack/generate-buildah-remote.sh
+ hack/generate-pipelines-readme.py
Subprocess: oc kustomize --output /var/folders/xt/fpwz0ghx3t7fyv06w859p9yc0000gn/T/tmp7oqglf78 ./pipelines/
+ hack/update_renovate_json_based_on_codeowners.py -o renovate.json

bash-5.3$ echo $?
0
```

Cc: @jhutar 