### PR TITLE
Fix source-build broken symlinks

### DIFF
--- a/task/source-build-oci-ta/0.2
+++ b/task/source-build-oci-ta/0.2
@@ -1,1 +1,1 @@
-archived-tasks/source-build-oci-ta/0.2/
+../../archived-tasks/source-build-oci-ta/0.2

--- a/task/source-build/0.2
+++ b/task/source-build/0.2
@@ -1,1 +1,1 @@
-archived-tasks/source-build/0.2/
+../../archived-tasks/source-build/0.2


### PR DESCRIPTION
The symlinks for 0.2 in task/source-build* are not actually pointing to the proper location in archived-tasks.