### PR TITLE
Output additional prefetch env files

### DIFF
--- a/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: 0.3.1
   name: prefetch-dependencies-oci-ta-min
 spec:
   description: Task that prefetches project dependencies for hermetic build.
@@ -114,7 +114,7 @@ spec:
     - name: KBC_PD_OUTPUT_DIR_MOUNT_POINT
       value: /cachi2/output
     - name: KBC_PD_ENV_FILES
-      value: /var/workdir/cachi2/cachi2.env
+      value: /var/workdir/cachi2/cachi2.env /var/workdir/cachi2/prefetch.env /var/workdir/cachi2/prefetch-env.json
     - name: KBC_PD_GIT_AUTH_DIRECTORY
       value: $(workspaces.git-basic-auth.path)
     - name: WORKSPACE_NETRC_PATH

--- a/task/prefetch-dependencies-oci-ta-min/CHANGELOG.md
+++ b/task/prefetch-dependencies-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,19 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.1
+
+### Added
+
+- In addition to the `cachi2.env` file, the output directory will also have
+  a `prefetch.env` file.
+  - Both files have the same content, `prefetch.env` is the primary one.
+    `cachi2.env` stays for now, for backwards compatibility with existing Tasks.
+- In addition to the `*.env` files, the output directory will also have
+  a `prefetch-env.json` file.
+  - This will enable future versions of the buildah Task to inject prefetch environment
+    variables without any invasive editing of the containerfile.
+
 ## 0.3
 
 - Removed deprecated `dev-package-managers` parameter.

--- a/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: 0.3.1
 spec:
   description: Task that prefetches project dependencies for hermetic build.
   params:
@@ -148,7 +148,8 @@ spec:
         - name: KBC_PD_OUTPUT_DIR_MOUNT_POINT
           value: /cachi2/output
         - name: KBC_PD_ENV_FILES
-          value: /var/workdir/cachi2/cachi2.env
+          value: /var/workdir/cachi2/cachi2.env /var/workdir/cachi2/prefetch.env
+            /var/workdir/cachi2/prefetch-env.json
         - name: KBC_PD_GIT_AUTH_DIRECTORY
           value: $(workspaces.git-basic-auth.path)
         - name: WORKSPACE_NETRC_PATH

--- a/task/prefetch-dependencies-oci-ta/CHANGELOG.md
+++ b/task/prefetch-dependencies-oci-ta/CHANGELOG.md
@@ -11,6 +11,19 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.1
+
+### Added
+
+- In addition to the `cachi2.env` file, the output directory will also have
+  a `prefetch.env` file.
+  - Both files have the same content, `prefetch.env` is the primary one.
+    `cachi2.env` stays for now, for backwards compatibility with existing Tasks.
+- In addition to the `*.env` files, the output directory will also have
+  a `prefetch-env.json` file.
+  - This will enable future versions of the buildah Task to inject prefetch environment
+    variables without any invasive editing of the containerfile.
+
 ## 0.3
 
 - Removed deprecated `dev-package-managers` parameter.

--- a/task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.3.1"
 spec:
   description: Task that prefetches project dependencies for hermetic build.
   params:
@@ -67,7 +67,10 @@ spec:
         - name: KBC_PD_OUTPUT_DIR_MOUNT_POINT
           value: /cachi2/output
         - name: KBC_PD_ENV_FILES
-          value: $(workspaces.source.path)/cachi2/cachi2.env
+          value: >-
+            $(workspaces.source.path)/cachi2/cachi2.env
+            $(workspaces.source.path)/cachi2/prefetch.env
+            $(workspaces.source.path)/cachi2/prefetch-env.json
         - name: KBC_PD_GIT_AUTH_DIRECTORY
           value: $(workspaces.git-basic-auth.path)
         - name: WORKSPACE_NETRC_PATH

--- a/task/prefetch-dependencies/CHANGELOG.md
+++ b/task/prefetch-dependencies/CHANGELOG.md
@@ -11,6 +11,19 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.3.1
+
+### Added
+
+- In addition to the `cachi2.env` file, the output directory will also have
+  a `prefetch.env` file.
+  - Both files have the same content, `prefetch.env` is the primary one.
+    `cachi2.env` stays for now, for backwards compatibility with existing Tasks.
+- In addition to the `*.env` files, the output directory will also have
+  a `prefetch-env.json` file.
+  - This will enable future versions of the buildah Task to inject prefetch environment
+    variables without any invasive editing of the containerfile.
+
 ## 0.3
 
 - Removed deprecated `dev-package-managers` parameter.

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -112,7 +112,7 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
-        - $(params.PREFETCH_ARTIFACT)=/var/workdir/cachi2
+        - $(params.PREFETCH_ARTIFACT)=/var/workdir/prefetch
       volumeMounts:
         - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
           name: trusted-ca
@@ -174,9 +174,12 @@ spec:
 
         PREFETCH_MOUNT=""
         PREFETCH_SOURCE=""
-        if [ -d "/var/workdir/cachi2" ]; then
-          PREFETCH_MOUNT="--volume /var/workdir/cachi2:/cachi2"
-          if [[ -f /var/workdir/cachi2/prefetch.env ]]; then
+        if [ -d "/var/workdir/prefetch" ]; then
+          # The mount point should stay /cachi2 because:
+          # a) that's what the prefetch task expects
+          # b) user scripts may be referring directly to /cachi2/output/deps/generic
+          PREFETCH_MOUNT="--volume /var/workdir/prefetch:/cachi2"
+          if [[ -f /var/workdir/prefetch/prefetch.env ]]; then
             echo "using prefetch.env file to enable prefetch integration"
             PREFETCH_SOURCE=". /cachi2/prefetch.env &&"
           else

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.1.1"
 spec:
   description: |-
     This task allows to run an script stored on the git repository and stores the resultant directory
@@ -176,7 +176,13 @@ spec:
         PREFETCH_SOURCE=""
         if [ -d "/var/workdir/cachi2" ]; then
           PREFETCH_MOUNT="--volume /var/workdir/cachi2:/cachi2"
-          PREFETCH_SOURCE=". /cachi2/cachi2.env &&"
+          if [[ -f /var/workdir/cachi2/prefetch.env ]]; then
+            echo "using prefetch.env file to enable prefetch integration"
+            PREFETCH_SOURCE=". /cachi2/prefetch.env &&"
+          else
+            echo "using cachi2.env file to enable prefetch integration"
+            PREFETCH_SOURCE=". /cachi2/cachi2.env &&"
+          fi
         fi
 
         # Create the script file

--- a/task/run-script-oci-ta/CHANGELOG.md
+++ b/task/run-script-oci-ta/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
+
+## Unreleased
+
+<!--
+When you make changes without bumping the version right away, document them here.
+If that's not something you ever plan to do, consider removing this section.
+-->
+
+*Nothing yet.*
+
+## 0.1.1
+
+### Added
+
+- Now also supports prefetch task versions that output a `prefetch.env` file
+  instead of `cachi2.env` (prefetch task version 0.3.1 outputs both, a future
+  version will drop `cachi2.env`).
+- Started tracking changes in this file.


### PR DESCRIPTION
See commit messages for details.

Note that the accompanying buildah task changes to prefer `prefetch.env` are not included, because they are currently being made in https://github.com/konflux-ci/konflux-build-cli/pull/94