### PR TITLE
fix(preflight): fail step on skopeo manifest fetch error

### DIFF
--- a/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
+++ b/task/ecosystem-cert-preflight-checks/0.2/ecosystem-cert-preflight-checks.yaml
@@ -380,8 +380,9 @@ spec:
           fi
         done < <(find /artifacts -type f -name "cert-image.json")
 
-        image_digest=$(retry skopeo inspect --raw --retry-times "$skopeo_retries" "docker://${PARAM_IMAGE_URL}" | sha256sum | awk '{print "sha256:" $1}')
-        if [[ -n "$image_digest" && ! " ${digests_processed[*]} " == *" \"$image_digest\" "* ]]; then
+        retry skopeo inspect --raw --retry-times "$skopeo_retries" "docker://${PARAM_IMAGE_URL}" > /tmp/raw-manifest.json
+        image_digest="sha256:$(sha256sum < /tmp/raw-manifest.json | awk '{print $1}')"
+        if [[ ! " ${digests_processed[*]} " == *" \"$image_digest\" "* ]]; then
           digests_processed+=("\"$image_digest\"")
         fi
 


### PR DESCRIPTION
The skopeo call that fetches the raw manifest to compute the image digest was wrapped in a variable assignment, which silently swallows non-zero exit codes even with `set -o errexit`. When skopeo failed transiently, sha256sum would hash empty input and produce a wrong digest. This caused downstream policy violations where the image digest appeared missing from the IMAGES_PROCESSED result.

Move the skopeo call to a standalone command with a file redirect so errexit can catch failures.

Ref: https://issues.redhat.com/browse/EC-1760
