### PR TITLE
fix: point hermeto image reference to image index

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -167,7 +167,7 @@ spec:
           yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}" >/mnt/config/config.yaml
         fi
     - name: prefetch-dependencies
-      image: quay.io/konflux-ci/hermeto:0.44.0@sha256:594c417a28d192ca12d1bad77dc6f74c28b58055f138d316df40889bbbc31342
+      image: quay.io/konflux-ci/hermeto:0.44.0@sha256:004b8a53cfb8cdb1f87c07c734025e0ad58699115feca6c371b4b9f354d85c48
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -87,7 +87,7 @@ spec:
       fi
 
   - name: prefetch-dependencies
-    image: quay.io/konflux-ci/hermeto:0.44.0@sha256:594c417a28d192ca12d1bad77dc6f74c28b58055f138d316df40889bbbc31342
+    image: quay.io/konflux-ci/hermeto:0.44.0@sha256:004b8a53cfb8cdb1f87c07c734025e0ad58699115feca6c371b4b9f354d85c48
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     env:


### PR DESCRIPTION
The hermeto image was built as multi arch but the pinned digest was an Image Manifest instead of an Image Index. Updating the digest to point to an Image Index.

```
$ oras manifest fetch --pretty quay.io/konflux-ci/hermeto:0.44.0@sha256:004b8a53cfb8cdb1f87c07c734025e0ad58699115feca6c371b4b9f354d85c48
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 920,
      "digest": "sha256:594c417a28d192ca12d1bad77dc6f74c28b58055f138d316df40889bbbc31342",
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "size": 920,
      "digest": "sha256:27621a2f16225cc82942e3204b0f2a72f307e6dec0e62a99e637854e567674b4",
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "variant": "v8"
      }
    }
  ]
}
```
