### PR TITLE
Migration: remove coverity tasks from existing pipelines

### DIFF
--- a/task/init/0.4/MIGRATION.md
+++ b/task/init/0.4/MIGRATION.md
@@ -1,3 +1,7 @@
 # Migration from 0.3 to 0.4
 
 No action required from users. Task started using konflux build cli instead of bash script.
+
+## Migration from 0.4 to 0.4.1
+
+Pipeline upgrade: Remove `sast-coverity-check` and `coverity-availability-check` as these tasks are not parts of default pipelines anymore and should be used only in specific cases.

--- a/task/init/0.4/init.yaml
+++ b/task/init/0.4/init.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.4"
+    app.kubernetes.io/version: "0.4.1"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/init/0.4/migrations/0.4.1.sh
+++ b/task/init/0.4/migrations/0.4.1.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: init@0.4.1
+# Creation time: 2026-04-26T18:28:34Z
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# Get task names, a same task ref may be used multiple times, task names are unique but can be changed by users
+tasks_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+# A migration script should find out tasks from a Pipeline/PipelineRun by the referenced real task name
+for task_refname in "coverity-availability-check" "sast-coverity-check" "sast-coverity-check-oci-ta"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#tasks_names[@]} tasks_names <<< "${tasks_found}"  # multiple tasks names can be returned
+    fi
+done
+
+if [ ${#tasks_names[@]} -eq 0 ]; then
+    echo "No tasks found"
+    exit 0
+fi
+
+for task_name in "${tasks_names[@]}"; do
+   export task_name
+   # shellcheck disable=SC2016
+   if yq -e "${tasks_selector} | select (.name == strenv(task_name)) | path" "$pipeline_file" >/tmp/path.yaml 2>&1; then
+    echo "Removing ${task_name}"
+    pmt modify -f "$pipeline_file" generic remove "$(cat /tmp/path.yaml)"
+   fi
+done

--- a/task/init/CHANGELOG.md
+++ b/task/init/CHANGELOG.md
@@ -9,6 +9,10 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.4.1
+
+- Pipeline upgrade: Removal of Coverity related tasks
+
 ## 0.4
 
 - Task started using konflux build cli instead of bash script.


### PR DESCRIPTION
This will remove coverity tasks from existing user pipelines.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
