### PR TITLE
chore(deps): update hermeto to 0.50.2

### DIFF
--- a/task/prefetch-dependencies-oci-ta-min/0.2/prefetch-dependencies-oci-ta-min.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.2/prefetch-dependencies-oci-ta-min.yaml
@@ -134,7 +134,7 @@ spec:
       value: $(workspaces.netrc.bound)
     - name: WORKSPACE_NETRC_PATH
       value: $(workspaces.netrc.path)
-    image: quay.io/konflux-ci/hermeto:0.50.1@sha256:429936e9da7f2f073bc18bf8bfa0a607f1a98a37a506540171860039aee6960d
+    image: quay.io/konflux-ci/hermeto:0.50.2@sha256:25a35443cdf557faeae3cb02146feba9c27c3fcecfae4cd831158c980f253c46
     name: prefetch-dependencies
     script: |
       #!/bin/bash

--- a/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
@@ -139,7 +139,7 @@ spec:
       value: $(params.config-file-content)
     - name: KBC_PD_ENABLE_PACKAGE_REGISTRY_PROXY
       value: $(params.enable-package-registry-proxy)
-    image: quay.io/konflux-ci/hermeto:0.50.1@sha256:429936e9da7f2f073bc18bf8bfa0a607f1a98a37a506540171860039aee6960d
+    image: quay.io/konflux-ci/hermeto:0.50.2@sha256:25a35443cdf557faeae3cb02146feba9c27c3fcecfae4cd831158c980f253c46
     name: prefetch-dependencies
     script: |
       #!/bin/bash

--- a/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.2/prefetch-dependencies-oci-ta.yaml
@@ -142,7 +142,7 @@ spec:
           yq 'del(.goproxy_url)' <<<"${CONFIG_FILE_CONTENT}" >/mnt/config/config.yaml
         fi
     - name: prefetch-dependencies
-      image: quay.io/konflux-ci/hermeto:0.50.1@sha256:429936e9da7f2f073bc18bf8bfa0a607f1a98a37a506540171860039aee6960d
+      image: quay.io/konflux-ci/hermeto:0.50.2@sha256:25a35443cdf557faeae3cb02146feba9c27c3fcecfae4cd831158c980f253c46
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca

--- a/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
@@ -146,7 +146,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: prefetch-dependencies
-      image: quay.io/konflux-ci/hermeto:0.50.1@sha256:429936e9da7f2f073bc18bf8bfa0a607f1a98a37a506540171860039aee6960d
+      image: quay.io/konflux-ci/hermeto:0.50.2@sha256:25a35443cdf557faeae3cb02146feba9c27c3fcecfae4cd831158c980f253c46
       volumeMounts:
         - mountPath: /activation-key
           name: activation-key

--- a/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.2/prefetch-dependencies.yaml
@@ -66,7 +66,7 @@ spec:
       fi
 
   - name: prefetch-dependencies
-    image: quay.io/konflux-ci/hermeto:0.50.1@sha256:429936e9da7f2f073bc18bf8bfa0a607f1a98a37a506540171860039aee6960d
+    image: quay.io/konflux-ci/hermeto:0.50.2@sha256:25a35443cdf557faeae3cb02146feba9c27c3fcecfae4cd831158c980f253c46
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     env:

--- a/task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
+++ b/task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
@@ -57,7 +57,7 @@ spec:
 
   steps:
     - name: prefetch-dependencies
-      image: quay.io/konflux-ci/hermeto:0.50.1@sha256:429936e9da7f2f073bc18bf8bfa0a607f1a98a37a506540171860039aee6960d
+      image: quay.io/konflux-ci/hermeto:0.50.2@sha256:25a35443cdf557faeae3cb02146feba9c27c3fcecfae4cd831158c980f253c46
       volumeMounts:
         - name: activation-key
           mountPath: /activation-key


### PR DESCRIPTION
This Hermeto update is necessary for Yarn Modern (Berry) to be able to use the package registry proxy.
