### PR TITLE
task(preflight-checks): set resources for generate-container-auth

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -162,6 +162,12 @@ spec:
         echo "Introspection concludes that this artifact is of type \"${_ARTIFACT_TYPE}\"."
 
     - name: generate-container-auth
+      resources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       env:
       - name: PARAM_IMAGE_URL


### PR DESCRIPTION
## Why
The `generate-container-auth` step in `ecosystem-cert-preflight-checks` (0.2)
had no `computeResources` defined, leaving it on cluster defaults. This PR sets
resource requests/limits based on measured P95 fleet usage across 12 production
clusters (15-day window, 5% safety margin).
## What
- `task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml`:
  Add `resources` to the `generate-container-auth` step:
  - memory request = limit = **64Mi**
  - cpu request = **50m** (no CPU limit)
This is the **only** step in the task that lacked resource definitions; all
other steps already had them. No OCI-TA variant exists for this task, so no
regeneration is required.
**No behavior change** — only resource requests/limits added.
## Follow-up
If OOM or CPU starvation is observed on outlier workloads, bump using the
Max-based recommendations from the same analyzer run (details in [KONFLUX-13032](https://redhat.atlassian.net/browse/KONFLUX-13032)).

[KONFLUX-13032]: https://redhat.atlassian.net/browse/KONFLUX-13032?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ