### PR TITLE
prefetch-dependencies: Clean dev-package-managers flag

### DIFF
--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -177,8 +177,6 @@ spec:
       env:
         - name: INPUT
           value: $(params.input)
-        - name: DEV_PACKAGE_MANAGERS
-          value: $(params.dev-package-managers)
         - name: LOG_LEVEL
           value: $(params.log-level)
         - name: SBOM_TYPE
@@ -343,12 +341,6 @@ spec:
           config_flag=""
         fi
 
-        if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
-          dev_pacman_flag=--dev-package-managers
-        else
-          dev_pacman_flag=""
-        fi
-
         # Copied from https://github.com/konflux-ci/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml
         if [ "${WORKSPACE_GIT_AUTH_BOUND}" = "true" ]; then
           if [ -f "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" ]; then
@@ -413,7 +405,6 @@ spec:
         INPUT=$(inject_rpm_summary_flag "$INPUT")
 
         hermeto --log-level="$LOG_LEVEL" --mode="$MODE" $config_flag fetch-deps \
-          $dev_pacman_flag \
           --source="/var/workdir/source" \
           --output="/var/workdir/cachi2/output" \
           --sbom-output-type="$SBOM_TYPE" \

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -93,8 +93,6 @@ spec:
     env:
     - name: INPUT
       value: $(params.input)
-    - name: DEV_PACKAGE_MANAGERS
-      value: $(params.dev-package-managers)
     - name: LOG_LEVEL
       value: $(params.log-level)
     - name: SBOM_TYPE
@@ -277,12 +275,6 @@ spec:
         config_flag=""
       fi
 
-      if [ "$DEV_PACKAGE_MANAGERS" = "true" ]; then
-        dev_pacman_flag=--dev-package-managers
-      else
-        dev_pacman_flag=""
-      fi
-
       # Copied from https://github.com/konflux-ci/build-definitions/blob/main/task/git-clone/0.1/git-clone.yaml
       if [ "${WORKSPACE_GIT_AUTH_BOUND}" = "true" ] ; then
         if [ -f "${WORKSPACE_GIT_AUTH_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_GIT_AUTH_PATH}/.gitconfig" ]; then
@@ -346,7 +338,6 @@ spec:
       INPUT=$(inject_rpm_summary_flag "$INPUT")
 
       hermeto --log-level="$LOG_LEVEL" --mode="$MODE" $config_flag fetch-deps \
-      $dev_pacman_flag \
       --source="$(workspaces.source.path)/source" \
       --output="$(workspaces.source.path)/cachi2/output" \
       --sbom-output-type="$SBOM_TYPE" \


### PR DESCRIPTION
This Hermeto CLI flag has been deprecated and has no effect -> delete the environment variable and relevant part of the task script.

But keep the task param for backwards compatibility if anyone still uses it in the pipeline.

---
https://github.com/hermetoproject/hermeto/blob/7e30329fcbe94915989afb804e9026df41993c6e/CONTRIBUTING.md?plain=1#L128

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
