### PR TITLE
fix(init): add migration to remove invalid sast-target-dirs param fro…

### DIFF
--- a/task/init/0.4/MIGRATION.md
+++ b/task/init/0.4/MIGRATION.md
@@ -5,3 +5,7 @@ No action required from users. Task started using konflux build cli instead of b
 ## Migration from 0.4 to 0.4.1
 
 Pipeline upgrade: Add `sast-target-dirs` pipeline-level parameter and wire it to SAST tasks (`sast-snyk-check`, `sast-shell-check`, `sast-unicode-check`, `sast-coverity-check` and their OCI-TA variants) as `TARGET_DIRS`.
+
+## Migration from 0.4.1 to 0.4.2
+
+Pipeline upgrade: Remove faulty paramter `sast-target-dirs` from `spec.params`. It contains invalid attributes from previous automatic updates and prevents pipeline runs to run. 

--- a/task/init/0.4/init.yaml
+++ b/task/init/0.4/init.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.4.1"
+    app.kubernetes.io/version: "0.4.2"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"

--- a/task/init/0.4/migrations/0.4.2.sh
+++ b/task/init/0.4/migrations/0.4.2.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Created for task: init@0.4.2
+# Creation time: 2026-05-07T00:00:00+00:00
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+if [[ "$(yq '.kind' "$pipeline_file")" != "PipelineRun" ]]; then
+    echo "Not a PipelineRun, skipping migration"
+    exit 0
+fi
+
+if ! yq -e '.spec.params[] | select(.name == "sast-target-dirs")' "$pipeline_file" >/dev/null 2>&1; then
+    echo "No sast-target-dirs parameter found in spec.params, skipping migration"
+    exit 0
+fi
+
+if yq -e '.spec.params[] | select(.name == "sast-target-dirs") | has("value")' "$pipeline_file" 2>/dev/null | grep -q true; then
+    echo "sast-target-dirs parameter in spec.params has a value, most likely already fixed, no update needed"
+    exit 0
+fi
+
+echo "Removing sast-target-dirs parameter from spec.params (no value attribute)"
+pmt_path=$(yq '.spec.params[] | select(.name == "sast-target-dirs") | path | tojson' "$pipeline_file")
+pmt modify -f "$pipeline_file" generic remove "$pmt_path"

--- a/task/init/CHANGELOG.md
+++ b/task/init/CHANGELOG.md
@@ -9,6 +9,10 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.4.2
+
+- Pipeline upgrade: Remove PipelineRun parameter `sast-target-dirs` with invalid attributes from PipelineRun `.spec.params` definition
+
 ## 0.4.1
 
 - Pipeline upgrade: Promote `TARGET_DIRS` parameter from SAST task level to pipeline level as `sast-target-dirs`


### PR DESCRIPTION
…m spec.params

The 0.4.1 migration could produce a sast-target-dirs entry in spec.params with type/default/description attributes, which are invalid for PipelineRun spec.params and prevent pipeline runs.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
