### PR TITLE
fix: validate base image architecture before build

### DIFF
--- a/task/buildah-min/0.9/buildah-min.yaml
+++ b/task/buildah-min/0.9/buildah-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.9.3
+    app.kubernetes.io/version: 0.9.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-min
 spec:

--- a/task/buildah-min/0.9/buildah-min.yaml
+++ b/task/buildah-min/0.9/buildah-min.yaml
@@ -539,26 +539,47 @@ spec:
             tr -d "'"
       )
 
+      echo "[$(date --utc -Ins)] Validate base image architectures"
+
+      host_arch=$(uname -m)
+      case "$host_arch" in
+        x86_64)  oci_arch="amd64" ;;
+        aarch64) oci_arch="arm64" ;;
+        *)       oci_arch="$host_arch" ;;
+      esac
+
+      set_proxy
+
+      # Pull each base image and verify its architecture matches the host, prevents building via emulation
+      # Pulled images are then reused when calling buildah build
+      buildah_retries=3
+      for image in $BASE_IMAGES; do
+        if ! retry buildah pull --retry "$buildah_retries" "$image"; then
+          echo "ERROR: Failed to pull base image ${image}" >&2
+          exit 1
+        fi
+
+        if ! image_arch=$(buildah inspect --type=image --format '{{.OCIv1.Architecture}}' "$image"); then
+          echo "ERROR: Failed to inspect base image ${image}" >&2
+          exit 1
+        fi
+
+        # If the image was an index without the correct arch, buildah pull would have already
+        # failed above. This check catches single-arch references.
+        if [ "$image_arch" != "$oci_arch" ]; then
+          echo "ERROR: Base image ${image} has architecture '${image_arch}', expected '${oci_arch}'. Use a multi-arch image reference instead of a single-architecture digest." >&2
+          exit 1
+        fi
+      done
+
+      unset_proxy
+
       BUILDAH_ARGS=()
       UNSHARE_ARGS=()
 
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS+=("--net")
-        buildah_retries=3
-
-        set_proxy
-
-        for image in $BASE_IMAGES; do
-          if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"
-          then
-            echo "Failed to pull base image ${image}"
-            exit 1
-          fi
-        done
-
-        unset_proxy
-
         echo "Build will be executed with network isolation"
       fi
 

--- a/task/buildah-min/CHANGELOG.md
+++ b/task/buildah-min/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.9.4
+
+### Fixed
+
+- Validate base image architecture before build. The task now fails if a base image
+  doesn't match the host architecture, preventing silent emulation builds.
+
 ## 0.9.3
 
 ### Fixed

--- a/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
@@ -574,25 +574,47 @@ spec:
           tr -d "'"
       )
 
+      echo "[$(date --utc -Ins)] Validate base image architectures"
+
+      host_arch=$(uname -m)
+      case "$host_arch" in
+      x86_64) oci_arch="amd64" ;;
+      aarch64) oci_arch="arm64" ;;
+      *) oci_arch="$host_arch" ;;
+      esac
+
+      set_proxy
+
+      # Pull each base image and verify its architecture matches the host, prevents building via emulation
+      # Pulled images are then reused when calling buildah build
+      buildah_retries=3
+      for image in $BASE_IMAGES; do
+        if ! retry buildah pull --retry "$buildah_retries" "$image"; then
+          echo "ERROR: Failed to pull base image ${image}" >&2
+          exit 1
+        fi
+
+        if ! image_arch=$(buildah inspect --type=image --format '{{.OCIv1.Architecture}}' "$image"); then
+          echo "ERROR: Failed to inspect base image ${image}" >&2
+          exit 1
+        fi
+
+        # If the image was an index without the correct arch, buildah pull would have already
+        # failed above. This check catches single-arch references.
+        if [ "$image_arch" != "$oci_arch" ]; then
+          echo "ERROR: Base image ${image} has architecture '${image_arch}', expected '${oci_arch}'. Use a multi-arch image reference instead of a single-architecture digest." >&2
+          exit 1
+        fi
+      done
+
+      unset_proxy
+
       BUILDAH_ARGS=()
       UNSHARE_ARGS=()
 
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS+=("--net")
-        buildah_retries=3
-
-        set_proxy
-
-        for image in $BASE_IMAGES; do
-          if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"; then
-            echo "Failed to pull base image ${image}"
-            exit 1
-          fi
-        done
-
-        unset_proxy
-
         echo "Build will be executed with network isolation"
       fi
 

--- a/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.9/buildah-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.9.3
+    app.kubernetes.io/version: 0.9.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-oci-ta-min
 spec:

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.9.4
+
+### Fixed
+
+- Validate base image architecture before build. The task now fails if a base image
+  doesn't match the host architecture, preventing silent emulation builds.
+
 ## 0.9.3
 
 ### Fixed

--- a/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
@@ -632,25 +632,47 @@ spec:
             tr -d "'"
         )
 
+        echo "[$(date --utc -Ins)] Validate base image architectures"
+
+        host_arch=$(uname -m)
+        case "$host_arch" in
+        x86_64) oci_arch="amd64" ;;
+        aarch64) oci_arch="arm64" ;;
+        *) oci_arch="$host_arch" ;;
+        esac
+
+        set_proxy
+
+        # Pull each base image and verify its architecture matches the host, prevents building via emulation
+        # Pulled images are then reused when calling buildah build
+        buildah_retries=3
+        for image in $BASE_IMAGES; do
+          if ! retry buildah pull --retry "$buildah_retries" "$image"; then
+            echo "ERROR: Failed to pull base image ${image}" >&2
+            exit 1
+          fi
+
+          if ! image_arch=$(buildah inspect --type=image --format '{{.OCIv1.Architecture}}' "$image"); then
+            echo "ERROR: Failed to inspect base image ${image}" >&2
+            exit 1
+          fi
+
+          # If the image was an index without the correct arch, buildah pull would have already
+          # failed above. This check catches single-arch references.
+          if [ "$image_arch" != "$oci_arch" ]; then
+            echo "ERROR: Base image ${image} has architecture '${image_arch}', expected '${oci_arch}'. Use a multi-arch image reference instead of a single-architecture digest." >&2
+            exit 1
+          fi
+        done
+
+        unset_proxy
+
         BUILDAH_ARGS=()
         UNSHARE_ARGS=()
 
         if [ "${HERMETIC}" == "true" ]; then
           BUILDAH_ARGS+=("--pull=never")
           UNSHARE_ARGS+=("--net")
-          buildah_retries=3
-
-          set_proxy
-
-          for image in $BASE_IMAGES; do
-            if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"; then
-              echo "Failed to pull base image ${image}"
-              exit 1
-            fi
-          done
-
-          unset_proxy
-
           echo "Build will be executed with network isolation"
         fi
 

--- a/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.9.3
+    app.kubernetes.io/version: 0.9.4
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.9.4
+
+### Fixed
+
+- Validate base image architecture before build. The task now fails if a base image
+  doesn't match the host architecture, preventing silent emulation builds.
+
 ## 0.9.3
 
 ### Fixed

--- a/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
@@ -659,25 +659,47 @@ spec:
           tr -d "'"
       )
 
+      echo "[$(date --utc -Ins)] Validate base image architectures"
+
+      host_arch=$(uname -m)
+      case "$host_arch" in
+      x86_64) oci_arch="amd64" ;;
+      aarch64) oci_arch="arm64" ;;
+      *) oci_arch="$host_arch" ;;
+      esac
+
+      set_proxy
+
+      # Pull each base image and verify its architecture matches the host, prevents building via emulation
+      # Pulled images are then reused when calling buildah build
+      buildah_retries=3
+      for image in $BASE_IMAGES; do
+        if ! retry buildah pull --retry "$buildah_retries" "$image"; then
+          echo "ERROR: Failed to pull base image ${image}" >&2
+          exit 1
+        fi
+
+        if ! image_arch=$(buildah inspect --type=image --format '{{.OCIv1.Architecture}}' "$image"); then
+          echo "ERROR: Failed to inspect base image ${image}" >&2
+          exit 1
+        fi
+
+        # If the image was an index without the correct arch, buildah pull would have already
+        # failed above. This check catches single-arch references.
+        if [ "$image_arch" != "$oci_arch" ]; then
+          echo "ERROR: Base image ${image} has architecture '${image_arch}', expected '${oci_arch}'. Use a multi-arch image reference instead of a single-architecture digest." >&2
+          exit 1
+        fi
+      done
+
+      unset_proxy
+
       BUILDAH_ARGS=()
       UNSHARE_ARGS=()
 
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS+=("--net")
-        buildah_retries=3
-
-        set_proxy
-
-        for image in $BASE_IMAGES; do
-          if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"; then
-            echo "Failed to pull base image ${image}"
-            exit 1
-          fi
-        done
-
-        unset_proxy
-
         echo "Build will be executed with network isolation"
       fi
 

--- a/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.9.3
+    app.kubernetes.io/version: 0.9.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.9.4
+
+### Fixed
+
+- Validate base image architecture before build. The task now fails if a base image
+  doesn't match the host architecture, preventing silent emulation builds.
+
 ## 0.9.3
 
 ### Fixed

--- a/task/buildah-remote/0.9/buildah-remote.yaml
+++ b/task/buildah-remote/0.9/buildah-remote.yaml
@@ -624,26 +624,47 @@ spec:
             tr -d "'"
       )
 
+      echo "[$(date --utc -Ins)] Validate base image architectures"
+
+      host_arch=$(uname -m)
+      case "$host_arch" in
+        x86_64)  oci_arch="amd64" ;;
+        aarch64) oci_arch="arm64" ;;
+        *)       oci_arch="$host_arch" ;;
+      esac
+
+      set_proxy
+
+      # Pull each base image and verify its architecture matches the host, prevents building via emulation
+      # Pulled images are then reused when calling buildah build
+      buildah_retries=3
+      for image in $BASE_IMAGES; do
+        if ! retry buildah pull --retry "$buildah_retries" "$image"; then
+          echo "ERROR: Failed to pull base image ${image}" >&2
+          exit 1
+        fi
+
+        if ! image_arch=$(buildah inspect --type=image --format '{{.OCIv1.Architecture}}' "$image"); then
+          echo "ERROR: Failed to inspect base image ${image}" >&2
+          exit 1
+        fi
+
+        # If the image was an index without the correct arch, buildah pull would have already
+        # failed above. This check catches single-arch references.
+        if [ "$image_arch" != "$oci_arch" ]; then
+          echo "ERROR: Base image ${image} has architecture '${image_arch}', expected '${oci_arch}'. Use a multi-arch image reference instead of a single-architecture digest." >&2
+          exit 1
+        fi
+      done
+
+      unset_proxy
+
       BUILDAH_ARGS=()
       UNSHARE_ARGS=()
 
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS+=("--net")
-        buildah_retries=3
-
-        set_proxy
-
-        for image in $BASE_IMAGES; do
-          if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"
-          then
-            echo "Failed to pull base image ${image}"
-            exit 1
-          fi
-        done
-
-        unset_proxy
-
         echo "Build will be executed with network isolation"
       fi
 

--- a/task/buildah-remote/0.9/buildah-remote.yaml
+++ b/task/buildah-remote/0.9/buildah-remote.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.9.3
+    app.kubernetes.io/version: 0.9.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.9.4
+
+### Fixed
+
+- Validate base image architecture before build. The task now fails if a base image
+  doesn't match the host architecture, preventing silent emulation builds.
+
 ## 0.9.3
 
 ### Fixed

--- a/task/buildah/0.9/buildah.yaml
+++ b/task/buildah/0.9/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.9.3"
+    app.kubernetes.io/version: "0.9.4"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"

--- a/task/buildah/0.9/buildah.yaml
+++ b/task/buildah/0.9/buildah.yaml
@@ -528,26 +528,47 @@ spec:
             tr -d "'"
       )
 
+      echo "[$(date --utc -Ins)] Validate base image architectures"
+
+      host_arch=$(uname -m)
+      case "$host_arch" in
+        x86_64)  oci_arch="amd64" ;;
+        aarch64) oci_arch="arm64" ;;
+        *)       oci_arch="$host_arch" ;;
+      esac
+
+      set_proxy
+
+      # Pull each base image and verify its architecture matches the host, prevents building via emulation
+      # Pulled images are then reused when calling buildah build
+      buildah_retries=3
+      for image in $BASE_IMAGES; do
+        if ! retry buildah pull --retry "$buildah_retries" "$image"; then
+          echo "ERROR: Failed to pull base image ${image}" >&2
+          exit 1
+        fi
+
+        if ! image_arch=$(buildah inspect --type=image --format '{{.OCIv1.Architecture}}' "$image"); then
+          echo "ERROR: Failed to inspect base image ${image}" >&2
+          exit 1
+        fi
+
+        # If the image was an index without the correct arch, buildah pull would have already
+        # failed above. This check catches single-arch references.
+        if [ "$image_arch" != "$oci_arch" ]; then
+          echo "ERROR: Base image ${image} has architecture '${image_arch}', expected '${oci_arch}'. Use a multi-arch image reference instead of a single-architecture digest." >&2
+          exit 1
+        fi
+      done
+
+      unset_proxy
+
       BUILDAH_ARGS=()
       UNSHARE_ARGS=()
 
       if [ "${HERMETIC}" == "true" ]; then
         BUILDAH_ARGS+=("--pull=never")
         UNSHARE_ARGS+=("--net")
-        buildah_retries=3
-
-        set_proxy
-
-        for image in $BASE_IMAGES; do
-          if ! retry unshare -Ufp --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 --mount -- buildah pull --retry "$buildah_retries" "$image"
-          then
-            echo "Failed to pull base image ${image}"
-            exit 1
-          fi
-        done
-
-        unset_proxy
-
         echo "Build will be executed with network isolation"
       fi
 

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.9.4
+
+### Fixed
+
+- Validate base image architecture before build. The task now fails if a base image
+  doesn't match the host architecture, preventing silent emulation builds.
+
 ## 0.9.3
 
 ### Fixed


### PR DESCRIPTION
When a base image is pinned by a single-arch digest (e.g. amd64), buildah pulls the manifest regardless of the host architecture and builds the image via emulation. Not only is it against the RH policy, but the resulting image-index contains manifests of the same architecture.

We must fail in this scenario. I've implemented the check after pulling the image, but before build. I've considered using skopeo instead of buildah pull+inspect, but the only benefit is that we would fail before pulling an image. Since konflux-build-cli already implements pre-pull logic regardless if it's a non-/hermetic build, this approach is simpler. Moreover, the bug doesn't happen that often, so failing a little later is a trade-off between user experience and simplicity/maintainability.

I've also removed the unshare flags from the hermetic pre-pulling, since it's redundant.

## Validation
Tested on staging — no regressions observed.
Staging PR: https://github.com/fmudry-konflux/devfile-sample-python-basic/pull/20
(you can focus only on the comments, the following commits are just more test)

## Risk Assessment
**Risk Level:** Low
**Description:** fail builds done via emulation
**Rollback:** Revert PR and redeploy the task
