### PR TITLE
build-helm-chart-oci-ta: add computeResources from P95 resource analysis

### DIFF
--- a/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
@@ -109,6 +109,12 @@ spec:
           name: trusted-ca
           readOnly: true
           subPath: ca-bundle.crt
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
     - name: package-and-push
       image: quay.io/konflux-ci/tools@sha256:d8d19e46eaaddbfa9f981aa6b3688519d70fb7da5dbea8121c7d7744ec9ddd9e
       workingDir: /var/workdir
@@ -131,6 +137,12 @@ spec:
           value: $(params.CHART_VERSION)
         - name: APP_VERSION
           value: $(params.APP_VERSION)
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 50m
+          memory: 256Mi
       args:
         - "$(params.VALUES_FILES[*])"
       script: |

--- a/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
@@ -109,7 +109,7 @@ spec:
           name: trusted-ca
           readOnly: true
           subPath: ca-bundle.crt
-      computeResources:
+      resources:
         limits:
           memory: 64Mi
         requests:
@@ -137,7 +137,7 @@ spec:
           value: $(params.CHART_VERSION)
         - name: APP_VERSION
           value: $(params.APP_VERSION)
-      computeResources:
+      resources:
         limits:
           memory: 256Mi
         requests:


### PR DESCRIPTION
Description:

This change adds computeResources to both steps of build-helm-chart-oci-ta (0.3), sized from P95 usage with a 5% margin from the tasks-and-steps resource analyzer.

use-trusted-artifact: memory request/limit 64Mi, CPU request 50m (no CPU limit).
package-and-push: memory request/limit 256Mi, CPU request 50m (no CPU limit).
Memory requests and limits are aligned; CPU is request-only, consistent with other Konflux tasks in this repo.

Note: P95 data for the packaging step is sparse in the sampled window; consider revisiting after more production usage if needed.