### PR TITLE
Propose 'rpms-signature-scan' task resource limits based on actual last 15 days usage data

### DIFF
--- a/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
+++ b/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
@@ -49,6 +49,13 @@ spec:
   steps:
     - name: rpms-signature-scan
       image: quay.io/konflux-ci/tools@sha256:32855ac28cd967b2016e097f603abe033caa68350ee00ada75f33a8de58fb749
+      computeResources:
+        limits:
+          memory: 512Mi
+          cpu: 3500m
+        requests:
+          memory: 512Mi
+          cpu: 3500m
       volumeMounts:
         - name: workdir
           mountPath: "$(params.workdir)"
@@ -74,6 +81,13 @@ spec:
           --workdir "${WORKDIR}" \
     - name: output-results
       image: quay.io/konflux-ci/konflux-test:v1.4.42@sha256:32112ba0f1b8a3944f4905be40308713c32beb6c059c42ef0bc2b5fe7947ff2f
+      computeResources:
+        limits:
+          memory: 256Mi
+          cpu: 100m
+        requests:
+          memory: 256Mi
+          cpu: 100m
       volumeMounts:
         - name: workdir
           mountPath: "$(params.workdir)"


### PR DESCRIPTION
**Summary**:
Add resource limits for rpms-signature-scan task based on actual usage data across Konflux clusters. Limits calculated using maximum observed values with 5% safety margin.

**Description**:
This commit adds resource limits (memory and CPU) for all steps in rpms-signature-scan task based on comprehensive analysis of actual resource consumption across multiple Konflux clusters over the last 15 days.

**The analysis methodology**:
- Uses maximum observed values (not percentile-based) to ensure all workloads fit within limits
- Applies a 5% safety margin on top of maximum values
- Values rounded to standard Kubernetes resource units

**Updated steps include**:
- rpms-signature-scan: Added computeResources with 512Mi memory, 3500m CPU
- output-results: Added computeResources with 256Mi memory, 100m CPU

These limits ensure adequate resources for 100% of observed workloads while optimizing resource allocation based on actual usage patterns.

**Assisted-by: Cursor-AI**.

* **The Analysis Report**:
```
$ time ./analyze_resource_limits.py --file https://github.com/konflux-ci/build-definitions/blob/main/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml --analyze-again --margin 5 --days 15 --pll-clusters 3 --debug

================================================================================
Checking Cluster Connectivity
================================================================================

Cluster Connectivity Report:
  ✓ kflux-ocp-p01: Connected
  ✓ kflux-osp-p01: Connected
  ✓ kflux-prd-es01: Connected
  ✓ kflux-prd-rh02: Connected
  ✓ kflux-prd-rh03: Connected
  ✓ kflux-rhel-p01: Connected
  ✓ kflux-stg-es01: Connected
  ✓ stone-prd-rh01: Connected
  ✓ stone-prod-p01: Connected
  ✓ stone-prod-p02: Connected
  ✓ stone-stage-p01: Connected
  ✓ stone-stg-rh01: Connected

✓ All clusters are accessible

================================================================================
CONFIRMATION: Task and Steps Configuration
================================================================================
Source: extracted from YAML file
Task Name: rpms-signature-scan
Steps (2):
  1. step-rpms-signature-scan
  2. step-output-results
================================================================================
Proceed with these values? [y/N]: y

================================================================================
Getting information from all clusters: (Completed No. of clusters: 100%)
================================================================================
Data Collection Summary
================================================================================
Total clusters processed: 12
Successful: 10
Failed: 2
================================================================================

Warning: 2 cluster(s) had issues:
  • kflux-prd-es01: No data rows (only CSV header - no pods found)
  • kflux-stg-es01: No data rows (only CSV header - no pods found)

Note: Cluster failures typically occur when:
  - No pods found for the specified task/steps in the given time period
  - Task/step names don't match what's actually running in that cluster
  - Time period is too short (try increasing --days)

Collected data from 10 cluster(s), total CSV lines: 20

cluster, "task", "step", "pod_max_mem", "namespace_max_mem", "component_max_mem", "application_max_mem", "mem_max_mb", "mem_p95_mb", "mem_p90_mb", "mem_median_mb", "pod_max_cpu", "namespace_max_cpu", "component_max_cpu", "application_max_cpu", "cpu_max", "cpu_p95", "cpu_p90", "cpu_median"
kflux-osp-p01, "rpms-signature-scan", "step-rpms-signature-scan", "openstack-nf5010b6dd4a57940587c8efff58b7c31be30dd9352245a35-pod", "openstack-tenant", "openstack-nova-compute-openstack-16-2", "openstack-16-2", "98", "64", "64", "64", "octavia-ampaf833ba84998ce49e4a5a15f2cb81fb5f14e339859464231-pod", "openstack-tenant", "octavia-amphora-image-openstack-18-0", "openstack-18-0", "49m", "48m", "48m", "49m"
kflux-osp-p01, "rpms-signature-scan", "step-output-results", "heat-operat17d030b150458be36d366b228bf51756d772a4869f657f4c-pod", "openstack-tenant", "heat-operator-openstack-18-0", "openstack-18-0", "10", "6", "7", "7", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-prd-rh02, "rpms-signature-scan", "step-rpms-signature-scan", "serve-tkn-cli-next-tkn-pac-c5ac5e9b9dc28ae91dba57435b3d8829-pod", "tekton-ecosystem-tenant", "serve-tkn-cli-next-tkn-pac", "openshift-pipelines-cli-next", "353", "209", "208", "206", "serve-tkn-cli-next-tkn-pac-db6150747eb34a0791ca005beb3e2782-pod", "tekton-ecosystem-tenant", "serve-tkn-cli-next-tkn-pac", "openshift-pipelines-cli-next", "849m", "849m", "836m", "836m"
kflux-prd-rh02, "rpms-signature-scan", "step-output-results", "operator-1-22-bundle-on-pulf624455deba5884669f9d202d87ea4fb-pod", "tekton-ecosystem-tenant", "operator-1-22-bundle", "openshift-pipelines-operator-1-22", "11", "9", "9", "9", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-rhel-p01, "rpms-signature-scan", "step-rpms-signature-scan", "rhelp01cm-app-vmhch-comp-0-d2edac4f0decdc8a012955f9a0355cc0-pod", "jhutar-tenant", "rhelp01cm-app-vmhch-comp-0", "rhelp01cm-app-vmhch", "181", "5", "145", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "12m"
kflux-rhel-p01, "rpms-signature-scan", "step-output-results", "koji-import-utils-on-pull-request-gl84v-rpms-signature-scan-pod", "rhel-on-konflux-tenant", "koji-import-utils", "tooling", "9", "4", "4", "4", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-prd-rh03, "rpms-signature-scan", "step-rpms-signature-scan", "bats-on-push-6jz75-rpms-signature-scan-pod", "ramalama-tenant", "bats", "ramalama", "211", "189", "189", "189", "cuda-rag-on-push-6tmhw-rpms-signature-scan-pod", "ramalama-tenant", "cuda-rag", "ramalama", "1099m", "1099m", "1088m", "1099m"
kflux-prd-rh03, "rpms-signature-scan", "step-output-results", "cuda-rag-on-push-4xk4z-rpms-signature-scan-pod", "ramalama-tenant", "cuda-rag", "ramalama", "13", "9", "9", "9", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-prod-p01, "rpms-signature-scan", "step-rpms-signature-scan", "prodp01cm-app-kivaf-comp-0-b8acd631cbcc6152867de77880848368-pod", "jhutar-tenant", "prodp01cm-app-kivaf-comp-0", "prodp01cm-app-kivaf", "12", "5", "4", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-prod-p01, "rpms-signature-scan", "step-output-results", "", "N/A", "N/A", "N/A", "0", "0", "0", "0", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-prod-p02, "rpms-signature-scan", "step-rpms-signature-scan", "odh-ta-lmes-job-v2-25-on-push-jx26w-rpms-signature-scan-pod", "rhoai-tenant", "odh-ta-lmes-job-v2-25", "rhoai-v2-25", "385", "248", "248", "243", "ossm-3-2-proxy-debug-on-push-56qnl-rpms-signature-scan-pod", "service-mesh-tenant", "ossm-3-2-proxy-debug", "ossm-3-2", "3328m", "3328m", "3328m", "3328m"
stone-prod-p02, "rpms-signature-scan", "step-output-results", "bootc-rocm-azure-on-pull-request-gct64-rpms-signature-scan-pod", "rhel-ai-tenant", "bootc-rocm-azure", "rhelai-bootc", "12", "9", "9", "9", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-stage-p01, "rpms-signature-scan", "step-rpms-signature-scan", "undef-app-vtenb-comp-0-on-push-g2xsf-rpms-signature-scan-pod", "jhutar-tenant", "undef-app-vtenb-comp-0", "undef-app-vtenb", "185", "22", "165", "18", "undef-app-zzqsm-comp-0-on-push-j9sfn-rpms-signature-scan-pod", "jhutar-tenant", "undef-app-zzqsm-comp-0", "undef-app-zzqsm", "5m", "5m", "5m", "0m"
stone-stage-p01, "rpms-signature-scan", "step-output-results", "undef-app-euhcb-comp-0-on-push-vf82k-rpms-signature-scan-pod", "jhutar-tenant", "undef-app-euhcb-comp-0", "undef-app-euhcb", "10", "4", "4", "4", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
kflux-ocp-p01, "rpms-signature-scan", "step-rpms-signature-scan", "ose-4-22-ci13ff13fb504764e798055d2a43be57258eebbfd8656c7f79-pod", "ocp-art-tenant", "ose-4-22-ci-openshift-build-root-latest-rhel8", "openshift-4-22", "328", "213", "210", "213", "ose-4-15-osdca28ba04a339df9462eb9cd0737684ddfa0a8bc4f557847-pod", "ocp-art-tenant", "ose-4-15-ose-installer-terraform-providers", "openshift-4-15", "498m", "469m", "469m", "498m"
kflux-ocp-p01, "rpms-signature-scan", "step-output-results", "ose-4-20-ose-cli-artifacts-2tfv4-rpms-signature-scan-pod", "ocp-art-tenant", "ose-4-20-ose-cli-artifacts", "openshift-4-20", "13", "7", "7", "7", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-stg-rh01, "rpms-signature-scan", "step-rpms-signature-scan", "java-quarku236e4315459434bebc66253d3fe2cdfb0ee43b211792d212-pod", "konflux-ui-automation-tenant", "java-quarkus-176394417", "test-app-176394417", "101", "90", "85", "58", "go-component-on-push-msgcj-rpms-signature-scan-pod", "rhtap-integration-tenant", "go-component", "group-snapshot-multi-component", "17m", "9m", "15m", "10m"
stone-stg-rh01, "rpms-signature-scan", "step-output-results", "prjctl-tst-cmp1-main-on-pul35615c4e0d2a9828c6a8e150830a8808-pod", "konflux-samples-tenant", "prjctl-tst-cmp1-main", "prjctl-tst-main", "8", "5", "7", "5", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"
stone-prd-rh01, "rpms-signature-scan", "step-rpms-signature-scan", "odh-workben9c472d8e7ccb612de225f827736f88708f72e286d6ccaf84-pod", "open-data-hub-tenant", "odh-workbench-jupyter-trustyai-cpu-py312-ubi9", "opendatahub-release", "370", "203", "332", "332", "odh-workbencf9feea8a8eb0bc30c00ee1ff1898ccc89fa1963213825bb-pod", "open-data-hub-tenant", "odh-workbench-jupyter-tensorflow-cuda-py312-ubi9", "opendatahub-release", "983m", "983m", "991m", "983m"
stone-prd-rh01, "rpms-signature-scan", "step-output-results", "rhtas-operator-bundle-on-pu0ce493ebf75da1bc5c430e7285b0df7f-pod", "rhtas-tenant", "rhtas-operator-bundle", "operator", "14", "7", "7", "7", "", "N/A", "N/A", "N/A", "0m", "0m", "0m", "0m"

================================================================================
RESOURCE LIMIT RECOMMENDATIONS (Max + 5% Safety Margin)
================================================================================

Step: step-output-results
--------------------------------------------------------------------------------
  Memory: 256Mi
    - Base (Max): 256Mi
    - Coverage: 9/9 clusters

  CPU: 100m
    - Base (Max): 100m
    - Coverage: 10/10 clusters

Step: step-rpms-signature-scan
--------------------------------------------------------------------------------
  Memory: 512Mi
    - Base (Max): 512Mi
    - Coverage: 10/10 clusters

  CPU: 3500m
    - Base (Max): 3400m
    - Coverage: 10/10 clusters


====================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
====================================================================================================

Step            Current Requests     Proposed Requests    Current Limits       Proposed Limits     
----------------------------------------------------------------------------------------------------
output-results  null / null          256Mi / 100m         null / null          256Mi / 100m        
rpms-signature-scan null / null          512Mi / 3500m        null / null          512Mi / 3500m       

Saved comparison table as HTML: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/tasks-and-steps-resource-analyzer/.analyze_cache/rpms-signature-scan_comparison_data_20260114_151445.html
Cached recommendations for task 'rpms-signature-scan' to: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/tasks-and-steps-resource-analyzer/.analyze_cache/rpms-signature-scan.json
Saved CSV data as HTML: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/tasks-and-steps-resource-analyzer/.analyze_cache/rpms-signature-scan_analyzed_data_20260114_151445.html

Recommendations cached for task 'rpms-signature-scan'. Run with --update to apply changes.

HTML files saved for trend analysis:
  - /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/tasks-and-steps-resource-analyzer/.analyze_cache/rpms-signature-scan_analyzed_data_20260114_151445.html
  - /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/tasks-and-steps-resource-analyzer/.analyze_cache/rpms-signature-scan_comparison_data_20260114_151445.html

real	33m59.413s
user	24m56.713s
sys	9m37.954s

bash-5.3$ ./analyze_resource_limits.py --file /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml --update --debug
Loading recommendations from cache for task 'rpms-signature-scan'
Cache info: original_file=https://github.com/konflux-ci/build-definitions/blob/main/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml, margin=5%, base=max
Updating local file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml

====================================================================================================
RESOURCE LIMITS COMPARISON: CURRENT vs PROPOSED
====================================================================================================

Step            Current Requests     Proposed Requests    Current Limits       Proposed Limits     
----------------------------------------------------------------------------------------------------
output-results  null / null          256Mi / 100m         null / null          256Mi / 100m        
rpms-signature-scan null / null          512Mi / 3500m        null / null          512Mi / 3500m       

Saved comparison table as HTML: /Users/subratamodak/redhat_branches/PROMQL_DATA_COLLECTION_CLUSTERS_METRICS/python_venv_perfscale_mem-usage-scripts-checkin_smodak/perfscale/tools/tasks-and-steps-resource-analyzer/.analyze_cache/rpms-signature-scan_comparison_data_20260114_170412.html
DEBUG: Looking for steps: ['output-results', 'rpms-signature-scan']
DEBUG: Entered steps section at line 49
DEBUG: Processing step 'output-results' at line 75
DEBUG: Processing step 'output-results', looking for computeResources...
DEBUG: Created computeResources for step 'output-results'
Updated step 'output-results': memory=256Mi, cpu=100m
DEBUG: Processing step 'rpms-signature-scan' at line 50
DEBUG: Processing step 'rpms-signature-scan', looking for computeResources...
DEBUG: Created computeResources for step 'rpms-signature-scan'
Updated step 'rpms-signature-scan': memory=512Mi, cpu=3500m

Updated YAML file: /Users/subratamodak/redhat_branches/konflux-ci-build-definitions-forked-smodak/build-definitions-smodak/task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
```
Cc: @jhutar 