### PR TITLE
replace appstudio-utils with task-runner

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -96,7 +96,10 @@ spec:
       - name: TEKTON_CHAINS_NS
         value: "openshift-pipelines"
     - name: capture-log
-      image: quay.io/konflux-ci/pull-request-builds:appstudio-utils-$(params.revision)
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      securityContext:
+        runAsUser: 0
+        runAsNonRoot: false
       script: |
         #!/bin/bash
         set -euo pipefail

--- a/.tekton/tasks/task-lint.yaml
+++ b/.tekton/tasks/task-lint.yaml
@@ -23,7 +23,7 @@ spec:
       default: ["--help"]
   steps:
     - name: ensure-params-not-in-script
-      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       script: |

--- a/task-generator/trusted-artifacts/golden/source-build/base.yaml
+++ b/task-generator/trusted-artifacts/golden/source-build/base.yaml
@@ -46,7 +46,7 @@ spec:
         mountPath: /var/source-build
   steps:
     - name: get-base-images
-      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       env:
         - name: BASE_IMAGES
           value: "$(params.BASE_IMAGES)"

--- a/task-generator/trusted-artifacts/golden/source-build/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/source-build/ta.yaml
@@ -59,7 +59,7 @@ spec:
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - name: get-base-images
-      image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       env:
         - name: BASE_IMAGES
           value: $(params.BASE_IMAGES)


### PR DESCRIPTION
`appstudio-utils` image will be decommissioned soon and the replacement image is the `task-runner`

### Testing
- Changes in the `.tekton` folder will be tested by the CI.
- Changes in the `task-generator` are safe to do, since the actual tasks already use the `task-runner`. 
