### PR TITLE
fix: add external-task/ to switchboard OPA prefix rules

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -103,8 +103,8 @@ spec:
             value: "$(params.image-target)"
           - name: expressions
             value:
-              - tasks := strings.any_prefix_match(input, ["task/", "hack/", ".tekton/"])
-              - tasks_pipelines := strings.any_prefix_match(input, ["task/", "pipelines/", "hack/", ".tekton/"])
+              - tasks := strings.any_prefix_match(input, ["task/", "external-task/", "hack/", ".tekton/"])
+              - tasks_pipelines := strings.any_prefix_match(input, ["task/", "external-task/", "pipelines/", "hack/", ".tekton/"])
               - check_partner_tasks := strings.any_prefix_match(input, ["partners/", "hack/", ".tekton/"])
         runAfter:
           - build-appstudio-utils-index


### PR DESCRIPTION
The task-switchboard OPA expressions did not match external-task/ paths, so build-bundles was skipped for external task changes. However, the e2e script already recognizes external-task/ and returns execute_e2e, causing downstream tasks to fail when referencing bundles that were never built.

Created to try and fix test issue in https://github.com/konflux-ci/build-definitions/pull/3415