### PR TITLE
fix: update fips stepaction

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -21,7 +21,7 @@ spec:
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.
-  image: quay.io/konflux-ci/konflux-test:v1.4.50@sha256:8b9c7be18bef49f60ac9926830174072cc2010c620c7b3d0a5bb53ba02fcf71d
+  image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:bb064cb9056dbcf43f499442a4589df53b2246c7f65b946ea1f4aac64e509c34
   securityContext:
     capabilities:
       add:


### PR DESCRIPTION
Updated fips stepaction to use konflux-test:v1.5.0 with check-payload 0.3.14.

Closes: [KFLUXSPRT-7801](https://redhat.atlassian.net/browse/KFLUXSPRT-7801)


[KFLUXSPRT-7801]: https://redhat.atlassian.net/browse/KFLUXSPRT-7801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ