### PR TITLE
task(fbc-fips-check): right-size resources from fleet p95 analysis

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -47,12 +47,6 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
-      computeResources:
-        requests:
-          memory: 64Mi
-          cpu: "50m"
-        limits:
-          memory: 64Mi
     - name: get-unique-related-images
       image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
       env:

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -306,10 +306,10 @@ spec:
         echo "${images_processed_template/\[%s]/[$digests_processed_string]}" >"/tekton/home/images_processed.txt"
       computeResources:
         limits:
-          memory: 4Gi
+          memory: 6Gi
         requests:
           cpu: 705m
-          memory: 4Gi
+          memory: 6Gi
       securityContext:
         capabilities:
           add:
@@ -320,10 +320,10 @@ spec:
           value: $(params.MAX_PARALLEL)
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 10Gi
         requests:
           cpu: 2059m
-          memory: 512Mi
+          memory: 10Gi
       ref:
         params:
           - name: url

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -47,6 +47,12 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: "50m"
+        limits:
+          memory: 64Mi
     - name: get-unique-related-images
       image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
       env:
@@ -306,11 +312,10 @@ spec:
         echo "${images_processed_template/\[%s]/[$digests_processed_string]}" >"/tekton/home/images_processed.txt"
       computeResources:
         limits:
-          cpu: "1"
-          memory: 12Gi
+          memory: 4Gi
         requests:
-          cpu: "1"
-          memory: 12Gi
+          cpu: 705m
+          memory: 4Gi
       securityContext:
         capabilities:
           add:
@@ -321,11 +326,10 @@ spec:
           value: $(params.MAX_PARALLEL)
       computeResources:
         limits:
-          cpu: "8"
-          memory: 12Gi
+          memory: 512Mi
         requests:
-          cpu: "8"
-          memory: 12Gi
+          cpu: 2059m
+          memory: 512Mi
       ref:
         params:
           - name: url
@@ -351,3 +355,9 @@ spec:
           echo "Task was skipped. Exiting"
           exit 0
         fi
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -41,10 +41,10 @@ spec:
       image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
       computeResources:
         requests:
-          memory: 4Gi
+          memory: 6Gi
           cpu: "705m"
         limits:
-          memory: 4Gi
+          memory: 6Gi
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -305,10 +305,10 @@ spec:
     - name: fips-operator-check-step-action
       computeResources:
         requests:
-          memory: 512Mi
+          memory: 10Gi
           cpu: "2059m"
         limits:
-          memory: 512Mi
+          memory: 10Gi
       params:
         - name: MAX_PARALLEL
           value: $(params.MAX_PARALLEL)

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -40,12 +40,11 @@ spec:
     - name: get-unique-related-images
       image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
       computeResources:
-        limits:
-          memory: 12Gi
-          cpu: '1'
         requests:
-          memory: 12Gi
-          cpu: '1'
+          memory: 4Gi
+          cpu: "705m"
+        limits:
+          memory: 4Gi
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -305,12 +304,11 @@ spec:
 
     - name: fips-operator-check-step-action
       computeResources:
-        limits:
-          memory: 12Gi
-          cpu: '8'
         requests:
-          memory: 12Gi
-          cpu: '8'
+          memory: 512Mi
+          cpu: "2059m"
+        limits:
+          memory: 512Mi
       params:
         - name: MAX_PARALLEL
           value: $(params.MAX_PARALLEL)
@@ -326,6 +324,12 @@ spec:
 
     - name: parse-images-processed-result
       image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: "50m"
+        limits:
+          memory: 64Mi
       env:
         - name: STEP_ACTION_TEST_OUTPUT
           value: $(steps.fips-operator-check-step-action.results.TEST_OUTPUT)


### PR DESCRIPTION
## Why

The task still used **coarse defaults** (for example **12Gi** memory and **1** / **8** CPU on heavy steps) that do not match **measured** usage. Internal **Konflux fleet** analysis (tasks-and-steps-resource-analyzer, **15-day** window) gives per-step **p95**-style signals per cluster; we use that to **right-size** requests while keeping **memory request = memory limit** and **CPU requests only** (no CPU limits).

## What

- **`task/fbc-fips-check/0.1/fbc-fips-check.yaml`:** Set **`computeResources`** from a **fleet p95 envelope** (max across clusters of per-step **`mem_p95_mb`** / **`cpu_p95`** from the analyzer, then rounded up):
  - **`get-unique-related-images`:** **`4Gi`** / **`705m`** (memory req = limit).
  - **`fips-operator-check-step-action`:** **`512Mi`** / **`2059m`** (memory req = limit).
  - **`parse-images-processed-result`:** **`64Mi`** / **`50m`** (memory req = limit).
- **`task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml`:** Same resources for the shared steps; add **`use-trusted-artifact`** with **`64Mi`** / **`50m`** (memory req = limit). Regenerate from base with **`./hack/generate-ta-tasks.sh`** when changing the base task; re-apply **`use-trusted-artifact`** resources if the generator drops them.
- **No behavior change** to scripts, params, or step order — **only** resource requests/limits as above.

## Follow-up

- If **OOM** or **CPU starvation** shows up on rare bundles, bump requests using **max** or higher percentiles from the same analyzer (p95 is not worst-case).