### PR TITLE
feat(ta): set 4Gi memory request/limit for use-trusted-artifact step

### DIFF
--- a/task-generator/trusted-artifacts/golden/buildah/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/buildah/ta.yaml
@@ -136,6 +136,11 @@ spec:
       - use
       - $(params.SOURCE_ARTIFACT)=/var/workdir/source
       - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
   - image: quay.io/redhat-appstudio/buildah:v1.31.0@sha256:34f12c7b72ec2c28f1ded0c494b428df4791c909f1f174dd21b8ed6a57cf5ddb
     name: build
     computeResources:

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -74,6 +74,11 @@ spec:
     args:
       - use
       - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
   - image: quay.io/konflux-ci/hermeto:0.29.0@sha256:f577e0399953471df7a9826c1550aef83d28e8b35f76dd65a193441822b629ee
     name: prefetch-dependencies
     env:

--- a/task-generator/trusted-artifacts/golden/sast-snyk-check/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/sast-snyk-check/ta.yaml
@@ -66,6 +66,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: sast-snyk-check
       image: quay.io/konflux-ci/konflux-test:v1.4.0@sha256:54d49b37c9a2e280d42961a57e4f7a16c171d6b065559f1329b548db85300bea
       workingDir: /var/workdir/source

--- a/task-generator/trusted-artifacts/golden/source-build/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/source-build/ta.yaml
@@ -58,6 +58,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: get-base-images
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       env:

--- a/task-generator/trusted-artifacts/ta.go
+++ b/task-generator/trusted-artifacts/ta.go
@@ -318,9 +318,17 @@ func perform(task *pipeline.Task, recipe *Recipe) error {
 		}
 
 		task.Spec.Steps = append([]pipeline.Step{{
-			Name:         "use-trusted-artifact",
-			Image:        image,
-			Args:         args,
+			Name:  "use-trusted-artifact",
+			Image: image,
+			Args:  args,
+			ComputeResources: core.ResourceRequirements{
+				Requests: core.ResourceList{
+					core.ResourceMemory: resource.MustParse("4Gi"),
+				},
+				Limits: core.ResourceList{
+					core.ResourceMemory: resource.MustParse("4Gi"),
+				},
+			},
 			VolumeMounts: recipe.AddTAVolumeMount,
 		}}, task.Spec.Steps...)
 	}

--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -101,6 +101,11 @@ spec:
       args:
         - use
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: prepare
       image: quay.io/konflux-ci/task-runner:1.5.0@sha256:200019314a50be5b6dd06f362c794c92a700583a522c5eee9a41e3eab7f706c5
       workingDir: /var/workdir

--- a/task/buildah-oci-ta-min/0.9/patch.yaml
+++ b/task/buildah-oci-ta-min/0.9/patch.yaml
@@ -8,6 +8,13 @@
 #      3	sbom-syft-generate
 #      4	prepare-sboms
 #      5	upload-sbom
+# use-trusted-artifact step
+- op: test
+  path: /spec/steps/0/name
+  value: use-trusted-artifact
+- op: remove
+  path: /spec/steps/0/computeResources
+
 # StepTemplate
 - op: replace
   path: /spec/stepTemplate/computeResources/limits/memory

--- a/task/buildah-oci-ta/0.8/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.8/buildah-oci-ta.yaml
@@ -391,6 +391,11 @@ spec:
           name: trusted-ca
           readOnly: true
           subPath: ca-bundle.crt
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: build
       image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
       args:

--- a/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
@@ -397,6 +397,11 @@ spec:
           name: trusted-ca
           readOnly: true
           subPath: ca-bundle.crt
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: build
       image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
       args:

--- a/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
@@ -354,7 +354,11 @@ spec:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
-    computeResources: {}
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        memory: 4Gi
     image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
     name: use-trusted-artifact
     volumeMounts:

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -47,6 +47,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: get-unique-related-images
       image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
       env:

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -53,6 +53,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: get-unique-related-images
       image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
       env:

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -83,6 +83,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: prepare
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       workingDir: /var/workdir

--- a/task/package-operator-package-oci-ta/0.1/package-operator-package-oci-ta.yaml
+++ b/task/package-operator-package-oci-ta/0.1/package-operator-package-oci-ta.yaml
@@ -67,6 +67,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: build-pkg
       image: quay.io/redhat-services-prod/mos-lpsre-tenant/package-operator-internal/kubectl-package-internal:fb55c52@sha256:3ac443d3f8b69c50b84e93acf3c8eac76f3c84d00d7cde2276dcbaa8809561bf
       args:

--- a/task/prefetch-dependencies-oci-ta-min/0.2/patch.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.2/patch.yaml
@@ -8,6 +8,13 @@
 #      3	prefetch-dependencies
 #      4	create-trusted-artifact
 
+# use-trusted-artifact step
+- op: test
+  path: /spec/steps/1/name
+  value: use-trusted-artifact
+- op: remove
+  path: /spec/steps/1/computeResources
+
 # prefetch-dependencies step
 - op: test
   path: /spec/steps/3/name

--- a/task/prefetch-dependencies-oci-ta-min/0.3/patch.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/patch.yaml
@@ -7,6 +7,13 @@
 #      2	prefetch-dependencies
 #      3	create-trusted-artifact
 
+# use-trusted-artifact step
+- op: test
+  path: /spec/steps/1/name
+  value: use-trusted-artifact
+- op: remove
+  path: /spec/steps/1/computeResources
+
 # prefetch-dependencies step
 - op: test
   path: /spec/steps/2/name

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -132,6 +132,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: sanitize-config-file-with-yq
       image: quay.io/konflux-ci/yq:latest@sha256:5a41c8ccca7219156b2a56209c4329e1dad1e4015c71a492dd2c7d3e01451c17
       script: |

--- a/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
@@ -145,6 +145,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: prefetch-dependencies
       image: quay.io/konflux-ci/hermeto:0.51.0@sha256:4899755ffd1574547102a58469aea916822c7fd7825cbec8e477e1b57668a6d7
       volumeMounts:

--- a/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
+++ b/task/push-dockerfile-oci-ta/0.1/push-dockerfile-oci-ta.yaml
@@ -78,6 +78,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: push
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       workingDir: /var/workdir

--- a/task/push-dockerfile-oci-ta/0.2/push-dockerfile-oci-ta.yaml
+++ b/task/push-dockerfile-oci-ta/0.2/push-dockerfile-oci-ta.yaml
@@ -78,6 +78,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: push
       image: quay.io/konflux-ci/oras:latest@sha256:eb3b1fe5e331ed26057e55116ea999bfbadc60d3f618f6769df78e120008d805
       workingDir: /var/workdir

--- a/task/push-dockerfile-oci-ta/0.3/push-dockerfile-oci-ta.yaml
+++ b/task/push-dockerfile-oci-ta/0.3/push-dockerfile-oci-ta.yaml
@@ -82,6 +82,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: push
       image: quay.io/konflux-ci/konflux-build-cli@sha256:b296232c9b0d478c0bd1f48911ead97cd786eebdc737b877797564567fda8eae
       command:

--- a/task/slack-webhook-notification-oci-ta/0.1/slack-webhook-notification-oci-ta.yaml
+++ b/task/slack-webhook-notification-oci-ta/0.1/slack-webhook-notification-oci-ta.yaml
@@ -64,6 +64,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: send-message
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       args:

--- a/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
@@ -91,6 +91,11 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: get-base-images
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       env:

--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -73,6 +73,11 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          memory: 4Gi
     - name: modify-task-files
       image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:deabe80a01dca3a8a0edb709324e30cbf0baa176f7a181bbb695323f506f7aac
       workingDir: /var/workdir


### PR DESCRIPTION
The create-trusted-artifact step already sets a 3Gi limit via the generator code. Apply similar resource limits to the use-trusted-artifact step to ensure consistent memory allocation.

The -min variant patches remove the explicit computeResources so those tasks inherit the smaller stepTemplate defaults instead.

Related: https://github.com/konflux-ci/konflux-sast-tasks/pull/103
