### PR TITLE
task(prefetch-dependencies-oci-ta): set resources for skip-ta step

### DIFF
--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/recipe.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/recipe.yaml
@@ -12,6 +12,12 @@ additionalSteps:
       value: $(params.input)
     - name: SOURCE_ARTIFACT
       value: $(params.SOURCE_ARTIFACT)
+    computeResources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
     script: |
       if [ -z "${INPUT}" ]; then
         mkdir -p /var/workdir/source

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -69,6 +69,12 @@ spec:
         echo -n "${SOURCE_ARTIFACT}" > $(results.SOURCE_ARTIFACT.path)
         echo -n "" > $(results.CACHI2_ARTIFACT.path)
       fi
+    computeResources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
   - image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved
     name: use-trusted-artifact
     args:

--- a/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
@@ -84,7 +84,13 @@ spec:
     - mountPath: /var/workdir
       name: workdir
   steps:
-  - env:
+  - computeResources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+    env:
     - name: INPUT
       value: $(params.input)
     - name: SOURCE_ARTIFACT

--- a/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
@@ -140,6 +140,12 @@ spec:
           echo -n "${SOURCE_ARTIFACT}" >"$(results.SOURCE_ARTIFACT.path)"
           echo -n "" >"$(results.CACHI2_ARTIFACT.path)"
         fi
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:69c9537ec111c5333ef3351e6afbe5e9ab76bc416057f2fe6675895f73c25239
       args:

--- a/task/prefetch-dependencies-oci-ta/0.3/recipe.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.3/recipe.yaml
@@ -13,6 +13,12 @@ additionalSteps:
       value: $(params.input)
     - name: SOURCE_ARTIFACT
       value: $(params.SOURCE_ARTIFACT)
+    computeResources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
     script: |
       #!/bin/bash
 


### PR DESCRIPTION
## Summary
The `skip-ta` step in `prefetch-dependencies-oci-ta` (and the
auto-generated `prefetch-dependencies-oci-ta-min` variant) had no
explicit `computeResources` block at all, leaving its memory and CPU
unbound. This PR sets the minimum floor values based on fleet-wide
analysis.
## What changed
- `task/prefetch-dependencies-oci-ta/0.3/recipe.yaml`: added
  `computeResources` for the `skip-ta` additional step (the correct
  place to make this change — the generator propagates it into the task
  YAML)
- `task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml`:
  auto-regenerated via `hack/generate-ta-tasks.sh`
- `task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml`:
  auto-regenerated via `hack/build-manifests.sh` (the oci-ta-min
  kustomize patch does not override the `skip-ta` step, so it inherits
  64Mi/50m from the oci-ta base, which is appropriate for the minimal
  variant)
- `task-generator/trusted-artifacts/golden/prefetch-dependencies/recipe.yaml`
  and `ta.yaml`: golden test files updated accordingly; all generator
  tests pass

memory: 64Mi (request = limit, per Konflux sizing policy) cpu: 50m (request only)


## Why these values

`skip-ta` is a trivial conditional step (~20 lines of bash) that simply
checks whether trusted artifacts should be skipped and, if so, writes
marker files. Fleet analysis across **110,404 pod executions** of the
`prefetch-dependencies-oci-ta` task shows:

| Metric     | Value  |
|------------|--------|
| mem_max    | 9 MiB  |
| mem_P95    | 5 MiB  |
| cpu_max    | 0m     |
| cpu_P95    | 0m     |

`64Mi` is the standard Konflux minimum floor for memory. The 50m CPU
request is the minimum floor, ensuring the scheduler has a non-zero
resource hint for placement.

## What was NOT changed and why

| Step                    | Current       | Analysis says   | Decision                                      |
|-------------------------|---------------|-----------------|-----------------------------------------------|
| `prefetch-dependencies` | 3Gi / 1 CPU   | P95 → 3Gi / 500m | Memory already correct (confirmed by oci-ta P95 = 1,986 MiB). CPU limit intentionally kept — an existing code comment documents that removing the CPU limit causes abnormally high memory consumption (OOM) on Go backends (set in #1763). |
| `create-trusted-artifact` | 3Gi / 1 CPU | P95 → 832Mi / 750m | Max usage reaches 5,289 MiB (heavy-tail ratio 7.15×). Reducing from 3Gi would OOM large workloads. CPU reduction is marginal (1000m→750m) and would require modifying `ta.go` affecting all oci-ta tasks. |
| `use-trusted-artifact`  | (not set)     | P95 → 256Mi / 150m | Deferred to sfowl's open PR #3405 which sets 4Gi consistently across all tasks. |

## Data note

The base `prefetch-dependencies` task had only **361 pod executions**
across 6 clusters in the analysis window, with partial coverage on all.
The `prefetch-dependencies-oci-ta` task had **110,404 executions** across
10 clusters — 306× more data — making the oci-ta fleet data the more
reliable signal for sizing the shared `prefetch-dependencies` step in
both variants.

## Related

- Jira: https://redhat.atlassian.net/browse/KONFLUX-13052
- sfowl's `use-trusted-artifact` resources PR: #3405
- Original resource sizing PR for this task: #1763
