### PR TITLE
Revert "fix: increase memory for step push and sbom-syft-generate"

### DIFF
--- a/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
@@ -991,10 +991,10 @@ spec:
   - computeResources:
       limits:
         cpu: 100m
-        memory: 512Mi
+        memory: 256Mi
       requests:
         cpu: 100m
-        memory: 512Mi
+        memory: 256Mi
     env:
     - name: HOME
       value: /root
@@ -1173,10 +1173,10 @@ spec:
   - computeResources:
       limits:
         cpu: 256m
-        memory: 1Gi
+        memory: 512Mi
       requests:
         cpu: 256m
-        memory: 1Gi
+        memory: 512Mi
     image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
     name: sbom-syft-generate
     script: |

--- a/task/buildah-oci-ta-min/0.9/patch.yaml
+++ b/task/buildah-oci-ta-min/0.9/patch.yaml
@@ -42,10 +42,10 @@
   value: push
 - op: replace
   path: /spec/steps/2/computeResources/limits/memory
-  value: 512Mi
+  value: 256Mi
 - op: replace
   path: /spec/steps/2/computeResources/requests/memory
-  value: 512Mi
+  value: 256Mi
 - op: replace
   path: /spec/steps/2/computeResources/limits/cpu
   value: 100m
@@ -59,10 +59,10 @@
   value: sbom-syft-generate
 - op: replace
   path: /spec/steps/3/computeResources/limits/memory
-  value: 1Gi
+  value: 512Mi
 - op: replace
   path: /spec/steps/3/computeResources/requests/memory
-  value: 1Gi
+  value: 512Mi
 - op: replace
   path: /spec/steps/3/computeResources/limits/cpu
   value: 256m


### PR DESCRIPTION
This reverts commit 051e7fd308c56f82881b217c7f6a8d984ac57db0.

We will use light weight samples in the e2e-tests.
