### PR TITLE
fix: enable helm charts with OCI-only dependencies

### DIFF
--- a/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
@@ -283,16 +283,25 @@ spec:
           echo "Building Helm dependencies from Chart.lock..."
 
           # Add required repositories from Chart.yaml dependencies
-          yq -r '.dependencies[].repository' Chart.yaml | sort -u | while read -r repo_url; do
+          http_repo_used=false
+          while read -r repo_url; do
             if [ -n "$repo_url" ]; then
-              repo_name=$(echo "$repo_url" | sed 's|https://||' | sed 's|http://||' | sed 's|/.*$||' | sed 's|\.|_|g')
-              echo "Adding repository: $repo_name ($repo_url)"
-              helm repo add "$repo_name" "$repo_url" || true
+              proto=$(echo "$repo_url" | cut -d: -f1)
+              if [ "$proto" = "oci" ]; then
+                echo "Skipping adding helm repository for OCI dependency: $repo_url"
+              else
+                http_repo_used=true
+                repo_name=$(echo "$repo_url" | sed 's|https://||' | sed 's|http://||' | sed 's|/.*$||' | sed 's|\.|_|g')
+                echo "Adding repository: $repo_name ($repo_url)"
+                helm repo add "$repo_name" "$repo_url" || true
+              fi
             fi
-          done
+          done < <(yq -r '.dependencies[].repository' Chart.yaml | sort -u)
 
           # Update repository index
-          helm repo update
+          if [ "$http_repo_used" = "true" ]; then
+            helm repo update
+          fi
 
           # Build dependencies
           helm dependency build .

--- a/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
@@ -273,14 +273,17 @@ spec:
           # Add required repositories from Chart.yaml dependencies
           yq -r '.dependencies[].repository' Chart.yaml | sort -u | while read -r repo_url; do
             if [ -n "$repo_url" ]; then
-              repo_name=$(echo "$repo_url" | sed 's|https://||' | sed 's|http://||' | sed 's|/.*$||' | sed 's|\.|_|g')
-              echo "Adding repository: $repo_name ($repo_url)"
-              helm repo add "$repo_name" "$repo_url" || true
+              proto=$(echo "$repo_url" | cut -d: -f1)
+              if [ "$proto" != "oci" ]; then
+                repo_name=$(echo "$repo_url" | sed 's|https://||' | sed 's|http://||' | sed 's|/.*$||' | sed 's|\.|_|g')
+                echo "Adding repository: $repo_name ($repo_url)"
+                helm repo add "$repo_name" "$repo_url" || true
+              fi
             fi
           done
 
           # Update repository index
-          helm repo update
+          helm repo update || true
 
           # Build dependencies
           helm dependency build .

--- a/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
@@ -271,19 +271,23 @@ spec:
           echo "Building Helm dependencies from Chart.lock..."
 
           # Add required repositories from Chart.yaml dependencies
-          yq -r '.dependencies[].repository' Chart.yaml | sort -u | while read -r repo_url; do
+          http_repo_used=false
+          while read -r repo_url; do
             if [ -n "$repo_url" ]; then
               proto=$(echo "$repo_url" | cut -d: -f1)
               if [ "$proto" != "oci" ]; then
+                http_repo_used=true
                 repo_name=$(echo "$repo_url" | sed 's|https://||' | sed 's|http://||' | sed 's|/.*$||' | sed 's|\.|_|g')
                 echo "Adding repository: $repo_name ($repo_url)"
                 helm repo add "$repo_name" "$repo_url" || true
               fi
             fi
-          done
+          done < <(yq -r '.dependencies[].repository' Chart.yaml | sort -u)
 
           # Update repository index
-          helm repo update || true
+          if $http_repo_used; then
+            helm repo update
+          fi
 
           # Build dependencies
           helm dependency build .


### PR DESCRIPTION
For charts that have OCI dependencies at all, attempting to add the repo fails as there is no method to do that for OCI artifact-packaged Helm charts. Additionally, if all dependencies are OCI dependencies, then `helm repo update` fails. Set `|| true` there as `helm dependency build .` should properly fail if helm is unable to resolve dependencies from available, configured repositories.

I don't see any applicable tests at all for this task. If there's anything you'd like added here, I'm happy to do it.
