### PR TITLE
add source artifact for snyk scans

### DIFF
--- a/task/oci-copy-oci-ta/0.2/README.md
+++ b/task/oci-copy-oci-ta/0.2/README.md
@@ -9,6 +9,7 @@ Copy content from arbitrary urls into the OCI registry. Downloads and pushes fil
 |AWS_SECRET_NAME|Name of a secret which will be made available to the build for downloading from Amazon S3 or S3-compatible storage using AWS CLI with parallel multipart transfers. If specified, this will take precedence over BEARER_TOKEN_SECRET_NAME. The secret must contain two keys: `aws_access_key_id` and `aws_secret_access_key`.|does-not-exist|false|
 |BEARER_TOKEN_SECRET_NAME|Name of a secret which will be made available to the build as an Authorization header. Note, the token will be sent to all servers found in the oci-copy.yaml file. If you do not wish to send the token to all servers, different taskruns and therefore different oci artifacts must be used.|does-not-exist|false|
 |IMAGE|Reference of the image we will push||true|
+|IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |OCI_COPY_FILE|Path to the oci copy file.|./oci-copy.yaml|false|
 |PARALLEL_JOBS|Number of files to download/push in parallel.|8|false|
 |SBOM_TYPE|Select the SBOM format to generate. Valid values: spdx, cyclonedx.|spdx|false|

--- a/task/oci-copy-oci-ta/0.2/README.md
+++ b/task/oci-copy-oci-ta/0.2/README.md
@@ -21,6 +21,7 @@ Copy content from arbitrary urls into the OCI registry. Downloads and pushes fil
 |IMAGE_REF|Image reference of the built image|
 |IMAGE_URL|Repository where the artifact was pushed|
 |SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to downloaded model files.|
 
 
 ## Additional info

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -33,6 +33,12 @@ spec:
     - name: IMAGE
       description: Reference of the image we will push
       type: string
+    - name: IMAGE_EXPIRES_AFTER
+      description: Delete image tag after specified time. Empty means to keep
+        the image tag. Time values could be something like 1h, 2d, 3w for
+        hours, days, and weeks, respectively.
+      type: string
+      default: ""
     - name: OCI_COPY_FILE
       description: Path to the oci copy file.
       type: string

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -57,10 +57,10 @@ spec:
       description: Image reference of the built image
     - name: IMAGE_URL
       description: Repository where the artifact was pushed
-    - name: SOURCE_ARTIFACT
-      description: The Trusted Artifact URI pointing to downloaded model files.
     - name: SBOM_BLOB_URL
       description: Link to the SBOM blob pushed to the registry.
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to downloaded model files.
   volumes:
     - name: varlibcontainers
       emptyDir: {}
@@ -81,7 +81,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4f97e1f367f2b79afaceb1606f4b9b9f2b10afb21577a552f3e743154917dda8
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -155,8 +155,6 @@ spec:
         # Use NVMe-backed emptyDir for downloads (faster than workspace PVC)
         export DOWNLOAD_DIR="/var/lib/containers/downloads"
         mkdir -p "$DOWNLOAD_DIR"
-        export MODEL_SOURCE_DIR="/var/workdir/model-source"
-        mkdir -p "$MODEL_SOURCE_DIR"
 
         # Configure AWS CLI once (avoid race condition in parallel downloads)
         mkdir -p ~/.aws
@@ -191,9 +189,6 @@ spec:
             echo "[DL] ERROR: Checksum mismatch for ${OCI_FILENAME}"
             exit 1
           fi
-          # Preserve a copy for trusted-artifact creation used by downstream scans.
-          mkdir -p "$(dirname "${MODEL_SOURCE_DIR}/${OCI_FILENAME}")"
-          cp "$dlpath" "${MODEL_SOURCE_DIR}/${OCI_FILENAME}"
           echo "[DL] Downloaded ${OCI_FILENAME} [OK]"
         }
 
@@ -540,6 +535,34 @@ spec:
         capabilities:
           add:
             - SETFCAP
+    - name: populate-model-source
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      workingDir: /var/workdir
+      script: |
+        #!/bin/bash
+        set -euo pipefail
+
+        mkdir -p /var/workdir/model-source
+        select-oci-auth "${IMAGE}" >auth.json
+        REPO=${IMAGE%:*}
+
+        shopt -s nullglob
+        varfiles=(/var/workdir/vars/*)
+        shopt -u nullglob
+
+        if [ "${#varfiles[@]}" -eq 0 ]; then
+          echo "No artifacts to include in SOURCE_ARTIFACT"
+          exit 0
+        fi
+
+        for varfile in "${varfiles[@]}"; do
+          # shellcheck source=/dev/null
+          source "$varfile"
+          output_path="/var/workdir/model-source/${OCI_FILENAME}"
+          mkdir -p "$(dirname "${output_path}")"
+          retry oras blob fetch --registry-config auth.json "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}" >"${output_path}"
+          echo "${OCI_ARTIFACT_DIGEST}  ${output_path}" | sha256sum --check --quiet
+        done
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
       args:

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -57,6 +57,8 @@ spec:
       description: Image reference of the built image
     - name: IMAGE_URL
       description: Repository where the artifact was pushed
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to downloaded model files.
     - name: SBOM_BLOB_URL
       description: Link to the SBOM blob pushed to the registry.
   volumes:
@@ -153,6 +155,8 @@ spec:
         # Use NVMe-backed emptyDir for downloads (faster than workspace PVC)
         export DOWNLOAD_DIR="/var/lib/containers/downloads"
         mkdir -p "$DOWNLOAD_DIR"
+        export MODEL_SOURCE_DIR="/var/workdir/model-source"
+        mkdir -p "$MODEL_SOURCE_DIR"
 
         # Configure AWS CLI once (avoid race condition in parallel downloads)
         mkdir -p ~/.aws
@@ -187,6 +191,9 @@ spec:
             echo "[DL] ERROR: Checksum mismatch for ${OCI_FILENAME}"
             exit 1
           fi
+          # Preserve a copy for trusted-artifact creation used by downstream scans.
+          mkdir -p "$(dirname "${MODEL_SOURCE_DIR}/${OCI_FILENAME}")"
+          cp "$dlpath" "${MODEL_SOURCE_DIR}/${OCI_FILENAME}"
           echo "[DL] Downloaded ${OCI_FILENAME} [OK]"
         }
 
@@ -533,6 +540,22 @@ spec:
         capabilities:
           add:
             - SETFCAP
+    - name: create-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
+      args:
+        - create
+        - --store
+        - $(params.IMAGE).source
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/model-source
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.IMAGE_EXPIRES_AFTER)
+      computeResources:
+        limits:
+          memory: 4Gi
+        requests:
+          cpu: "2"
+          memory: 4Gi
     - name: sbom-generate
       image: quay.io/konflux-ci/mobster:1.2.0-1774868067@sha256:2e00c2f0aeff55713150b51822013327ea0e0d75b8164a52f837fb297c17703d
       workingDir: /var/workdir

--- a/task/oci-copy-oci-ta/0.2/recipe.yaml
+++ b/task/oci-copy-oci-ta/0.2/recipe.yaml
@@ -2,6 +2,56 @@
 base: ../../oci-copy/0.2/oci-copy.yaml
 add:
   - use-source
+addResult:
+  - name: SOURCE_ARTIFACT
+    description: The Trusted Artifact URI pointing to downloaded model files.
+additionalSteps:
+  - at: 3
+    name: populate-model-source
+    image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+    workingDir: /var/workdir
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+
+      mkdir -p /var/workdir/model-source
+      select-oci-auth "${IMAGE}" >auth.json
+      REPO=${IMAGE%:*}
+
+      shopt -s nullglob
+      varfiles=(/var/workdir/vars/*)
+      shopt -u nullglob
+
+      if [ "${#varfiles[@]}" -eq 0 ]; then
+        echo "No artifacts to include in SOURCE_ARTIFACT"
+        exit 0
+      fi
+
+      for varfile in "${varfiles[@]}"; do
+        # shellcheck source=/dev/null
+        source "$varfile"
+        output_path="/var/workdir/model-source/${OCI_FILENAME}"
+        mkdir -p "$(dirname "${output_path}")"
+        retry oras blob fetch --registry-config auth.json "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}" >"${output_path}"
+        echo "${OCI_ARTIFACT_DIGEST}  ${output_path}" | sha256sum --check --quiet
+      done
+  - at: 4
+    name: create-trusted-artifact
+    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
+    args:
+      - create
+      - --store
+      - $(params.IMAGE).source
+      - $(results.SOURCE_ARTIFACT.path)=/var/workdir/model-source
+    env:
+      - name: IMAGE_EXPIRES_AFTER
+        value: $(params.IMAGE_EXPIRES_AFTER)
+    computeResources:
+      limits:
+        memory: 4Gi
+      requests:
+        cpu: "2"
+        memory: 4Gi
 removeWorkspaces:
   - source
 replacements:

--- a/task/oci-copy-oci-ta/0.2/recipe.yaml
+++ b/task/oci-copy-oci-ta/0.2/recipe.yaml
@@ -2,6 +2,13 @@
 base: ../../oci-copy/0.2/oci-copy.yaml
 add:
   - use-source
+addParams:
+  - name: IMAGE_EXPIRES_AFTER
+    description: Delete image tag after specified time. Empty means to keep
+      the image tag. Time values could be something like 1h, 2d, 3w for
+      hours, days, and weeks, respectively.
+    type: string
+    default: ""
 addResult:
   - name: SOURCE_ARTIFACT
     description: The Trusted Artifact URI pointing to downloaded model files.


### PR DESCRIPTION
oci-copy-oci-ta: emit downloaded-model SOURCE_ARTIFACT for downstream Snyk scans.

## Summary

- Update `build-definitions/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml` so the task produces a new `SOURCE_ARTIFACT` result that points to downloaded model files.

- Preserve existing oci-copy behavior and performance characteristics by keeping downloads in /var/lib/containers/downloads, while copying verified files to /var/workdir/model-source for trusted-artifact creation.

- Add a create-trusted-artifact step that publishes /var/workdir/model-source and writes the resulting URI to $(results.SOURCE_ARTIFACT.path).

- Align create-trusted-artifact computeResources with oci-copy.

## Why

- sast-snyk-check should scan the files actually downloaded by oci-copy.

- This change enables downstream tasks to consume a trusted artifact representing those downloaded model files without significantly altering existing oci-copy flow.