### PR TITLE
added UNSET_LABLES to prevent inheriting labels from base image and also provides default list that will be ignored

### DIFF
--- a/task/buildah-min/0.9/README.md
+++ b/task/buildah-min/0.9/README.md
@@ -37,6 +37,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|UNSET_LABELS|Array of label names that should not be inherited from the base image. This is useful to prevent inheriting base image metadata like name, version, description, etc. Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags|[name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags]|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|

--- a/task/buildah-min/0.9/buildah-min.yaml
+++ b/task/buildah-min/0.9/buildah-min.yaml
@@ -127,6 +127,26 @@ spec:
     description: Additional key=value labels that should be applied to the image
     name: LABELS
     type: array
+  - default:
+    - name
+    - version
+    - release
+    - summary
+    - description
+    - io.k8s.description
+    - io.k8s.display-name
+    - com.redhat.component
+    - url
+    - vcs-ref
+    - vcs-type
+    - vendor
+    - io.openshift.tags
+    description: |-
+      Array of label names that should not be inherited from the base image.
+      This is useful to prevent inheriting base image metadata like name, version, description, etc.
+      Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags
+    name: UNSET_LABELS
+    type: array
   - default: []
     description: Additional key=value annotations that should be applied to the image
     name: ANNOTATIONS
@@ -333,6 +353,8 @@ spec:
     - $(params.ENV_VARS[*])
     - --labels
     - $(params.LABELS[*])
+    - --unset-labels
+    - $(params.UNSET_LABELS[*])
     - --annotations
     - $(params.ANNOTATIONS[*])
     computeResources:
@@ -472,6 +494,7 @@ spec:
       env_vars=()
 
       LABELS=()
+      UNSET_LABELS=()
       ANNOTATIONS=()
       # Append any annotations from the specified file
       if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
@@ -502,6 +525,10 @@ spec:
               --labels)
                   shift
                   while [[ $# -gt 0 && $1 != --* ]]; do LABELS+=("--label" "$1"); shift; done
+                  ;;
+              --unset-labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do UNSET_LABELS+=("--unsetlabel" "$1"); shift; done
                   ;;
               --annotations)
                   shift
@@ -597,6 +624,11 @@ spec:
 
       if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ] ; then
         BUILDAH_ARGS+=("--inherit-labels=false")
+      fi
+
+      # Add --unsetlabel flags for labels that should not be inherited from base image
+      if [ ${#UNSET_LABELS[@]} -gt 0 ]; then
+        BUILDAH_ARGS+=("${UNSET_LABELS[@]}")
       fi
 
       if [ -n "${BUILDAH_SOURCE_DATE_EPOCH}" ]; then

--- a/task/buildah-oci-ta/0.9/README.md
+++ b/task/buildah-oci-ta/0.9/README.md
@@ -31,6 +31,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|UNSET_LABELS|Array of label names that should not be inherited from the base image. This is useful to prevent inheriting base image metadata like name, version, description, etc. Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags|[name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags]|false|
 |NO_PROXY|Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.|""|false|
 |OMIT_HISTORY|Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.|false|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|

--- a/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
@@ -124,6 +124,26 @@ spec:
         image
       type: array
       default: []
+    - name: UNSET_LABELS
+      description: |-
+        Array of label names that should not be inherited from the base image.
+        This is useful to prevent inheriting base image metadata like name, version, description, etc.
+        Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags
+      type: array
+      default:
+      - name
+      - version
+      - release
+      - summary
+      - description
+      - io.k8s.description
+      - io.k8s.display-name
+      - com.redhat.component
+      - url
+      - vcs-ref
+      - vcs-type
+      - vendor
+      - io.openshift.tags
     - name: NO_PROXY
       description: Comma separated list of hosts or domains which should bypass
         the HTTP/HTTPS proxy.
@@ -406,6 +426,8 @@ spec:
         - $(params.ENV_VARS[*])
         - --labels
         - $(params.LABELS[*])
+        - --unset-labels
+        - $(params.UNSET_LABELS[*])
         - --annotations
         - $(params.ANNOTATIONS[*])
       workingDir: /var/workdir
@@ -553,6 +575,7 @@ spec:
         env_vars=()
 
         LABELS=()
+        UNSET_LABELS=()
         ANNOTATIONS=()
         # Append any annotations from the specified file
         if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
@@ -590,6 +613,13 @@ spec:
             shift
             while [[ $# -gt 0 && $1 != --* ]]; do
               LABELS+=("--label" "$1")
+              shift
+            done
+            ;;
+          --unset-labels)
+            shift
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              UNSET_LABELS+=("--unsetlabel" "$1")
               shift
             done
             ;;
@@ -689,6 +719,11 @@ spec:
 
         if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ]; then
           BUILDAH_ARGS+=("--inherit-labels=false")
+        fi
+
+        # Add --unsetlabel flags for labels that should not be inherited from base image
+        if [ ${#UNSET_LABELS[@]} -gt 0 ]; then
+          BUILDAH_ARGS+=("${UNSET_LABELS[@]}")
         fi
 
         if [ -n "${BUILDAH_SOURCE_DATE_EPOCH}" ]; then

--- a/task/buildah-remote-oci-ta/0.9/README.md
+++ b/task/buildah-remote-oci-ta/0.9/README.md
@@ -31,6 +31,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|UNSET_LABELS|Array of label names that should not be inherited from the base image. This is useful to prevent inheriting base image metadata like name, version, description, etc. Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags|[name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags]|false|
 |NO_PROXY|Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.|""|false|
 |OMIT_HISTORY|Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.|false|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|

--- a/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
@@ -121,6 +121,26 @@ spec:
     description: Additional key=value labels that should be applied to the image
     name: LABELS
     type: array
+  - default:
+    - name
+    - version
+    - release
+    - summary
+    - description
+    - io.k8s.description
+    - io.k8s.display-name
+    - com.redhat.component
+    - url
+    - vcs-ref
+    - vcs-type
+    - vendor
+    - io.openshift.tags
+    description: |-
+      Array of label names that should not be inherited from the base image.
+      This is useful to prevent inheriting base image metadata like name, version, description, etc.
+      Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags
+    name: UNSET_LABELS
+    type: array
   - default: ""
     description: Comma separated list of hosts or domains which should bypass the
       HTTP/HTTPS proxy.
@@ -370,6 +390,8 @@ spec:
     - $(params.ENV_VARS[*])
     - --labels
     - $(params.LABELS[*])
+    - --unset-labels
+    - $(params.UNSET_LABELS[*])
     - --annotations
     - $(params.ANNOTATIONS[*])
     computeResources:
@@ -578,6 +600,7 @@ spec:
       env_vars=()
 
       LABELS=()
+      UNSET_LABELS=()
       ANNOTATIONS=()
       # Append any annotations from the specified file
       if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
@@ -615,6 +638,13 @@ spec:
           shift
           while [[ $# -gt 0 && $1 != --* ]]; do
             LABELS+=("--label" "$1")
+            shift
+          done
+          ;;
+        --unset-labels)
+          shift
+          while [[ $# -gt 0 && $1 != --* ]]; do
+            UNSET_LABELS+=("--unsetlabel" "$1")
             shift
           done
           ;;
@@ -714,6 +744,11 @@ spec:
 
       if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ]; then
         BUILDAH_ARGS+=("--inherit-labels=false")
+      fi
+
+      # Add --unsetlabel flags for labels that should not be inherited from base image
+      if [ ${#UNSET_LABELS[@]} -gt 0 ]; then
+        BUILDAH_ARGS+=("${UNSET_LABELS[@]}")
       fi
 
       if [ -n "${BUILDAH_SOURCE_DATE_EPOCH}" ]; then

--- a/task/buildah-remote/0.9/README.md
+++ b/task/buildah-remote/0.9/README.md
@@ -33,6 +33,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|UNSET_LABELS|Array of label names that should not be inherited from the base image. This is useful to prevent inheriting base image metadata like name, version, description, etc. Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags|[name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags]|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|

--- a/task/buildah-remote/0.9/buildah-remote.yaml
+++ b/task/buildah-remote/0.9/buildah-remote.yaml
@@ -127,6 +127,26 @@ spec:
     description: Additional key=value labels that should be applied to the image
     name: LABELS
     type: array
+  - default:
+    - name
+    - version
+    - release
+    - summary
+    - description
+    - io.k8s.description
+    - io.k8s.display-name
+    - com.redhat.component
+    - url
+    - vcs-ref
+    - vcs-type
+    - vendor
+    - io.openshift.tags
+    description: |-
+      Array of label names that should not be inherited from the base image.
+      This is useful to prevent inheriting base image metadata like name, version, description, etc.
+      Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags
+    name: UNSET_LABELS
+    type: array
   - default: []
     description: Additional key=value annotations that should be applied to the image
     name: ANNOTATIONS
@@ -347,6 +367,8 @@ spec:
     - $(params.ENV_VARS[*])
     - --labels
     - $(params.LABELS[*])
+    - --unset-labels
+    - $(params.UNSET_LABELS[*])
     - --annotations
     - $(params.ANNOTATIONS[*])
     computeResources:
@@ -555,6 +577,7 @@ spec:
       env_vars=()
 
       LABELS=()
+      UNSET_LABELS=()
       ANNOTATIONS=()
       # Append any annotations from the specified file
       if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
@@ -585,6 +608,10 @@ spec:
               --labels)
                   shift
                   while [[ $# -gt 0 && $1 != --* ]]; do LABELS+=("--label" "$1"); shift; done
+                  ;;
+              --unset-labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do UNSET_LABELS+=("--unsetlabel" "$1"); shift; done
                   ;;
               --annotations)
                   shift
@@ -680,6 +707,11 @@ spec:
 
       if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ] ; then
         BUILDAH_ARGS+=("--inherit-labels=false")
+      fi
+
+      # Add --unsetlabel flags for labels that should not be inherited from base image
+      if [ ${#UNSET_LABELS[@]} -gt 0 ]; then
+        BUILDAH_ARGS+=("${UNSET_LABELS[@]}")
       fi
 
       if [ -n "${BUILDAH_SOURCE_DATE_EPOCH}" ]; then

--- a/task/buildah/0.9/README.md
+++ b/task/buildah/0.9/README.md
@@ -33,6 +33,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|UNSET_LABELS|Array of label names that should not be inherited from the base image. This is useful to prevent inheriting base image metadata like name, version, description, etc. Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags|[name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags]|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|

--- a/task/buildah/0.9/buildah.yaml
+++ b/task/buildah/0.9/buildah.yaml
@@ -114,6 +114,26 @@ spec:
     description: Additional key=value labels that should be applied to the image
     type: array
     default: []
+  - name: UNSET_LABELS
+    description: |-
+      Array of label names that should not be inherited from the base image.
+      This is useful to prevent inheriting base image metadata like name, version, description, etc.
+      Common examples: name, version, release, summary, description, io.k8s.description, io.k8s.display-name, com.redhat.component, url, vcs-ref, vcs-type, vendor, io.openshift.tags
+    type: array
+    default:
+    - name
+    - version
+    - release
+    - summary
+    - description
+    - io.k8s.description
+    - io.k8s.display-name
+    - com.redhat.component
+    - url
+    - vcs-ref
+    - vcs-type
+    - vendor
+    - io.openshift.tags
   - name: ANNOTATIONS
     description: Additional key=value annotations that should be applied to the image
     type: array
@@ -350,6 +370,8 @@ spec:
     - $(params.ENV_VARS[*])
     - --labels
     - $(params.LABELS[*])
+    - --unset-labels
+    - $(params.UNSET_LABELS[*])
     - --annotations
     - $(params.ANNOTATIONS[*])
 
@@ -461,6 +483,7 @@ spec:
       env_vars=()
 
       LABELS=()
+      UNSET_LABELS=()
       ANNOTATIONS=()
       # Append any annotations from the specified file
       if [ -n "${ANNOTATIONS_FILE}" ] && [ -f "${SOURCE_CODE_DIR}/${ANNOTATIONS_FILE}" ]; then
@@ -491,6 +514,10 @@ spec:
               --labels)
                   shift
                   while [[ $# -gt 0 && $1 != --* ]]; do LABELS+=("--label" "$1"); shift; done
+                  ;;
+              --unset-labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do UNSET_LABELS+=("--unsetlabel" "$1"); shift; done
                   ;;
               --annotations)
                   shift
@@ -586,6 +613,11 @@ spec:
 
       if [ "${INHERIT_BASE_IMAGE_LABELS}" != "true" ] ; then
         BUILDAH_ARGS+=("--inherit-labels=false")
+      fi
+
+      # Add --unsetlabel flags for labels that should not be inherited from base image
+      if [ ${#UNSET_LABELS[@]} -gt 0 ]; then
+        BUILDAH_ARGS+=("${UNSET_LABELS[@]}")
       fi
 
       if [ -n "${BUILDAH_SOURCE_DATE_EPOCH}" ]; then


### PR DESCRIPTION
Prevent inheriting labels from base  image, so added UNSET_LABELS in buildah that has default list that will be ignored but if user wants to override they can pass their custom list which means can also be empty.

Closes issue: #1881 
