### PR TITLE
fix(KONFLUX-12211): update fbc tasks to use --file flag

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -48,7 +48,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: get-unique-related-images
-      image: <TODO>
+      image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -298,7 +298,7 @@ spec:
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git
     - name: parse-images-processed-result
-      image: <TODO>
+      image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
       env:
         - name: STEP_ACTION_TEST_OUTPUT
           value: $(steps.fips-operator-check-step-action.results.TEST_OUTPUT)

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -48,7 +48,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.4.46@sha256:c7e2099ad87d4c65284cba5df8488eae64d16ea0baff344c549ed7ca2415ebce
+      image: <TODO>
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -67,8 +67,6 @@ spec:
         unique_related_images=()
         digests_processed=()
         images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
-        rendered_fbc_image_file=/tmp/fbc-fragment-opm-render.json
-        rendered_target_index_file=/tmp/opm-render-target-index.json
 
         image_mirror_map=""
         mirror_set="${SOURCE_CODE_DIR}/source/${IMAGE_MIRROR_SET_PATH}"
@@ -104,16 +102,15 @@ spec:
 
         # Get package names from fragment
         echo "Rendering FBC fragment: ${image_and_digest}"
-        render_opm -t "${image_and_digest}" >"${rendered_fbc_image_file}"
+        rendered_fbc_image_file=$(render_opm -t "${image_and_digest}" --file)
         if [[ ! -f "${rendered_fbc_image_file}" ]]; then
           note="Task $(context.task.name) failed: Unable to render the FBC fragment image: ${image_and_digest}"
           echo "${note}"
           TEST_OUTPUT=$(make_result_json -r ERROR -t "${note}")
           exit 0
         fi
-        rendered_fbc_image=$(cat "${rendered_fbc_image_file}")
         echo "Getting package names in FBC fragment"
-        if ! fragment_pkg_names=$(extract_unique_package_names_from_catalog "${rendered_fbc_image}"); then
+        if ! fragment_pkg_names=$(extract_unique_package_names_from_catalog "${rendered_fbc_image_file}" --file); then
           note="Task $(context.task.name) failed: Could not get package names from FBC fragment."
           echo "${note}"
           TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
@@ -124,7 +121,7 @@ spec:
 
         # Get package names from target index
         echo "Rendering target index: ${target_index_url}"
-        render_opm -t "${target_index_url}" >"${rendered_target_index_file}"
+        rendered_target_index_file=$(render_opm -t "${target_index_url}" --file)
         if [[ ! -f "${rendered_target_index_file}" ]]; then
           note="Task $(context.task.name) failed: Unable to render the fragment target index image: ${IMAGE_URL}"
           echo "${note}"
@@ -132,8 +129,7 @@ spec:
           exit 0
         fi
 
-        rendered_ti=$(cat "${rendered_target_index_file}")
-        if ! ti_pkg_names=$(extract_unique_package_names_from_catalog "${rendered_ti}"); then
+        if ! ti_pkg_names=$(extract_unique_package_names_from_catalog "${rendered_target_index_file}" --file); then
           note="Task $(context.task.name) failed: Could not get package names from the target index."
           echo "${note}"
           TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
@@ -302,7 +298,7 @@ spec:
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.4.46@sha256:c7e2099ad87d4c65284cba5df8488eae64d16ea0baff344c549ed7ca2415ebce
+      image: <TODO>
       env:
         - name: STEP_ACTION_TEST_OUTPUT
           value: $(steps.fips-operator-check-step-action.results.TEST_OUTPUT)

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -35,7 +35,7 @@ spec:
       description: Images processed in the task.
   steps:
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.4.46@sha256:c7e2099ad87d4c65284cba5df8488eae64d16ea0baff344c549ed7ca2415ebce
+      image: <TODO>
       computeResources:
         limits:
           memory: 12Gi
@@ -65,8 +65,6 @@ spec:
         unique_related_images=()
         digests_processed=()
         images_processed_template='{"image": {"pullspec": "'"$IMAGE_URL"'", "digests": [%s]}}'
-        rendered_fbc_image_file=/tmp/fbc-fragment-opm-render.json
-        rendered_target_index_file=/tmp/opm-render-target-index.json
 
         image_mirror_map=""
         mirror_set="${SOURCE_CODE_DIR}/source/${IMAGE_MIRROR_SET_PATH}"
@@ -102,16 +100,15 @@ spec:
 
         # Get package names from fragment
         echo "Rendering FBC fragment: ${image_and_digest}"
-        render_opm -t "${image_and_digest}" > "${rendered_fbc_image_file}"
+        rendered_fbc_image_file=$(render_opm -t "${image_and_digest}" --file"
         if [[ ! -f "${rendered_fbc_image_file}" ]]; then
           note="Task $(context.task.name) failed: Unable to render the FBC fragment image: ${image_and_digest}"
           echo "${note}"
           TEST_OUTPUT=$(make_result_json -r ERROR -t "${note}")
           exit 0
         fi
-        rendered_fbc_image=$(cat "${rendered_fbc_image_file}")
         echo "Getting package names in FBC fragment"
-        if ! fragment_pkg_names=$(extract_unique_package_names_from_catalog "${rendered_fbc_image}"); then
+        if ! fragment_pkg_names=$(extract_unique_package_names_from_catalog "${rendered_fbc_image_file}" --file); then
           note="Task $(context.task.name) failed: Could not get package names from FBC fragment."
           echo "${note}"
           TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
@@ -122,7 +119,7 @@ spec:
 
         # Get package names from target index
         echo "Rendering target index: ${target_index_url}"
-        render_opm -t "${target_index_url}" > "${rendered_target_index_file}"
+        rendered_target_index_file=$(render_opm -t "${target_index_url}" --file)"
         if [[ ! -f "${rendered_target_index_file}" ]]; then
           note="Task $(context.task.name) failed: Unable to render the fragment target index image: ${IMAGE_URL}"
           echo "${note}"
@@ -130,8 +127,7 @@ spec:
           exit 0
         fi
 
-        rendered_ti=$(cat "${rendered_target_index_file}")
-        if ! ti_pkg_names=$(extract_unique_package_names_from_catalog "${rendered_ti}"); then
+        if ! ti_pkg_names=$(extract_unique_package_names_from_catalog "${rendered_target_index_file}" --file); then
           note="Task $(context.task.name) failed: Could not get package names from the target index."
           echo "${note}"
           TEST_OUTPUT=$(make_result_json -r FAILURE -f 1 -t "$note")
@@ -288,7 +284,7 @@ spec:
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.4.46@sha256:c7e2099ad87d4c65284cba5df8488eae64d16ea0baff344c549ed7ca2415ebce
+      image: <TODO>
       env:
         - name: STEP_ACTION_TEST_OUTPUT
           value: $(steps.fips-operator-check-step-action.results.TEST_OUTPUT)

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -35,7 +35,7 @@ spec:
       description: Images processed in the task.
   steps:
     - name: get-unique-related-images
-      image: <TODO>
+      image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
       computeResources:
         limits:
           memory: 12Gi
@@ -284,7 +284,7 @@ spec:
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 
     - name: parse-images-processed-result
-      image: <TODO>
+      image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
       env:
         - name: STEP_ACTION_TEST_OUTPUT
           value: $(steps.fips-operator-check-step-action.results.TEST_OUTPUT)

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -100,7 +100,7 @@ spec:
 
         # Get package names from fragment
         echo "Rendering FBC fragment: ${image_and_digest}"
-        rendered_fbc_image_file=$(render_opm -t "${image_and_digest}" --file"
+        rendered_fbc_image_file=$(render_opm -t "${image_and_digest}" --file)
         if [[ ! -f "${rendered_fbc_image_file}" ]]; then
           note="Task $(context.task.name) failed: Unable to render the FBC fragment image: ${image_and_digest}"
           echo "${note}"
@@ -119,7 +119,7 @@ spec:
 
         # Get package names from target index
         echo "Rendering target index: ${target_index_url}"
-        rendered_target_index_file=$(render_opm -t "${target_index_url}" --file)"
+        rendered_target_index_file=$(render_opm -t "${target_index_url}" --file)
         if [[ ! -f "${rendered_target_index_file}" ]]; then
           note="Task $(context.task.name) failed: Unable to render the fragment target index image: ${IMAGE_URL}"
           echo "${note}"

--- a/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
+++ b/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
@@ -71,7 +71,7 @@ spec:
           exit 1
         fi
     - name: run-pruning-check
-      image: quay.io/redhat-appstudio/konflux-test:v1.4.31@sha256:a7cae9e96663e277a3904d0c78630508ddb6cc8eebaa912a840bd20f68dcaad1
+      image: <TODO>
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: /var/workdir
@@ -110,8 +110,6 @@ spec:
         fi
 
         rendered_fbc_image=/shared/catalog.json
-        rendered_target_index=/tmp/opm-render-target-index.json
-
         if [[ ! -f "${rendered_fbc_image}" ]]; then
           note="Task $(context.task.name) failed: Rendered FBC fragment does not exist: ${rendered_fbc_image}"
           echo "${note}"
@@ -123,7 +121,7 @@ spec:
         ocp_version=$(get_ocp_version_from_fbc_fragment "${IMAGE_URL}")
         target_index_pullspec="${TARGET_INDEX}:${ocp_version}"
         echo "Rendering target index: ${target_index_pullspec}"
-        render_opm -t "${target_index_pullspec}" > "${rendered_target_index}"
+        rendered_target_index=$(render_opm -t "${target_index_pullspec}" --file)
         if [[ ! -f "${rendered_target_index}" ]]; then
           note="Task $(context.task.name) failed: Unable to render the fragment target index image: ${IMAGE_URL}"
           echo "${note}"

--- a/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
+++ b/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
@@ -71,7 +71,7 @@ spec:
           exit 1
         fi
     - name: run-pruning-check
-      image: <TODO>
+      image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: /var/workdir

--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -188,7 +188,7 @@ spec:
           exit 0
         fi
     - name: extract-and-validate
-      image: quay.io/konflux-ci/konflux-test:v1.4.44@sha256:00d5ba3ac4fadb315da2199e931c1167f2b45884d2990de39104dfa9b78117d4
+      image: <TODO>
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: /var/workdir/extract-and-validate
@@ -471,6 +471,7 @@ spec:
         # Get the new related images that are being added so that we can check them for validity
         echo "Rendering target index and finding unreleased related images."
         status=0
+        echo "Running command: get_unreleased_fbc_related_images -i ${image_with_digest}"
         related_images=$(get_unreleased_fbc_related_images -i "$image_with_digest") || status=$?
         if [ $status -ne 0 ]; then
           get_unreleased_fbc_related_images -i "$image_with_digest"

--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -188,7 +188,7 @@ spec:
           exit 0
         fi
     - name: extract-and-validate
-      image: <TODO>
+      image: quay.io/konflux-ci/konflux-test:v1.4.48@sha256:9b815268fb2bf10b5d745518da1c6568944f15816efe51adc192972b42a6e74d
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       workingDir: /var/workdir/extract-and-validate


### PR DESCRIPTION
Updated FBC tasks to use the new flag introduced in this konflux-test PR: https://github.com/konflux-ci/konflux-test/pull/717

Resolves: [KONFLUX-12211](https://issues.redhat.com/browse/KONFLUX-12211)