### PR TITLE
buildah: support compression-format and force-compression during push

### DIFF
--- a/task/buildah-min/0.8/buildah-min.yaml
+++ b/task/buildah-min/0.8/buildah-min.yaml
@@ -170,6 +170,14 @@ spec:
       oci (default) or docker.
     name: BUILDAH_FORMAT
     type: string
+  - default: ""
+    description: Compression format for image layers (e.g., gzip, zstd, zstd:chunked)
+    name: COMPRESSION_FORMAT
+    type: string
+  - default: "false"
+    description: Force recompression of all layers including base image layers
+    name: FORCE_COMPRESSION
+    type: string
   - default: []
     description: Additional base image references to include to the SBOM. Array of
       image_reference_with_digest strings
@@ -975,6 +983,14 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
+    - name: COMPRESSION_FORMAT
+      value: $(params.COMPRESSION_FORMAT)
+    - name: FORCE_COMPRESSION
+      value: $(params.FORCE_COMPRESSION)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
     image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
     name: push
     script: |
@@ -1000,6 +1016,16 @@ spec:
         push_format=docker
       fi
 
+      COMPRESSION_ARGS=()
+
+      if [ -n "${COMPRESSION_FORMAT}" ]; then
+        COMPRESSION_ARGS+=(--compression-format="${COMPRESSION_FORMAT}")
+      fi
+
+      if [ "${FORCE_COMPRESSION}" == "true" ]; then
+        COMPRESSION_ARGS+=(--force-compression)
+      fi
+
       echo "[$(date --utc -Ins)] Push image with unique tag"
 
       buildah_retries=3
@@ -1010,6 +1036,7 @@ spec:
         --format="$push_format" \
         --retry "$buildah_retries" \
         --tls-verify="$TLSVERIFY" \
+        "${COMPRESSION_ARGS[@]}" \
         "$IMAGE" \
         "docker://${IMAGE%:*}:${TASKRUN_NAME}"
       then
@@ -1025,6 +1052,7 @@ spec:
         --format="$push_format" \
         --retry "$buildah_retries" \
         --tls-verify="$TLSVERIFY" \
+        "${COMPRESSION_ARGS[@]}" \
         --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
         "docker://$IMAGE"
       then

--- a/task/buildah-oci-ta/0.8/README.md
+++ b/task/buildah-oci-ta/0.8/README.md
@@ -19,11 +19,13 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |BUILD_TIMESTAMP|Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.|""|false|
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
 |COMMIT_SHA|The image is built from this commit.|""|false|
+|COMPRESSION_FORMAT|Compression format for image layers (e.g., gzip, zstd, zstd:chunked)|""|false|
 |CONTEXT|Path to the directory to use as context.|.|false|
 |CONTEXTUALIZE_SBOM|Determines if SBOM will be contextualized.|true|false|
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |ENV_VARS|Array of --env values ("env=value" strings)|[]|false|
+|FORCE_COMPRESSION|Force recompression of all layers including base image layers|false|false|
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |HTTP_PROXY|HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.|""|false|
 |ICM_KEEP_COMPAT_LOCATION|Whether to keep compatibility location at /root/buildinfo/ for ICM injection|true|false|

--- a/task/buildah-oci-ta/0.8/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.8/buildah-oci-ta.yaml
@@ -71,6 +71,11 @@ spec:
       description: The image is built from this commit.
       type: string
       default: ""
+    - name: COMPRESSION_FORMAT
+      description: Compression format for image layers (e.g., gzip, zstd,
+        zstd:chunked)
+      type: string
+      default: ""
     - name: CONTEXT
       description: Path to the directory to use as context.
       type: string
@@ -91,6 +96,11 @@ spec:
       description: Array of --env values ("env=value" strings)
       type: array
       default: []
+    - name: FORCE_COMPRESSION
+      description: Force recompression of all layers including base image
+        layers
+      type: string
+      default: "false"
     - name: HERMETIC
       description: Determines if build will be executed without network access.
       type: string
@@ -1059,6 +1069,14 @@ spec:
           value: $(params.BUILDAH_FORMAT)
         - name: TASKRUN_NAME
           value: $(context.taskRun.name)
+        - name: COMPRESSION_FORMAT
+          value: $(params.COMPRESSION_FORMAT)
+        - name: FORCE_COMPRESSION
+          value: $(params.FORCE_COMPRESSION)
+        - name: IMAGE
+          value: $(params.IMAGE)
+        - name: TLSVERIFY
+          value: $(params.TLSVERIFY)
       script: |
         #!/bin/bash
         set -e
@@ -1082,6 +1100,16 @@ spec:
           push_format=docker
         fi
 
+        COMPRESSION_ARGS=()
+
+        if [ -n "${COMPRESSION_FORMAT}" ]; then
+          COMPRESSION_ARGS+=(--compression-format="${COMPRESSION_FORMAT}")
+        fi
+
+        if [ "${FORCE_COMPRESSION}" == "true" ]; then
+          COMPRESSION_ARGS+=(--force-compression)
+        fi
+
         echo "[$(date --utc -Ins)] Push image with unique tag"
 
         buildah_retries=3
@@ -1092,6 +1120,7 @@ spec:
           --format="$push_format" \
           --retry "$buildah_retries" \
           --tls-verify="$TLSVERIFY" \
+          "${COMPRESSION_ARGS[@]}" \
           "$IMAGE" \
           "docker://${IMAGE%:*}:${TASKRUN_NAME}"; then
           echo "Failed to push sbom image to ${IMAGE%:*}:${TASKRUN_NAME}"
@@ -1106,6 +1135,7 @@ spec:
           --format="$push_format" \
           --retry "$buildah_retries" \
           --tls-verify="$TLSVERIFY" \
+          "${COMPRESSION_ARGS[@]}" \
           --digestfile "/var/workdir/image-digest" "$IMAGE" \
           "docker://$IMAGE"; then
           echo "Failed to push sbom image to $IMAGE"

--- a/task/buildah/0.8/buildah.yaml
+++ b/task/buildah/0.8/buildah.yaml
@@ -156,11 +156,20 @@ spec:
     description: The format for the resulting image's mediaType. Valid values are oci (default) or docker.
     type: string
     default: oci
+  - name: COMPRESSION_FORMAT
+    description: Compression format for image layers (e.g., gzip, zstd, zstd:chunked)
+    type: string
+    default: ""
+  - name: FORCE_COMPRESSION
+    description: Force recompression of all layers including base image layers
+    type: string
+    default: "false"
   - name: ADDITIONAL_BASE_IMAGES
     description: |-
       Additional base image references to include to the SBOM. Array of image_reference_with_digest strings
     type: array
     default: []
+
   - name: WORKINGDIR_MOUNT
     description: >-
       Mount the current working directory into the build using
@@ -975,6 +984,14 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
+    - name: COMPRESSION_FORMAT
+      value: $(params.COMPRESSION_FORMAT)
+    - name: FORCE_COMPRESSION
+      value: $(params.FORCE_COMPRESSION)
+    - name: IMAGE
+      value: $(params.IMAGE)
+    - name: TLSVERIFY
+      value: $(params.TLSVERIFY)
     script: |
       #!/bin/bash
       set -e
@@ -998,6 +1015,16 @@ spec:
         push_format=docker
       fi
 
+      COMPRESSION_ARGS=()
+
+      if [ -n "${COMPRESSION_FORMAT}" ]; then
+        COMPRESSION_ARGS+=(--compression-format="${COMPRESSION_FORMAT}")
+      fi
+
+      if [ "${FORCE_COMPRESSION}" == "true" ]; then
+        COMPRESSION_ARGS+=(--force-compression)
+      fi
+
       echo "[$(date --utc -Ins)] Push image with unique tag"
 
       buildah_retries=3
@@ -1008,6 +1035,7 @@ spec:
         --format="$push_format" \
         --retry "$buildah_retries" \
         --tls-verify="$TLSVERIFY" \
+        "${COMPRESSION_ARGS[@]}" \
         "$IMAGE" \
         "docker://${IMAGE%:*}:${TASKRUN_NAME}"
       then
@@ -1023,6 +1051,7 @@ spec:
         --format="$push_format" \
         --retry "$buildah_retries" \
         --tls-verify="$TLSVERIFY" \
+        "${COMPRESSION_ARGS[@]}" \
         --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
         "docker://$IMAGE"
       then


### PR DESCRIPTION
Adds support for the following parameters to the buildah Task push step:

- COMPRESSION_FORMAT
- FORCE_COMPRESSION

These parameters are now applied to both push operations:
1. The unique TaskRun tag push
2. The final image push with digest

## Details

- Introduces --compression-format and --force-compression flags when invoking `buildah push`
- Applies the flags conditionally to preserve existing behavior
- Regenerates Trusted Artifact (OCI-TA) variants
- Rebuilds kustomize-generated manifests

## Backward Compatibility

- Default values preserve existing behavior
- No changes occur unless parameters are explicitly set

Fixes: #3188