### PR TITLE
Add unset labels param to buildah

### DIFF
--- a/task/buildah-min/0.8/README.md
+++ b/task/buildah-min/0.8/README.md
@@ -37,6 +37,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|UNSET_LABELS|List of label names to remove from the base image. By default, common base image labels are removed so the final image does not look like the parent image. Provide your own list to override the defaults, or use an empty array to keep all base image labels.|["name","release","version","summary","description","url","maintainer","com.redhat.component","com.redhat.license_terms","io.k8s.display-name","io.k8s.description","io.openshift.tags","io.openshift.expose-services","distribution-scope","vendor"]|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|

--- a/task/buildah-min/0.8/buildah-min.yaml
+++ b/task/buildah-min/0.8/buildah-min.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.8.3
+    app.kubernetes.io/version: 0.8.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-min
 spec:
@@ -127,6 +127,28 @@ spec:
   - default: []
     description: Additional key=value labels that should be applied to the image
     name: LABELS
+    type: array
+  - default:
+    - name
+    - release
+    - version
+    - summary
+    - description
+    - url
+    - maintainer
+    - com.redhat.component
+    - com.redhat.license_terms
+    - io.k8s.display-name
+    - io.k8s.description
+    - io.openshift.tags
+    - io.openshift.expose-services
+    - distribution-scope
+    - vendor
+    description: List of label names to remove from the base image. By default, common
+      base image labels are removed so the final image does not look like the parent
+      image. Provide your own list to override the defaults, or use an empty array
+      to keep all base image labels.
+    name: UNSET_LABELS
     type: array
   - default: []
     description: Additional key=value annotations that should be applied to the image
@@ -336,6 +358,8 @@ spec:
     - $(params.LABELS[*])
     - --annotations
     - $(params.ANNOTATIONS[*])
+    - --unset-labels
+    - $(params.UNSET_LABELS[*])
     computeResources:
       limits:
         memory: 4Gi
@@ -520,6 +544,10 @@ spec:
               --annotations)
                   shift
                   while [[ $# -gt 0 && $1 != --* ]]; do ANNOTATIONS+=("--annotation" "$1"); shift; done
+                  ;;
+              --unset-labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do BUILDAH_ARGS+=("--unsetlabel" "$1"); shift; done
                   ;;
               *)
                   echo "unexpected argument: $1" >&2

--- a/task/buildah-min/CHANGELOG.md
+++ b/task/buildah-min/CHANGELOG.md
@@ -23,6 +23,16 @@ If that's not something you ever plan to do, consider removing this section.
 ### Removed
 - BREAKING: Support for Dockerfile downloading in Konflux Build Pipeline.
 
+## 0.8.4
+
+### Added
+
+- Added `UNSET_LABELS`, a parameter for choosing which labels should not be
+  inherited from the base image. It comes with a default list of common
+  UBI/RHEL labels so the final image does not look like the parent image.
+  You can replace that list with your own, or use an empty list to keep all
+  base image labels.
+
 ## 0.8.3
 
 ### Fixed

--- a/task/buildah-oci-ta/0.8/README.md
+++ b/task/buildah-oci-ta/0.8/README.md
@@ -52,6 +52,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|UNSET_LABELS|List of label names to remove from the base image. By default, common base image labels are removed so the final image does not look like the parent image. Provide your own list to override the defaults, or use an empty array to keep all base image labels.|["name","release","version","summary","description","url","maintainer","com.redhat.component","com.redhat.license_terms","io.k8s.display-name","io.k8s.description","io.openshift.tags","io.openshift.expose-services","distribution-scope","vendor"]|false|
 |WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
 |YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|

--- a/task/buildah-oci-ta/0.8/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.8/buildah-oci-ta.yaml
@@ -8,7 +8,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.8.3
+    app.kubernetes.io/version: 0.8.4
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -234,6 +234,28 @@ spec:
         to a non-TLS registry)
       type: string
       default: "true"
+    - name: UNSET_LABELS
+      description: List of label names to remove from the base image. By default,
+        common base image labels are removed so the final image does not look
+        like the parent image. Provide your own list to override the defaults,
+        or use an empty array to keep all base image labels.
+      type: array
+      default:
+        - name
+        - release
+        - version
+        - summary
+        - description
+        - url
+        - maintainer
+        - com.redhat.component
+        - com.redhat.license_terms
+        - io.k8s.display-name
+        - io.k8s.description
+        - io.openshift.tags
+        - io.openshift.expose-services
+        - distribution-scope
+        - vendor
     - name: WORKINGDIR_MOUNT
       description: Mount the current working directory into the build using
         --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context
@@ -402,6 +424,8 @@ spec:
         - $(params.LABELS[*])
         - --annotations
         - $(params.ANNOTATIONS[*])
+        - --unset-labels
+        - $(params.UNSET_LABELS[*])
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers
@@ -604,6 +628,13 @@ spec:
             shift
             while [[ $# -gt 0 && $1 != --* ]]; do
               ANNOTATIONS+=("--annotation" "$1")
+              shift
+            done
+            ;;
+          --unset-labels)
+            shift
+            while [[ $# -gt 0 && $1 != --* ]]; do
+              BUILDAH_ARGS+=("--unsetlabel" "$1")
               shift
             done
             ;;

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -23,6 +23,16 @@ If that's not something you ever plan to do, consider removing this section.
 ### Removed
 - BREAKING: Support for Dockerfile downloading in Konflux Build Pipeline.
 
+## 0.8.4
+
+### Added
+
+- Added `UNSET_LABELS`, a parameter for choosing which labels should not be
+  inherited from the base image. It comes with a default list of common
+  UBI/RHEL labels so the final image does not look like the parent image.
+  You can replace that list with your own, or use an empty list to keep all
+  base image labels.
+
 ## 0.8.3
 
 ### Fixed

--- a/task/buildah-remote-oci-ta/0.8/README.md
+++ b/task/buildah-remote-oci-ta/0.8/README.md
@@ -52,6 +52,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |TLSVERIFY|Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)|true|false|
+|UNSET_LABELS|List of label names to remove from the base image. By default, common base image labels are removed so the final image does not look like the parent image. Provide your own list to override the defaults, or use an empty array to keep all base image labels.|["name","release","version","summary","description","url","maintainer","com.redhat.component","com.redhat.license_terms","io.k8s.display-name","io.k8s.description","io.openshift.tags","io.openshift.expose-services","distribution-scope","vendor"]|false|
 |WORKINGDIR_MOUNT|Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).|""|false|
 |YUM_REPOS_D_FETCHED|Path in source workspace where dynamically-fetched repos are present|fetched.repos.d|false|
 |YUM_REPOS_D_SRC|Path in the git repository in which yum repository files are stored|repos.d|false|

--- a/task/buildah-remote-oci-ta/0.8/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.8/buildah-remote-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.8.3
+    app.kubernetes.io/version: 0.8.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -227,6 +227,28 @@ spec:
       registry)
     name: TLSVERIFY
     type: string
+  - default:
+    - name
+    - release
+    - version
+    - summary
+    - description
+    - url
+    - maintainer
+    - com.redhat.component
+    - com.redhat.license_terms
+    - io.k8s.display-name
+    - io.k8s.description
+    - io.openshift.tags
+    - io.openshift.expose-services
+    - distribution-scope
+    - vendor
+    description: List of label names to remove from the base image. By default, common
+      base image labels are removed so the final image does not look like the parent
+      image. Provide your own list to override the defaults, or use an empty array
+      to keep all base image labels.
+    name: UNSET_LABELS
+    type: array
   - default: ""
     description: Mount the current working directory into the build using --volume
       $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for
@@ -373,6 +395,8 @@ spec:
     - $(params.LABELS[*])
     - --annotations
     - $(params.ANNOTATIONS[*])
+    - --unset-labels
+    - $(params.UNSET_LABELS[*])
     computeResources:
       limits:
         cpu: 4600m
@@ -636,6 +660,13 @@ spec:
           shift
           while [[ $# -gt 0 && $1 != --* ]]; do
             ANNOTATIONS+=("--annotation" "$1")
+            shift
+          done
+          ;;
+        --unset-labels)
+          shift
+          while [[ $# -gt 0 && $1 != --* ]]; do
+            BUILDAH_ARGS+=("--unsetlabel" "$1")
             shift
           done
           ;;

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -23,6 +23,16 @@ If that's not something you ever plan to do, consider removing this section.
 ### Removed
 - BREAKING: Support for Dockerfile downloading in Konflux Build Pipeline.
 
+## 0.8.4
+
+### Added
+
+- Added `UNSET_LABELS`, a parameter for choosing which labels should not be
+  inherited from the base image. It comes with a default list of common
+  UBI/RHEL labels so the final image does not look like the parent image.
+  You can replace that list with your own, or use an empty list to keep all
+  base image labels.
+
 ## 0.8.3
 
 ### Fixed

--- a/task/buildah-remote/0.8/README.md
+++ b/task/buildah-remote/0.8/README.md
@@ -33,6 +33,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|UNSET_LABELS|List of label names to remove from the base image. By default, common base image labels are removed so the final image does not look like the parent image. Provide your own list to override the defaults, or use an empty array to keep all base image labels.|["name","release","version","summary","description","url","maintainer","com.redhat.component","com.redhat.license_terms","io.k8s.display-name","io.k8s.description","io.openshift.tags","io.openshift.expose-services","distribution-scope","vendor"]|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|

--- a/task/buildah-remote/0.8/buildah-remote.yaml
+++ b/task/buildah-remote/0.8/buildah-remote.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/tags: image-build, konflux
   creationTimestamp: null
   labels:
-    app.kubernetes.io/version: 0.8.3
+    app.kubernetes.io/version: 0.8.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -127,6 +127,28 @@ spec:
   - default: []
     description: Additional key=value labels that should be applied to the image
     name: LABELS
+    type: array
+  - default:
+    - name
+    - release
+    - version
+    - summary
+    - description
+    - url
+    - maintainer
+    - com.redhat.component
+    - com.redhat.license_terms
+    - io.k8s.display-name
+    - io.k8s.description
+    - io.openshift.tags
+    - io.openshift.expose-services
+    - distribution-scope
+    - vendor
+    description: List of label names to remove from the base image. By default, common
+      base image labels are removed so the final image does not look like the parent
+      image. Provide your own list to override the defaults, or use an empty array
+      to keep all base image labels.
+    name: UNSET_LABELS
     type: array
   - default: []
     description: Additional key=value annotations that should be applied to the image
@@ -350,6 +372,8 @@ spec:
     - $(params.LABELS[*])
     - --annotations
     - $(params.ANNOTATIONS[*])
+    - --unset-labels
+    - $(params.UNSET_LABELS[*])
     computeResources:
       limits:
         cpu: 4600m
@@ -603,6 +627,10 @@ spec:
               --annotations)
                   shift
                   while [[ $# -gt 0 && $1 != --* ]]; do ANNOTATIONS+=("--annotation" "$1"); shift; done
+                  ;;
+              --unset-labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do BUILDAH_ARGS+=("--unsetlabel" "$1"); shift; done
                   ;;
               *)
                   echo "unexpected argument: $1" >&2

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -23,6 +23,16 @@ If that's not something you ever plan to do, consider removing this section.
 ### Removed
 - BREAKING: Support for Dockerfile downloading in Konflux Build Pipeline.
 
+## 0.8.4
+
+### Added
+
+- Added `UNSET_LABELS`, a parameter for choosing which labels should not be
+  inherited from the base image. It comes with a default list of common
+  UBI/RHEL labels so the final image does not look like the parent image.
+  You can replace that list with your own, or use an empty list to keep all
+  base image labels.
+
 ## 0.8.3
 
 ### Fixed

--- a/task/buildah/0.8/README.md
+++ b/task/buildah/0.8/README.md
@@ -33,6 +33,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |STORAGE_DRIVER|Storage driver to configure for buildah|overlay|false|
 |SKIP_UNUSED_STAGES|Whether to skip stages in Containerfile that seem unused by subsequent stages|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|UNSET_LABELS|List of label names to remove from the base image. By default, common base image labels are removed so the final image does not look like the parent image. Provide your own list to override the defaults, or use an empty array to keep all base image labels.|["name","release","version","summary","description","url","maintainer","com.redhat.component","com.redhat.license_terms","io.k8s.display-name","io.k8s.description","io.openshift.tags","io.openshift.expose-services","distribution-scope","vendor"]|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |PRIVILEGED_NESTED|Whether to enable privileged mode, should be used only with remote VMs|false|false|

--- a/task/buildah/0.8/buildah.yaml
+++ b/task/buildah/0.8/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.8.3"
+    app.kubernetes.io/version: "0.8.4"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     build.appstudio.redhat.com/expires-on: "2026-04-30T00:00:00Z"
@@ -115,6 +115,29 @@ spec:
     description: Additional key=value labels that should be applied to the image
     type: array
     default: []
+  - name: UNSET_LABELS
+    description: >-
+      List of label names to remove from the base image. By default, common
+      base image labels are removed so the final image does not look like the
+      parent image. Provide your own list to override the defaults, or use an
+      empty array to keep all base image labels.
+    type: array
+    default:
+      - name
+      - release
+      - version
+      - summary
+      - description
+      - url
+      - maintainer
+      - com.redhat.component
+      - com.redhat.license_terms
+      - io.k8s.display-name
+      - io.k8s.description
+      - io.openshift.tags
+      - io.openshift.expose-services
+      - distribution-scope
+      - vendor
   - name: ANNOTATIONS
     description: Additional key=value annotations that should be applied to the image
     type: array
@@ -353,6 +376,8 @@ spec:
     - $(params.LABELS[*])
     - --annotations
     - $(params.ANNOTATIONS[*])
+    - --unset-labels
+    - $(params.UNSET_LABELS[*])
 
     script: |
       #!/bin/bash
@@ -509,6 +534,10 @@ spec:
               --annotations)
                   shift
                   while [[ $# -gt 0 && $1 != --* ]]; do ANNOTATIONS+=("--annotation" "$1"); shift; done
+                  ;;
+              --unset-labels)
+                  shift
+                  while [[ $# -gt 0 && $1 != --* ]]; do BUILDAH_ARGS+=("--unsetlabel" "$1"); shift; done
                   ;;
               *)
                   echo "unexpected argument: $1" >&2

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -8,7 +8,6 @@
 When you make changes without bumping the version right away, document them here.
 If that's not something you ever plan to do, consider removing this section.
 -->
-
 *Nothing yet.*
 
 ## 0.9.1
@@ -22,6 +21,16 @@ If that's not something you ever plan to do, consider removing this section.
 
 ### Removed
 - BREAKING: Support for Dockerfile downloading in Konflux Build Pipeline.
+
+## 0.8.4
+
+### Added
+
+- Added `UNSET_LABELS`, a parameter for choosing which labels should not be
+  inherited from the base image. It comes with a default list of common
+  UBI/RHEL labels so the final image does not look like the parent image.
+  You can replace that list with your own, or use an empty list to keep all
+  base image labels.
 
 ## 0.8.3
 


### PR DESCRIPTION
This updates the buildah task so child images do not keep unwanted labels from the parent image by default.

The original issue was that images built from a base like ubi9 were inheriting parent labels, which made the child image look like the base image. It was suggested using buildah’s --unsetlabel support and this to be controlled by a parameter.

This change adds UNSET_LABELS, with a default list of common base-image labels to remove. Can replace that list with their own, or set it to an empty list if they want to keep all inherited labels.

closes #1881 