### PR TITLE
Propose 'clamav-scan' task resource limits based on actual last 10 days usage data

### DIFF
--- a/task/clamav-scan/0.3/clamav-scan.yaml
+++ b/task/clamav-scan/0.3/clamav-scan.yaml
@@ -63,10 +63,11 @@ spec:
           value: $(params.clamd-max-threads)
       computeResources:
         limits:
-          memory: 8Gi
+          memory: 12Gi
+          cpu: 7300m
         requests:
-          memory: 2Gi
-          cpu: 500m
+          memory: 12Gi
+          cpu: 7300m
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -200,7 +201,8 @@ spec:
       image: quay.io/konflux-ci/oras:latest@sha256:4542f5a2a046ca36653749a8985e46744a5d2d36ee10ca14409be718ce15129e
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 256Mi
+          cpu: 100m
         requests:
           memory: 256Mi
           cpu: 100m


### PR DESCRIPTION
**Summary**:
Update resource limits for clamav-scan task based on actual usage data across Konflux clusters. Limits calculated using maximum observed values with 5% safety margin.

**Description**:
This commit updates resource limits (memory and CPU) for all steps in clamav-scan task based on comprehensive analysis of actual resource consumption across multiple Konflux clusters.

**The analysis methodology**:
- Uses maximum observed values (not percentile-based) to ensure all workloads fit within limits
- Applies a 5% safety margin on top of maximum values
- Values rounded to standard Kubernetes resource units

**Updated steps include**:
- extract-and-scan-image: Updated memory limits to 12Gi (from 2Gi requests, 8Gi limits), updated CPU limits to 7300m (from 500m)
- upload: Updated memory limits to 256Mi (from 512Mi), added CPU limits

These limits ensure adequate resources for 100% of observed workloads while optimizing resource allocation based on actual usage patterns.

Assisted-by: Cursor-AI.

- **Full Analysis run with help of tool: https://github.com/redhat-appstudio/perfscale/tree/main/tools/task-mem-and-cpu-usage-scripts**:

```
$ time ./analyze_resource_limits.py --file /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/clamav-scan/0.3/clamav-scan.yaml --analyze-again --margin 5 --days 10 --pll-clusters 4 --debug

================================================================================
Checking Cluster Connectivity
================================================================================

Cluster Connectivity Report:
  ✓ kflux-osp-p01: Connected
  ✓ kflux-prd-es01: Connected
  ✓ kflux-prd-rh02: Connected
  ✓ kflux-prd-rh03: Connected
  ✓ kflux-rhel-p01: Connected
  ✓ kflux-stg-es01: Connected
  ✓ stone-prd-rh01: Connected
  ✓ stone-prod-p01: Connected
  ✓ stone-stage-p01: Connected
  ✓ stone-stg-rh01: Connected

✓ All clusters are accessible

================================================================================
CONFIRMATION: Task and Steps Configuration
================================================================================
Source: extracted from YAML file
Task Name: clamav-scan
Steps (2):
  1. step-extract-and-scan-image
  2. step-upload
================================================================================
Proceed with these values? [y/N]: y

================================================================================
Data Collection Summary
================================================================================
Total clusters processed: 10
Successful: 8
Failed: 2
================================================================================

Warning: 2 cluster(s) had issues:
  • kflux-prd-es01: No data rows (only CSV header - no pods found)
  • kflux-stg-es01: No data rows (only CSV header - no pods found)

Note: Cluster failures typically occur when:
  - No pods found for the specified task/steps in the given time period
  - Task/step names don't match what's actually running in that cluster
  - Time period is too short (try increasing --days)

Collected data from 8 cluster(s), total CSV lines: 15

cluster, "task", "step", "pod_max_mem", "namespace_max_mem", "component_max_mem", "application_max_mem", "mem_max_mb", "mem_p95_mb", "mem_p90_mb", "mem_median_mb", "pod_max_cpu", "namespace_max_cpu", "component_max_cpu", "application_max_cpu", "cpu_max", "cpu_p95", "cpu_p90", "cpu_median"
kflux-osp-p01, "clamav-scan", "step-extract-and-scan-image", "octavia-amphora-ima608a7401a2c4283a935928012d491fb352804e5b-pod", "openstack-tenant", "octavia-amphora-image-openstack-18-0", "openstack-18-0", "12288", "8985", "8817", "5810", "octavia-amphora-ima11f37ec751d05bb38245b69551e374a8685033b4-pod", "openstack-tenant", "octavia-amphora-image-openstack-18-0", "openstack-18-0", "1770m", "1686m", "1602m", "1483m"
kflux-osp-p01, "clamav-scan", "step-upload", "openstack-baremetalae991b0ad91f6d25f42a62e5f5b5b1db51bf802f-pod", "openstack-tenant", "openstack-baremetal-operator-openstack-18-0", "openstack-18-0", "20", "13", "13", "10", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-rhel-p01, "clamav-scan", "step-extract-and-scan-image", "koji-import-utils-on-pull-request-lfhsn-clamav-scan-pod", "rhel-on-konflux-tenant", "koji-import-utils", "tooling", "3865", "1567", "1567", "1438", "koji-import-utils-on-pull-request-gl84v-clamav-scan-pod", "rhel-on-konflux-tenant", "koji-import-utils", "tooling", "1340m", "865m", "865m", "865m"
stone-prod-p01, "clamav-scan", "step-extract-and-scan-image", "prodp01cm-app-pljxp-comp-0-on-push-69g2b-clamav-scan-0-pod", "jhutar-tenant", "prodp01cm-app-pljxp-comp-0", "prodp01cm-app-pljxp", "1803", "1422", "1426", "1432", "prodp01cm-app-rdyth-comp-0-on-push-hn8vl-clamav-scan-1-pod", "jhutar-tenant", "prodp01cm-app-rdyth-comp-0", "prodp01cm-app-rdyth", "283m", "87m", "87m", "283m"
stone-prod-p01, "clamav-scan", "step-upload", "prodp01cm-app-lrzwm-comp-0-on-push-84jdj-clamav-scan-0-pod", "jhutar-tenant", "prodp01cm-app-lrzwm-comp-0", "prodp01cm-app-lrzwm", "13", "5", "14", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-stage-p01, "clamav-scan", "step-extract-and-scan-image", "undef-app-jicot-comp-0-on-push-qkgbs-clamav-scan-2-pod", "jhutar-tenant", "undef-app-jicot-comp-0", "undef-app-jicot", "1859", "1554", "1507", "1423", "undef-app-jnblr-comp-0-on-push-mlt9z-clamav-scan-1-pod", "jhutar-tenant", "undef-app-jnblr-comp-0", "undef-app-jnblr", "397m", "397m", "397m", "397m"
stone-stage-p01, "clamav-scan", "step-upload", "undef-app-kabsu-comp-0-on-push-dl85m-clamav-scan-2-pod", "jhutar-tenant", "undef-app-kabsu-comp-0", "undef-app-kabsu", "18", "16", "15", "9", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-prd-rh03, "clamav-scan", "step-extract-and-scan-image", "cuda-rag-on-push-tjxbt-clamav-scan-0-pod", "ramalama-tenant", "cuda-rag", "ramalama", "8199", "7258", "7063", "2618", "cuda-rag-on-push-ps6lx-clamav-scan-1-pod", "ramalama-tenant", "cuda-rag", "ramalama", "5903m", "5379m", "5347m", "4521m"
kflux-prd-rh03, "clamav-scan", "step-upload", "core-runtime--hatchling--ma6bc40501df990611e01ee7d8d3b4e544-pod", "hummingbird-tenant", "core-runtime--hatchling--main", "containers-main", "19", "17", "16", "17", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-prd-rh02, "clamav-scan", "step-extract-and-scan-image", "copr-image-builder-on-pull-request-l9wr7-clamav-scan-pod", "fedora-copr-tenant", "copr-image-builder", "fedora-copr-builder", "12288", "6587", "6227", "1794", "aegis-ai-on-pull-request-xcfwn-clamav-scan-pod", "aegis-tenant", "aegis-ai", "aegis", "3883m", "3574m", "3574m", "3883m"
kflux-prd-rh02, "clamav-scan", "step-upload", "tekton-kueue-next-kueue-on-pull-request-b8hms-clamav-scan-pod", "tekton-ecosystem-tenant", "tekton-kueue-next-kueue", "openshift-pipelines-core-next", "25", "16", "16", "16", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-stg-rh01, "clamav-scan", "step-extract-and-scan-image", "go-component-on-push-msgcj-clamav-scan-pod", "rhtap-integration-tenant", "go-component", "group-snapshot-multi-component", "2738", "1549", "1500", "1445", "go-component-on-pull-request-j6z75-clamav-scan-pod", "rhtap-integration-tenant", "go-component", "group-snapshot-multi-component", "1533m", "1533m", "1071m", "1188m"
stone-stg-rh01, "clamav-scan", "step-upload", "java-quarkus-176783250-on-pull-request-c4lfk-clamav-scan-pod", "konflux-ui-automation-tenant", "java-quarkus-176783250", "test-app-176783250", "19", "16", "16", "16", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-prd-rh01, "clamav-scan", "step-extract-and-scan-image", "hive-mce-211-on-push-tppjf-clamav-scan-pod", "crt-redhat-acm-tenant", "hive-mce-211", "release-mce-211", "8192", "7672", "7492", "4659", "odh-workbench-jupytb21cc5d1d301bc5f4d40d2f4e659786667f40064-pod", "open-data-hub-tenant", "odh-workbench-jupyter-pytorch-llmcompressor-cuda-py312-ubi9", "opendatahub-release", "6912m", "6796m", "6716m", "5868m"
stone-prd-rh01, "clamav-scan", "step-upload", "scanner-db-on-push-fq7fr-clamav-scan-0-pod", "rh-acs-tenant", "scanner-db-4-9", "acs-4-9", "23", "18", "18", "18", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"

================================================================================
RESOURCE LIMIT RECOMMENDATIONS (Max + 5% Safety Margin)
================================================================================

Step: step-extract-and-scan-image
--------------------------------------------------------------------------------
  Memory: 12Gi
    - Base (Max): 12Gi
    - Coverage: 8/8 clusters

  CPU: 7300m
    - Base (Max): 7000m
    - Coverage: 8/8 clusters

Step: step-upload
--------------------------------------------------------------------------------
  Memory: 256Mi
    - Base (Max): 256Mi
    - Coverage: 7/7 clusters

  CPU: 100m
    - Base (Max): 100m
    - Coverage: 7/7 clusters


====================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
====================================================================================================

Step            Current Requests     Proposed Requests    Current Limits       Proposed Limits     
----------------------------------------------------------------------------------------------------
extract-and-scan-image 2Gi / 500m           12Gi / 7300m         8Gi / null           12Gi / 7300m        
upload          256Mi / 100m         256Mi / 100m         512Mi / null         256Mi / 100m        

Cached recommendations to: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/task-mem-and-cpu-usage-scripts/.analyze_cache/4fbb02daafa24842a5a869e5a98d3f45.json

Recommendations cached. Run with --update to apply changes.

real	37m38.329s
user	17m14.180s
sys	5m24.937s
```

- **Update/create diff from all the recommendations**:
```
$ time ./analyze_resource_limits.py --file /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/clamav-scan/0.3/clamav-scan.yaml --update --debug
Loading recommendations from cache: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/task-mem-and-cpu-usage-scripts/.analyze_cache/4fbb02daafa24842a5a869e5a98d3f45.json
Cache info: original_file=/Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/clamav-scan/0.3/clamav-scan.yaml, margin=5%, base=max
Updating local file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/clamav-scan/0.3/clamav-scan.yaml

====================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
====================================================================================================

Step            Current Requests     Proposed Requests    Current Limits       Proposed Limits     
----------------------------------------------------------------------------------------------------
extract-and-scan-image 2Gi / 500m           12Gi / 7300m         8Gi / null           12Gi / 7300m        
upload          256Mi / 100m         256Mi / 100m         512Mi / null         256Mi / 100m        

DEBUG: Looking for steps: ['extract-and-scan-image', 'upload']
DEBUG: Entered steps section at line 41
DEBUG: Left steps section at line 247: volumes:
DEBUG: Processing step 'upload' at line 199
DEBUG: Processing step 'upload', looking for computeResources...
DEBUG: Found computeResources at line 201, indent=6 (step_content_indent=6)
DEBUG: Found limits at line 202, indent=8
DEBUG: Updated memory in limits at line 203: 256Mi
DEBUG: Added cpu to limits at line 204: 100m
DEBUG: Found requests at line 205, indent=8
DEBUG: Updated memory in requests at line 206: 256Mi
DEBUG: Updated cpu in requests at line 207: 100m
Updated step 'upload': memory=256Mi, cpu=100m
DEBUG: Processing step 'extract-and-scan-image' at line 42
DEBUG: Processing step 'extract-and-scan-image', looking for computeResources...
DEBUG: Found computeResources at line 64, indent=6 (step_content_indent=6)
DEBUG: Found limits at line 65, indent=8
DEBUG: Updated memory in limits at line 66: 12Gi
DEBUG: Added cpu to limits at line 67: 7300m
DEBUG: Found requests at line 68, indent=8
DEBUG: Updated memory in requests at line 69: 12Gi
DEBUG: Updated cpu in requests at line 70: 7300m
Updated step 'extract-and-scan-image': memory=12Gi, cpu=7300m

Updated YAML file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/clamav-scan/0.3/clamav-scan.yaml

real	0m0.200s
user	0m0.089s
sys	0m0.040s
```

- **Running "hack/generate-everything.sh"**:
```
bash-5.3$ hack/generate-everything.sh
+++ dirname hack/generate-everything.sh
++ cd hack
++ pwd
+ SCRIPTDIR=/Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/hack
+ cd /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/hack/..
+ yq --version
+ grep -q mikefarah/yq
+ hack/build-manifests.sh
Building task manifest for: sealights-go-oci-ta/0.1
Skip generating manifest for the task: sealights-go-oci-ta/0.1
Building task manifest for: sealights-nodejs-oci-ta/0.1
Skip generating manifest for the task: sealights-nodejs-oci-ta/0.1
Building task manifest for: sealights-python-oci-ta/0.1
Skip generating manifest for the task: sealights-python-oci-ta/0.1
Building task manifest for: buildah-min/0.7
Building task manifest for: buildah-min/0.6
Building task manifest for: pnc-prebuild-git-clone-oci-ta/0.1
Building task manifest for: build-image-manifest/0.1
Building task manifest for: git-clone-oci-ta/0.1
Skip generating manifest for the task: git-clone-oci-ta/0.1
Building task manifest for: build-image-index/0.2
Skip generating manifest for the task: build-image-index/0.2
Building task manifest for: build-image-index/0.1
Skip generating manifest for the task: build-image-index/0.1
Building task manifest for: build-maven-zip/0.1
Skip generating manifest for the task: build-maven-zip/0.1
Building task manifest for: buildah/0.7
Skip generating manifest for the task: buildah/0.7
Building task manifest for: buildah/0.6
Skip generating manifest for the task: buildah/0.6
Building task manifest for: sast-coverity-check/0.3
Building task manifest for: coverity-availability-check/0.2
Skip generating manifest for the task: coverity-availability-check/0.2
Building pipeline manifest for: tekton-bundle-builder
Building pipeline manifest for: tekton-bundle-builder-oci-ta
Building pipeline manifest for: docker-build-oci-ta
Building pipeline manifest for: ko-build-oci-ta
Building pipeline manifest for: fbc-builder
Building pipeline manifest for: package-operator-package
Building pipeline manifest for: core-services
Building pipeline manifest for: maven-zip-build-oci-ta
Building pipeline manifest for: docker-build
Building pipeline manifest for: maven-zip-build
Building pipeline manifest for: docker-build-multi-platform-oci-ta
Building pipeline manifest for: template-build
Skip generating manifest for the pipeline: template-build
+ hack/generate-ta-tasks.sh
+ hack/generate-buildah-remote.sh
+ hack/generate-pipelines-readme.py
Subprocess: oc kustomize --output /var/folders/xt/fpwz0ghx3t7fyv06w859p9yc0000gn/T/tmp5x_cy446 ./pipelines/
+ hack/update_renovate_json_based_on_codeowners.py -o renovate.json

bash-5.3$ echo $?
0
```

Cc: @jhutar 