### PR TITLE
Build-time param defaults in in tkn-bundle

### DIFF
--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -122,6 +122,7 @@
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |HOME| Value for the HOME environment variable.| /tekton/home| |
 |IMAGE| Reference of the image task will produce.| None| '$(params.output-image)'|
+|PARAM_DEFAULTS| Optional space-separated list of PARAM_NAME=VALUE entries. Each entry sets the default value of the named param in the task YAML files.| ""| |
 |REVISION| Revision| None| '$(params.revision)'|
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)'|
 |STEPS_IMAGE| An optional image to configure task steps with in the bundle| ""| |

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -116,6 +116,7 @@
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |HOME| Value for the HOME environment variable.| /tekton/home| |
 |IMAGE| Reference of the image task will produce.| None| '$(params.output-image)'|
+|PARAM_DEFAULTS| Optional space-separated list of PARAM_NAME=VALUE entries. Each entry sets the default value of the named param in the task YAML files.| ""| |
 |REVISION| Revision| None| '$(params.revision)'|
 |STEPS_IMAGE| An optional image to configure task steps with in the bundle| ""| |
 |STEPS_IMAGE_STEP_NAMES| Optional comma- or space-separated step names to control which steps are updated with STEPS_IMAGE. If names are prefixed with ! then all steps except those are updated. Otherwise only the listed steps are updated. If empty, all step images are updated.| ""| |

--- a/task/tkn-bundle-oci-ta/0.2/README.md
+++ b/task/tkn-bundle-oci-ta/0.2/README.md
@@ -8,6 +8,7 @@ Creates and pushes a Tekton bundle containing the specified Tekton YAML files.
 |CONTEXT|Path to the directory to use as context.|.|false|
 |HOME|Value for the HOME environment variable.|/tekton/home|false|
 |IMAGE|Reference of the image task will produce.||true|
+|PARAM_DEFAULTS|Optional space-separated list of PARAM_NAME=VALUE entries. Each entry sets the default value of the named param in the task YAML files.|""|false|
 |REVISION|Revision||true|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
 |STEPS_IMAGE|An optional image to configure task steps with in the bundle|""|false|

--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.2.2
+    app.kubernetes.io/version: 0.2.3
     build.appstudio.redhat.com/build_type: tkn-bundle
 spec:
   description: Creates and pushes a Tekton bundle containing the specified
@@ -24,6 +24,12 @@ spec:
     - name: IMAGE
       description: Reference of the image task will produce.
       type: string
+    - name: PARAM_DEFAULTS
+      description: Optional space-separated list of PARAM_NAME=VALUE entries.
+        Each entry sets the default value of the named param in the task YAML
+        files.
+      type: string
+      default: ""
     - name: REVISION
       description: Revision
       type: string
@@ -83,6 +89,8 @@ spec:
           value: $(params.STEPS_IMAGE)
         - name: STEPS_IMAGE_STEP_NAMES
           value: $(params.STEPS_IMAGE_STEP_NAMES)
+        - name: PARAM_DEFAULTS
+          value: $(params.PARAM_DEFAULTS)
       script: |
         #!/bin/env bash
         set -o errexit
@@ -191,6 +199,31 @@ spec:
             else
               yq '(.spec.steps[] | select(has("image")).image) = strenv(STEPS_IMAGE)' -i "$f"
             fi
+          done
+        fi
+
+        # Allow default values for params in the task being built to be set at build time
+        # PARAM_DEFAULTS should be a space-separated list of `PARAM_NAME=default_value` pairs.
+        if [[ -n "${PARAM_DEFAULTS}" ]]; then
+          set -f
+          IFS=' ' read -r -a PD_ENTRIES <<<"${PARAM_DEFAULTS}"
+          set +f
+          for entry in "${PD_ENTRIES[@]}"; do
+            if [[ "${entry}" != *"="* ]]; then
+              echo "ERROR: invalid PARAM_DEFAULTS entry '${entry}', expected NAME=VALUE format" >&2
+              exit 1
+            fi
+            PARAM_NAME="${entry%%=*}"
+            PARAM_VALUE="${entry#*=}"
+            for f in "${FILES[@]}"; do
+              if ! PARAM_NAME="${PARAM_NAME}" yq -e '.spec.params[]? | select(.name == strenv(PARAM_NAME))' "$f" &>/dev/null; then
+                echo "Param '${PARAM_NAME}' does not exist in task file '${f##*/}', skipping" >&2
+                continue
+              fi
+              echo "Setting param default: ${PARAM_NAME}=${PARAM_VALUE} in task file '${f##*/}'"
+              PARAM_NAME="${PARAM_NAME}" PARAM_VALUE="${PARAM_VALUE}" \
+                yq '(.spec.params[]? | select(.name == strenv(PARAM_NAME)).default) = strenv(PARAM_VALUE)' -i "$f"
+            done
           done
         fi
 

--- a/task/tkn-bundle-oci-ta/CHANGELOG.md
+++ b/task/tkn-bundle-oci-ta/CHANGELOG.md
@@ -9,6 +9,11 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
+## 0.2.3
+
+### Added
+
+Version 0.2.3 supports modifying task parameter default values at build time.
 
 ## 0.2.2
 

--- a/task/tkn-bundle/0.2/spec/test1.yaml
+++ b/task/tkn-bundle/0.2/spec/test1.yaml
@@ -5,6 +5,10 @@ metadata:
     app.kubernetes.io/version: "0.1"
   name: test1
 spec:
+  params:
+    - name: MY_PARAM
+      type: string
+      default: original-value
   steps:
     - name: build
       image: ubuntu

--- a/task/tkn-bundle/0.2/spec/tkn-bundle_spec.sh
+++ b/task/tkn-bundle/0.2/spec/tkn-bundle_spec.sh
@@ -354,6 +354,21 @@ spec:
     The output should include 'TASK_FAILED=Failed'
   End
 
+  It 'sets param defaults with PARAM_DEFAULTS'
+    build_and_inspect_param_defaults() {
+      restore_source_files
+      tkn task start tkn-bundle -p IMAGE=registry:5000/bundle:param-defaults -p "PARAM_DEFAULTS=MY_PARAM=custom-value" -p URL=https://example.com -p REVISION=main --use-param-defaults --timeout 15m --showlog -w name=source,claimName=source-pvc
+      tkn bundle list -o=go-template --template '{{range .spec.params}}{{printf "%s=%s\n" .name .default}}{{end}}' localhost:5000/bundle:param-defaults 2>/dev/null
+    }
+
+    When call build_and_inspect_param_defaults
+    The output should include 'Setting param default: MY_PARAM=custom-value'
+    The output should include 'Added Task: test1 to image'
+    The output should include 'Pushed Tekton Bundle to registry:5000/bundle'
+    The output should include 'MY_PARAM=custom-value'
+    The output should not include 'MY_PARAM=original-value'
+  End
+
   It 'replaces named step images with space-separated STEPS_IMAGE_STEP_NAMES'
     build_and_inspect_space_sep() {
       restore_source_files
@@ -384,5 +399,6 @@ End
   #   tkn bundle list localhost:5000/bundle:exclude-one
   #   tkn bundle list localhost:5000/bundle:exclude-multi
   #   tkn bundle list localhost:5000/bundle:no-match
+  #   tkn bundle list localhost:5000/bundle:param-defaults
   #   tkn bundle list localhost:5000/bundle:space-sep
   # Note: mixed-fail has no bundle — the task fails before pushing.

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.2"
+    app.kubernetes.io/version: "0.2.3"
     build.appstudio.redhat.com/build_type: "tkn-bundle"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -35,6 +35,12 @@ spec:
       steps except those are updated. Otherwise only the listed steps are
       updated. If empty, all step images are updated.
     default: ""
+  - name: PARAM_DEFAULTS
+    type: string
+    description: >-
+      Optional space-separated list of PARAM_NAME=VALUE entries. Each entry
+      sets the default value of the named param in the task YAML files.
+    default: ""
   - name: URL
     type: string
     description: Source code Git URL
@@ -66,6 +72,8 @@ spec:
       value: $(params.STEPS_IMAGE)
     - name: STEPS_IMAGE_STEP_NAMES
       value: $(params.STEPS_IMAGE_STEP_NAMES)
+    - name: PARAM_DEFAULTS
+      value: $(params.PARAM_DEFAULTS)
     script: |
       #!/bin/env bash
       set -o errexit
@@ -174,6 +182,31 @@ spec:
           else
             yq '(.spec.steps[] | select(has("image")).image) = strenv(STEPS_IMAGE)' -i "$f"
           fi
+        done
+      fi
+
+      # Allow default values for params in the task being built to be set at build time
+      # PARAM_DEFAULTS should be a space-separated list of `PARAM_NAME=default_value` pairs.
+      if [[ -n "${PARAM_DEFAULTS}" ]]; then
+        set -f
+        IFS=' ' read -r -a PD_ENTRIES <<< "${PARAM_DEFAULTS}"
+        set +f
+        for entry in "${PD_ENTRIES[@]}"; do
+          if [[ "${entry}" != *"="* ]]; then
+            echo "ERROR: invalid PARAM_DEFAULTS entry '${entry}', expected NAME=VALUE format" >&2
+            exit 1
+          fi
+          PARAM_NAME="${entry%%=*}"
+          PARAM_VALUE="${entry#*=}"
+          for f in "${FILES[@]}"; do
+            if ! PARAM_NAME="${PARAM_NAME}" yq -e '.spec.params[]? | select(.name == strenv(PARAM_NAME))' "$f" &>/dev/null; then
+              echo "Param '${PARAM_NAME}' does not exist in task file '${f##*/}', skipping" >&2
+              continue
+            fi
+            echo "Setting param default: ${PARAM_NAME}=${PARAM_VALUE} in task file '${f##*/}'"
+            PARAM_NAME="${PARAM_NAME}" PARAM_VALUE="${PARAM_VALUE}" \
+              yq '(.spec.params[]? | select(.name == strenv(PARAM_NAME)).default) = strenv(PARAM_VALUE)' -i "$f"
+          done
         done
       fi
 

--- a/task/tkn-bundle/CHANGELOG.md
+++ b/task/tkn-bundle/CHANGELOG.md
@@ -9,6 +9,11 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
+## 0.2.3
+
+### Added
+
+Version 0.2.3 supports modifying task parameter default values at build time.
 
 ## 0.2.2
 


### PR DESCRIPTION
It's a long story, but we want to reduce the number of moving parts related to updating Conforma in Red Hat Konflux. Being able to pin the policy bundle when building the Conforma tasks means we can reduce breakages related to old incompatible versions of the cli being used with the latest policy bundle.

See also the related PR at https://github.com/conforma/cli/pull/3268

Ref: https://redhat.atlassian.net/browse/EC-1790
