### PR TITLE
fix(buildah): preserve label values containing equals signs in labels.json

### DIFF
--- a/task/buildah-min/0.8/buildah-min.yaml
+++ b/task/buildah-min/0.8/buildah-min.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.8.3
+    app.kubernetes.io/version: 0.8.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-min
 spec:
@@ -771,7 +771,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-min/0.9/buildah-min.yaml
+++ b/task/buildah-min/0.9/buildah-min.yaml
@@ -757,7 +757,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-min/CHANGELOG.md
+++ b/task/buildah-min/CHANGELOG.md
@@ -11,6 +11,18 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.9.1 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
+## 0.8.4 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
 ## 0.9.1
 
 ### Changed

--- a/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
@@ -791,7 +791,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,12 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.9.1 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
 ## 0.9.0
 
 ### Added

--- a/task/buildah-oci-ta/0.8/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.8/buildah-oci-ta.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.8.3
+    app.kubernetes.io/version: 0.8.4
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -856,7 +856,7 @@ spec:
 
         printf '%s\n' "${label_pairs[@]}" | jq -Rn '
           [ inputs | select(length>0) ]
-        | map( split("=") | {(.[0]): (.[1] // "")} )
+        | map( split("=") | {(.[0]): (.[1:] | join("="))} )
           | add' >"image_labels.json"
 
         jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
@@ -849,7 +849,7 @@ spec:
 
         printf '%s\n' "${label_pairs[@]}" | jq -Rn '
           [ inputs | select(length>0) ]
-        | map( split("=") | {(.[0]): (.[1] // "")} )
+        | map( split("=") | {(.[0]): (.[1:] | join("="))} )
           | add' >"image_labels.json"
 
         jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -19,6 +19,18 @@ If that's not something you ever plan to do, consider removing this section.
   locally stored OCI image index. This is not a user-facing change. It is for
   optimizing buildah-remote-oci-ta task.
 
+## 0.9.1 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
+## 0.8.1 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
 ## 0.9.1
 
 ### Changed

--- a/task/buildah-remote-oci-ta/0.8/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.8/buildah-remote-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.8.3
+    app.kubernetes.io/version: 0.8.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -888,7 +888,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
@@ -874,7 +874,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -17,6 +17,18 @@ If that's not something you ever plan to do, consider removing this section.
 
 - The task now only stores one local OCI directory copy of the built image, not two.
 
+## 0.9.1 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
+## 0.8.3 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
 ## 0.9.1
 
 ### Changed

--- a/task/buildah-remote/0.8/buildah-remote.yaml
+++ b/task/buildah-remote/0.8/buildah-remote.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.8.3
+    app.kubernetes.io/version: 0.8.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -854,7 +854,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-remote/0.9/buildah-remote.yaml
+++ b/task/buildah-remote/0.9/buildah-remote.yaml
@@ -840,7 +840,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -17,6 +17,18 @@ If that's not something you ever plan to do, consider removing this section.
 
 - The task now only stores one local OCI directory copy of the built image, not two.
 
+## 0.9.1 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
+## 0.8.3 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
 ## 0.9.1
 
 ### Changed

--- a/task/buildah/0.8/buildah.yaml
+++ b/task/buildah/0.8/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.8.3"
+    app.kubernetes.io/version: "0.8.4"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     build.appstudio.redhat.com/expires-on: "2026-04-30T00:00:00Z"
@@ -760,7 +760,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah/0.9/buildah.yaml
+++ b/task/buildah/0.9/buildah.yaml
@@ -746,7 +746,7 @@ spec:
 
       printf '%s\n' "${label_pairs[@]}" | jq -Rn '
         [ inputs | select(length>0) ]
-      | map( split("=") | {(.[0]): (.[1] // "")} )
+      | map( split("=") | {(.[0]): (.[1:] | join("="))} )
         | add' >"image_labels.json"
 
       jq -s '(.[0] // {}) * (.[1] // {})' "base_images_labels.json" "image_labels.json" >"$SOURCE_CODE_DIR/$CONTEXT/labels.json"

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -19,6 +19,18 @@ If that's not something you ever plan to do, consider removing this section.
   locally stored OCI image index. This is not a user-facing change. It is for
   optimizing buildah-remote task.
 
+## 0.9.1 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
+## 0.8.4 - 2026-03-10
+
+### Fixed
+
+- Preserve label values containing equals signs in labels.json
+
 ## 0.9.1
 
 ### Changed


### PR DESCRIPTION
### Summary

Fixes a silent truncation bug during `labels.json` generation where label values containing `=` signs were incorrectly truncated, losing data.

### Root Cause

The `jq` expression used to convert `key=value` label pairs into JSON uses `split("=")` to separate the key from the value. 
However, `split("=")` splits the string on *every* equals sign, producing an array of all segments. The old code then used `.[1]` to select only the second element, which silently discarded anything after the first `=` in the value.
**Example of the bug:**
A label like `description=foo=bar=baz` would produce:
`{"description": "foo"}`  (data lost)

### The Fix

This PR replaces `.[1]` with `.[1:] | join("=")` to re-join all segments after the key, preserving the full original value.
The same example now correctly produces:
`{"description": "foo=bar=baz"}` 
This fix has been applied consistently to all five buildah task variants:
- [buildah.yaml]
- [buildah-min.yaml]
- [buildah-remote.yaml]
- [buildah-oci-ta.yaml]
- [buildah-remote-oci-ta.yaml]

### How this was found

This was discovered during a manual code audit of the Buildah Tekton tasks to ensure edge case robustness in the scripts.
