### PR TITLE
task(build-vm-image): set resources for all steps

### DIFF
--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -83,11 +83,23 @@ spec:
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:77563b5fb4b82f9b6a47070ba06e60486567d34e03ea60cd5169be0be53ad5dc
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: validate-bib-config
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       script: |-
         #!/bin/bash
         set -o verbose
@@ -133,7 +145,7 @@ spec:
       image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
       computeResources:
         limits:
-          memory: 512Mi
+          memory: 128Mi
         requests:
           cpu: 250m
           memory: 128Mi


### PR DESCRIPTION
## Summary

Three resource issues existed in `build-vm-image.yaml`:

1. `use-trusted-artifact` — no `computeResources` defined (fully unbound)
2. `validate-bib-config` — no `computeResources` defined (fully unbound)
3. `build` — asymmetric configuration (`limits.memory: 512Mi` !=
   `requests.memory: 128Mi`), violating the Konflux sizing policy
   (`mem.request = mem.limit`)

This PR addresses all three.

## What changed

| Step | Before | After |
|---|---|---|
| `use-trusted-artifact` | *(not set)* | `mem: 64Mi (req=limit), cpu: 50m (req)` |
| `validate-bib-config` | *(not set)* | `mem: 64Mi (req=limit), cpu: 50m (req)` |
| `build` | `limit: 512Mi / request: 128Mi / cpu: 250m` | `limit: 128Mi / request: 128Mi / cpu: 250m` |

Only `task/build-vm-image/0.1/build-vm-image.yaml` is modified
directly — there is no OCI-TA variant, no `recipe.yaml`, and no
generated files for this task.

## Why these values

Fleet-wide analysis (P95 + 5% margin) across **166 pod executions**
from 2 clusters (May 2026):

| Step | mem_max | mem_P95 | cpu_max | cpu_P95 | K8s rec |
|---|---|---|---|---|---|
| `use-trusted-artifact` | 1 MiB | 1 MiB | 0m | 0m | 64Mi / 50m |
| `validate-bib-config` | 1 MiB | 1 MiB | 0m | 0m | 64Mi / 50m |
| `build` | 16 MiB | 15 MiB | 2m | 1m | 64Mi / 50m |

`64Mi` and `50m` are the standard Konflux minimum floor values and are
appropriate for the two lightweight steps.

## Rationale for build step: 128Mi rather than 64Mi

The raw P95 recommendation for `build` is 64Mi (floor), but the
analysis window is short — the primary cluster had only **1.6 days**
of coverage with 105 pods. The `build` step orchestrates a
`bootc-image-builder` VM image build, which can exhibit unpredictable
memory spikes not captured in such a limited window. Retaining the
current request of `128Mi` (and aligning the limit to match it) is
the conservative, policy-compliant choice that avoids OOM risk on
heavier builds.

The CPU request of `250m` is unchanged — it is already well above the
observed max (2m) and provides sufficient scheduling headroom for
burst activity.

## Note on use-trusted-artifact

This task's `use-trusted-artifact` step is hand-embedded (not a
generated OCI-TA variant), so it is **not** covered by sfowl's open
PR [#3405](https://github.com/konflux-ci/build-definitions/pull/3405)
which only applies to generated `-oci-ta` tasks. The floor value of
64Mi / 50m is set here independently.

## Related

- Jira: https://redhat.atlassian.net/browse/KONFLUX-13030
- Fleet analysis tool: `analyze_resource_limits.py` (P95 + 5% margin,
  15-day window, May 2026)
- `use-trusted-artifact` resources for oci-ta tasks: PR
  [#3405](https://github.com/konflux-ci/build-definitions/pull/3405)

---
Assisted-by: CursorAI