### PR TITLE
fix: point konflux-test:v1.4.39 to proper digest

### DIFF
--- a/task/deprecated-image-check/0.5/deprecated-image-check.yaml
+++ b/task/deprecated-image-check/0.5/deprecated-image-check.yaml
@@ -42,7 +42,7 @@ spec:
 
   steps:
     - name: check-images
-      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:2b1e6e5e9b28f17770476039d1c3e68166b61fefcf0d4a6359f30d044b149b65
+      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:89cdc9d251e15d07018548137b4034669df8e9e2b171a188c8b8201d3638cb17
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -132,7 +132,7 @@ spec:
         - "bash"
         - $(params.OPM_ARGS[*])
     - name: convert-image-tags-to-digests
-      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:2b1e6e5e9b28f17770476039d1c3e68166b61fefcf0d4a6359f30d044b149b65
+      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:89cdc9d251e15d07018548137b4034669df8e9e2b171a188c8b8201d3638cb17
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0

--- a/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
+++ b/task/sast-shell-check-oci-ta/0.1/sast-shell-check-oci-ta.yaml
@@ -97,7 +97,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: sast-shell-check
-      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:2b1e6e5e9b28f17770476039d1c3e68166b61fefcf0d4a6359f30d044b149b65
+      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:89cdc9d251e15d07018548137b4034669df8e9e2b171a188c8b8201d3638cb17
       workingDir: /var/workdir/source
       volumeMounts:
         - mountPath: /mnt/trusted-ca

--- a/task/sast-shell-check/0.1/sast-shell-check.yaml
+++ b/task/sast-shell-check/0.1/sast-shell-check.yaml
@@ -68,7 +68,7 @@ spec:
         optional: true
   steps:
     - name: sast-shell-check
-      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:2b1e6e5e9b28f17770476039d1c3e68166b61fefcf0d4a6359f30d044b149b65
+      image: quay.io/konflux-ci/konflux-test:v1.4.39@sha256:89cdc9d251e15d07018548137b4034669df8e9e2b171a188c8b8201d3638cb17
       computeResources:
         limits:
           memory: 4Gi


### PR DESCRIPTION
The image digest was previously only pointing at an x86 Image Manifest. This new digest is pointing at the Image Index.

```
$ oras manifest fetch --pretty quay.io/konflux-ci/konflux-test:v1.4.39@sha256:89cdc9d251e15d07018548137b4034669df8e9e2b171a188c8b8201d3638cb17
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.index.v1+json",
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:2b1e6e5e9b28f17770476039d1c3e68166b61fefcf0d4a6359f30d044b149b65",
      "size": 787,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:524b563233d97ef80b1e79d4d93a37fe1ea1c81ac8aad915eefd6088c1a16cbc",
      "size": 787,
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "variant": "v8"
      }
    }
  ]
}
```
