### PR TITLE
chore(KFLUXVNGD-960): update task bundle for rpms-signature-scan

### DIFF
--- a/external-task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
+++ b/external-task/rpms-signature-scan/0.2/rpms-signature-scan.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:2ee16a60a5ca7189f48ba71860286adbb8bc771bb33c331e03d1b3c11587202d
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:8f7f445df165eb6498cfd5f36a043670f8275fdd739f08a4accf69868dfaa821


### PR DESCRIPTION
Update the task bundle to use the latest version of the task for `rpms-signature-scan`.


