### PR TITLE
fix: increase memory for push and sbom-syft-generate steps

### DIFF
--- a/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
@@ -991,10 +991,10 @@ spec:
   - computeResources:
       limits:
         cpu: 100m
-        memory: 256Mi
+        memory: 512Mi
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 512Mi
     env:
     - name: HOME
       value: /root
@@ -1173,10 +1173,10 @@ spec:
   - computeResources:
       limits:
         cpu: 256m
-        memory: 512Mi
+        memory: 1Gi
       requests:
         cpu: 256m
-        memory: 512Mi
+        memory: 1Gi
     image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
     name: sbom-syft-generate
     script: |

--- a/task/buildah-oci-ta-min/0.9/patch.yaml
+++ b/task/buildah-oci-ta-min/0.9/patch.yaml
@@ -42,10 +42,10 @@
   value: push
 - op: replace
   path: /spec/steps/2/computeResources/limits/memory
-  value: 256Mi
+  value: 512Mi
 - op: replace
   path: /spec/steps/2/computeResources/requests/memory
-  value: 256Mi
+  value: 512Mi
 - op: replace
   path: /spec/steps/2/computeResources/limits/cpu
   value: 100m
@@ -59,10 +59,10 @@
   value: sbom-syft-generate
 - op: replace
   path: /spec/steps/3/computeResources/limits/memory
-  value: 512Mi
+  value: 1Gi
 - op: replace
   path: /spec/steps/3/computeResources/requests/memory
-  value: 512Mi
+  value: 1Gi
 - op: replace
   path: /spec/steps/3/computeResources/limits/cpu
   value: 256m


### PR DESCRIPTION
Increasing the memory for `push` and `sbom-syft-generate` steps, since they are failing with `OOMKilled` intermittently while using minimal pipeline in e2e-tests.
one such occurrence is in latest execution [here](https://github.com/konflux-ci/build-service/pull/591#issuecomment-4345396083), artifacts can be fetched using `oras pull quay.io/konflux-test-storage/konflux-team/build-service:konflux-e2e-build-service-9582t`

```
"message": "\"step-sbom-syft-generate\" exited with code 137: OOMKilled"
"message": "\"step-push\" exited with code 137: OOMKilled"
```
