### PR TITLE
fix(source-build): validate base image refs and SBOM PURLs

### DIFF
--- a/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
@@ -107,7 +107,18 @@ spec:
 
         if [[ -n "$BASE_IMAGES" ]]; then
           echo "BASE_IMAGES param received:"
-          printf "%s" "$BASE_IMAGES" | tee "$BASE_IMAGES_FILE"
+          printf "%s" "$BASE_IMAGES" | while IFS= read -r line; do
+            if [[ -z "$line" ]]; then continue; fi
+            if [[ "$line" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+              echo "ERROR: Invalid BASE_IMAGES entry '$line': bare digests are not supported. Please provide a full image reference (e.g., registry.io/repo/name:tag or registry.io/repo/name@sha256:...)." >&2
+              exit 1
+            fi
+            if ! [[ "$line" =~ ^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(\:[0-9]+)?/)?[a-z0-9]+([._-][a-z0-9]+)*(/.+)*([:@].*)?$ ]]; then
+              echo "ERROR: Invalid BASE_IMAGES entry '$line': must be a valid image reference." >&2
+              exit 1
+            fi
+            echo "$line"
+          done | tee "$BASE_IMAGES_FILE"
           exit
         fi
 
@@ -158,30 +169,42 @@ spec:
         # base image for the last FROM instruction. That is the only base image we care about.
         if jq -e '.bomFormat == "CycloneDX"' <<<"$sbom" >/dev/null; then
           echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
-          jq -r '
+          base_image_info=$(jq -r '
                 .formulation[]?
                 | .components[]?
                 | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
-                | (
-                    .purl
-                    | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
-                  ) as $matched
-                | $matched.repository_url + "@" + $matched.digest
-            ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
+                | .purl
+                | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                | {repository_url, digest}
+            ' <<<"$sbom")
         else
           echo ' (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)'
-          jq -r '
-                  .packages[]
-                  | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
-                  | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
-                  | (
-                      $purls | first
-                      | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
-                    ) as $matched
-                  | $matched.repository_url + "@" + $matched.digest
-
-            ' <<<"$sbom" | tee "$BASE_IMAGES_FILE"
+          base_image_info=$(jq -r '
+                .packages[]
+                | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
+                | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                | $purls | first
+                | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                | {repository_url, digest}
+            ' <<<"$sbom")
         fi
+
+        repository_url=$(jq -r '.repository_url // empty' <<<"$base_image_info")
+        digest=$(jq -r '.digest // empty' <<<"$base_image_info")
+
+        if [[ -z "$repository_url" ]] || [[ "$repository_url" == "null" ]]; then
+          echo "ERROR: Base image found in SBOM is missing repository_url in PURL. Cannot determine base image reference." >&2
+          echo "Found digest: $digest" >&2
+          echo "The SBOM must include repository_url parameter in the base image PURL (e.g., pkg:oci/image@sha256:...?repository_url=registry.io/repo/name)" >&2
+          exit 1
+        fi
+
+        if [[ -z "$digest" ]]; then
+          echo "ERROR: Base image found in SBOM is missing digest in PURL." >&2
+          exit 1
+        fi
+
+        echo "${repository_url}@${digest}" | tee "$BASE_IMAGES_FILE"
     - name: build
       image: quay.io/konflux-ci/source-container-build:latest@sha256:b60d4b3b68d2026ed0c2c85ca1af8bb38cfa73e44d862b0f96c54bd343dd32fd
       workingDir: /var/workdir

--- a/task/source-build/0.3/source-build.yaml
+++ b/task/source-build/0.3/source-build.yaml
@@ -95,7 +95,18 @@ spec:
 
         if [[ -n "$BASE_IMAGES" ]]; then
             echo "BASE_IMAGES param received:"
-            printf "%s" "$BASE_IMAGES" | tee "$BASE_IMAGES_FILE"
+            printf "%s" "$BASE_IMAGES" | while IFS= read -r line; do
+                if [[ -z "$line" ]]; then continue; fi
+                if [[ "$line" =~ ^sha256:[a-f0-9]{64}$ ]]; then
+                    echo "ERROR: Invalid BASE_IMAGES entry '$line': bare digests are not supported. Please provide a full image reference (e.g., registry.io/repo/name:tag or registry.io/repo/name@sha256:...)." >&2
+                    exit 1
+                fi
+                if ! [[ "$line" =~ ^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*(\:[0-9]+)?/)?[a-z0-9]+([._-][a-z0-9]+)*(/.+)*([:@].*)?$ ]]; then
+                    echo "ERROR: Invalid BASE_IMAGES entry '$line': must be a valid image reference." >&2
+                    exit 1
+                fi
+                echo "$line"
+            done | tee "$BASE_IMAGES_FILE"
             exit
         fi
 
@@ -145,31 +156,43 @@ spec:
         # Note: the SBOM should contain at most one image with the is_base_image property - the
         # base image for the last FROM instruction. That is the only base image we care about.
         if jq -e '.bomFormat == "CycloneDX"' <<< "$sbom" >/dev/null; then
-            echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
-            jq -r '
+              echo " (.formulation[].components[] with 'konflux:container:is_base_image' property)"
+            base_image_info=$(jq -r '
                 .formulation[]?
                 | .components[]?
                 | select(any(.properties[]?; .name == "konflux:container:is_base_image"))
-                | (
-                    .purl
-                    | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
-                  ) as $matched
-                | $matched.repository_url + "@" + $matched.digest
-            ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
+                | .purl
+                | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                | {repository_url, digest}
+            ' <<< "$sbom")
         else
             echo ' (a package with a {"name": "konflux:container:is_base_image"} JSON-encoded annotation)'
-            jq -r '
-                  .packages[]
-                  | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
-                  | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
-                  | (
-                      $purls | first
-                      | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
-                    ) as $matched
-                  | $matched.repository_url + "@" + $matched.digest
-
-            ' <<< "$sbom" | tee "$BASE_IMAGES_FILE"
+            base_image_info=$(jq -r '
+                .packages[]
+                | select(any(.annotations[]?.comment; (fromjson?).name? == "konflux:container:is_base_image"))
+                | [.externalRefs[]? | select(.referenceType == "purl").referenceLocator] as $purls
+                | $purls | first
+                | capture("^pkg:oci/.*?@(?<digest>[a-z0-9]+:[a-f0-9]+)(?:\\?[^#]*repository_url=(?<repository_url>[^&#]*))?")
+                | {repository_url, digest}
+            ' <<< "$sbom")
         fi
+
+        repository_url=$(jq -r '.repository_url // empty' <<< "$base_image_info")
+        digest=$(jq -r '.digest // empty' <<< "$base_image_info")
+
+        if [[ -z "$repository_url" ]] || [[ "$repository_url" == "null" ]]; then
+            echo "ERROR: Base image found in SBOM is missing repository_url in PURL. Cannot determine base image reference." >&2
+            echo "Found digest: $digest" >&2
+            echo "The SBOM must include repository_url parameter in the base image PURL (e.g., pkg:oci/image@sha256:...?repository_url=registry.io/repo/name)" >&2
+            exit 1
+        fi
+
+        if [[ -z "$digest" ]]; then
+            echo "ERROR: Base image found in SBOM is missing digest in PURL." >&2
+            exit 1
+        fi
+
+        echo "${repository_url}@${digest}" | tee "$BASE_IMAGES_FILE"
 
     - name: build
       image: quay.io/konflux-ci/source-container-build:latest@sha256:b60d4b3b68d2026ed0c2c85ca1af8bb38cfa73e44d862b0f96c54bd343dd32fd


### PR DESCRIPTION
## Description
This PR fixes **#1413** by adding strict validation to the source-build task to prevent skopeo from crashing when a bare digest is provided.

### Changes:
-  Added a regex check for the `BASE_IMAGES` parameter to ensure it contains a full image reference (registry/repo) rather than just a sha256 digest.
-  Refactored jq logic for CycloneDX and SPDX to extract PURL data into a Json object
-  The task now exits with a descriptive error message 

**Fixes: #1413**