### PR TITLE
Fix SBOM issues in ko-oci-ta.

### DIFF
--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -119,6 +119,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### ko-oci-ta:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
+|ADDITIONAL_BASE_IMAGES| Additional base image references to include to the SBOM. Array of image_reference_with_digest strings| []| |
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
 |IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
 |IMAGE_NAMING_STRATEGY| One of --base-import-paths, --bare, or --preserve-import-paths| --base-import-paths| |

--- a/task/ko-oci-ta/0.1/ko-oci-ta.yaml
+++ b/task/ko-oci-ta/0.1/ko-oci-ta.yaml
@@ -15,6 +15,11 @@ metadata:
 spec:
   description: This Task builds source into a container image using ko.
   params:
+    - name: ADDITIONAL_BASE_IMAGES
+      description: Additional base image references to include to the SBOM.
+        Array of image_reference_with_digest strings
+      type: array
+      default: []
     - name: COMMIT_SHA
       description: The image is built from this commit.
       type: string
@@ -157,6 +162,9 @@ spec:
         echo "Completed."
     - name: prepare-sbom
       image: quay.io/konflux-ci/mobster@sha256:a8c97bf769bf0797ec9a07667fe82ec253db328b3f462b4f691a838ed2b1d0be
+      args:
+        - --additional-base-images
+        - $(params.ADDITIONAL_BASE_IMAGES[*])
       workingDir: /var/workdir/source
       computeResources:
         limits:
@@ -172,12 +180,45 @@ spec:
 
         echo "[$(date --utc -Ins)] Prepare SBOM"
 
+        # Convert Tekton array params into Mobster params
+        ADDITIONAL_BASE_IMAGES=()
+        while [[ $# -gt 0 ]]; do
+          case $1 in
+          --additional-base-images)
+            shift
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              ADDITIONAL_BASE_IMAGES+=("$1")
+              shift
+            done
+            ;;
+          *)
+            echo "unexpected argument: $1" >&2
+            exit 2
+            ;;
+          esac
+        done
+
+        echo "[$(date --utc -Ins)] Generate SBOM with mobster"
+
+        mobster_args=(
+          generate
+          --output sbom.json
+        )
+
         image_pullspec="$(cat "$(results.IMAGE_URL.path)")"
         echo "IMAGE_PULLSPEC=${image_pullspec}"
-        # generate sbom via image-pullspec option
-        mobster generate --output sbom.json oci-image --image-pullspec "${image_pullspec}"
 
-        echo
+        mobster_args+=(
+          oci-image
+          --image-pullspec "${image_pullspec}"
+        )
+
+        for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
+          mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
+        done
+
+        mobster "${mobster_args[@]}"
+
         echo "[$(date --utc -Ins)] End prepare-sboms"
     - name: upload-sbom
       image: quay.io/konflux-ci/appstudio-utils:latest@sha256:5beab55042923b241f6ce0c653c622c2eefb4fcc46f7e4f04febc499291fcbcd
@@ -218,11 +259,14 @@ spec:
             echo "Failed to push sbom to registry"
             exit 1
         fi
-        # Remove tag from IMAGE while allowing registry to contain a port number.
-        sbom_repo="${image%:*}"
+        # Remove digest from image reference
+        ref="${image/@*}"
+        # Remove tag from ref while allowing registry to contain a port number.
+        ref="$(image | sed 's_/\(.*\):\(.*\)_/\1_g')"
+
         sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
         # The SBOM_BLOB_URL is created by `cosign attach sbom`.
-        echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
+        echo -n "${ref}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
 
         echo
         echo "[$(date --utc -Ins)] End upload-sbom"


### PR DESCRIPTION
Fix SBOM issues in the ko-oci-ta.yaml task.

- Fix bug in creating the ref when generating the SBOM.
- Add ADDITIONAL_BASE_IMAGES parameter and include them in the generated SBOM.
