### PR TITLE
fix skopeo  to copy all arch instead just of default once

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -125,7 +125,7 @@ spec:
       echo "Successfully sanitized image reference: ${sanitized_related_image}. Using sanitized image reference for conversion to OCI format"
 
       # Convert image to OCI format since umoci can only handle the OCI format
-      if ! retry skopeo copy --remove-signatures "docker://${sanitized_related_image}" "oci:///tekton/home/${image_num}-${component_label}-${version_label}-${release_label}:latest"; then
+      if ! retry skopeo copy --all --remove-signatures "docker://${sanitized_related_image}" "oci:///tekton/home/${image_num}-${component_label}-${version_label}-${release_label}:latest"; then
         echo -e "Error: Unable to scan image: Could not convert image ${related_image} to OCI format\n"
         # Clean up any partial OCI image artifacts to prevent resource accumulation
         cleanup_image_artifacts "${image_num}" "${component_label}" "${version_label}" "${release_label}"


### PR DESCRIPTION
[KONFLUX-11753](https://issues.redhat.com/browse/KONFLUX-11753) : This change patches skopeo to use --all  option , so fips check does not fails trying to copy an image having arch different from host system. 