### PR TITLE
Reproducible build: added build flags and validated pipeline with deterministic images

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -137,10 +137,17 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
   - default: "false"
     description: Whether to enable privileged mode, should be used only with remote
       VMs
@@ -245,6 +252,10 @@ spec:
       value: $(tasks.init.results.no-proxy)
     - name: SOURCE_DATE_EPOCH
       value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:
@@ -405,6 +416,12 @@ spec:
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])

--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -134,13 +134,17 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
-  - default: ""
-    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
-    name: build-args-file
+  - default: "false"
+    description: Whether to enable privileged mode, should be used only with remote
+      VMs
+    name: privileged-nested
     type: string
   - default: ""
     name: infra-deployment-update-script
@@ -239,6 +243,8 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
     - name: IMAGE_APPEND_PLATFORM
       value: "true"
     runAfter:

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -24,6 +24,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-images:0.9:PRIVILEGED_NESTED|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-images:0.9:SOURCE_DATE_EPOCH|
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters
@@ -93,7 +94,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
-|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| |
+|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| '$(params.source-date-epoch)'|
 |SOURCE_URL| The image is built from this URL.| ""| '$(tasks.clone-repository.results.url)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -18,13 +18,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.9:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.9:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
+|omit-history| Omit build history information from the resulting image| false| build-images:0.9:OMIT_HISTORY ; sast-coverity-check:0.3:OMIT_HISTORY|
 |output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-images:0.9:IMAGE ; build-image-index:0.2:IMAGE ; sast-coverity-check:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.9:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.3:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-images:0.9:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-images:0.9:PRIVILEGED_NESTED|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| build-images:0.9:REWRITE_TIMESTAMP ; sast-coverity-check:0.3:REWRITE_TIMESTAMP|
 |skip-checks| Skip checks against built image| false| |
-|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-images:0.9:SOURCE_DATE_EPOCH|
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-images:0.9:SOURCE_DATE_EPOCH ; sast-coverity-check:0.3:SOURCE_DATE_EPOCH|
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters
@@ -79,13 +81,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
-|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
+|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| '$(params.omit-history)'|
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
-|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -68,6 +68,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -178,6 +181,8 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -71,6 +71,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -183,6 +189,10 @@ spec:
       value: $(tasks.init.results.no-proxy)
     - name: SOURCE_DATE_EPOCH
       value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -354,6 +364,12 @@ spec:
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])

--- a/pipelines/docker-build-oci-ta-min/README.md
+++ b/pipelines/docker-build-oci-ta-min/README.md
@@ -24,6 +24,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.9:PRIVILEGED_NESTED|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-container:0.9:SOURCE_DATE_EPOCH|
 
 ## Available params from tasks
 ### build-image-index-min:0.2 task parameters
@@ -82,7 +83,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
-|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| |
+|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| '$(params.source-date-epoch)'|
 |SOURCE_URL| The image is built from this URL.| ""| '$(tasks.clone-repository.results.url)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |

--- a/pipelines/docker-build-oci-ta-min/README.md
+++ b/pipelines/docker-build-oci-ta-min/README.md
@@ -18,11 +18,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.9:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.9:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER|
+|omit-history| Omit build history information from the resulting image| false| build-container:0.9:OMIT_HISTORY|
 |output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.9:IMAGE ; build-image-index:0.2:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.9:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-container:0.9:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.9:PRIVILEGED_NESTED|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| build-container:0.9:REWRITE_TIMESTAMP|
 |skip-checks| Skip checks against built image| false| |
 |source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-container:0.9:SOURCE_DATE_EPOCH|
 
@@ -69,12 +71,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
-|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
+|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| '$(params.omit-history)'|
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
-|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
+++ b/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
@@ -66,6 +66,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -165,6 +168,8 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
+++ b/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
@@ -69,6 +69,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -170,6 +176,10 @@ spec:
       value: $(tasks.init.results.no-proxy)
     - name: SOURCE_DATE_EPOCH
       value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -23,6 +23,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.9:PRIVILEGED_NESTED|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-container:0.9:SOURCE_DATE_EPOCH|
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters
@@ -90,7 +91,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
-|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| |
+|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| '$(params.source-date-epoch)'|
 |SOURCE_URL| The image is built from this URL.| ""| '$(tasks.clone-repository.results.url)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -17,13 +17,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.9:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.9:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
+|omit-history| Omit build history information from the resulting image| false| build-container:0.9:OMIT_HISTORY ; sast-coverity-check:0.3:OMIT_HISTORY|
 |output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.9:IMAGE ; build-image-index:0.2:IMAGE ; sast-coverity-check:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.9:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.3:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-container:0.9:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.9:PRIVILEGED_NESTED|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| build-container:0.9:REWRITE_TIMESTAMP ; sast-coverity-check:0.3:REWRITE_TIMESTAMP|
 |skip-checks| Skip checks against built image| false| |
-|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-container:0.9:SOURCE_DATE_EPOCH|
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-container:0.9:SOURCE_DATE_EPOCH ; sast-coverity-check:0.3:SOURCE_DATE_EPOCH|
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters
@@ -77,12 +79,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
-|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
+|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| '$(params.omit-history)'|
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
-|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -68,6 +68,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -167,6 +170,8 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -71,6 +71,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -172,6 +178,10 @@ spec:
       value: $(tasks.init.results.no-proxy)
     - name: SOURCE_DATE_EPOCH
       value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT
@@ -326,6 +336,12 @@ spec:
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])

--- a/pipelines/docker-build-oci-ta/patch.yaml
+++ b/pipelines/docker-build-oci-ta/patch.yaml
@@ -17,25 +17,6 @@
     "pipelines.openshift.io/strategy": "docker"
 - op: remove
   path: /spec/workspaces/0
-# Order of Tasks from the base docker-build Pipeline:
-# $ kustomize build pipelines/docker-build | yq .spec.tasks.[].name | nl -v 0
-#   0  init
-#   1  clone-repository
-#   2  prefetch-dependencies
-#   3  build-container
-#   4  build-image-index
-#   5  build-source-image
-#   6  deprecated-base-image-check
-#   7  clair-scan
-#   8  ecosystem-cert-preflight-checks
-#   9  sast-snyk-check
-#  10  clamav-scan
-#  11  sast-coverity-check
-#  12  coverity-availability-check
-#  13  sast-shell-check
-#  14  sast-unicode-check
-#  15  apply-tags
-#  16  push-dockerfile
 
 # clone-repository Task
 - op: replace
@@ -118,8 +99,6 @@
   path: /spec/tasks/9/taskRef/name
   value: sast-snyk-check-oci-ta
 - op: add
-  # In the docker-build Pipeline, the snyk Task does not receive any parameters, so we cannot
-  # append to it.
   path: /spec/tasks/9/params/-
   value:
     name: SOURCE_ARTIFACT

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -23,6 +23,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.9:PRIVILEGED_NESTED|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-container:0.9:SOURCE_DATE_EPOCH|
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters
@@ -88,7 +89,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_INJECTIONS| Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.| false| |
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
-|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| |
+|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| '$(params.source-date-epoch)'|
 |SOURCE_URL| The image is built from this URL.| ""| '$(tasks.clone-repository.results.url)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -17,13 +17,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.9:HERMETIC ; sast-coverity-check:0.3:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.9:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER ; sast-coverity-check:0.3:IMAGE_EXPIRES_AFTER|
+|omit-history| Omit build history information from the resulting image| false| build-container:0.9:OMIT_HISTORY ; sast-coverity-check:0.3:OMIT_HISTORY|
 |output-image| Fully Qualified Output Image| None| build-container:0.9:IMAGE ; build-image-index:0.2:IMAGE ; sast-coverity-check:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.9:CONTEXT ; sast-coverity-check:0.3:CONTEXT ; push-dockerfile:0.3:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-container:0.9:PREFETCH_INPUT ; sast-coverity-check:0.3:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.9:PRIVILEGED_NESTED|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| build-container:0.9:REWRITE_TIMESTAMP ; sast-coverity-check:0.3:REWRITE_TIMESTAMP|
 |skip-checks| Skip checks against built image| false| |
-|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-container:0.9:SOURCE_DATE_EPOCH|
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-container:0.9:SOURCE_DATE_EPOCH ; sast-coverity-check:0.3:SOURCE_DATE_EPOCH|
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters
@@ -76,12 +78,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
-|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
+|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| '$(params.omit-history)'|
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
-|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -71,6 +71,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -166,6 +172,10 @@ spec:
       value: $(tasks.init.results.no-proxy)
     - name: SOURCE_DATE_EPOCH
       value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     runAfter:
     - prefetch-dependencies
     taskRef:
@@ -314,6 +324,12 @@ spec:
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: BUILD_ARGS
       value:
       - $(params.build-args[*])

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -68,6 +68,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -161,6 +164,8 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
     runAfter:
     - prefetch-dependencies
     taskRef:

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -15,25 +15,6 @@
     "pipelines.openshift.io/used-by": "build-cloud"
     "pipelines.openshift.io/runtime": "generic"
     "pipelines.openshift.io/strategy": "docker"
-#  yq ".spec.tasks.[].name" pipelines/template-build/template-build.yaml | nl -v 0
-#      0  init
-#      1  clone-repository
-#      2  prefetch-dependencies
-#      3  build-container
-#      4  build-image-index
-#      5  build-source-image
-#      6  deprecated-base-image-check
-#      7  clair-scan
-#      8  ecosystem-cert-preflight-checks
-#      9  sast-snyk-check
-#     10  clamav-scan
-#     11  sast-coverity-check
-#     12  coverity-availability-check
-#     13  sast-shell-check
-#     14  sast-unicode-check
-#     15  apply-tags
-#     16  push-dockerfile
-#     17  rpms-signature-scan
 
 # build-container
 - op: test
@@ -99,8 +80,11 @@
     value: "$(tasks.init.results.no-proxy)"
   - name: SOURCE_DATE_EPOCH
     value: "$(params.source-date-epoch)"
+  - name: REWRITE_TIMESTAMP
+    value: "$(params.rewrite-timestamp)"
+  - name: OMIT_HISTORY
+    value: "$(params.omit-history)"
 
-# FIXME: duplicate the "add" operations for sast-coverity-check, which is based on build-container
 - op: test
   path: /spec/tasks/11/name
   value: sast-coverity-check
@@ -139,6 +123,21 @@
   value:
     name: COMMIT_SHA
     value: "$(tasks.clone-repository.results.commit)"
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: SOURCE_DATE_EPOCH
+    value: "$(params.source-date-epoch)"
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: REWRITE_TIMESTAMP
+    value: "$(params.rewrite-timestamp)"
+- op: add
+  path: /spec/tasks/11/params/-
+  value:
+    name: OMIT_HISTORY
+    value: "$(params.omit-history)"
 - op: add
   path: /spec/tasks/11/params/-
   value:

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -97,6 +97,8 @@
     value: "$(tasks.init.results.http-proxy)"
   - name: NO_PROXY
     value: "$(tasks.init.results.no-proxy)"
+  - name: SOURCE_DATE_EPOCH
+    value: "$(params.source-date-epoch)"
 
 # FIXME: duplicate the "add" operations for sast-coverity-check, which is based on build-container
 - op: test

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -8,7 +8,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
 |build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.9:BUILD_ARGS|
-|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.9:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.2:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
@@ -20,8 +19,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; run-opm-command:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-images:0.9:IMAGE ; build-image-index:0.2:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.9:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-images:0.9:PREFETCH_INPUT|
+|privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-images:0.9:SOURCE_DATE_EPOCH|
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters
@@ -91,7 +92,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| |
 |SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
-|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| |
+|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| '$(params.source-date-epoch)'|
 |SOURCE_URL| The image is built from this URL.| ""| '$(tasks.clone-repository.results.url)'|
 |SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
 |STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -8,6 +8,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
 |build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.9:BUILD_ARGS|
+|build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.9:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.2:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
@@ -21,6 +22,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-images:0.9:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| build-images:0.9:REWRITE_TIMESTAMP|
 |skip-checks| Skip checks against built image| false| |
 |source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | build-images:0.9:SOURCE_DATE_EPOCH|
 
@@ -77,13 +79,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
 |LABELS| Additional key=value labels that should be applied to the image| []| |
 |NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| '$(tasks.init.results.no-proxy)'|
-|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| |
+|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| '$(params.omit-history)'|
 |PLATFORM| The platform to build on| None| |
 |PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
 |PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| |
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
-|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| |
+|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -63,13 +63,17 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
-  - default: ""
-    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
-    name: build-args-file
+  - default: "false"
+    description: Whether to enable privileged mode, should be used only with remote
+      VMs
+    name: privileged-nested
     type: string
   - default:
     - linux/x86_64
@@ -183,6 +187,8 @@ spec:
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
       value: $(tasks.init.results.no-proxy)
+    - name: SOURCE_DATE_EPOCH
+      value: $(params.source-date-epoch)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -66,10 +66,17 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
     type: array
+  - default: ""
+    description: Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file
+    name: build-args-file
+    type: string
   - default: "false"
     description: Whether to enable privileged mode, should be used only with remote
       VMs
@@ -189,6 +196,10 @@ spec:
       value: $(tasks.init.results.no-proxy)
     - name: SOURCE_DATE_EPOCH
       value: $(params.source-date-epoch)
+    - name: REWRITE_TIMESTAMP
+      value: $(params.rewrite-timestamp)
+    - name: OMIT_HISTORY
+      value: $(params.omit-history)
     - name: SOURCE_ARTIFACT
       value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
     - name: CACHI2_ARTIFACT

--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -14,11 +14,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.1:IMAGE_EXPIRES_AFTER ; build-image-index:0.2:IMAGE_EXPIRES_AFTER|
 |import-path| Import path to build| | build-container:0.1:IMPORT_PATH|
 |ko-docker-repo| Setting for KO_DOCKER_REPO| | build-container:0.1:KO_DOCKER_REPO|
+|omit-history| Omit build history information from the resulting image| false| |
 |output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-image-index:0.2:IMAGE|
 |pr-tag| PR tag to use on image| pr-tag| build-container:0.1:TAG|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
 |preprocessing-script| Preprocessing script for source code| | |
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| |
 |skip-checks| Skip checks against built image| false| |
 |source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 

--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -20,6 +20,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |preprocessing-script| Preprocessing script for source code| | |
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters

--- a/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
+++ b/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
@@ -46,6 +46,9 @@ spec:
     description: Enable cache proxy configuration
     name: enable-cache-proxy
   - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
+  - default: ""
     description: Default base image for ko
     name: default-base-image
     type: string

--- a/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
+++ b/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
@@ -48,6 +48,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   - default: ""
     description: Default base image for ko
     name: default-base-image

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -10,9 +10,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
+|omit-history| Omit build history information from the resulting image| false| |
 |output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-oci-artifact:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
 |prefetch-input| Build dependencies to be prefetched| generic| prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| |
 |skip-checks| Skip checks against built image| false| |
 |source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -14,6 +14,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |prefetch-input| Build dependencies to be prefetched| generic| prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 
 ## Available params from tasks
 ### build-maven-zip-oci-ta:0.1 task parameters

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -44,6 +44,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   results:
   - name: IMAGE_URL
     value: $(tasks.build-oci-artifact.results.IMAGE_URL)

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -41,6 +41,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   results:
   - name: IMAGE_URL
     value: $(tasks.build-oci-artifact.results.IMAGE_URL)

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -14,6 +14,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |prefetch-input| Build dependencies to be prefetched| generic| prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 
 ## Available params from tasks
 ### build-maven-zip:0.1 task parameters

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -10,9 +10,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
+|omit-history| Omit build history information from the resulting image| false| |
 |output-image| Fully Qualified Output Image| None| build-oci-artifact:0.1:IMAGE ; sast-coverity-check:0.3:IMAGE|
 |prefetch-input| Build dependencies to be prefetched| generic| prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| |
 |skip-checks| Skip checks against built image| false| |
 |source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -44,6 +44,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   results:
   - name: IMAGE_URL
     value: $(tasks.build-oci-artifact.results.IMAGE_URL)

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -41,6 +41,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   results:
   - name: IMAGE_URL
     value: $(tasks.build-oci-artifact.results.IMAGE_URL)

--- a/pipelines/package-operator-package/README.md
+++ b/pipelines/package-operator-package/README.md
@@ -19,6 +19,7 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters

--- a/pipelines/package-operator-package/README.md
+++ b/pipelines/package-operator-package/README.md
@@ -14,10 +14,12 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-image-index:0.2:IMAGE_EXPIRES_AFTER|
 |labels| Additional key=value labels to add to the OCI  image.| []| build-container:0.1:LABELS|
+|omit-history| Omit build history information from the resulting image| false| |
 |output-image| Fully Qualified Output Image| None| build-container:0.1:DST_URL ; build-image-index:0.2:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:SRC_PATH|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| |
 |skip-checks| Skip checks against built image| false| |
 |source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 

--- a/pipelines/package-operator-package/package-operator-package.yaml
+++ b/pipelines/package-operator-package/package-operator-package.yaml
@@ -65,6 +65,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   - default: []
     description: Additional key=value labels to add to the OCI  image.
     name: labels

--- a/pipelines/package-operator-package/package-operator-package.yaml
+++ b/pipelines/package-operator-package/package-operator-package.yaml
@@ -62,6 +62,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   - default: []
     description: Additional key=value labels to add to the OCI  image.
     name: labels

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -10,10 +10,12 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-image-index:0.2:IMAGE_EXPIRES_AFTER|
+|omit-history| Omit build history information from the resulting image| false| |
 |output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.2:IMAGE ; build-image-index:0.2:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| |
 |skip-checks| Skip checks against built image| false| |
 |source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -15,6 +15,7 @@
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -61,6 +61,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -58,6 +58,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -15,6 +15,7 @@
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
 |skip-checks| Skip checks against built image| false| |
+|source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 
 ## Available params from tasks
 ### apply-tags:0.3 task parameters

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -10,10 +10,12 @@
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-image-index:0.2:IMAGE_EXPIRES_AFTER|
+|omit-history| Omit build history information from the resulting image| false| |
 |output-image| Fully Qualified Output Image| None| build-container:0.2:IMAGE ; build-image-index:0.2:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
 |revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
+|rewrite-timestamp| Clamp mtime of all files to at most SOURCE_DATE_EPOCH| false| |
 |skip-checks| Skip checks against built image| false| |
 |source-date-epoch| Timestamp in seconds since Unix epoch for reproducible builds.| | |
 

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -61,6 +61,12 @@ spec:
   - default: ""
     description: Timestamp in seconds since Unix epoch for reproducible builds.
     name: source-date-epoch
+  - default: "false"
+    description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+    name: rewrite-timestamp
+  - default: "false"
+    description: Omit build history information from the resulting image
+    name: omit-history
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -58,6 +58,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: ""
+    description: Timestamp in seconds since Unix epoch for reproducible builds.
+    name: source-date-epoch
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -64,6 +64,12 @@ spec:
     - name: source-date-epoch
       description: Timestamp in seconds since Unix epoch for reproducible builds.
       default: ""
+    - name: rewrite-timestamp
+      description: Clamp mtime of all files to at most SOURCE_DATE_EPOCH
+      default: "false"
+    - name: omit-history
+      description: Omit build history information from the resulting image
+      default: "false"
   tasks:
     - name: init
       params:
@@ -113,6 +119,10 @@ spec:
       params:
         - name: SOURCE_DATE_EPOCH
           value: "$(params.source-date-epoch)"
+        - name: REWRITE_TIMESTAMP
+          value: "$(params.rewrite-timestamp)"
+        - name: OMIT_HISTORY
+          value: "$(params.omit-history)"
       workspaces:
         - name: source
           workspace: workspace

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -61,6 +61,9 @@ spec:
     - name: enable-cache-proxy
       description: Enable cache proxy configuration
       default: "false"
+    - name: source-date-epoch
+      description: Timestamp in seconds since Unix epoch for reproducible builds.
+      default: ""
   tasks:
     - name: init
       params:
@@ -107,6 +110,9 @@ spec:
         - prefetch-dependencies
       taskRef:
         name: $REPLACE_ME
+      params:
+        - name: SOURCE_DATE_EPOCH
+          value: "$(params.source-date-epoch)"
       workspaces:
         - name: source
           workspace: workspace


### PR DESCRIPTION
this pull request implemented phase 1 and 2 of Reproducible Build by introducing deterministic build flags. Added SOURCE_DATE_EPOCH, REWRITE_TIMESTAMP, and OMIT_HISTORY parameters to the build pipeline. passed this parameters into the build pipeline to ensure bit-for-bit image identity. completed repository manifest generation using ./hack/generate-everything....

I have successfully verified the bit-for-bit container image building using -> quay.io/konflux-ci/buildah-task

Build 1 Image ID: f79fae53a529a9690e6dfa34e8a3390c789bb18a168c92d84fd49600601d6d8c
Build 2 Image ID: f79fae53a529a9690e6dfa34e8a3390c789bb18a168c92d84fd49600601d6d8c
Status: 100% Match