### PR TITLE
Add enable-package-registry-proxy parameter for prefetch

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -134,6 +134,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -193,6 +196,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/core-services/patch.yaml
+++ b/pipelines/core-services/patch.yaml
@@ -82,14 +82,15 @@
 # 10	build-image-index
 # 11	buildah-format
 # 12	enable-cache-proxy
-# 13	build-args
-# 14	build-args-file
-# 15	privileged-nested
+# 13	enable-package-registry-proxy
+# 14	build-args
+# 15	build-args-file
+# 16	privileged-nested
 
 
 # Remove privilege-nested pipeline param
 - op: remove
-  path: /spec/params/15
+  path: /spec/params/16
 # We want to always build OCI images by default
 - op: replace
   path: /spec/params/11/default  # buildah-format

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -15,6 +15,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-images:0.9:BUILDAH_FORMAT ; build-image-index:0.3:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.9:DOCKERFILE ; push-dockerfile:0.3:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.9:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.9:IMAGE_EXPIRES_AFTER|
@@ -175,10 +176,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -68,6 +68,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -126,6 +129,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/docker-build-multi-platform-oci-ta/patch.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/patch.yaml
@@ -93,9 +93,10 @@
 # 10	build-image-index
 # 11	buildah-format
 # 12	enable-cache-proxy
-# 13	build-args
-# 14	build-args-file
-# 15	privileged-nested
+# 13	enable-package-registry-proxy
+# 14	build-args
+# 15	build-args-file
+# 16	privileged-nested
 
 # We want to always build the image index by default
 - op: replace

--- a/pipelines/docker-build-oci-ta-min/README.md
+++ b/pipelines/docker-build-oci-ta-min/README.md
@@ -15,6 +15,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-container:0.9:BUILDAH_FORMAT ; build-image-index:0.3:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.9:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.9:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.9:IMAGE_EXPIRES_AFTER|
@@ -148,10 +149,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
+++ b/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
@@ -66,6 +66,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -118,6 +121,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -14,6 +14,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-container:0.9:BUILDAH_FORMAT ; build-image-index:0.3:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.9:DOCKERFILE ; push-dockerfile:0.3:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.9:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.9:IMAGE_EXPIRES_AFTER|
@@ -172,10 +173,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -68,6 +68,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -120,6 +123,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -14,6 +14,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-container:0.9:BUILDAH_FORMAT ; build-image-index:0.3:BUILDAH_FORMAT|
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.9:DOCKERFILE ; push-dockerfile:0.3:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.9:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.9:IMAGE_EXPIRES_AFTER|
@@ -171,9 +172,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -68,6 +68,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -118,6 +121,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -14,6 +14,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.9:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| true| build-images:0.9:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; run-opm-command:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.9:IMAGE_EXPIRES_AFTER|
@@ -161,10 +162,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.run-opm-command.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -63,6 +63,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   - default: []
     description: Array of --build-arg values ("arg=value" strings) for buildah
     name: build-args
@@ -135,6 +138,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.run-opm-command.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -30,13 +30,14 @@
 # 10	build-image-index
 # 11	buildah-format
 # 12	enable-cache-proxy
-# 13	build-args
-# 14	build-args-file
-# 15	privileged-nested
-# 16	build-platforms
+# 13	enable-package-registry-proxy
+# 14	build-args
+# 15	build-args-file
+# 16	privileged-nested
+# 17	build-platforms
 
 - op: remove
-  path: /spec/params/15  # privileged-nested
+  path: /spec/params/16  # privileged-nested
 - op: remove
   path: /spec/params/11  # buildah-format - FBC is always OCI
 - op: replace
@@ -139,7 +140,7 @@
   path: /spec/tasks/3/runAfter/0
   value: run-opm-command
 - op: replace
-  path: /spec/tasks/3/params/1/value
+  path: /spec/tasks/3/params/2/value
   value: $(tasks.run-opm-command.results.SOURCE_ARTIFACT)
 - op: replace
   path: /spec/tasks/4/runAfter/0

--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -10,6 +10,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |build-source-image| Build a source image.| false| |
 |default-base-image| Default base image for ko| | build-container:0.1:KO_DEFAULTBASEIMAGE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.1:IMAGE_EXPIRES_AFTER|
 |import-path| Import path to build| | build-container:0.1:IMPORT_PATH|
@@ -129,10 +130,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
+++ b/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
@@ -45,6 +45,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   - default: ""
     description: Default base image for ko
     name: default-base-image
@@ -104,6 +107,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/ko-build-oci-ta/patch.yaml
+++ b/pipelines/ko-build-oci-ta/patch.yaml
@@ -31,6 +31,7 @@
 # 10	build-image-index
 # 11	buildah-format
 # 12	enable-cache-proxy
+# 13	enable-package-registry-proxy
 
 # Remove buildah-format parameter.
 - op: remove

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -8,6 +8,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-oci-artifact:0.1:IMAGE|
@@ -62,10 +63,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -41,6 +41,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   results:
   - name: IMAGE_URL
     value: $(tasks.build-oci-artifact.results.IMAGE_URL)
@@ -80,6 +83,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -8,6 +8,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| build-oci-artifact:0.1:IMAGE|
@@ -62,9 +63,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -41,6 +41,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   results:
   - name: IMAGE_URL
     value: $(tasks.build-oci-artifact.results.IMAGE_URL)
@@ -78,6 +81,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/maven-zip-build/patch.yaml
+++ b/pipelines/maven-zip-build/patch.yaml
@@ -30,6 +30,7 @@
 # 10	build-image-index
 # 11	buildah-format
 # 12	enable-cache-proxy
+# 13	enable-package-registry-proxy
 
 - op: remove
   path: /spec/params/11  # buildah-format

--- a/pipelines/package-operator-package/README.md
+++ b/pipelines/package-operator-package/README.md
@@ -10,6 +10,7 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |build-source-image| Build a source image.| false| |
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-image-index:0.3:BUILDAH_FORMAT|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
@@ -121,9 +122,12 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/package-operator-package/package-operator-package.yaml
+++ b/pipelines/package-operator-package/package-operator-package.yaml
@@ -62,6 +62,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   - default: []
     description: Additional key=value labels to add to the OCI  image.
     name: labels
@@ -103,6 +106,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -7,6 +7,7 @@
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter|
@@ -73,10 +74,13 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -58,6 +58,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -97,6 +100,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
     - name: ociStorage

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -7,6 +7,7 @@
 |build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
@@ -74,9 +75,12 @@
 |name|description|default value|already set by|
 |---|---|---|---|
 |ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.| service-ca.crt| |
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.| openshift-service-ca.crt| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |config-file-content| Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! | ""| |
+|enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| '$(params.enable-package-registry-proxy)'|
 |input| Configures project packages that will have their dependencies prefetched.| None| '$(params.prefetch-input)'|
 |log-level| Set the logging level (debug, info, warn, error, fatal).| debug| |
 |mode| Control how input requirement violations are handled: strict (errors) or permissive (warnings).| strict| |

--- a/pipelines/tekton-bundle-builder/patch.yaml
+++ b/pipelines/tekton-bundle-builder/patch.yaml
@@ -71,6 +71,7 @@
 # 10	build-image-index
 # 11	buildah-format
 # 12	enable-cache-proxy
+# 13	enable-package-registry-proxy
 - op: remove
   path: /spec/params/11  # buildah-format
 # Remove build-index-image task params

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -58,6 +58,9 @@ spec:
   - default: "false"
     description: Enable cache proxy configuration
     name: enable-cache-proxy
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -95,6 +98,8 @@ spec:
     params:
     - name: input
       value: $(params.prefetch-input)
+    - name: enable-package-registry-proxy
+      value: $(params.enable-package-registry-proxy)
     runAfter:
     - clone-repository
     taskRef:

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -61,6 +61,9 @@ spec:
     - name: enable-cache-proxy
       description: Enable cache proxy configuration
       default: "false"
+    - name: enable-package-registry-proxy
+      description: Use the package registry proxy when prefetching dependencies
+      default: "true"
   tasks:
     - name: init
       params:
@@ -90,6 +93,8 @@ spec:
       params:
         - name: input
           value: $(params.prefetch-input)
+        - name: enable-package-registry-proxy
+          value: "$(params.enable-package-registry-proxy)"
       runAfter:
         - clone-repository
       taskRef:

--- a/task/prefetch-dependencies-oci-ta-min/0.3/MIGRATION.md
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/MIGRATION.md
@@ -6,3 +6,13 @@
 ## Action from users
 
 Please remove the `dev-package-managers` task parameter from your pipelines.
+
+## Migration from 0.3 to 0.3.1
+
+* New `enable-package-registry-proxy` parameter has been added.
+* New `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have been added.
+
+## Action from users
+
+Add the `enable-package-registry-proxy` parameter (default `"true"`) and pass it to the prefetch-dependencies task.
+The `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have default values and require no action.

--- a/task/prefetch-dependencies-oci-ta-min/0.3/MIGRATION.md
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/MIGRATION.md
@@ -6,3 +6,13 @@
 ## Action from users
 
 Please remove the `dev-package-managers` task parameter from your pipelines.
+
+## Migration from 0.3.1 to 0.3.2
+
+* New `enable-package-registry-proxy` parameter has been added.
+* New `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have been added.
+
+## Action from users
+
+Add the `enable-package-registry-proxy` parameter (default `"true"`) and pass it to the prefetch-dependencies task.
+The `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have default values and require no action.

--- a/task/prefetch-dependencies-oci-ta-min/0.3/README.md
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/README.md
@@ -6,10 +6,13 @@ Task that prefetches project dependencies for hermetic build.
 |name|description|default value|required|
 |---|---|---|---|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.|service-ca.crt|false|
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.|openshift-service-ca.crt|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |config-file-content|Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|enable-package-registry-proxy|Use the package registry proxy when prefetching dependencies|true|false|
 |input|Configures project packages that will have their dependencies prefetched.||true|
 |log-level|Set prefetch tool log level (debug, info, warning, error)|info|false|
 |mode|Control how input requirement violations are handled: strict (errors) or permissive (warnings).|strict|false|

--- a/task/prefetch-dependencies-oci-ta-min/0.3/migrations/0.3.1.sh
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/migrations/0.3.1.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: prefetch-dependencies-oci-ta-min@0.3.1
+# Creation time: 2026-04-09T17:09:19+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# 1. Find all prefetch-dependencies tasks in the pipeline
+task_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "prefetch-dependencies" "prefetch-dependencies-oci-ta" "prefetch-dependencies-oci-ta-min"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#task_names[@]} task_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#task_names[@]} -eq 0 ]; then
+    echo "Pipeline does not use prefetch-dependencies task, skipping migration"
+    exit 0
+fi
+
+# 2. Add enable-package-registry-proxy to the pipeline's top-level params
+# pmt generic insert is not idempotent, so check first
+if yq -e '(.spec.params[], .spec.pipelineSpec.params[]) | select(.name == "enable-package-registry-proxy")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "enable-package-registry-proxy pipeline parameter already exists"
+else
+    echo "Adding enable-package-registry-proxy pipeline param"
+
+    # Params live at different paths in Pipeline vs PipelineRun (embedded spec)
+    if yq -e '.spec.pipelineSpec' "$pipeline_file" >/dev/null 2>&1; then
+        params_path=".spec.pipelineSpec.params"
+        pmt_params_path='["spec", "pipelineSpec", "params"]'
+        pmt_spec_path='["spec", "pipelineSpec"]'
+    else
+        params_path=".spec.params"
+        pmt_params_path='["spec", "params"]'
+        pmt_spec_path='["spec"]'
+    fi
+
+    param_json='{"name": "enable-package-registry-proxy", "default": "true", "description": "Use the package registry proxy when prefetching dependencies", "type": "string"}'
+
+    if yq -e "$params_path" "$pipeline_file" >/dev/null 2>&1; then
+        pmt modify -f "$pipeline_file" generic insert "$pmt_params_path" "$param_json"
+    else
+        pmt modify -f "$pipeline_file" generic insert "$pmt_spec_path" "{\"params\": [$param_json]}"
+    fi
+fi
+
+# 3. Pass the pipeline param to each prefetch-dependencies task (add-param is idempotent)
+for task_name in "${task_names[@]}"; do
+    echo "Ensuring enable-package-registry-proxy parameter exists for task $task_name"
+    pmt modify -f "$pipeline_file" task "$task_name" add-param enable-package-registry-proxy "\$(params.enable-package-registry-proxy)"
+done

--- a/task/prefetch-dependencies-oci-ta-min/0.3/migrations/0.3.2.sh
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/migrations/0.3.2.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: prefetch-dependencies-oci-ta-min@0.3.1
+# Creation time: 2026-04-09T17:09:19+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# 1. Find all prefetch-dependencies tasks in the pipeline
+task_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "prefetch-dependencies" "prefetch-dependencies-oci-ta" "prefetch-dependencies-oci-ta-min"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#task_names[@]} task_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#task_names[@]} -eq 0 ]; then
+    echo "Pipeline does not use prefetch-dependencies task, skipping migration"
+    exit 0
+fi
+
+# 2. Add enable-package-registry-proxy to the pipeline's top-level params
+# pmt generic insert is not idempotent, so check first
+if yq -e '(.spec.params[], .spec.pipelineSpec.params[]) | select(.name == "enable-package-registry-proxy")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "enable-package-registry-proxy pipeline parameter already exists"
+else
+    echo "Adding enable-package-registry-proxy pipeline param"
+
+    # Params live at different paths in Pipeline vs PipelineRun (embedded spec)
+    if yq -e '.spec.pipelineSpec' "$pipeline_file" >/dev/null 2>&1; then
+        params_path=".spec.pipelineSpec.params"
+        pmt_params_path='["spec", "pipelineSpec", "params"]'
+        pmt_spec_path='["spec", "pipelineSpec"]'
+    else
+        params_path=".spec.params"
+        pmt_params_path='["spec", "params"]'
+        pmt_spec_path='["spec"]'
+    fi
+
+    param_json='{"name": "enable-package-registry-proxy", "default": "true", "description": "Use the package registry proxy when prefetching dependencies", "type": "string"}'
+
+    if yq -e "$params_path" "$pipeline_file" >/dev/null 2>&1; then
+        pmt modify -f "$pipeline_file" generic insert "$pmt_params_path" "$param_json"
+    else
+        pmt modify -f "$pipeline_file" generic insert "$pmt_spec_path" "{\"params\": [$param_json]}"
+    fi
+fi
+
+# 3. Pass the pipeline param to each prefetch-dependencies task (add-param is idempotent)
+for task_name in "${task_names[@]}"; do
+    echo "Ensuring enable-package-registry-proxy parameter exists for task $task_name"
+    pmt modify -f "$pipeline_file" task "$task_name" add-param enable-package-registry-proxy "\$(params.enable-package-registry-proxy)"
+done

--- a/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.3.1
+    app.kubernetes.io/version: 0.3.2
   name: prefetch-dependencies-oci-ta-min
 spec:
   description: Task that prefetches project dependencies for hermetic build.
@@ -14,6 +14,18 @@ spec:
   - default: activation-key
     description: Name of secret which contains subscription activation key
     name: ACTIVATION_KEY
+    type: string
+  - default: service-ca.crt
+    description: The name of the key in the ConfigMap that contains the service CA
+      bundle data. Used to verify TLS connections to in-cluster services such as the
+      package registry proxy.
+    name: SERVICE_CA_TRUST_CONFIG_MAP_KEY
+    type: string
+  - default: openshift-service-ca.crt
+    description: The name of the ConfigMap to read service CA bundle data from. Used
+      to verify TLS connections to in-cluster services such as the package registry
+      proxy.
+    name: SERVICE_CA_TRUST_CONFIG_MAP_NAME
     type: string
   - description: The Trusted Artifact URI pointing to the artifact with the application
       source code.
@@ -33,6 +45,10 @@ spec:
       Pass configuration to the prefetch tool.
       Note this needs to be passed as a YAML-formatted config dump, not as a file path!
     name: config-file-content
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
+    type: string
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
   - default: debug
@@ -121,6 +137,8 @@ spec:
       value: $(workspaces.netrc.path)
     - name: CONFIG_FILE_CONTENT
       value: $(params.config-file-content)
+    - name: KBC_PD_ENABLE_PACKAGE_REGISTRY_PROXY
+      value: $(params.enable-package-registry-proxy)
     image: quay.io/konflux-ci/hermeto:0.50.1@sha256:429936e9da7f2f073bc18bf8bfa0a607f1a98a37a506540171860039aee6960d
     name: prefetch-dependencies
     script: |
@@ -131,8 +149,22 @@ spec:
       fi
 
       CA_BUNDLE_PATH=/mnt/trusted-ca/ca-bundle.crt
+      SERVICE_CA_BUNDLE_PATH=/mnt/service-ca/ca-bundle.crt
+      UPDATE_CA_TRUST=false
+
       if [ -f "$CA_BUNDLE_PATH" ]; then
-        cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors
+        echo "Using mounted CA bundle: $CA_BUNDLE_PATH"
+        cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+        UPDATE_CA_TRUST=true
+      fi
+
+      if [ -f "$SERVICE_CA_BUNDLE_PATH" ]; then
+        echo "Using mounted service CA bundle: $SERVICE_CA_BUNDLE_PATH"
+        cp -vf "$SERVICE_CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/service-ca.crt
+        UPDATE_CA_TRUST=true
+      fi
+
+      if [ "$UPDATE_CA_TRUST" = "true" ]; then
         update-ca-trust
       fi
 
@@ -154,6 +186,9 @@ spec:
       name: config
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
+      readOnly: true
+    - mountPath: /mnt/service-ca
+      name: service-ca
       readOnly: true
   - args:
     - create
@@ -180,6 +215,13 @@ spec:
       secretName: $(params.ACTIVATION_KEY)
   - emptyDir: {}
     name: config
+  - configMap:
+      items:
+      - key: $(params.SERVICE_CA_TRUST_CONFIG_MAP_KEY)
+        path: ca-bundle.crt
+      name: $(params.SERVICE_CA_TRUST_CONFIG_MAP_NAME)
+      optional: true
+    name: service-ca
   - configMap:
       items:
       - key: $(params.caTrustConfigMapKey)

--- a/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: 0.3.1
   name: prefetch-dependencies-oci-ta-min
 spec:
   description: Task that prefetches project dependencies for hermetic build.
@@ -14,6 +14,18 @@ spec:
   - default: activation-key
     description: Name of secret which contains subscription activation key
     name: ACTIVATION_KEY
+    type: string
+  - default: service-ca.crt
+    description: The name of the key in the ConfigMap that contains the service CA
+      bundle data. Used to verify TLS connections to in-cluster services such as the
+      package registry proxy.
+    name: SERVICE_CA_TRUST_CONFIG_MAP_KEY
+    type: string
+  - default: openshift-service-ca.crt
+    description: The name of the ConfigMap to read service CA bundle data from. Used
+      to verify TLS connections to in-cluster services such as the package registry
+      proxy.
+    name: SERVICE_CA_TRUST_CONFIG_MAP_NAME
     type: string
   - description: The Trusted Artifact URI pointing to the artifact with the application
       source code.
@@ -33,6 +45,10 @@ spec:
       Pass configuration to the prefetch tool.
       Note this needs to be passed as a YAML-formatted config dump, not as a file path!
     name: config-file-content
+  - default: "true"
+    description: Use the package registry proxy when prefetching dependencies
+    name: enable-package-registry-proxy
+    type: string
   - description: Configures project packages that will have their dependencies prefetched.
     name: input
   - default: debug
@@ -121,6 +137,8 @@ spec:
       value: $(workspaces.netrc.path)
     - name: CONFIG_FILE_CONTENT
       value: $(params.config-file-content)
+    - name: KBC_PD_ENABLE_PACKAGE_REGISTRY_PROXY
+      value: $(params.enable-package-registry-proxy)
     image: quay.io/konflux-ci/hermeto:0.50.1@sha256:429936e9da7f2f073bc18bf8bfa0a607f1a98a37a506540171860039aee6960d
     name: prefetch-dependencies
     script: |
@@ -131,8 +149,22 @@ spec:
       fi
 
       CA_BUNDLE_PATH=/mnt/trusted-ca/ca-bundle.crt
+      SERVICE_CA_BUNDLE_PATH=/mnt/service-ca/ca-bundle.crt
+      UPDATE_CA_TRUST=false
+
       if [ -f "$CA_BUNDLE_PATH" ]; then
-        cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors
+        echo "Using mounted CA bundle: $CA_BUNDLE_PATH"
+        cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+        UPDATE_CA_TRUST=true
+      fi
+
+      if [ -f "$SERVICE_CA_BUNDLE_PATH" ]; then
+        echo "Using mounted service CA bundle: $SERVICE_CA_BUNDLE_PATH"
+        cp -vf "$SERVICE_CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/service-ca.crt
+        UPDATE_CA_TRUST=true
+      fi
+
+      if [ "$UPDATE_CA_TRUST" = "true" ]; then
         update-ca-trust
       fi
 
@@ -154,6 +186,9 @@ spec:
       name: config
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
+      readOnly: true
+    - mountPath: /mnt/service-ca
+      name: service-ca
       readOnly: true
   - args:
     - create
@@ -180,6 +215,13 @@ spec:
       secretName: $(params.ACTIVATION_KEY)
   - emptyDir: {}
     name: config
+  - configMap:
+      items:
+      - key: $(params.SERVICE_CA_TRUST_CONFIG_MAP_KEY)
+        path: ca-bundle.crt
+      name: $(params.SERVICE_CA_TRUST_CONFIG_MAP_NAME)
+      optional: true
+    name: service-ca
   - configMap:
       items:
       - key: $(params.caTrustConfigMapKey)

--- a/task/prefetch-dependencies-oci-ta-min/CHANGELOG.md
+++ b/task/prefetch-dependencies-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,11 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.2
+
+- Added `enable-package-registry-proxy` parameter to enable use of the package registry proxy when prefetching dependencies.
+- Added `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters to mount the OpenShift service CA for verifying TLS connections to in-cluster services such as the package registry proxy.
+
 ## 0.3.1
 
 ### Added

--- a/task/prefetch-dependencies-oci-ta-min/CHANGELOG.md
+++ b/task/prefetch-dependencies-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,11 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.1
+
+- Added `enable-package-registry-proxy` parameter to enable use of the package registry proxy when prefetching dependencies.
+- Added `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters to mount the OpenShift service CA for verifying TLS connections to in-cluster services such as the package registry proxy.
+
 ## 0.3
 
 - Removed deprecated `dev-package-managers` parameter.

--- a/task/prefetch-dependencies-oci-ta/0.3/MIGRATION.md
+++ b/task/prefetch-dependencies-oci-ta/0.3/MIGRATION.md
@@ -6,3 +6,13 @@
 ## Action from users
 
 Please remove the `dev-package-managers` task parameter from your pipelines.
+
+## Migration from 0.3 to 0.3.1
+
+* New `enable-package-registry-proxy` parameter has been added.
+* New `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have been added.
+
+## Action from users
+
+Add the `enable-package-registry-proxy` parameter (default `"true"`) and pass it to the prefetch-dependencies task.
+The `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have default values and require no action.

--- a/task/prefetch-dependencies-oci-ta/0.3/MIGRATION.md
+++ b/task/prefetch-dependencies-oci-ta/0.3/MIGRATION.md
@@ -6,3 +6,13 @@
 ## Action from users
 
 Please remove the `dev-package-managers` task parameter from your pipelines.
+
+## Migration from 0.3.1 to 0.3.2
+
+* New `enable-package-registry-proxy` parameter has been added.
+* New `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have been added.
+
+## Action from users
+
+Add the `enable-package-registry-proxy` parameter (default `"true"`) and pass it to the prefetch-dependencies task.
+The `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have default values and require no action.

--- a/task/prefetch-dependencies-oci-ta/0.3/README.md
+++ b/task/prefetch-dependencies-oci-ta/0.3/README.md
@@ -6,10 +6,13 @@ Task that prefetches project dependencies for hermetic build.
 |name|description|default value|required|
 |---|---|---|---|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.|service-ca.crt|false|
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.|openshift-service-ca.crt|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |config-file-content|Pass configuration to the prefetch tool. Note this needs to be passed as a YAML-formatted config dump, not as a file path! |""|false|
+|enable-package-registry-proxy|Use the package registry proxy when prefetching dependencies|true|false|
 |input|Configures project packages that will have their dependencies prefetched.||true|
 |log-level|Set the logging level (debug, info, warn, error, fatal).|debug|false|
 |mode|Control how input requirement violations are handled: strict (errors) or permissive (warnings).|strict|false|

--- a/task/prefetch-dependencies-oci-ta/0.3/migrations/0.3.1.sh
+++ b/task/prefetch-dependencies-oci-ta/0.3/migrations/0.3.1.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: prefetch-dependencies-oci-ta@0.3.1
+# Creation time: 2026-04-09T17:09:19+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# 1. Find all prefetch-dependencies tasks in the pipeline
+task_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "prefetch-dependencies" "prefetch-dependencies-oci-ta" "prefetch-dependencies-oci-ta-min"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#task_names[@]} task_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#task_names[@]} -eq 0 ]; then
+    echo "Pipeline does not use prefetch-dependencies task, skipping migration"
+    exit 0
+fi
+
+# 2. Add enable-package-registry-proxy to the pipeline's top-level params
+# pmt generic insert is not idempotent, so check first
+if yq -e '(.spec.params[], .spec.pipelineSpec.params[]) | select(.name == "enable-package-registry-proxy")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "enable-package-registry-proxy pipeline parameter already exists"
+else
+    echo "Adding enable-package-registry-proxy pipeline param"
+
+    # Params live at different paths in Pipeline vs PipelineRun (embedded spec)
+    if yq -e '.spec.pipelineSpec' "$pipeline_file" >/dev/null 2>&1; then
+        params_path=".spec.pipelineSpec.params"
+        pmt_params_path='["spec", "pipelineSpec", "params"]'
+        pmt_spec_path='["spec", "pipelineSpec"]'
+    else
+        params_path=".spec.params"
+        pmt_params_path='["spec", "params"]'
+        pmt_spec_path='["spec"]'
+    fi
+
+    param_json='{"name": "enable-package-registry-proxy", "default": "true", "description": "Use the package registry proxy when prefetching dependencies", "type": "string"}'
+
+    if yq -e "$params_path" "$pipeline_file" >/dev/null 2>&1; then
+        pmt modify -f "$pipeline_file" generic insert "$pmt_params_path" "$param_json"
+    else
+        pmt modify -f "$pipeline_file" generic insert "$pmt_spec_path" "{\"params\": [$param_json]}"
+    fi
+fi
+
+# 3. Pass the pipeline param to each prefetch-dependencies task (add-param is idempotent)
+for task_name in "${task_names[@]}"; do
+    echo "Ensuring enable-package-registry-proxy parameter exists for task $task_name"
+    pmt modify -f "$pipeline_file" task "$task_name" add-param enable-package-registry-proxy "\$(params.enable-package-registry-proxy)"
+done

--- a/task/prefetch-dependencies-oci-ta/0.3/migrations/0.3.2.sh
+++ b/task/prefetch-dependencies-oci-ta/0.3/migrations/0.3.2.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: prefetch-dependencies-oci-ta@0.3.1
+# Creation time: 2026-04-09T17:09:19+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# 1. Find all prefetch-dependencies tasks in the pipeline
+task_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "prefetch-dependencies" "prefetch-dependencies-oci-ta" "prefetch-dependencies-oci-ta-min"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#task_names[@]} task_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#task_names[@]} -eq 0 ]; then
+    echo "Pipeline does not use prefetch-dependencies task, skipping migration"
+    exit 0
+fi
+
+# 2. Add enable-package-registry-proxy to the pipeline's top-level params
+# pmt generic insert is not idempotent, so check first
+if yq -e '(.spec.params[], .spec.pipelineSpec.params[]) | select(.name == "enable-package-registry-proxy")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "enable-package-registry-proxy pipeline parameter already exists"
+else
+    echo "Adding enable-package-registry-proxy pipeline param"
+
+    # Params live at different paths in Pipeline vs PipelineRun (embedded spec)
+    if yq -e '.spec.pipelineSpec' "$pipeline_file" >/dev/null 2>&1; then
+        params_path=".spec.pipelineSpec.params"
+        pmt_params_path='["spec", "pipelineSpec", "params"]'
+        pmt_spec_path='["spec", "pipelineSpec"]'
+    else
+        params_path=".spec.params"
+        pmt_params_path='["spec", "params"]'
+        pmt_spec_path='["spec"]'
+    fi
+
+    param_json='{"name": "enable-package-registry-proxy", "default": "true", "description": "Use the package registry proxy when prefetching dependencies", "type": "string"}'
+
+    if yq -e "$params_path" "$pipeline_file" >/dev/null 2>&1; then
+        pmt modify -f "$pipeline_file" generic insert "$pmt_params_path" "$param_json"
+    else
+        pmt modify -f "$pipeline_file" generic insert "$pmt_spec_path" "{\"params\": [$param_json]}"
+    fi
+fi
+
+# 3. Pass the pipeline param to each prefetch-dependencies task (add-param is idempotent)
+for task_name in "${task_names[@]}"; do
+    echo "Ensuring enable-package-registry-proxy parameter exists for task $task_name"
+    pmt modify -f "$pipeline_file" task "$task_name" add-param enable-package-registry-proxy "\$(params.enable-package-registry-proxy)"
+done

--- a/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.3.1
+    app.kubernetes.io/version: 0.3.2
 spec:
   description: Task that prefetches project dependencies for hermetic build.
   params:
@@ -15,6 +15,18 @@ spec:
       description: Name of secret which contains subscription activation key
       type: string
       default: activation-key
+    - name: SERVICE_CA_TRUST_CONFIG_MAP_KEY
+      description: The name of the key in the ConfigMap that contains the
+        service CA bundle data. Used to verify TLS connections to in-cluster
+        services such as the package registry proxy.
+      type: string
+      default: service-ca.crt
+    - name: SERVICE_CA_TRUST_CONFIG_MAP_NAME
+      description: The name of the ConfigMap to read service CA bundle data
+        from. Used to verify TLS connections to in-cluster services such as
+        the package registry proxy.
+      type: string
+      default: openshift-service-ca.crt
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -33,6 +45,10 @@ spec:
         Pass configuration to the prefetch tool.
         Note this needs to be passed as a YAML-formatted config dump, not as a file path!
       default: ""
+    - name: enable-package-registry-proxy
+      description: Use the package registry proxy when prefetching dependencies
+      type: string
+      default: "true"
     - name: input
       description: Configures project packages that will have their dependencies
         prefetched.
@@ -72,6 +88,13 @@ spec:
         secretName: $(params.ACTIVATION_KEY)
     - name: config
       emptyDir: {}
+    - name: service-ca
+      configMap:
+        items:
+          - key: $(params.SERVICE_CA_TRUST_CONFIG_MAP_KEY)
+            path: ca-bundle.crt
+        name: $(params.SERVICE_CA_TRUST_CONFIG_MAP_NAME)
+        optional: true
     - name: trusted-ca
       configMap:
         items:
@@ -132,6 +155,9 @@ spec:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
+        - mountPath: /mnt/service-ca
+          name: service-ca
+          readOnly: true
       env:
         - name: KBC_LOG_LEVEL
           value: $(params.log-level)
@@ -156,6 +182,8 @@ spec:
           value: $(workspaces.netrc.path)
         - name: CONFIG_FILE_CONTENT
           value: $(params.config-file-content)
+        - name: KBC_PD_ENABLE_PACKAGE_REGISTRY_PROXY
+          value: $(params.enable-package-registry-proxy)
       script: |
         #!/bin/bash
 
@@ -164,8 +192,22 @@ spec:
         fi
 
         CA_BUNDLE_PATH=/mnt/trusted-ca/ca-bundle.crt
+        SERVICE_CA_BUNDLE_PATH=/mnt/service-ca/ca-bundle.crt
+        UPDATE_CA_TRUST=false
+
         if [ -f "$CA_BUNDLE_PATH" ]; then
-          cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors
+          echo "Using mounted CA bundle: $CA_BUNDLE_PATH"
+          cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+          UPDATE_CA_TRUST=true
+        fi
+
+        if [ -f "$SERVICE_CA_BUNDLE_PATH" ]; then
+          echo "Using mounted service CA bundle: $SERVICE_CA_BUNDLE_PATH"
+          cp -vf "$SERVICE_CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/service-ca.crt
+          UPDATE_CA_TRUST=true
+        fi
+
+        if [ "$UPDATE_CA_TRUST" = "true" ]; then
           update-ca-trust
         fi
 

--- a/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: 0.3.1
 spec:
   description: Task that prefetches project dependencies for hermetic build.
   params:
@@ -15,6 +15,18 @@ spec:
       description: Name of secret which contains subscription activation key
       type: string
       default: activation-key
+    - name: SERVICE_CA_TRUST_CONFIG_MAP_KEY
+      description: The name of the key in the ConfigMap that contains the
+        service CA bundle data. Used to verify TLS connections to in-cluster
+        services such as the package registry proxy.
+      type: string
+      default: service-ca.crt
+    - name: SERVICE_CA_TRUST_CONFIG_MAP_NAME
+      description: The name of the ConfigMap to read service CA bundle data
+        from. Used to verify TLS connections to in-cluster services such as
+        the package registry proxy.
+      type: string
+      default: openshift-service-ca.crt
     - name: SOURCE_ARTIFACT
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
@@ -33,6 +45,10 @@ spec:
         Pass configuration to the prefetch tool.
         Note this needs to be passed as a YAML-formatted config dump, not as a file path!
       default: ""
+    - name: enable-package-registry-proxy
+      description: Use the package registry proxy when prefetching dependencies
+      type: string
+      default: "true"
     - name: input
       description: Configures project packages that will have their dependencies
         prefetched.
@@ -72,6 +88,13 @@ spec:
         secretName: $(params.ACTIVATION_KEY)
     - name: config
       emptyDir: {}
+    - name: service-ca
+      configMap:
+        items:
+          - key: $(params.SERVICE_CA_TRUST_CONFIG_MAP_KEY)
+            path: ca-bundle.crt
+        name: $(params.SERVICE_CA_TRUST_CONFIG_MAP_NAME)
+        optional: true
     - name: trusted-ca
       configMap:
         items:
@@ -132,6 +155,9 @@ spec:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
           readOnly: true
+        - mountPath: /mnt/service-ca
+          name: service-ca
+          readOnly: true
       env:
         - name: KBC_LOG_LEVEL
           value: $(params.log-level)
@@ -155,6 +181,8 @@ spec:
           value: $(workspaces.netrc.path)
         - name: CONFIG_FILE_CONTENT
           value: $(params.config-file-content)
+        - name: KBC_PD_ENABLE_PACKAGE_REGISTRY_PROXY
+          value: $(params.enable-package-registry-proxy)
       script: |
         #!/bin/bash
 
@@ -163,8 +191,22 @@ spec:
         fi
 
         CA_BUNDLE_PATH=/mnt/trusted-ca/ca-bundle.crt
+        SERVICE_CA_BUNDLE_PATH=/mnt/service-ca/ca-bundle.crt
+        UPDATE_CA_TRUST=false
+
         if [ -f "$CA_BUNDLE_PATH" ]; then
-          cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors
+          echo "Using mounted CA bundle: $CA_BUNDLE_PATH"
+          cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+          UPDATE_CA_TRUST=true
+        fi
+
+        if [ -f "$SERVICE_CA_BUNDLE_PATH" ]; then
+          echo "Using mounted service CA bundle: $SERVICE_CA_BUNDLE_PATH"
+          cp -vf "$SERVICE_CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/service-ca.crt
+          UPDATE_CA_TRUST=true
+        fi
+
+        if [ "$UPDATE_CA_TRUST" = "true" ]; then
           update-ca-trust
         fi
 

--- a/task/prefetch-dependencies-oci-ta/CHANGELOG.md
+++ b/task/prefetch-dependencies-oci-ta/CHANGELOG.md
@@ -11,6 +11,11 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.2
+
+- Added `enable-package-registry-proxy` parameter to enable use of the package registry proxy when prefetching dependencies.
+- Added `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters to mount the OpenShift service CA for verifying TLS connections to in-cluster services such as the package registry proxy.
+
 ## 0.3.1
 
 ### Added

--- a/task/prefetch-dependencies-oci-ta/CHANGELOG.md
+++ b/task/prefetch-dependencies-oci-ta/CHANGELOG.md
@@ -11,6 +11,11 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.1
+
+- Added `enable-package-registry-proxy` parameter to enable use of the package registry proxy when prefetching dependencies.
+- Added `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters to mount the OpenShift service CA for verifying TLS connections to in-cluster services such as the package registry proxy.
+
 ## 0.3
 
 - Removed deprecated `dev-package-managers` parameter.

--- a/task/prefetch-dependencies/0.3/MIGRATION.md
+++ b/task/prefetch-dependencies/0.3/MIGRATION.md
@@ -6,3 +6,13 @@
 ## Action from users
 
 Please remove the `dev-package-managers` task parameter from your pipelines.
+
+## Migration from 0.3 to 0.3.1
+
+* New `enable-package-registry-proxy` parameter has been added.
+* New `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have been added.
+
+## Action from users
+
+Add the `enable-package-registry-proxy` parameter (default `"true"`) and pass it to the prefetch-dependencies task.
+The `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have default values and require no action.

--- a/task/prefetch-dependencies/0.3/MIGRATION.md
+++ b/task/prefetch-dependencies/0.3/MIGRATION.md
@@ -6,3 +6,13 @@
 ## Action from users
 
 Please remove the `dev-package-managers` task parameter from your pipelines.
+
+## Migration from 0.3.1 to 0.3.2
+
+* New `enable-package-registry-proxy` parameter has been added.
+* New `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have been added.
+
+## Action from users
+
+Add the `enable-package-registry-proxy` parameter (default `"true"`) and pass it to the prefetch-dependencies task.
+The `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters have default values and require no action.

--- a/task/prefetch-dependencies/0.3/README.md
+++ b/task/prefetch-dependencies/0.3/README.md
@@ -29,6 +29,9 @@ params:
 |mode|Control how input requirement violations are handled: strict (errors) or permissive (warnings). Valid values: strict, permissive.|strict|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|SERVICE_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the service CA bundle data. Used to verify TLS connections to in-cluster services such as the package registry proxy.|service-ca.crt|false|
+|SERVICE_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read service CA bundle data from. Used to verify TLS connections to in-cluster services such as the package registry proxy.|openshift-service-ca.crt|false|
+|enable-package-registry-proxy|Use the package registry proxy when prefetching dependencies|true|false|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
 
 ## Workspaces

--- a/task/prefetch-dependencies/0.3/migrations/0.3.1.sh
+++ b/task/prefetch-dependencies/0.3/migrations/0.3.1.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: prefetch-dependencies@0.3.1
+# Creation time: 2026-04-09T17:09:19+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# 1. Find all prefetch-dependencies tasks in the pipeline
+task_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "prefetch-dependencies" "prefetch-dependencies-oci-ta" "prefetch-dependencies-oci-ta-min"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#task_names[@]} task_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#task_names[@]} -eq 0 ]; then
+    echo "Pipeline does not use prefetch-dependencies task, skipping migration"
+    exit 0
+fi
+
+# 2. Add enable-package-registry-proxy to the pipeline's top-level params
+# pmt generic insert is not idempotent, so check first
+if yq -e '(.spec.params[], .spec.pipelineSpec.params[]) | select(.name == "enable-package-registry-proxy")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "enable-package-registry-proxy pipeline parameter already exists"
+else
+    echo "Adding enable-package-registry-proxy pipeline param"
+
+    # Params live at different paths in Pipeline vs PipelineRun (embedded spec)
+    if yq -e '.spec.pipelineSpec' "$pipeline_file" >/dev/null 2>&1; then
+        params_path=".spec.pipelineSpec.params"
+        pmt_params_path='["spec", "pipelineSpec", "params"]'
+        pmt_spec_path='["spec", "pipelineSpec"]'
+    else
+        params_path=".spec.params"
+        pmt_params_path='["spec", "params"]'
+        pmt_spec_path='["spec"]'
+    fi
+
+    param_json='{"name": "enable-package-registry-proxy", "default": "true", "description": "Use the package registry proxy when prefetching dependencies", "type": "string"}'
+
+    if yq -e "$params_path" "$pipeline_file" >/dev/null 2>&1; then
+        pmt modify -f "$pipeline_file" generic insert "$pmt_params_path" "$param_json"
+    else
+        pmt modify -f "$pipeline_file" generic insert "$pmt_spec_path" "{\"params\": [$param_json]}"
+    fi
+fi
+
+# 3. Pass the pipeline param to each prefetch-dependencies task (add-param is idempotent)
+for task_name in "${task_names[@]}"; do
+    echo "Ensuring enable-package-registry-proxy parameter exists for task $task_name"
+    pmt modify -f "$pipeline_file" task "$task_name" add-param enable-package-registry-proxy "\$(params.enable-package-registry-proxy)"
+done

--- a/task/prefetch-dependencies/0.3/migrations/0.3.2.sh
+++ b/task/prefetch-dependencies/0.3/migrations/0.3.2.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: prefetch-dependencies@0.3.1
+# Creation time: 2026-04-09T17:09:19+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+# 1. Find all prefetch-dependencies tasks in the pipeline
+task_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "prefetch-dependencies" "prefetch-dependencies-oci-ta" "prefetch-dependencies-oci-ta-min"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#task_names[@]} task_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#task_names[@]} -eq 0 ]; then
+    echo "Pipeline does not use prefetch-dependencies task, skipping migration"
+    exit 0
+fi
+
+# 2. Add enable-package-registry-proxy to the pipeline's top-level params
+# pmt generic insert is not idempotent, so check first
+if yq -e '(.spec.params[], .spec.pipelineSpec.params[]) | select(.name == "enable-package-registry-proxy")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "enable-package-registry-proxy pipeline parameter already exists"
+else
+    echo "Adding enable-package-registry-proxy pipeline param"
+
+    # Params live at different paths in Pipeline vs PipelineRun (embedded spec)
+    if yq -e '.spec.pipelineSpec' "$pipeline_file" >/dev/null 2>&1; then
+        params_path=".spec.pipelineSpec.params"
+        pmt_params_path='["spec", "pipelineSpec", "params"]'
+        pmt_spec_path='["spec", "pipelineSpec"]'
+    else
+        params_path=".spec.params"
+        pmt_params_path='["spec", "params"]'
+        pmt_spec_path='["spec"]'
+    fi
+
+    param_json='{"name": "enable-package-registry-proxy", "default": "true", "description": "Use the package registry proxy when prefetching dependencies", "type": "string"}'
+
+    if yq -e "$params_path" "$pipeline_file" >/dev/null 2>&1; then
+        pmt modify -f "$pipeline_file" generic insert "$pmt_params_path" "$param_json"
+    else
+        pmt modify -f "$pipeline_file" generic insert "$pmt_spec_path" "{\"params\": [$param_json]}"
+    fi
+fi
+
+# 3. Pass the pipeline param to each prefetch-dependencies task (add-param is idempotent)
+for task_name in "${task_names[@]}"; do
+    echo "Ensuring enable-package-registry-proxy parameter exists for task $task_name"
+    pmt modify -f "$pipeline_file" task "$task_name" add-param enable-package-registry-proxy "\$(params.enable-package-registry-proxy)"
+done

--- a/task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.3.1"
+    app.kubernetes.io/version: "0.3.2"
 spec:
   description: Task that prefetches project dependencies for hermetic build.
   params:
@@ -35,6 +35,21 @@ spec:
     type: string
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
+  - name: SERVICE_CA_TRUST_CONFIG_MAP_KEY
+    description: The name of the key in the ConfigMap that contains the service CA bundle
+      data. Used to verify TLS connections to in-cluster services such as the package
+      registry proxy.
+    type: string
+    default: service-ca.crt
+  - name: SERVICE_CA_TRUST_CONFIG_MAP_NAME
+    description: The name of the ConfigMap to read service CA bundle data from. Used to
+      verify TLS connections to in-cluster services such as the package registry proxy.
+    type: string
+    default: openshift-service-ca.crt
+  - name: enable-package-registry-proxy
+    description: Use the package registry proxy when prefetching dependencies
+    type: string
+    default: "true"
   - name: ACTIVATION_KEY
     default: activation-key
     description: Name of secret which contains subscription activation key
@@ -50,6 +65,9 @@ spec:
           mountPath: /mnt/config
         - name: trusted-ca
           mountPath: /mnt/trusted-ca
+          readOnly: true
+        - name: service-ca
+          mountPath: /mnt/service-ca
           readOnly: true
       env:
         - name: KBC_LOG_LEVEL
@@ -77,6 +95,8 @@ spec:
           value: $(workspaces.netrc.path)
         - name: CONFIG_FILE_CONTENT
           value: $(params.config-file-content)
+        - name: KBC_PD_ENABLE_PACKAGE_REGISTRY_PROXY
+          value: $(params.enable-package-registry-proxy)
       computeResources:
         limits:
           # We have seen strange behavior where prefetch memory consumption is
@@ -95,8 +115,22 @@ spec:
         fi
 
         CA_BUNDLE_PATH=/mnt/trusted-ca/ca-bundle.crt
+        SERVICE_CA_BUNDLE_PATH=/mnt/service-ca/ca-bundle.crt
+        UPDATE_CA_TRUST=false
+
         if [ -f "$CA_BUNDLE_PATH" ]; then
-          cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors
+          echo "Using mounted CA bundle: $CA_BUNDLE_PATH"
+          cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+          UPDATE_CA_TRUST=true
+        fi
+
+        if [ -f "$SERVICE_CA_BUNDLE_PATH" ]; then
+          echo "Using mounted service CA bundle: $SERVICE_CA_BUNDLE_PATH"
+          cp -vf "$SERVICE_CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/service-ca.crt
+          UPDATE_CA_TRUST=true
+        fi
+
+        if [ "$UPDATE_CA_TRUST" = "true" ]; then
           update-ca-trust
         fi
 
@@ -137,6 +171,13 @@ spec:
         name: $(params.caTrustConfigMapName)
         items:
           - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+    - name: service-ca
+      configMap:
+        name: $(params.SERVICE_CA_TRUST_CONFIG_MAP_NAME)
+        items:
+          - key: $(params.SERVICE_CA_TRUST_CONFIG_MAP_KEY)
             path: ca-bundle.crt
         optional: true
     - name: config

--- a/task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.3.1"
 spec:
   description: Task that prefetches project dependencies for hermetic build.
   params:
@@ -35,6 +35,21 @@ spec:
     type: string
     description: The name of the key in the ConfigMap that contains the CA bundle data.
     default: ca-bundle.crt
+  - name: SERVICE_CA_TRUST_CONFIG_MAP_KEY
+    description: The name of the key in the ConfigMap that contains the service CA bundle
+      data. Used to verify TLS connections to in-cluster services such as the package
+      registry proxy.
+    type: string
+    default: service-ca.crt
+  - name: SERVICE_CA_TRUST_CONFIG_MAP_NAME
+    description: The name of the ConfigMap to read service CA bundle data from. Used to
+      verify TLS connections to in-cluster services such as the package registry proxy.
+    type: string
+    default: openshift-service-ca.crt
+  - name: enable-package-registry-proxy
+    description: Use the package registry proxy when prefetching dependencies
+    type: string
+    default: "true"
   - name: ACTIVATION_KEY
     default: activation-key
     description: Name of secret which contains subscription activation key
@@ -50,6 +65,9 @@ spec:
           mountPath: /mnt/config
         - name: trusted-ca
           mountPath: /mnt/trusted-ca
+          readOnly: true
+        - name: service-ca
+          mountPath: /mnt/service-ca
           readOnly: true
       env:
         - name: KBC_LOG_LEVEL
@@ -74,6 +92,8 @@ spec:
           value: $(workspaces.netrc.path)
         - name: CONFIG_FILE_CONTENT
           value: $(params.config-file-content)
+        - name: KBC_PD_ENABLE_PACKAGE_REGISTRY_PROXY
+          value: $(params.enable-package-registry-proxy)
       computeResources:
         limits:
           # We have seen strange behavior where prefetch memory consumption is
@@ -92,8 +112,22 @@ spec:
         fi
 
         CA_BUNDLE_PATH=/mnt/trusted-ca/ca-bundle.crt
+        SERVICE_CA_BUNDLE_PATH=/mnt/service-ca/ca-bundle.crt
+        UPDATE_CA_TRUST=false
+
         if [ -f "$CA_BUNDLE_PATH" ]; then
-          cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors
+          echo "Using mounted CA bundle: $CA_BUNDLE_PATH"
+          cp -vf "$CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/ca-bundle.crt
+          UPDATE_CA_TRUST=true
+        fi
+
+        if [ -f "$SERVICE_CA_BUNDLE_PATH" ]; then
+          echo "Using mounted service CA bundle: $SERVICE_CA_BUNDLE_PATH"
+          cp -vf "$SERVICE_CA_BUNDLE_PATH" /etc/pki/ca-trust/source/anchors/service-ca.crt
+          UPDATE_CA_TRUST=true
+        fi
+
+        if [ "$UPDATE_CA_TRUST" = "true" ]; then
           update-ca-trust
         fi
 
@@ -134,6 +168,13 @@ spec:
         name: $(params.caTrustConfigMapName)
         items:
           - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true
+    - name: service-ca
+      configMap:
+        name: $(params.SERVICE_CA_TRUST_CONFIG_MAP_NAME)
+        items:
+          - key: $(params.SERVICE_CA_TRUST_CONFIG_MAP_KEY)
             path: ca-bundle.crt
         optional: true
     - name: config

--- a/task/prefetch-dependencies/CHANGELOG.md
+++ b/task/prefetch-dependencies/CHANGELOG.md
@@ -11,6 +11,11 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.2
+
+- Added `enable-package-registry-proxy` parameter to enable use of the package registry proxy when prefetching dependencies.
+- Added `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters to mount the OpenShift service CA for verifying TLS connections to in-cluster services such as the package registry proxy.
+
 ## 0.3.1
 
 ### Added

--- a/task/prefetch-dependencies/CHANGELOG.md
+++ b/task/prefetch-dependencies/CHANGELOG.md
@@ -11,6 +11,11 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.1
+
+- Added `enable-package-registry-proxy` parameter to enable use of the package registry proxy when prefetching dependencies.
+- Added `SERVICE_CA_TRUST_CONFIG_MAP_NAME` and `SERVICE_CA_TRUST_CONFIG_MAP_KEY` parameters to mount the OpenShift service CA for verifying TLS connections to in-cluster services such as the package registry proxy.
+
 ## 0.3
 
 - Removed deprecated `dev-package-managers` parameter.


### PR DESCRIPTION
This parameter controls whether package registry requests are routed through the package registry proxy when prefetching dependencies. Includes migration scripts to automatically wire the parameter into existing pipelines.

Related to: https://github.com/konflux-ci/konflux-build-cli/pull/90
