### PR TITLE
task(operator-sdk-generate-bundle): set floor resources for the step

### DIFF
--- a/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
+++ b/task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml
@@ -43,6 +43,12 @@ spec:
       workingDir: $(workspaces.source.path)/source
       securityContext:
         runAsUser: 0
+      resources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       env:
         - name: CHANNELS
           value: $(params.channels)


### PR DESCRIPTION
## Summary

The single step `operator-sdk-generate-bundle` had no `resources` block defined (this task uses `apiVersion: tekton.dev/v1beta1`, so the field is `resources:` rather than `computeResources:`), leaving memory and CPU entirely unbound.

## What changed

| Step | Before | After |
|---|---|---|
| `operator-sdk-generate-bundle` | _(not set)_ | mem: 64Mi (req=limit), cpu: 50m (req only) |

Only `task/operator-sdk-generate-bundle/0.1/operator-sdk-generate-bundle.yaml` is modified — there is no OCI-TA variant and no generated files for this task.

## Why these values — no fleet data available

Fleet-wide analysis was run across all **11 Konflux clusters** with a **15-day window** (May 2026) using the `analyze_resource_limits.py` tool:

```
Task: operator-sdk-generate-bundle
Steps: operator-sdk-generate-bundle
Days: 15

Error: No data from detailed collection (no pods or no metrics).
```

`operator-sdk-generate-bundle` is a niche OLM bundle-generation task that has not accumulated observable pod metrics in the current analysis window. With no execution data to guide sizing, the **Konflux minimum floor values** are applied:

- `memory: 64Mi` (request = limit, per Konflux sizing policy)
- `cpu: 50m` (request only — no CPU limit, per policy)

This is consistent with the floor values applied to other lightweight or no-data steps across the fleet (e.g. `use-trusted-artifact`, `validate-bib-config`, `skip-ta` in recent PRs).

## Important note — revisit if OOM is observed

These are conservative placeholder values based on zero observed data. **If this task sees wider adoption and OOM events are encountered, the `resources` block should be revisited** using a fresh fleet analysis to replace the floor values with data-backed ones.

## Related

- Jira: https://redhat.atlassian.net/browse/KONFLUX-13046
- Fleet analysis tool: `analyze_resource_limits.py` (15-day window, May 2026)
- Epic: https://redhat.atlassian.net/browse/KONFLUX-11509

---

Assisted-by: CursorAI

Made with [Cursor](https://cursor.com)