### PR TITLE
Remove sast-coverity-check from pko pipeline

### DIFF
--- a/pipelines/package-operator-package/README.md
+++ b/pipelines/package-operator-package/README.md
@@ -145,56 +145,6 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |image-digest| Image digest to scan| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-url| Image URL| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |workdir| Directory that will be used for storing temporary files produced by this task. | /tmp| |
-### sast-coverity-check:0.3 task parameters
-|name|description|default value|already set by|
-|---|---|---|---|
-|ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
-|ADDITIONAL_BASE_IMAGES| Additional base image references to include to the SBOM. Array of image_reference_with_digest strings| []| |
-|ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
-|ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| ""| |
-|ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
-|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| ""| |
-|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |
-|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| |
-|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| ""| |
-|COMMIT_SHA| The image is built from this commit.| ""| |
-|CONTEXT| Path to the directory to use as context.| .| |
-|COV_ANALYZE_ARGS| Arguments to be appended to the cov-analyze command| --enable HARDCODED_CREDENTIALS --security --concurrency --spotbugs-max-mem=4096| |
-|COV_LICENSE| Name of secret which contains the Coverity license| cov-license| |
-|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| |
-|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
-|HERMETIC| Determines if build will be executed without network access.| false| |
-|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| |
-|ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
-|IMAGE| The task will build a container image and tag it locally as $IMAGE, but will not push the image anywhere. Due to the relationship between this task and the buildah task, the parameter is required, but its value is mostly irrelevant.| None| |
-|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| |
-|IMP_FINDINGS_ONLY| Report only important findings. Default is true. To report all findings, specify "false"| true| |
-|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
-|KFP_GIT_URL| Known False Positives (KFP) git URL (optionally taking a revision delimited by \#). Defaults to "SITE_DEFAULT", which means the default value "https://gitlab.cee.redhat.com/osh/known-false-positives.git" for internal Konflux instance and empty string for external Konflux instance. If set to an empty string, the KFP filtering is disabled.| SITE_DEFAULT| |
-|LABELS| Additional key=value labels that should be applied to the image| []| |
-|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
-|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| |
-|PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
-|PROJECT_NAME| | ""| |
-|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
-|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| proxy-ca-bundle| |
-|RECORD_EXCLUDED| | false| |
-|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
-|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
-|SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
-|SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
-|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
-|TARGET_DIRS| Target directories in component's source code. Multiple values should be separated with commas. This only applies to buildless capture, which is only attempted if buildful capture fails to produce and results.| .| |
-|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| ""| |
-|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
-|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| ""| |
-|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
-|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
-|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
-|caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
-|caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-|image-digest| Digest of the image to which the scan results should be associated.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
-|image-url| URL of the image to which the scan results should be associated.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 ### sast-shell-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -256,9 +206,9 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| build-source-image:0.3:BINARY_IMAGE_DIGEST ; deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.3:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.3:image-digest ; sast-coverity-check:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.3:image-digest ; apply-tags:0.2:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| build-source-image:0.3:BINARY_IMAGE_DIGEST ; deprecated-base-image-check:0.5:IMAGE_DIGEST ; clair-scan:0.3:image-digest ; sast-snyk-check:0.4:image-digest ; clamav-scan:0.3:image-digest ; sast-shell-check:0.1:image-digest ; sast-unicode-check:0.3:image-digest ; apply-tags:0.2:IMAGE_DIGEST ; rpms-signature-scan:0.2:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| build-source-image:0.3:BINARY_IMAGE ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.3:image-url ; ecosystem-cert-preflight-checks:0.2:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.3:image-url ; sast-coverity-check:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.3:image-url ; apply-tags:0.2:IMAGE_URL ; rpms-signature-scan:0.2:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| build-source-image:0.3:BINARY_IMAGE ; deprecated-base-image-check:0.5:IMAGE_URL ; clair-scan:0.3:image-url ; ecosystem-cert-preflight-checks:0.2:image-url ; sast-snyk-check:0.4:image-url ; clamav-scan:0.3:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.3:image-url ; apply-tags:0.2:IMAGE_URL ; rpms-signature-scan:0.2:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### clair-scan:0.3 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -318,10 +268,6 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |IMAGES_PROCESSED| Images processed in the task.| |
 |RPMS_DATA| Information about signed and unsigned RPMs| |
 |TEST_OUTPUT| Tekton task test output.| |
-### sast-coverity-check:0.3 task results
-|name|description|used in params (taskname:taskrefversion:taskparam)
-|---|---|---|
-|TEST_OUTPUT| Tekton task test output.| |
 ### sast-shell-check:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -347,7 +293,7 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |---|---|---|---|
 |git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.2:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.2:netrc|
-|workspace| |False| clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.1:package ; build-source-image:0.3:workspace ; sast-snyk-check:0.4:workspace ; sast-coverity-check:0.3:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.3:workspace|
+|workspace| |False| clone-repository:0.1:output ; prefetch-dependencies:0.2:source ; build-container:0.1:source ; build-source-image:0.3:workspace ; sast-snyk-check:0.4:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.3:workspace|
 ## Available workspaces from tasks
 ### git-clone:0.1 task workspaces
 |name|description|optional|workspace from pipeline
@@ -365,10 +311,6 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |git-basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before prefetch is run. Any other files in this Workspace are ignored. It is strongly recommended to bind a Secret to this Workspace over other volume types. | True| git-auth|
 |netrc| Workspace containing a .netrc file. Prefetch will use the credentials in this file when performing http(s) requests. | True| netrc|
 |source| Workspace with the source code, prefetch artifacts will be stored on the workspace as well| False| workspace|
-### sast-coverity-check:0.3 task workspaces
-|name|description|optional|workspace from pipeline
-|---|---|---|---|
-|source| Workspace containing the source code to build.| False| workspace|
 ### sast-shell-check:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|

--- a/pipelines/package-operator-package/package-operator-package.yaml
+++ b/pipelines/package-operator-package/package-operator-package.yaml
@@ -143,7 +143,7 @@ spec:
       values:
       - "true"
     workspaces:
-    - name: package
+    - name: source
       workspace: workspace
   - name: build-image-index
     params:
@@ -274,29 +274,6 @@ spec:
       operator: in
       values:
       - "false"
-  - name: sast-coverity-check
-    params:
-    - name: image-digest
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-    - name: image-url
-      value: $(tasks.build-image-index.results.IMAGE_URL)
-    runAfter:
-    - coverity-availability-check
-    taskRef:
-      name: sast-coverity-check
-      version: "0.3"
-    when:
-    - input: $(params.skip-checks)
-      operator: in
-      values:
-      - "false"
-    - input: $(tasks.coverity-availability-check.results.STATUS)
-      operator: in
-      values:
-      - success
-    workspaces:
-    - name: source
-      workspace: workspace
   - name: coverity-availability-check
     runAfter:
     - build-image-index

--- a/pipelines/package-operator-package/patch.yaml
+++ b/pipelines/package-operator-package/patch.yaml
@@ -23,9 +23,11 @@
 - op: replace
   path: /spec/tasks/3/workspaces
   value:
-  - name: package
+  - name: source
     workspace: workspace
 - op: remove
-  path: /spec/params/4 # dockerfile
-- op: remove
   path: /spec/tasks/16 # push-dockerfile
+- op: remove
+  path: /spec/tasks/11 # sast-coverity-check
+- op: remove
+  path: /spec/params/4 # dockerfile


### PR DESCRIPTION
Check assumes that image is built from Dockerfile, which it isn't.

