### PR TITLE
Update git-clone to use konflux-build-cli

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -5,7 +5,7 @@ metadata:
   name: build-definitions-pull-request
   annotations:
     pipelinesascode.tekton.dev/on-cel-expression: (event == "pull_request" && target_branch == "main" && ( !has(body.pull_request) || !body.pull_request.draft) ) || (event == "push" && target_branch.startsWith("gh-readonly-queue/main/") && body.head_commit != "null" )
-    pipelinesascode.tekton.dev/task: "[task/git-clone/0.1/git-clone.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, .tekton/tasks/task-switchboard.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/git-clone/0.2/git-clone.yaml, .tekton/tasks/task-lint.yaml, .tekton/tasks/e2e-test.yaml, .tekton/tasks/task-switchboard.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-event: "push"
     pipelinesascode.tekton.dev/on-target-branch: "main"
-    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.2/git-clone.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:

--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -191,7 +191,7 @@ spec:
     - init
     taskRef:
       name: git-clone
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: output
       workspace: workspace

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -16,14 +16,14 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.10:DOCKERFILE ; push-dockerfile:0.3:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
 |hermetic| Execute the build with network isolation| false| build-images:0.10:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.10:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-images:0.10:IMAGE ; build-image-index:0.3:IMAGE|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.10:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-images:0.10:IMAGE ; build-image-index:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.10:CONTEXT ; push-dockerfile:0.3:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-images:0.10:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-images:0.10:PRIVILEGED_NESTED|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-snyk-check:0.5:TARGET_DIRS ; sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -143,7 +143,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-url| Image url to scan.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |platform| The platform the image is built on.| ""| |
-### git-clone-oci-ta:0.1 task parameters
+### git-clone-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -153,6 +153,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -168,8 +169,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -318,7 +317,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ARTIFACT_TYPE_SET_BY| How the artifact type was set.| |
 |IMAGES_PROCESSED| Collected image digests| |
 |TEST_OUTPUT| Ecosystem checks pass or fail outcome.| |
-### git-clone-oci-ta:0.1 task results
+### git-clone-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -372,10 +371,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
 ## Available workspaces from tasks
-### git-clone-oci-ta:0.1 task workspaces
+### git-clone-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -126,7 +126,7 @@ spec:
     - init
     taskRef:
       name: git-clone-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: basic-auth
       workspace: git-auth

--- a/pipelines/docker-build-oci-ta-min/README.md
+++ b/pipelines/docker-build-oci-ta-min/README.md
@@ -16,14 +16,14 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.10:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.10:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.10:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.10:IMAGE ; build-image-index:0.3:IMAGE|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.10:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.10:IMAGE ; build-image-index:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.10:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-container:0.10:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.10:PRIVILEGED_NESTED|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -116,7 +116,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_URL| Fully qualified image name.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |POLICY_DIR| Path to directory containing Conftest policies.| /project/repository/| |
 |POLICY_NAMESPACE| Namespace for Conftest policy.| required_checks| |
-### git-clone-oci-ta-min:0.1 task parameters
+### git-clone-oci-ta-min:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -126,6 +126,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -141,8 +142,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -244,7 +243,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### git-clone-oci-ta-min:0.1 task results
+### git-clone-oci-ta-min:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -290,10 +289,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
 ## Available workspaces from tasks
-### git-clone-oci-ta-min:0.1 task workspaces
+### git-clone-oci-ta-min:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
+++ b/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
@@ -118,7 +118,7 @@ spec:
     - init
     taskRef:
       name: git-clone-oci-ta-min
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: basic-auth
       workspace: git-auth

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -15,14 +15,14 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.10:DOCKERFILE ; push-dockerfile:0.3:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.10:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.10:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.10:IMAGE ; build-image-index:0.3:IMAGE|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.10:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.10:IMAGE ; build-image-index:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.10:CONTEXT ; push-dockerfile:0.3:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-container:0.10:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.10:PRIVILEGED_NESTED|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-snyk-check:0.5:TARGET_DIRS ; sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -140,7 +140,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-url| Image url to scan.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |platform| The platform the image is built on.| ""| |
-### git-clone-oci-ta:0.1 task parameters
+### git-clone-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -150,6 +150,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -165,8 +166,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -315,7 +314,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ARTIFACT_TYPE_SET_BY| How the artifact type was set.| |
 |IMAGES_PROCESSED| Collected image digests| |
 |TEST_OUTPUT| Ecosystem checks pass or fail outcome.| |
-### git-clone-oci-ta:0.1 task results
+### git-clone-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -369,10 +368,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
 ## Available workspaces from tasks
-### git-clone-oci-ta:0.1 task workspaces
+### git-clone-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -120,7 +120,7 @@ spec:
     - init
     taskRef:
       name: git-clone-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: basic-auth
       workspace: git-auth

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -15,14 +15,14 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-container:0.10:DOCKERFILE ; push-dockerfile:0.3:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
 |hermetic| Execute the build with network isolation| false| build-container:0.10:HERMETIC|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-container:0.10:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| build-container:0.10:IMAGE ; build-image-index:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.10:CONTEXT ; push-dockerfile:0.3:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-container:0.10:PREFETCH_INPUT|
 |privileged-nested| Whether to enable privileged mode, should be used only with remote VMs| false| build-container:0.10:PRIVILEGED_NESTED|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-snyk-check:0.5:TARGET_DIRS ; sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -138,7 +138,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-url| Image url to scan.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |platform| The platform the image is built on.| ""| |
-### git-clone:0.1 task parameters
+### git-clone:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -147,9 +147,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |depth| Perform a shallow clone, fetching only the most recent N commits.| 1| |
 |enableSymlinkCheck| Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. | true| |
 |fetchTags| Fetch all tags for the repo.| false| |
-|gitInitImage| Deprecated. Has no effect. Will be removed in the future.| ""| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -164,8 +164,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -300,7 +298,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ARTIFACT_TYPE_SET_BY| How the artifact type was set.| |
 |IMAGES_PROCESSED| Collected image digests| |
 |TEST_OUTPUT| Ecosystem checks pass or fail outcome.| |
-### git-clone:0.1 task results
+### git-clone:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -348,15 +346,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
-|workspace| |False| clone-repository:0.1:output ; prefetch-dependencies:0.3:source ; build-container:0.10:source ; build-source-image:0.3:workspace ; sast-snyk-check:0.5:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.4:workspace ; push-dockerfile:0.3:workspace|
+|workspace| |False| clone-repository:0.2:output ; prefetch-dependencies:0.3:source ; build-container:0.10:source ; build-source-image:0.3:workspace ; sast-snyk-check:0.5:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.4:workspace ; push-dockerfile:0.3:workspace|
 ## Available workspaces from tasks
 ### buildah:0.10 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |source| Workspace containing the source code to build.| False| workspace|
-### git-clone:0.1 task workspaces
+### git-clone:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -116,7 +116,7 @@ spec:
     - init
     taskRef:
       name: git-clone
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: output
       workspace: workspace

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -15,13 +15,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.10:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
 |hermetic| Execute the build with network isolation| true| build-images:0.10:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; run-opm-command:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.10:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; run-opm-command:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-images:0.10:IMAGE ; build-image-index:0.3:IMAGE|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; run-opm-command:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.10:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; run-opm-command:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-images:0.10:IMAGE ; build-image-index:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.10:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-images:0.10:PREFETCH_INPUT|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| |
 |skip-checks| Skip checks against built image| false| |
 
@@ -129,7 +129,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_URL| Fully qualified image name.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |RENDERED_CATALOG_DIGEST| Digest for attached json file containing the FBC fragment's opm rendered catalog.| None| '$(tasks.validate-fbc.results.RENDERED_CATALOG_DIGEST)'|
 |TARGET_INDEX| Image name of target index, minus tag.| registry.redhat.io/redhat/redhat-operator-index| 'registry.redhat.io/redhat/redhat-operator-index'|
-### git-clone-oci-ta:0.1 task parameters
+### git-clone-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -139,6 +139,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -154,8 +155,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -234,7 +233,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
 |TEST_OUTPUT| Tekton task test output.| |
-### git-clone-oci-ta:0.1 task results
+### git-clone-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -272,10 +271,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
 ## Available workspaces from tasks
-### git-clone-oci-ta:0.1 task workspaces
+### git-clone-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -116,7 +116,7 @@ spec:
     - init
     taskRef:
       name: git-clone-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: basic-auth
       workspace: git-auth

--- a/pipelines/ko-build-oci-ta/README.md
+++ b/pipelines/ko-build-oci-ta/README.md
@@ -11,15 +11,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |default-base-image| Default base image for ko| | build-container:0.1:KO_DEFAULTBASEIMAGE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.1:IMAGE_EXPIRES_AFTER|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-container:0.1:IMAGE_EXPIRES_AFTER|
 |import-path| Import path to build| | build-container:0.1:IMPORT_PATH|
 |ko-docker-repo| Setting for KO_DOCKER_REPO| | build-container:0.1:KO_DOCKER_REPO|
-|output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-image-index:0.3:IMAGE|
+|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-image-index:0.3:IMAGE|
 |pr-tag| PR tag to use on image| pr-tag| build-container:0.1:TAG|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
 |preprocessing-script| Preprocessing script for source code| | |
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-snyk-check:0.5:TARGET_DIRS ; sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -82,7 +82,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-url| Image url to scan.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |platform| The platform the image is built on.| ""| |
-### git-clone-oci-ta:0.1 task parameters
+### git-clone-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -92,6 +92,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -107,8 +108,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -251,7 +250,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ARTIFACT_TYPE_SET_BY| How the artifact type was set.| |
 |IMAGES_PROCESSED| Collected image digests| |
 |TEST_OUTPUT| Ecosystem checks pass or fail outcome.| |
-### git-clone-oci-ta:0.1 task results
+### git-clone-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -308,10 +307,10 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
 ## Available workspaces from tasks
-### git-clone-oci-ta:0.1 task workspaces
+### git-clone-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
+++ b/pipelines/ko-build-oci-ta/ko-build-oci-ta.yaml
@@ -104,7 +104,7 @@ spec:
     - init
     taskRef:
       name: git-clone-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: basic-auth
       workspace: git-auth

--- a/pipelines/maven-zip-build-oci-ta/README.md
+++ b/pipelines/maven-zip-build-oci-ta/README.md
@@ -9,11 +9,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
-|output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-oci-artifact:0.1:IMAGE|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
+|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-oci-artifact:0.1:IMAGE|
 |prefetch-input| Build dependencies to be prefetched| generic| prefetch-dependencies:0.3:input|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-snyk-check:0.5:TARGET_DIRS ; sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -29,7 +29,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-### git-clone-oci-ta:0.1 task parameters
+### git-clone-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -39,6 +39,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -54,8 +55,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -140,7 +139,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| OCI-Artifact reference of the built OCI-Artifact| |
 |IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| sast-snyk-check:0.5:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.4:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### git-clone-oci-ta:0.1 task results
+### git-clone-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -177,11 +176,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
 |workspace| |False| |
 ## Available workspaces from tasks
-### git-clone-oci-ta:0.1 task workspaces
+### git-clone-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
+++ b/pipelines/maven-zip-build-oci-ta/maven-zip-build-oci-ta.yaml
@@ -80,7 +80,7 @@ spec:
     - init
     taskRef:
       name: git-clone-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: basic-auth
       workspace: git-auth

--- a/pipelines/maven-zip-build/README.md
+++ b/pipelines/maven-zip-build/README.md
@@ -9,11 +9,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|---|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | build-oci-artifact:0.1:IMAGE_EXPIRES_AFTER|
 |output-image| Fully Qualified Output Image| None| build-oci-artifact:0.1:IMAGE|
 |prefetch-input| Build dependencies to be prefetched| generic| prefetch-dependencies:0.3:input|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-snyk-check:0.5:TARGET_DIRS ; sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -28,7 +28,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| false| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
-### git-clone:0.1 task parameters
+### git-clone:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -37,9 +37,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |depth| Perform a shallow clone, fetching only the most recent N commits.| 1| |
 |enableSymlinkCheck| Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. | true| |
 |fetchTags| Fetch all tags for the repo.| false| |
-|gitInitImage| Deprecated. Has no effect. Will be removed in the future.| ""| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -54,8 +54,6 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -129,7 +127,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IMAGE_REF| OCI-Artifact reference of the built OCI-Artifact| |
 |IMAGE_URL| OCI-Artifact repository and tag where the built OCI-Artifact was pushed| sast-snyk-check:0.5:image-url ; sast-shell-check:0.1:image-url ; sast-unicode-check:0.4:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### git-clone:0.1 task results
+### git-clone:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -160,15 +158,15 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
-|workspace| |False| clone-repository:0.1:output ; prefetch-dependencies:0.3:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.5:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.4:workspace|
+|workspace| |False| clone-repository:0.2:output ; prefetch-dependencies:0.3:source ; build-oci-artifact:0.1:source ; sast-snyk-check:0.5:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.4:workspace|
 ## Available workspaces from tasks
 ### build-maven-zip:0.1 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |source| Workspace containing the source code to build.| False| workspace|
-### git-clone:0.1 task workspaces
+### git-clone:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/maven-zip-build/maven-zip-build.yaml
+++ b/pipelines/maven-zip-build/maven-zip-build.yaml
@@ -76,7 +76,7 @@ spec:
     - init
     taskRef:
       name: git-clone
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: output
       workspace: workspace

--- a/pipelines/package-operator-package/README.md
+++ b/pipelines/package-operator-package/README.md
@@ -11,14 +11,14 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |buildah-format| The format for the resulting image's mediaType. Valid values are oci or docker.| docker| build-image-index:0.3:BUILDAH_FORMAT|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url|
+|git-url| Source Repository URL| None| clone-repository:0.2:url|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |labels| Additional key=value labels to add to the OCI  image.| []| build-container:0.1:LABELS|
 |output-image| Fully Qualified Output Image| None| build-container:0.1:DST_URL ; build-image-index:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.1:SRC_PATH|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-snyk-check:0.5:TARGET_DIRS ; sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -81,7 +81,7 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |ca-trust-config-map-name| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
 |image-url| Image url to scan.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
 |platform| The platform the image is built on.| ""| |
-### git-clone:0.1 task parameters
+### git-clone:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -90,9 +90,9 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |depth| Perform a shallow clone, fetching only the most recent N commits.| 1| |
 |enableSymlinkCheck| Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. | true| |
 |fetchTags| Fetch all tags for the repo.| false| |
-|gitInitImage| Deprecated. Has no effect. Will be removed in the future.| ""| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -107,8 +107,6 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -230,7 +228,7 @@ The process of how a pko package is defined and packaged is documented [here](ht
 |ARTIFACT_TYPE_SET_BY| How the artifact type was set.| |
 |IMAGES_PROCESSED| Collected image digests| |
 |TEST_OUTPUT| Ecosystem checks pass or fail outcome.| |
-### git-clone:0.1 task results
+### git-clone:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -281,11 +279,11 @@ The process of how a pko package is defined and packaged is documented [here](ht
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
-|workspace| |False| clone-repository:0.1:output ; prefetch-dependencies:0.3:source ; build-container:0.1:package ; build-source-image:0.3:workspace ; sast-snyk-check:0.5:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.4:workspace|
+|workspace| |False| clone-repository:0.2:output ; prefetch-dependencies:0.3:source ; build-container:0.1:package ; build-source-image:0.3:workspace ; sast-snyk-check:0.5:workspace ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.4:workspace|
 ## Available workspaces from tasks
-### git-clone:0.1 task workspaces
+### git-clone:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/package-operator-package/package-operator-package.yaml
+++ b/pipelines/package-operator-package/package-operator-package.yaml
@@ -101,7 +101,7 @@ spec:
     - init
     taskRef:
       name: git-clone
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: output
       workspace: workspace

--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -8,13 +8,13 @@
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
+|git-url| Source Repository URL| None| clone-repository:0.2:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter|
-|output-image| Fully Qualified Output Image| None| clone-repository:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.2:IMAGE ; build-image-index:0.3:IMAGE|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter|
+|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-container:0.2:IMAGE ; build-image-index:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision ; build-container:0.2:REVISION|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -40,7 +40,7 @@
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from| trusted-ca| |
-### git-clone-oci-ta:0.1 task parameters
+### git-clone-oci-ta:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -50,6 +50,7 @@
 |fetchTags| Fetch all tags for the repo.| false| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -65,8 +66,6 @@
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -144,7 +143,7 @@
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| sast-shell-check:0.1:image-url ; sast-unicode-check:0.4:image-url ; apply-tags:0.3:IMAGE_URL|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### git-clone-oci-ta:0.1 task results
+### git-clone-oci-ta:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -183,10 +182,10 @@
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
 ## Available workspaces from tasks
-### git-clone-oci-ta:0.1 task workspaces
+### git-clone-oci-ta:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -97,7 +97,7 @@ spec:
     - init
     taskRef:
       name: git-clone-oci-ta
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: basic-auth
       workspace: git-auth

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -8,13 +8,13 @@
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
-|git-url| Source Repository URL| None| clone-repository:0.1:url ; build-container:0.2:URL|
+|git-url| Source Repository URL| None| clone-repository:0.2:url ; build-container:0.2:URL|
 |hermetic| Execute the build with network isolation| false| |
 |image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | |
 |output-image| Fully Qualified Output Image| None| build-container:0.2:IMAGE ; build-image-index:0.3:IMAGE|
 |path-context| Path to the source code of an application's component from where to build image.| .| build-container:0.2:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input|
-|revision| Revision of the Source Repository| | clone-repository:0.1:revision ; build-container:0.2:REVISION|
+|revision| Revision of the Source Repository| | clone-repository:0.2:revision ; build-container:0.2:REVISION|
 |sast-target-dirs| Target directories in component's source code to scan with SAST tools. Multiple values should be separated with commas.| .| sast-shell-check:0.1:TARGET_DIRS ; sast-unicode-check:0.4:TARGET_DIRS|
 |skip-checks| Skip checks against built image| false| |
 
@@ -40,7 +40,7 @@
 |TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from| trusted-ca| |
-### git-clone:0.1 task parameters
+### git-clone:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
@@ -49,9 +49,9 @@
 |depth| Perform a shallow clone, fetching only the most recent N commits.| 1| |
 |enableSymlinkCheck| Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. | true| |
 |fetchTags| Fetch all tags for the repo.| false| |
-|gitInitImage| Deprecated. Has no effect. Will be removed in the future.| ""| |
 |httpProxy| HTTP proxy server for non-SSL requests.| ""| |
 |httpsProxy| HTTPS proxy server for SSL requests.| ""| |
+|logLevel| Log level for the git-clone command.| info| |
 |mergeSourceDepth| Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. | ""| |
 |mergeSourceRepoUrl| URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. | ""| |
 |mergeTargetBranch| Set to "true" to merge the targetBranch into the checked-out revision.| false| |
@@ -66,8 +66,6 @@
 |submodules| Initialize and fetch git submodules.| true| |
 |targetBranch| The target branch to merge into the revision (if mergeTargetBranch is true).| main| |
 |url| Repository URL to clone from.| None| '$(params.git-url)'|
-|userHome| Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. | /tekton/home| |
-|verbose| Log the commands that are executed during `git-clone`'s operation.| false| |
 ### init:0.4 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -137,7 +135,7 @@
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| sast-shell-check:0.1:image-url ; sast-unicode-check:0.4:image-url ; apply-tags:0.3:IMAGE_URL|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
-### git-clone:0.1 task results
+### git-clone:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
@@ -170,11 +168,11 @@
 ## Workspaces
 |name|description|optional|used in tasks
 |---|---|---|---|
-|git-auth| |True| clone-repository:0.1:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
+|git-auth| |True| clone-repository:0.2:basic-auth ; prefetch-dependencies:0.3:git-basic-auth|
 |netrc| |True| prefetch-dependencies:0.3:netrc|
-|workspace| |False| clone-repository:0.1:output ; prefetch-dependencies:0.3:source ; build-container:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.4:workspace|
+|workspace| |False| clone-repository:0.2:output ; prefetch-dependencies:0.3:source ; build-container:0.2:source ; sast-shell-check:0.1:workspace ; sast-unicode-check:0.4:workspace|
 ## Available workspaces from tasks
-### git-clone:0.1 task workspaces
+### git-clone:0.2 task workspaces
 |name|description|optional|workspace from pipeline
 |---|---|---|---|
 |basic-auth| A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. | True| git-auth|

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -93,7 +93,7 @@ spec:
     - init
     taskRef:
       name: git-clone
-      version: "0.1"
+      version: "0.2"
     workspaces:
     - name: output
       workspace: workspace

--- a/pipelines/template-build/template-build.yaml
+++ b/pipelines/template-build/template-build.yaml
@@ -87,7 +87,7 @@ spec:
           value: "$(params.revision)"
       taskRef:
         name: git-clone
-        version: "0.1"
+        version: "0.2"
       workspaces:
         - name: output
           workspace: workspace

--- a/task/git-clone-oci-ta-min/0.1/git-clone-oci-ta-min.yaml
+++ b/task/git-clone-oci-ta-min/0.1/git-clone-oci-ta-min.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2026-08-20T00:00:00Z"
     tekton.dev/categories: Git
     tekton.dev/displayName: git clone oci trusted artifacts
     tekton.dev/pipelines.minVersion: 0.21.0

--- a/task/git-clone-oci-ta-min/0.2/MIGRATION.md
+++ b/task/git-clone-oci-ta-min/0.2/MIGRATION.md
@@ -1,0 +1,14 @@
+# Migration from 0.1 to 0.2
+
+## What changed
+
+- **Removed parameters:** `gitInitImage`, `verbose`, `userHome`.
+- **New parameter:** `logLevel` (default `info`) replaces `verbose`. Valid values: `debug`, `info`, `warn`, `error`.
+- **Image changed:** The task now uses `konflux-build-cli` instead of the previous `git-clone` image.
+- **Step consolidation:** The separate `symlink-check` step has been merged into the `clone` step. Symlink checking is now handled internally by the Go binary.
+
+## Action from users
+
+The migration should be done automatically by renovate.
+For users who don't have automatic updates, remove `gitInitImage`, `verbose`, and `userHome` parameters if present.
+Replace `verbose: "true"` with `logLevel: "debug"` if needed.

--- a/task/git-clone-oci-ta-min/0.2/README.md
+++ b/task/git-clone-oci-ta-min/0.2/README.md
@@ -1,0 +1,51 @@
+# git-clone-oci-ta-min task
+
+The git-clone-oci-ta Task will clone a repo from the provided url and store it as a trusted artifact in the provided OCI repository.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
+|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
+|fetchTags|Fetch all tags for the repo.|false|false|
+|httpProxy|HTTP proxy server for non-SSL requests.|""|false|
+|httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. |""|false|
+|mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. |""|false|
+|mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
+|noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
+|ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
+|ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
+|refspec|Refspec to fetch before checking out revision.|""|false|
+|revision|Revision to checkout. (branch, tag, sha, ref, etc...)|""|false|
+|shortCommitLength|Length of short commit SHA|7|false|
+|sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
+|sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
+|submodulePaths|Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. |""|false|
+|submodules|Initialize and fetch git submodules.|true|false|
+|targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
+|url|Repository URL to clone from.||true|
+|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
+|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
+
+## Results
+|name|description|
+|---|---|
+|CHAINS-GIT_COMMIT|The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|CHAINS-GIT_URL|The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
+|commit|The precise commit SHA that was fetched by this Task.|
+|commit-timestamp|The commit timestamp of the checkout|
+|merged_sha|The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).|
+|short-commit|The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters|
+|url|The precise URL that was fetched by this Task.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. |true|
+|ssh-directory|A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. |true|
+
+## Additional info

--- a/task/git-clone-oci-ta-min/0.2/README.md
+++ b/task/git-clone-oci-ta-min/0.2/README.md
@@ -12,6 +12,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |fetchTags|Fetch all tags for the repo.|false|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|logLevel|Log level for the git-clone command.|info|false|
 |mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. |""|false|
 |mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. |""|false|
 |mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
@@ -27,8 +28,6 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |submodules|Initialize and fetch git submodules.|true|false|
 |targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
 |url|Repository URL to clone from.||true|
-|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
-|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
 
 ## Results
 |name|description|

--- a/task/git-clone-oci-ta-min/0.2/git-clone-oci-ta-min.yaml
+++ b/task/git-clone-oci-ta-min/0.2/git-clone-oci-ta-min.yaml
@@ -45,6 +45,10 @@ spec:
     description: HTTPS proxy server for SSL requests.
     name: httpsProxy
     type: string
+  - default: info
+    description: Log level for the git-clone command.
+    name: logLevel
+    type: string
   - default: ""
     description: |
       Perform a shallow fetch of the target branch, fetching only the most recent N commits.
@@ -113,15 +117,6 @@ spec:
   - description: Repository URL to clone from.
     name: url
     type: string
-  - default: /tekton/home
-    description: |
-      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
-    name: userHome
-    type: string
-  - default: "false"
-    description: Log the commands that are executed during `git-clone`'s operation.
-    name: verbose
-    type: string
   results:
   - description: The precise commit SHA that was fetched by this Task. This result
       uses Chains type hinting to include in the provenance.
@@ -153,196 +148,82 @@ spec:
         cpu: 100m
         memory: 256Mi
     env:
-    - name: HOME
-      value: $(params.userHome)
-    - name: PARAM_URL
+    - name: KBC_GIT_CLONE_URL
       value: $(params.url)
-    - name: PARAM_REVISION
+    - name: KBC_GIT_CLONE_REVISION
       value: $(params.revision)
-    - name: PARAM_REFSPEC
+    - name: KBC_GIT_CLONE_REFSPEC
       value: $(params.refspec)
-    - name: PARAM_SUBMODULES
+    - name: KBC_GIT_CLONE_SUBMODULES
       value: $(params.submodules)
-    - name: PARAM_SUBMODULE_PATHS
+    - name: KBC_GIT_CLONE_SUBMODULE_PATHS
       value: $(params.submodulePaths)
-    - name: PARAM_DEPTH
+    - name: KBC_GIT_CLONE_DEPTH
       value: $(params.depth)
-    - name: PARAM_SHORT_COMMIT_LENGTH
+    - name: KBC_GIT_CLONE_SHORT_COMMIT_LENGTH
       value: $(params.shortCommitLength)
-    - name: PARAM_SSL_VERIFY
+    - name: KBC_GIT_CLONE_SSL_VERIFY
       value: $(params.sslVerify)
+    - name: KBC_GIT_CLONE_SPARSE_CHECKOUT_DIRECTORIES
+      value: $(params.sparseCheckoutDirectories)
+    - name: KBC_GIT_CLONE_ENABLE_SYMLINK_CHECK
+      value: $(params.enableSymlinkCheck)
+    - name: KBC_GIT_CLONE_FETCH_TAGS
+      value: $(params.fetchTags)
+    - name: KBC_GIT_CLONE_MERGE_TARGET_BRANCH
+      value: $(params.mergeTargetBranch)
+    - name: KBC_GIT_CLONE_TARGET_BRANCH
+      value: $(params.targetBranch)
+    - name: KBC_GIT_CLONE_MERGE_SOURCE_REPO_URL
+      value: $(params.mergeSourceRepoUrl)
+    - name: KBC_GIT_CLONE_MERGE_SOURCE_DEPTH
+      value: $(params.mergeSourceDepth)
+    - name: KBC_GIT_CLONE_BASIC_AUTH_DIRECTORY
+      value: $(workspaces.basic-auth.path)
+    - name: KBC_GIT_CLONE_SSH_DIRECTORY
+      value: $(workspaces.ssh-directory.path)
     - name: PARAM_HTTP_PROXY
       value: $(params.httpProxy)
     - name: PARAM_HTTPS_PROXY
       value: $(params.httpsProxy)
     - name: PARAM_NO_PROXY
       value: $(params.noProxy)
-    - name: PARAM_VERBOSE
-      value: $(params.verbose)
-    - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
-      value: $(params.sparseCheckoutDirectories)
-    - name: PARAM_USER_HOME
-      value: $(params.userHome)
-    - name: PARAM_FETCH_TAGS
-      value: $(params.fetchTags)
-    - name: PARAM_MERGE_TARGET_BRANCH
-      value: $(params.mergeTargetBranch)
-    - name: PARAM_TARGET_BRANCH
-      value: $(params.targetBranch)
-    - name: PARAM_MERGE_SOURCE_REPO_URL
-      value: $(params.mergeSourceRepoUrl)
-    - name: PARAM_MERGE_SOURCE_DEPTH
-      value: $(params.mergeSourceDepth)
-    - name: WORKSPACE_SSH_DIRECTORY_BOUND
-      value: $(workspaces.ssh-directory.bound)
-    - name: WORKSPACE_SSH_DIRECTORY_PATH
-      value: $(workspaces.ssh-directory.path)
-    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
-      value: $(workspaces.basic-auth.bound)
-    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
-      value: $(workspaces.basic-auth.path)
-    - name: CHECKOUT_DIR
-      value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    - name: KBC_LOG_LEVEL
+      value: $(params.logLevel)
+    - name: KBC_GIT_CLONE_OUTPUT_DIR
+      value: /var/workdir
+    - name: KBC_GIT_CLONE_SUBDIRECTORY
+      value: source
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:dd49bd35038c1cba174e6c166291e5df3d0d5f9be18ed3b2fb852fc6ce3181ed
     name: clone
     script: |
-      #!/usr/bin/env sh
-      set -eu
+      #!/usr/bin/env bash
+      set -euo pipefail
 
-      if [ "${PARAM_VERBOSE}" = "true" ]; then
-        set -x
-      fi
-
-      if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ]; then
-        if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
-          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
-          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
-        # Compatibility with kubernetes.io/basic-auth secrets
-        elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
-          HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
-          echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" >"${PARAM_USER_HOME}/.git-credentials"
-          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" >"${PARAM_USER_HOME}/.gitconfig"
-        else
-          echo "Unknown basic-auth workspace format"
-          exit 1
-        fi
-        chmod 400 "${PARAM_USER_HOME}/.git-credentials"
-        chmod 400 "${PARAM_USER_HOME}/.gitconfig"
-      fi
-
-      # Should be called after the gitconfig is copied from the repository secret
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
-        git config --global http.sslCAInfo "$ca_bundle"
-      fi
-
-      if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ]; then
-        cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
-        chmod 700 "${PARAM_USER_HOME}"/.ssh
-        chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        cp -vf "$ca_bundle" /etc/pki/ca-trust/source/anchors
+        update-ca-trust
       fi
 
       test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
       test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
       test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
-      /ko-app/git-init \
-        -url="${PARAM_URL}" \
-        -revision="${PARAM_REVISION}" \
-        -refspec="${PARAM_REFSPEC}" \
-        -path="${CHECKOUT_DIR}" \
-        -sslVerify="${PARAM_SSL_VERIFY}" \
-        -submodules="${PARAM_SUBMODULES}" \
-        -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
-        -depth="${PARAM_DEPTH}" \
-        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
-        -retryMaxAttempts=10
-      cd "${CHECKOUT_DIR}"
-      RESULT_SHA="$(git rev-parse HEAD)"
-      RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
+      RESULT_FILE="$(mktemp)"
+      konflux-build-cli git-clone >"${RESULT_FILE}"
 
-      if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
-        echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+      printf "%s" "$(jq -r '.commit' "${RESULT_FILE}")" >"$(results.commit.path)"
+      printf "%s" "$(jq -r '.shortCommit' "${RESULT_FILE}")" >"$(results.short-commit.path)"
+      printf "%s" "$(jq -r '.url' "${RESULT_FILE}")" >"$(results.url.path)"
+      printf "%s" "$(jq -r '.commitTimestamp' "${RESULT_FILE}")" >"$(results.commit-timestamp.path)"
+      printf "%s" "$(jq -r '."CHAINS-GIT_URL"' "${RESULT_FILE}")" >"$(results.CHAINS-GIT_URL.path)"
+      printf "%s" "$(jq -r '."CHAINS-GIT_COMMIT"' "${RESULT_FILE}")" >"$(results.CHAINS-GIT_COMMIT.path)"
 
-        if [ "${PARAM_DEPTH}" = "1" ]; then
-          echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
-        fi
-
-        if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
-          echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
-        fi
-
-        # Determine if merging from a different repository or the same one
-        if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
-          # Normalize URLs for comparison (remove trailing slashes and .git suffix)
-          normalize_url() {
-            echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
-          }
-
-          NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
-          NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
-
-          if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
-            echo "Merge source URL is the same as origin. Using existing 'origin' remote."
-            MERGE_REMOTE="origin"
-          else
-            echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
-            echo "Adding remote 'merge-source'..."
-            git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
-            MERGE_REMOTE="merge-source"
-          fi
-        else
-          echo "Merging from the same repository (origin)"
-          MERGE_REMOTE="origin"
-        fi
-
-        echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
-        if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
-          retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
-        else
-          retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
-        fi
-
-        echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
-        git config --global user.email "tekton-git-clone@tekton.dev"
-        git config --global user.name "Tekton Git Clone Task"
-
-        if ! git merge FETCH_HEAD --no-commit --no-ff --allow-unrelated-histories; then
-          echo "ERROR: Merge conflict detected or merge failed before commit." >&2
-          echo "--- Git Status ---"
-          git status
-          echo "------------------"
-          exit 1
-        fi
-
-        # Check if there are changes staged for commit
-        if git diff --staged --quiet; then
-          echo "No diff was found, skipping merge..." >&2
-        else
-          echo "Merge successful (no conflicts found), committing..."
-          if ! git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"; then
-            echo "ERROR: Failed to commit merge." >&2
-            exit 1
-          fi
-          MERGED_SHA=$(git rev-parse HEAD)
-          echo "New HEAD after merge: ${MERGED_SHA}"
-          echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
-        fi
-
-      else
-        echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
-      fi
-      printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
-      printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"
-      printf "%s" "${RESULT_SHA_SHORT}" >"$(results.short-commit.path)"
-      printf "%s" "${PARAM_URL}" >"$(results.url.path)"
-      printf "%s" "${PARAM_URL}" >"$(results.CHAINS-GIT_URL.path)"
-      printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
-
-      if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
-        echo "Fetching tags"
-        retry git fetch --tags
+      MERGED_SHA=$(jq -r '.mergedSha // empty' "${RESULT_FILE}")
+      if [ -n "${MERGED_SHA}" ]; then
+        printf "%s" "${MERGED_SHA}" >"$(results.merged_sha.path)"
       fi
     securityContext:
       runAsUser: 0
@@ -350,44 +231,6 @@ spec:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
-    - mountPath: /var/workdir
-      name: workdir
-  - computeResources:
-      limits:
-        memory: 64Mi
-      requests:
-        cpu: 50m
-        memory: 64Mi
-    env:
-    - name: PARAM_ENABLE_SYMLINK_CHECK
-      value: $(params.enableSymlinkCheck)
-    - name: CHECKOUT_DIR
-      value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
-    name: symlink-check
-    script: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-
-      check_symlinks() {
-        FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
-        while read -r symlink; do
-          target=$(readlink -m "$symlink")
-          if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
-            echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
-            FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
-          fi
-        done < <(find $CHECKOUT_DIR -type l -print)
-        if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ]; then
-          return 1
-        fi
-      }
-
-      if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ]; then
-        echo "Running symlink check"
-        check_symlinks
-      fi
-    volumeMounts:
     - mountPath: /var/workdir
       name: workdir
   - args:
@@ -404,7 +247,7 @@ spec:
     env:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.ociArtifactExpiresAfter)
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:f53e69930a5c6a6008ea55a29146e4c860ef3d88c390350bada38361b3feeb1a
     name: create-trusted-artifact
     volumeMounts:
     - mountPath: /var/workdir

--- a/task/git-clone-oci-ta-min/0.2/git-clone-oci-ta-min.yaml
+++ b/task/git-clone-oci-ta-min/0.2/git-clone-oci-ta-min.yaml
@@ -1,0 +1,441 @@
+# WARNING: This is an auto generated file, do not modify this file directly
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/displayName: git clone oci trusted artifacts
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: git
+  labels:
+    app.kubernetes.io/version: "0.2"
+  name: git-clone-oci-ta-min
+spec:
+  description: The git-clone-oci-ta Task will clone a repo from the provided url and
+    store it as a trusted artifact in the provided OCI repository.
+  params:
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: "1"
+    description: Perform a shallow clone, fetching only the most recent N commits.
+    name: depth
+    type: string
+  - default: "true"
+    description: |
+      Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
+    name: enableSymlinkCheck
+    type: string
+  - default: "false"
+    description: Fetch all tags for the repo.
+    name: fetchTags
+    type: string
+  - default: ""
+    description: HTTP proxy server for non-SSL requests.
+    name: httpProxy
+    type: string
+  - default: ""
+    description: HTTPS proxy server for SSL requests.
+    name: httpsProxy
+    type: string
+  - default: ""
+    description: |
+      Perform a shallow fetch of the target branch, fetching only the most recent N commits.
+      If empty, fetches the full history of the target branch.
+    name: mergeSourceDepth
+    type: string
+  - default: ""
+    description: |
+      URL of the repository to fetch the target branch from when mergeTargetBranch is true.
+      If empty, uses the same repository (origin). This allows merging a branch from a different repository.
+    name: mergeSourceRepoUrl
+    type: string
+  - default: "false"
+    description: Set to "true" to merge the targetBranch into the checked-out revision.
+    name: mergeTargetBranch
+    type: string
+  - default: ""
+    description: Opt out of proxying HTTP/HTTPS requests.
+    name: noProxy
+    type: string
+  - default: ""
+    description: Expiration date for the trusted artifacts created in the OCI repository.
+      An empty string means the artifacts do not expire.
+    name: ociArtifactExpiresAfter
+    type: string
+  - description: The OCI repository where the Trusted Artifacts are stored.
+    name: ociStorage
+    type: string
+  - default: ""
+    description: Refspec to fetch before checking out revision.
+    name: refspec
+    type: string
+  - default: ""
+    description: Revision to checkout. (branch, tag, sha, ref, etc...)
+    name: revision
+    type: string
+  - default: "7"
+    description: Length of short commit SHA
+    name: shortCommitLength
+    type: string
+  - default: ""
+    description: Define the directory patterns to match or exclude when performing
+      a sparse checkout.
+    name: sparseCheckoutDirectories
+    type: string
+  - default: "true"
+    description: Set the `http.sslVerify` global git config. Setting this to `false`
+      is not advised unless you are sure that you trust your git remote.
+    name: sslVerify
+    type: string
+  - default: ""
+    description: |
+      Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched.
+      Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable.
+    name: submodulePaths
+    type: string
+  - default: "true"
+    description: Initialize and fetch git submodules.
+    name: submodules
+    type: string
+  - default: main
+    description: The target branch to merge into the revision (if mergeTargetBranch
+      is true).
+    name: targetBranch
+    type: string
+  - description: Repository URL to clone from.
+    name: url
+    type: string
+  - default: /tekton/home
+    description: |
+      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
+    name: userHome
+    type: string
+  - default: "false"
+    description: Log the commands that are executed during `git-clone`'s operation.
+    name: verbose
+    type: string
+  results:
+  - description: The precise commit SHA that was fetched by this Task. This result
+      uses Chains type hinting to include in the provenance.
+    name: CHAINS-GIT_COMMIT
+  - description: The precise URL that was fetched by this Task. This result uses Chains
+      type hinting to include in the provenance.
+    name: CHAINS-GIT_URL
+  - description: The Trusted Artifact URI pointing to the artifact with the application
+      source code.
+    name: SOURCE_ARTIFACT
+    type: string
+  - description: The precise commit SHA that was fetched by this Task.
+    name: commit
+  - description: The commit timestamp of the checkout
+    name: commit-timestamp
+  - description: The SHA of the commit after merging the target branch (if the param
+      mergeTargetBranch is true).
+    name: merged_sha
+  - description: The commit SHA that was fetched by this Task limited to params.shortCommitLength
+      number of characters
+    name: short-commit
+  - description: The precise URL that was fetched by this Task.
+    name: url
+  steps:
+  - computeResources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    env:
+    - name: HOME
+      value: $(params.userHome)
+    - name: PARAM_URL
+      value: $(params.url)
+    - name: PARAM_REVISION
+      value: $(params.revision)
+    - name: PARAM_REFSPEC
+      value: $(params.refspec)
+    - name: PARAM_SUBMODULES
+      value: $(params.submodules)
+    - name: PARAM_SUBMODULE_PATHS
+      value: $(params.submodulePaths)
+    - name: PARAM_DEPTH
+      value: $(params.depth)
+    - name: PARAM_SHORT_COMMIT_LENGTH
+      value: $(params.shortCommitLength)
+    - name: PARAM_SSL_VERIFY
+      value: $(params.sslVerify)
+    - name: PARAM_HTTP_PROXY
+      value: $(params.httpProxy)
+    - name: PARAM_HTTPS_PROXY
+      value: $(params.httpsProxy)
+    - name: PARAM_NO_PROXY
+      value: $(params.noProxy)
+    - name: PARAM_VERBOSE
+      value: $(params.verbose)
+    - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+      value: $(params.sparseCheckoutDirectories)
+    - name: PARAM_USER_HOME
+      value: $(params.userHome)
+    - name: PARAM_FETCH_TAGS
+      value: $(params.fetchTags)
+    - name: PARAM_MERGE_TARGET_BRANCH
+      value: $(params.mergeTargetBranch)
+    - name: PARAM_TARGET_BRANCH
+      value: $(params.targetBranch)
+    - name: PARAM_MERGE_SOURCE_REPO_URL
+      value: $(params.mergeSourceRepoUrl)
+    - name: PARAM_MERGE_SOURCE_DEPTH
+      value: $(params.mergeSourceDepth)
+    - name: WORKSPACE_SSH_DIRECTORY_BOUND
+      value: $(workspaces.ssh-directory.bound)
+    - name: WORKSPACE_SSH_DIRECTORY_PATH
+      value: $(workspaces.ssh-directory.path)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+      value: $(workspaces.basic-auth.bound)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+      value: $(workspaces.basic-auth.path)
+    - name: CHECKOUT_DIR
+      value: /var/workdir/source
+    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    name: clone
+    script: |
+      #!/usr/bin/env sh
+      set -eu
+
+      if [ "${PARAM_VERBOSE}" = "true" ]; then
+        set -x
+      fi
+
+      if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ]; then
+        if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+        # Compatibility with kubernetes.io/basic-auth secrets
+        elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
+          HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
+          echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" >"${PARAM_USER_HOME}/.git-credentials"
+          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" >"${PARAM_USER_HOME}/.gitconfig"
+        else
+          echo "Unknown basic-auth workspace format"
+          exit 1
+        fi
+        chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+        chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+      fi
+
+      # Should be called after the gitconfig is copied from the repository secret
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        git config --global http.sslCAInfo "$ca_bundle"
+      fi
+
+      if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ]; then
+        cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+        chmod 700 "${PARAM_USER_HOME}"/.ssh
+        chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+      fi
+
+      test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+      test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+      test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+      /ko-app/git-init \
+        -url="${PARAM_URL}" \
+        -revision="${PARAM_REVISION}" \
+        -refspec="${PARAM_REFSPEC}" \
+        -path="${CHECKOUT_DIR}" \
+        -sslVerify="${PARAM_SSL_VERIFY}" \
+        -submodules="${PARAM_SUBMODULES}" \
+        -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
+        -depth="${PARAM_DEPTH}" \
+        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
+        -retryMaxAttempts=10
+      cd "${CHECKOUT_DIR}"
+      RESULT_SHA="$(git rev-parse HEAD)"
+      RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
+
+      if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
+        echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+
+        if [ "${PARAM_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        # Determine if merging from a different repository or the same one
+        if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
+          # Normalize URLs for comparison (remove trailing slashes and .git suffix)
+          normalize_url() {
+            echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
+          }
+
+          NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
+          NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
+
+          if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
+            echo "Merge source URL is the same as origin. Using existing 'origin' remote."
+            MERGE_REMOTE="origin"
+          else
+            echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
+            echo "Adding remote 'merge-source'..."
+            git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
+            MERGE_REMOTE="merge-source"
+          fi
+        else
+          echo "Merging from the same repository (origin)"
+          MERGE_REMOTE="origin"
+        fi
+
+        echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
+        if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
+          retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        else
+          retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        fi
+
+        echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
+        git config --global user.email "tekton-git-clone@tekton.dev"
+        git config --global user.name "Tekton Git Clone Task"
+
+        if ! git merge FETCH_HEAD --no-commit --no-ff --allow-unrelated-histories; then
+          echo "ERROR: Merge conflict detected or merge failed before commit." >&2
+          echo "--- Git Status ---"
+          git status
+          echo "------------------"
+          exit 1
+        fi
+
+        # Check if there are changes staged for commit
+        if git diff --staged --quiet; then
+          echo "No diff was found, skipping merge..." >&2
+        else
+          echo "Merge successful (no conflicts found), committing..."
+          if ! git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"; then
+            echo "ERROR: Failed to commit merge." >&2
+            exit 1
+          fi
+          MERGED_SHA=$(git rev-parse HEAD)
+          echo "New HEAD after merge: ${MERGED_SHA}"
+          echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
+        fi
+
+      else
+        echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
+      fi
+      printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
+      printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"
+      printf "%s" "${RESULT_SHA_SHORT}" >"$(results.short-commit.path)"
+      printf "%s" "${PARAM_URL}" >"$(results.url.path)"
+      printf "%s" "${PARAM_URL}" >"$(results.CHAINS-GIT_URL.path)"
+      printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
+
+      if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
+        echo "Fetching tags"
+        retry git fetch --tags
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    - mountPath: /var/workdir
+      name: workdir
+  - computeResources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+    env:
+    - name: PARAM_ENABLE_SYMLINK_CHECK
+      value: $(params.enableSymlinkCheck)
+    - name: CHECKOUT_DIR
+      value: /var/workdir/source
+    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    name: symlink-check
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      check_symlinks() {
+        FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
+        while read -r symlink; do
+          target=$(readlink -m "$symlink")
+          if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
+            echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
+            FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
+          fi
+        done < <(find $CHECKOUT_DIR -type l -print)
+        if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ]; then
+          return 1
+        fi
+      }
+
+      if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ]; then
+        echo "Running symlink check"
+        check_symlinks
+      fi
+    volumeMounts:
+    - mountPath: /var/workdir
+      name: workdir
+  - args:
+    - create
+    - --store
+    - $(params.ociStorage)
+    - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+    computeResources:
+      limits:
+        memory: 256Mi
+      requests:
+        cpu: 100m
+        memory: 256Mi
+    env:
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.ociArtifactExpiresAfter)
+    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+    name: create-trusted-artifact
+    volumeMounts:
+    - mountPath: /var/workdir
+      name: workdir
+    - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
+  volumes:
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  - emptyDir: {}
+    name: workdir
+  workspaces:
+  - description: |
+      A Workspace containing a .gitconfig and .git-credentials file or username and password.
+      These will be copied to the user's home before any git commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to use ssh-directory over basic-auth whenever possible and to bind a
+      Secret to this Workspace over other volume types.
+    name: basic-auth
+    optional: true
+  - description: |
+      A .ssh directory with private key, known_hosts, config, etc. Copied to
+      the user's home before git commands are executed. Used to authenticate
+      with the git remote when performing the clone. Binding a Secret to this
+      Workspace is strongly recommended over other volume types.
+    name: ssh-directory
+    optional: true

--- a/task/git-clone-oci-ta-min/0.2/kustomization.yaml
+++ b/task/git-clone-oci-ta-min/0.2/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../git-clone-oci-ta/0.2
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Task

--- a/task/git-clone-oci-ta-min/0.2/migrations/0.2.sh
+++ b/task/git-clone-oci-ta-min/0.2/migrations/0.2.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+declare -r pipeline_file=${1:?missing pipeline file}
+
+tasks_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "git-clone" "git-clone-oci-ta" "git-clone-oci-ta-min" "pnc-prebuild-git-clone-oci-ta"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null 2>&1; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#tasks_names[@]} tasks_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#tasks_names[@]} -eq 0 ]; then
+    echo "No git-clone tasks found"
+    exit 0
+fi
+
+for task_name in "${tasks_names[@]}"; do
+    task_name_selector="${tasks_selector} | select(.name == \"${task_name}\")"
+    verbose_val=$(yq -e "${task_name_selector} | .params[] | select(.name == \"verbose\") | .value" "$pipeline_file" 2>/dev/null) || true
+
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param gitInitImage
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param verbose
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param userHome
+    if [ "${verbose_val}" = "true" ]; then
+        pmt modify -f "$pipeline_file" task "$task_name" add-param logLevel "debug"
+    fi
+done

--- a/task/git-clone-oci-ta-min/0.2/patch.yaml
+++ b/task/git-clone-oci-ta-min/0.2/patch.yaml
@@ -1,0 +1,33 @@
+- op: replace
+  path: /metadata/name
+  value: git-clone-oci-ta-min
+# kustomize build task/git-clone-oci-ta/0.1 | yq '.spec.steps.[].name' | nl -v 0
+#      0	clone
+#      1	symlink-check
+#      2	create-trusted-artifact
+# clone step: cap to 256Mi for resource-constrained pipelines (full variant uses 2Gi for large monorepos)
+- op: test
+  path: /spec/steps/0/name
+  value: clone
+- op: replace
+  path: /spec/steps/0/computeResources/limits/memory
+  value: 256Mi
+- op: replace
+  path: /spec/steps/0/computeResources/requests/memory
+  value: 256Mi
+- op: replace
+  path: /spec/steps/0/computeResources/requests/cpu
+  value: 100m
+# create-trusted-artifact step
+- op: test
+  path: /spec/steps/2/name
+  value: create-trusted-artifact
+- op: replace
+  path: /spec/steps/2/computeResources/limits/memory
+  value: 256Mi
+- op: replace
+  path: /spec/steps/2/computeResources/requests/memory
+  value: 256Mi
+- op: replace
+  path: /spec/steps/2/computeResources/requests/cpu
+  value: 100m

--- a/task/git-clone-oci-ta-min/0.2/patch.yaml
+++ b/task/git-clone-oci-ta-min/0.2/patch.yaml
@@ -1,11 +1,10 @@
 - op: replace
   path: /metadata/name
   value: git-clone-oci-ta-min
-# kustomize build task/git-clone-oci-ta/0.1 | yq '.spec.steps.[].name' | nl -v 0
+# kustomize build task/git-clone-oci-ta/0.2 | yq '.spec.steps.[].name' | nl -v 0
 #      0	clone
-#      1	symlink-check
-#      2	create-trusted-artifact
-# clone step: cap to 256Mi for resource-constrained pipelines (full variant uses 2Gi for large monorepos)
+#      1	create-trusted-artifact
+# clone step
 - op: test
   path: /spec/steps/0/name
   value: clone
@@ -20,14 +19,14 @@
   value: 100m
 # create-trusted-artifact step
 - op: test
-  path: /spec/steps/2/name
+  path: /spec/steps/1/name
   value: create-trusted-artifact
 - op: replace
-  path: /spec/steps/2/computeResources/limits/memory
+  path: /spec/steps/1/computeResources/limits/memory
   value: 256Mi
 - op: replace
-  path: /spec/steps/2/computeResources/requests/memory
+  path: /spec/steps/1/computeResources/requests/memory
   value: 256Mi
 - op: replace
-  path: /spec/steps/2/computeResources/requests/cpu
+  path: /spec/steps/1/computeResources/requests/cpu
   value: 100m

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -4,6 +4,7 @@ kind: Task
 metadata:
   name: git-clone-oci-ta
   annotations:
+    build.appstudio.redhat.com/expires-on: "2026-08-20T00:00:00Z"
     tekton.dev/categories: Git
     tekton.dev/displayName: git clone oci trusted artifacts
     tekton.dev/pipelines.minVersion: 0.21.0

--- a/task/git-clone-oci-ta/0.2/MIGRATION.md
+++ b/task/git-clone-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,14 @@
+# Migration from 0.1 to 0.2
+
+## What changed
+
+- **Removed parameters:** `gitInitImage`, `verbose`, `userHome`.
+- **New parameter:** `logLevel` (default `info`) replaces `verbose`. Valid values: `debug`, `info`, `warn`, `error`.
+- **Image changed:** The task now uses `konflux-build-cli` instead of the previous `git-clone` image.
+- **Step consolidation:** The separate `symlink-check` step has been merged into the `clone` step. Symlink checking is now handled internally by the Go binary.
+
+## Action from users
+
+The migration should be done automatically by renovate.
+For users who don't have automatic updates, remove `gitInitImage`, `verbose`, and `userHome` parameters if present.
+Replace `verbose: "true"` with `logLevel: "debug"` if needed.

--- a/task/git-clone-oci-ta/0.2/README.md
+++ b/task/git-clone-oci-ta/0.2/README.md
@@ -12,6 +12,7 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |fetchTags|Fetch all tags for the repo.|false|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|logLevel|Log level for the git-clone command.|info|false|
 |mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. |""|false|
 |mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. |""|false|
 |mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
@@ -27,8 +28,6 @@ The git-clone-oci-ta Task will clone a repo from the provided url and store it a
 |submodules|Initialize and fetch git submodules.|true|false|
 |targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
 |url|Repository URL to clone from.||true|
-|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
-|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
 
 ## Results
 |name|description|

--- a/task/git-clone-oci-ta/0.2/README.md
+++ b/task/git-clone-oci-ta/0.2/README.md
@@ -1,0 +1,51 @@
+# git-clone-oci-ta task
+
+The git-clone-oci-ta Task will clone a repo from the provided url and store it as a trusted artifact in the provided OCI repository.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
+|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
+|fetchTags|Fetch all tags for the repo.|false|false|
+|httpProxy|HTTP proxy server for non-SSL requests.|""|false|
+|httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. |""|false|
+|mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. |""|false|
+|mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
+|noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
+|ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
+|ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
+|refspec|Refspec to fetch before checking out revision.|""|false|
+|revision|Revision to checkout. (branch, tag, sha, ref, etc...)|""|false|
+|shortCommitLength|Length of short commit SHA|7|false|
+|sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
+|sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
+|submodulePaths|Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. |""|false|
+|submodules|Initialize and fetch git submodules.|true|false|
+|targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
+|url|Repository URL to clone from.||true|
+|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
+|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
+
+## Results
+|name|description|
+|---|---|
+|CHAINS-GIT_COMMIT|The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|CHAINS-GIT_URL|The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
+|commit|The precise commit SHA that was fetched by this Task.|
+|commit-timestamp|The commit timestamp of the checkout|
+|merged_sha|The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).|
+|short-commit|The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters|
+|url|The precise URL that was fetched by this Task.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. |true|
+|ssh-directory|A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. |true|
+
+## Additional info

--- a/task/git-clone-oci-ta/0.2/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.2/git-clone-oci-ta.yaml
@@ -46,6 +46,10 @@ spec:
       description: HTTPS proxy server for SSL requests.
       type: string
       default: ""
+    - name: logLevel
+      description: Log level for the git-clone command.
+      type: string
+      default: info
     - name: mergeSourceDepth
       description: |
         Perform a shallow fetch of the target branch, fetching only the most recent N commits.
@@ -116,16 +120,6 @@ spec:
     - name: url
       description: Repository URL to clone from.
       type: string
-    - name: userHome
-      description: |
-        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
-      type: string
-      default: /tekton/home
-    - name: verbose
-      description: Log the commands that are executed during `git-clone`'s
-        operation.
-      type: string
-      default: "false"
   results:
     - name: CHAINS-GIT_COMMIT
       description: The precise commit SHA that was fetched by this Task. This
@@ -177,7 +171,7 @@ spec:
       optional: true
   steps:
     - name: clone
-      image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:dd49bd35038c1cba174e6c166291e5df3d0d5f9be18ed3b2fb852fc6ce3181ed
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca
@@ -185,194 +179,80 @@ spec:
         - mountPath: /var/workdir
           name: workdir
       env:
-        - name: HOME
-          value: $(params.userHome)
-        - name: PARAM_URL
+        - name: KBC_GIT_CLONE_URL
           value: $(params.url)
-        - name: PARAM_REVISION
+        - name: KBC_GIT_CLONE_REVISION
           value: $(params.revision)
-        - name: PARAM_REFSPEC
+        - name: KBC_GIT_CLONE_REFSPEC
           value: $(params.refspec)
-        - name: PARAM_SUBMODULES
+        - name: KBC_GIT_CLONE_SUBMODULES
           value: $(params.submodules)
-        - name: PARAM_SUBMODULE_PATHS
+        - name: KBC_GIT_CLONE_SUBMODULE_PATHS
           value: $(params.submodulePaths)
-        - name: PARAM_DEPTH
+        - name: KBC_GIT_CLONE_DEPTH
           value: $(params.depth)
-        - name: PARAM_SHORT_COMMIT_LENGTH
+        - name: KBC_GIT_CLONE_SHORT_COMMIT_LENGTH
           value: $(params.shortCommitLength)
-        - name: PARAM_SSL_VERIFY
+        - name: KBC_GIT_CLONE_SSL_VERIFY
           value: $(params.sslVerify)
+        - name: KBC_GIT_CLONE_SPARSE_CHECKOUT_DIRECTORIES
+          value: $(params.sparseCheckoutDirectories)
+        - name: KBC_GIT_CLONE_ENABLE_SYMLINK_CHECK
+          value: $(params.enableSymlinkCheck)
+        - name: KBC_GIT_CLONE_FETCH_TAGS
+          value: $(params.fetchTags)
+        - name: KBC_GIT_CLONE_MERGE_TARGET_BRANCH
+          value: $(params.mergeTargetBranch)
+        - name: KBC_GIT_CLONE_TARGET_BRANCH
+          value: $(params.targetBranch)
+        - name: KBC_GIT_CLONE_MERGE_SOURCE_REPO_URL
+          value: $(params.mergeSourceRepoUrl)
+        - name: KBC_GIT_CLONE_MERGE_SOURCE_DEPTH
+          value: $(params.mergeSourceDepth)
+        - name: KBC_GIT_CLONE_BASIC_AUTH_DIRECTORY
+          value: $(workspaces.basic-auth.path)
+        - name: KBC_GIT_CLONE_SSH_DIRECTORY
+          value: $(workspaces.ssh-directory.path)
         - name: PARAM_HTTP_PROXY
           value: $(params.httpProxy)
         - name: PARAM_HTTPS_PROXY
           value: $(params.httpsProxy)
         - name: PARAM_NO_PROXY
           value: $(params.noProxy)
-        - name: PARAM_VERBOSE
-          value: $(params.verbose)
-        - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
-          value: $(params.sparseCheckoutDirectories)
-        - name: PARAM_USER_HOME
-          value: $(params.userHome)
-        - name: PARAM_FETCH_TAGS
-          value: $(params.fetchTags)
-        - name: PARAM_MERGE_TARGET_BRANCH
-          value: $(params.mergeTargetBranch)
-        - name: PARAM_TARGET_BRANCH
-          value: $(params.targetBranch)
-        - name: PARAM_MERGE_SOURCE_REPO_URL
-          value: $(params.mergeSourceRepoUrl)
-        - name: PARAM_MERGE_SOURCE_DEPTH
-          value: $(params.mergeSourceDepth)
-        - name: WORKSPACE_SSH_DIRECTORY_BOUND
-          value: $(workspaces.ssh-directory.bound)
-        - name: WORKSPACE_SSH_DIRECTORY_PATH
-          value: $(workspaces.ssh-directory.path)
-        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
-          value: $(workspaces.basic-auth.bound)
-        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
-          value: $(workspaces.basic-auth.path)
-        - name: CHECKOUT_DIR
-          value: /var/workdir/source
+        - name: KBC_LOG_LEVEL
+          value: $(params.logLevel)
+        - name: KBC_GIT_CLONE_OUTPUT_DIR
+          value: /var/workdir
+        - name: KBC_GIT_CLONE_SUBDIRECTORY
+          value: source
       script: |
-        #!/usr/bin/env sh
-        set -eu
+        #!/usr/bin/env bash
+        set -euo pipefail
 
-        if [ "${PARAM_VERBOSE}" = "true" ]; then
-          set -x
-        fi
-
-        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ]; then
-          if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
-            cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
-            cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
-          # Compatibility with kubernetes.io/basic-auth secrets
-          elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
-            HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
-            echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" >"${PARAM_USER_HOME}/.git-credentials"
-            echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" >"${PARAM_USER_HOME}/.gitconfig"
-          else
-            echo "Unknown basic-auth workspace format"
-            exit 1
-          fi
-          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
-          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
-        fi
-
-        # Should be called after the gitconfig is copied from the repository secret
         ca_bundle=/mnt/trusted-ca/ca-bundle.crt
         if [ -f "$ca_bundle" ]; then
           echo "INFO: Using mounted CA bundle: $ca_bundle"
-          git config --global http.sslCAInfo "$ca_bundle"
-        fi
-
-        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ]; then
-          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
-          chmod 700 "${PARAM_USER_HOME}"/.ssh
-          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+          cp -vf "$ca_bundle" /etc/pki/ca-trust/source/anchors
+          update-ca-trust
         fi
 
         test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
         test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
         test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
-        /ko-app/git-init \
-          -url="${PARAM_URL}" \
-          -revision="${PARAM_REVISION}" \
-          -refspec="${PARAM_REFSPEC}" \
-          -path="${CHECKOUT_DIR}" \
-          -sslVerify="${PARAM_SSL_VERIFY}" \
-          -submodules="${PARAM_SUBMODULES}" \
-          -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
-          -depth="${PARAM_DEPTH}" \
-          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
-          -retryMaxAttempts=10
-        cd "${CHECKOUT_DIR}"
-        RESULT_SHA="$(git rev-parse HEAD)"
-        RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
+        RESULT_FILE="$(mktemp)"
+        konflux-build-cli git-clone >"${RESULT_FILE}"
 
-        if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
-          echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+        printf "%s" "$(jq -r '.commit' "${RESULT_FILE}")" >"$(results.commit.path)"
+        printf "%s" "$(jq -r '.shortCommit' "${RESULT_FILE}")" >"$(results.short-commit.path)"
+        printf "%s" "$(jq -r '.url' "${RESULT_FILE}")" >"$(results.url.path)"
+        printf "%s" "$(jq -r '.commitTimestamp' "${RESULT_FILE}")" >"$(results.commit-timestamp.path)"
+        printf "%s" "$(jq -r '."CHAINS-GIT_URL"' "${RESULT_FILE}")" >"$(results.CHAINS-GIT_URL.path)"
+        printf "%s" "$(jq -r '."CHAINS-GIT_COMMIT"' "${RESULT_FILE}")" >"$(results.CHAINS-GIT_COMMIT.path)"
 
-          if [ "${PARAM_DEPTH}" = "1" ]; then
-            echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
-          fi
-
-          if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
-            echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
-          fi
-
-          # Determine if merging from a different repository or the same one
-          if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
-            # Normalize URLs for comparison (remove trailing slashes and .git suffix)
-            normalize_url() {
-              echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
-            }
-
-            NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
-            NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
-
-            if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
-              echo "Merge source URL is the same as origin. Using existing 'origin' remote."
-              MERGE_REMOTE="origin"
-            else
-              echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
-              echo "Adding remote 'merge-source'..."
-              git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
-              MERGE_REMOTE="merge-source"
-            fi
-          else
-            echo "Merging from the same repository (origin)"
-            MERGE_REMOTE="origin"
-          fi
-
-          echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
-          if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
-            retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
-          else
-            retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
-          fi
-
-          echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
-          git config --global user.email "tekton-git-clone@tekton.dev"
-          git config --global user.name "Tekton Git Clone Task"
-
-          if ! git merge FETCH_HEAD --no-commit --no-ff --allow-unrelated-histories; then
-            echo "ERROR: Merge conflict detected or merge failed before commit." >&2
-            echo "--- Git Status ---"
-            git status
-            echo "------------------"
-            exit 1
-          fi
-
-          # Check if there are changes staged for commit
-          if git diff --staged --quiet; then
-            echo "No diff was found, skipping merge..." >&2
-          else
-            echo "Merge successful (no conflicts found), committing..."
-            if ! git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"; then
-              echo "ERROR: Failed to commit merge." >&2
-              exit 1
-            fi
-            MERGED_SHA=$(git rev-parse HEAD)
-            echo "New HEAD after merge: ${MERGED_SHA}"
-            echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
-          fi
-
-        else
-          echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
-        fi
-        printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
-        printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"
-        printf "%s" "${RESULT_SHA_SHORT}" >"$(results.short-commit.path)"
-        printf "%s" "${PARAM_URL}" >"$(results.url.path)"
-        printf "%s" "${PARAM_URL}" >"$(results.CHAINS-GIT_URL.path)"
-        printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
-
-        if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
-          echo "Fetching tags"
-          retry git fetch --tags
+        MERGED_SHA=$(jq -r '.mergedSha // empty' "${RESULT_FILE}")
+        if [ -n "${MERGED_SHA}" ]; then
+          printf "%s" "${MERGED_SHA}" >"$(results.merged_sha.path)"
         fi
       computeResources:
         limits:
@@ -382,46 +262,8 @@ spec:
           memory: 2Gi
       securityContext:
         runAsUser: 0
-    - name: symlink-check
-      image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
-      volumeMounts:
-        - mountPath: /var/workdir
-          name: workdir
-      env:
-        - name: PARAM_ENABLE_SYMLINK_CHECK
-          value: $(params.enableSymlinkCheck)
-        - name: CHECKOUT_DIR
-          value: /var/workdir/source
-      script: |
-        #!/usr/bin/env bash
-        set -euo pipefail
-
-        check_symlinks() {
-          FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
-          while read -r symlink; do
-            target=$(readlink -m "$symlink")
-            if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
-              echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
-              FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
-            fi
-          done < <(find $CHECKOUT_DIR -type l -print)
-          if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ]; then
-            return 1
-          fi
-        }
-
-        if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ]; then
-          echo "Running symlink check"
-          check_symlinks
-        fi
-      computeResources:
-        limits:
-          memory: 64Mi
-        requests:
-          cpu: 50m
-          memory: 64Mi
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:f53e69930a5c6a6008ea55a29146e4c860ef3d88c390350bada38361b3feeb1a
       args:
         - create
         - --store

--- a/task/git-clone-oci-ta/0.2/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.2/git-clone-oci-ta.yaml
@@ -1,0 +1,445 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: git-clone-oci-ta
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/displayName: git clone oci trusted artifacts
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: git
+  labels:
+    app.kubernetes.io/version: "0.2"
+spec:
+  description: The git-clone-oci-ta Task will clone a repo from the provided
+    url and store it as a trusted artifact in the provided OCI repository.
+  params:
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: depth
+      description: Perform a shallow clone, fetching only the most recent
+        N commits.
+      type: string
+      default: "1"
+    - name: enableSymlinkCheck
+      description: |
+        Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
+      type: string
+      default: "true"
+    - name: fetchTags
+      description: Fetch all tags for the repo.
+      type: string
+      default: "false"
+    - name: httpProxy
+      description: HTTP proxy server for non-SSL requests.
+      type: string
+      default: ""
+    - name: httpsProxy
+      description: HTTPS proxy server for SSL requests.
+      type: string
+      default: ""
+    - name: mergeSourceDepth
+      description: |
+        Perform a shallow fetch of the target branch, fetching only the most recent N commits.
+        If empty, fetches the full history of the target branch.
+      type: string
+      default: ""
+    - name: mergeSourceRepoUrl
+      description: |
+        URL of the repository to fetch the target branch from when mergeTargetBranch is true.
+        If empty, uses the same repository (origin). This allows merging a branch from a different repository.
+      type: string
+      default: ""
+    - name: mergeTargetBranch
+      description: Set to "true" to merge the targetBranch into the checked-out
+        revision.
+      type: string
+      default: "false"
+    - name: noProxy
+      description: Opt out of proxying HTTP/HTTPS requests.
+      type: string
+      default: ""
+    - name: ociArtifactExpiresAfter
+      description: Expiration date for the trusted artifacts created in the
+        OCI repository. An empty string means the artifacts do not expire.
+      type: string
+      default: ""
+    - name: ociStorage
+      description: The OCI repository where the Trusted Artifacts are stored.
+      type: string
+    - name: refspec
+      description: Refspec to fetch before checking out revision.
+      type: string
+      default: ""
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      type: string
+      default: ""
+    - name: shortCommitLength
+      description: Length of short commit SHA
+      type: string
+      default: "7"
+    - name: sparseCheckoutDirectories
+      description: Define the directory patterns to match or exclude when
+        performing a sparse checkout.
+      type: string
+      default: ""
+    - name: sslVerify
+      description: Set the `http.sslVerify` global git config. Setting this
+        to `false` is not advised unless you are sure that you trust your
+        git remote.
+      type: string
+      default: "true"
+    - name: submodulePaths
+      description: |
+        Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched.
+        Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable.
+      type: string
+      default: ""
+    - name: submodules
+      description: Initialize and fetch git submodules.
+      type: string
+      default: "true"
+    - name: targetBranch
+      description: The target branch to merge into the revision (if mergeTargetBranch
+        is true).
+      type: string
+      default: main
+    - name: url
+      description: Repository URL to clone from.
+      type: string
+    - name: userHome
+      description: |
+        Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
+      type: string
+      default: /tekton/home
+    - name: verbose
+      description: Log the commands that are executed during `git-clone`'s
+        operation.
+      type: string
+      default: "false"
+  results:
+    - name: CHAINS-GIT_COMMIT
+      description: The precise commit SHA that was fetched by this Task. This
+        result uses Chains type hinting to include in the provenance.
+    - name: CHAINS-GIT_URL
+      description: The precise URL that was fetched by this Task. This result
+        uses Chains type hinting to include in the provenance.
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task.
+    - name: commit-timestamp
+      description: The commit timestamp of the checkout
+    - name: merged_sha
+      description: The SHA of the commit after merging the target branch (if
+        the param mergeTargetBranch is true).
+    - name: short-commit
+      description: The commit SHA that was fetched by this Task limited to
+        params.shortCommitLength number of characters
+    - name: url
+      description: The precise URL that was fetched by this Task.
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  workspaces:
+    - name: basic-auth
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file or username and password.
+        These will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
+      optional: true
+    - name: ssh-directory
+      description: |
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types.
+      optional: true
+  steps:
+    - name: clone
+      image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+      volumeMounts:
+        - mountPath: /mnt/trusted-ca
+          name: trusted-ca
+          readOnly: true
+        - mountPath: /var/workdir
+          name: workdir
+      env:
+        - name: HOME
+          value: $(params.userHome)
+        - name: PARAM_URL
+          value: $(params.url)
+        - name: PARAM_REVISION
+          value: $(params.revision)
+        - name: PARAM_REFSPEC
+          value: $(params.refspec)
+        - name: PARAM_SUBMODULES
+          value: $(params.submodules)
+        - name: PARAM_SUBMODULE_PATHS
+          value: $(params.submodulePaths)
+        - name: PARAM_DEPTH
+          value: $(params.depth)
+        - name: PARAM_SHORT_COMMIT_LENGTH
+          value: $(params.shortCommitLength)
+        - name: PARAM_SSL_VERIFY
+          value: $(params.sslVerify)
+        - name: PARAM_HTTP_PROXY
+          value: $(params.httpProxy)
+        - name: PARAM_HTTPS_PROXY
+          value: $(params.httpsProxy)
+        - name: PARAM_NO_PROXY
+          value: $(params.noProxy)
+        - name: PARAM_VERBOSE
+          value: $(params.verbose)
+        - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+          value: $(params.sparseCheckoutDirectories)
+        - name: PARAM_USER_HOME
+          value: $(params.userHome)
+        - name: PARAM_FETCH_TAGS
+          value: $(params.fetchTags)
+        - name: PARAM_MERGE_TARGET_BRANCH
+          value: $(params.mergeTargetBranch)
+        - name: PARAM_TARGET_BRANCH
+          value: $(params.targetBranch)
+        - name: PARAM_MERGE_SOURCE_REPO_URL
+          value: $(params.mergeSourceRepoUrl)
+        - name: PARAM_MERGE_SOURCE_DEPTH
+          value: $(params.mergeSourceDepth)
+        - name: WORKSPACE_SSH_DIRECTORY_BOUND
+          value: $(workspaces.ssh-directory.bound)
+        - name: WORKSPACE_SSH_DIRECTORY_PATH
+          value: $(workspaces.ssh-directory.path)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+          value: $(workspaces.basic-auth.bound)
+        - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+          value: $(workspaces.basic-auth.path)
+        - name: CHECKOUT_DIR
+          value: /var/workdir/source
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${PARAM_VERBOSE}" = "true" ]; then
+          set -x
+        fi
+
+        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ]; then
+          if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
+            cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+            cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+          # Compatibility with kubernetes.io/basic-auth secrets
+          elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
+            HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
+            echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" >"${PARAM_USER_HOME}/.git-credentials"
+            echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" >"${PARAM_USER_HOME}/.gitconfig"
+          else
+            echo "Unknown basic-auth workspace format"
+            exit 1
+          fi
+          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+        fi
+
+        # Should be called after the gitconfig is copied from the repository secret
+        ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+        if [ -f "$ca_bundle" ]; then
+          echo "INFO: Using mounted CA bundle: $ca_bundle"
+          git config --global http.sslCAInfo "$ca_bundle"
+        fi
+
+        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ]; then
+          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          chmod 700 "${PARAM_USER_HOME}"/.ssh
+          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        fi
+
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+        /ko-app/git-init \
+          -url="${PARAM_URL}" \
+          -revision="${PARAM_REVISION}" \
+          -refspec="${PARAM_REFSPEC}" \
+          -path="${CHECKOUT_DIR}" \
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
+          -depth="${PARAM_DEPTH}" \
+          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
+          -retryMaxAttempts=10
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
+
+        if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
+          echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+
+          if [ "${PARAM_DEPTH}" = "1" ]; then
+            echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
+          fi
+
+          if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
+            echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
+          fi
+
+          # Determine if merging from a different repository or the same one
+          if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
+            # Normalize URLs for comparison (remove trailing slashes and .git suffix)
+            normalize_url() {
+              echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
+            }
+
+            NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
+            NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
+
+            if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
+              echo "Merge source URL is the same as origin. Using existing 'origin' remote."
+              MERGE_REMOTE="origin"
+            else
+              echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
+              echo "Adding remote 'merge-source'..."
+              git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
+              MERGE_REMOTE="merge-source"
+            fi
+          else
+            echo "Merging from the same repository (origin)"
+            MERGE_REMOTE="origin"
+          fi
+
+          echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
+          if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
+            retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+          else
+            retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+          fi
+
+          echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
+          git config --global user.email "tekton-git-clone@tekton.dev"
+          git config --global user.name "Tekton Git Clone Task"
+
+          if ! git merge FETCH_HEAD --no-commit --no-ff --allow-unrelated-histories; then
+            echo "ERROR: Merge conflict detected or merge failed before commit." >&2
+            echo "--- Git Status ---"
+            git status
+            echo "------------------"
+            exit 1
+          fi
+
+          # Check if there are changes staged for commit
+          if git diff --staged --quiet; then
+            echo "No diff was found, skipping merge..." >&2
+          else
+            echo "Merge successful (no conflicts found), committing..."
+            if ! git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"; then
+              echo "ERROR: Failed to commit merge." >&2
+              exit 1
+            fi
+            MERGED_SHA=$(git rev-parse HEAD)
+            echo "New HEAD after merge: ${MERGED_SHA}"
+            echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
+          fi
+
+        else
+          echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
+        fi
+        printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
+        printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"
+        printf "%s" "${RESULT_SHA_SHORT}" >"$(results.short-commit.path)"
+        printf "%s" "${PARAM_URL}" >"$(results.url.path)"
+        printf "%s" "${PARAM_URL}" >"$(results.CHAINS-GIT_URL.path)"
+        printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
+
+        if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
+          echo "Fetching tags"
+          retry git fetch --tags
+        fi
+      computeResources:
+        limits:
+          memory: 2Gi
+        requests:
+          cpu: 350m
+          memory: 2Gi
+      securityContext:
+        runAsUser: 0
+    - name: symlink-check
+      image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+      volumeMounts:
+        - mountPath: /var/workdir
+          name: workdir
+      env:
+        - name: PARAM_ENABLE_SYMLINK_CHECK
+          value: $(params.enableSymlinkCheck)
+        - name: CHECKOUT_DIR
+          value: /var/workdir/source
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        check_symlinks() {
+          FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
+          while read -r symlink; do
+            target=$(readlink -m "$symlink")
+            if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
+              echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
+              FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
+            fi
+          done < <(find $CHECKOUT_DIR -type l -print)
+          if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ]; then
+            return 1
+          fi
+        }
+
+        if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ]; then
+          echo "Running symlink check"
+          check_symlinks
+        fi
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+    - name: create-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+      volumeMounts:
+        - mountPath: /var/workdir
+          name: workdir
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+      computeResources:
+        limits:
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 3Gi

--- a/task/git-clone-oci-ta/0.2/kustomization.yaml
+++ b/task/git-clone-oci-ta/0.2/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- git-clone-oci-ta.yaml

--- a/task/git-clone-oci-ta/0.2/migrations/0.2.sh
+++ b/task/git-clone-oci-ta/0.2/migrations/0.2.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+declare -r pipeline_file=${1:?missing pipeline file}
+
+tasks_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "git-clone" "git-clone-oci-ta" "git-clone-oci-ta-min" "pnc-prebuild-git-clone-oci-ta"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null 2>&1; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#tasks_names[@]} tasks_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#tasks_names[@]} -eq 0 ]; then
+    echo "No git-clone tasks found"
+    exit 0
+fi
+
+for task_name in "${tasks_names[@]}"; do
+    task_name_selector="${tasks_selector} | select(.name == \"${task_name}\")"
+    verbose_val=$(yq -e "${task_name_selector} | .params[] | select(.name == \"verbose\") | .value" "$pipeline_file" 2>/dev/null) || true
+
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param gitInitImage
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param verbose
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param userHome
+    if [ "${verbose_val}" = "true" ]; then
+        pmt modify -f "$pipeline_file" task "$task_name" add-param logLevel "debug"
+    fi
+done

--- a/task/git-clone-oci-ta/0.2/recipe.yaml
+++ b/task/git-clone-oci-ta/0.2/recipe.yaml
@@ -1,12 +1,13 @@
 ---
 base: ../../git-clone/0.2/git-clone.yaml
 removeParams:
-  - gitInitImage
   - deleteExisting
   - subdirectory
 addEnvironment:
-  - name: CHECKOUT_DIR
-    value: /var/workdir/source
+  - name: KBC_GIT_CLONE_OUTPUT_DIR
+    value: /var/workdir
+  - name: KBC_GIT_CLONE_SUBDIRECTORY
+    value: source
 add:
   - create-source
 useTAVolumeMount: true

--- a/task/git-clone-oci-ta/0.2/recipe.yaml
+++ b/task/git-clone-oci-ta/0.2/recipe.yaml
@@ -1,0 +1,16 @@
+---
+base: ../../git-clone/0.2/git-clone.yaml
+removeParams:
+  - gitInitImage
+  - deleteExisting
+  - subdirectory
+addEnvironment:
+  - name: CHECKOUT_DIR
+    value: /var/workdir/source
+add:
+  - create-source
+useTAVolumeMount: true
+removeWorkspaces:
+  - output
+description: The git-clone-oci-ta Task will clone a repo from the provided url and store it as a trusted
+    artifact in the provided OCI repository.

--- a/task/git-clone-oci-ta/CHANGELOG.md
+++ b/task/git-clone-oci-ta/CHANGELOG.md
@@ -1,15 +1,7 @@
 # Changelog
 
-<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
-
 ## 0.2
 
-- Updated base task to git-clone-oci-ta 0.2.
+- Use git-clone implementation from konflux-build-cli instead of inline Bash.
 - Removed `gitInitImage` (deprecated since 0.1), `verbose` (replaced by `logLevel`), and `userHome` (handled by konflux-build-cli) parameters.
 - Added `logLevel` parameter.
-
-## 0.1
-
-### Added
-
-- The initial version of the `git-clone-oci-ta-min` task!

--- a/task/git-clone/0.1/git-clone.yaml
+++ b/task/git-clone/0.1/git-clone.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
+    build.appstudio.redhat.com/expires-on: "2026-08-20T00:00:00Z"
     tekton.dev/categories: Git
     tekton.dev/displayName: git clone
     tekton.dev/pipelines.minVersion: 0.21.0

--- a/task/git-clone/0.2/MIGRATION.md
+++ b/task/git-clone/0.2/MIGRATION.md
@@ -1,0 +1,14 @@
+# Migration from 0.1 to 0.2
+
+## What changed
+
+- **Removed parameters:** `gitInitImage`, `verbose`, `userHome`.
+- **New parameter:** `logLevel` (default `info`) replaces `verbose`. Valid values: `debug`, `info`, `warn`, `error`.
+- **Image changed:** The task now uses `konflux-build-cli` instead of the previous `git-clone` image.
+- **Step consolidation:** The separate `symlink-check` step has been merged into the `clone` step. Symlink checking is now handled internally by the Go binary.
+
+## Action from users
+
+The migration should be done automatically by renovate.
+For users who don't have automatic updates, remove `gitInitImage`, `verbose`, and `userHome` parameters if present.
+Replace `verbose: "true"` with `logLevel: "debug"` if needed.

--- a/task/git-clone/0.2/README.md
+++ b/task/git-clone/0.2/README.md
@@ -1,0 +1,52 @@
+# git-clone task
+
+The git-clone Task will clone a repo from the provided url into the output Workspace. By default the repo will be cloned into the root of your Workspace.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|url|Repository URL to clone from.||true|
+|revision|Revision to checkout. (branch, tag, sha, ref, etc...)|""|false|
+|refspec|Refspec to fetch before checking out revision.|""|false|
+|submodules|Initialize and fetch git submodules.|true|false|
+|submodulePaths|Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. |""|false|
+|depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
+|shortCommitLength|Length of short commit SHA|7|false|
+|sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
+|subdirectory|Subdirectory inside the `output` Workspace to clone the repo into.|source|false|
+|sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
+|deleteExisting|Clean out the contents of the destination directory if it already exists before cloning.|true|false|
+|httpProxy|HTTP proxy server for non-SSL requests.|""|false|
+|httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
+|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
+|gitInitImage|Deprecated. Has no effect. Will be removed in the future.|""|false|
+|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
+|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
+|fetchTags|Fetch all tags for the repo.|false|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
+|targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
+|mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository.|""|false|
+|mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch.|""|false|
+
+## Results
+|name|description|
+|---|---|
+|commit|The precise commit SHA that was fetched by this Task.|
+|short-commit|The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters|
+|url|The precise URL that was fetched by this Task.|
+|commit-timestamp|The commit timestamp of the checkout|
+|CHAINS-GIT_URL|The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|CHAINS-GIT_COMMIT|The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|merged_sha|The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|output|The git repo will be cloned onto the volume backing this Workspace.|false|
+|ssh-directory|A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. |true|
+|basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. |true|
+
+## Additional info

--- a/task/git-clone/0.2/README.md
+++ b/task/git-clone/0.2/README.md
@@ -18,18 +18,16 @@ The git-clone Task will clone a repo from the provided url into the output Works
 |deleteExisting|Clean out the contents of the destination directory if it already exists before cloning.|true|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|logLevel|Log level for the git-clone command.|info|false|
 |noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
-|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
-|gitInitImage|Deprecated. Has no effect. Will be removed in the future.|""|false|
-|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
 |enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
 |fetchTags|Fetch all tags for the repo.|false|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
 |targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
-|mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository.|""|false|
-|mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch.|""|false|
+|mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. |""|false|
+|mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. |""|false|
 
 ## Results
 |name|description|

--- a/task/git-clone/0.2/git-clone.yaml
+++ b/task/git-clone/0.2/git-clone.yaml
@@ -1,0 +1,442 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.2"
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/displayName: git clone
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: git
+  name: git-clone
+spec:
+  description: |-
+    The git-clone Task will clone a repo from the provided url into the output Workspace. By default the repo will be cloned into the root of your Workspace.
+  params:
+  - description: Repository URL to clone from.
+    name: url
+    type: string
+  - default: ""
+    description: Revision to checkout. (branch, tag, sha, ref, etc...)
+    name: revision
+    type: string
+  - default: ""
+    description: Refspec to fetch before checking out revision.
+    name: refspec
+    type: string
+  - default: "true"
+    description: Initialize and fetch git submodules.
+    name: submodules
+    type: string
+  - name: submodulePaths
+    description: |
+      Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched.
+      Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable.
+    type: string
+    default: ""
+  - default: "1"
+    description: Perform a shallow clone, fetching only the most recent N commits.
+    name: depth
+    type: string
+  - name: shortCommitLength
+    description: Length of short commit SHA
+    type: string
+    default: "7"
+  - default: "true"
+    description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
+    name: sslVerify
+    type: string
+  - default: "source"
+    description: Subdirectory inside the `output` Workspace to clone the repo into.
+    name: subdirectory
+    type: string
+  - default: ""
+    description: Define the directory patterns to match or exclude when performing a sparse checkout.
+    name: sparseCheckoutDirectories
+    type: string
+  - default: "true"
+    description: Clean out the contents of the destination directory if it already exists before cloning.
+    name: deleteExisting
+    type: string
+  - default: ""
+    description: HTTP proxy server for non-SSL requests.
+    name: httpProxy
+    type: string
+  - default: ""
+    description: HTTPS proxy server for SSL requests.
+    name: httpsProxy
+    type: string
+  - default: ""
+    description: Opt out of proxying HTTP/HTTPS requests.
+    name: noProxy
+    type: string
+  - default: "false"
+    description: Log the commands that are executed during `git-clone`'s operation.
+    name: verbose
+    type: string
+  - default: ""
+    description: Deprecated. Has no effect. Will be removed in the future.
+    name: gitInitImage
+  - default: /tekton/home
+    description: |
+      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
+    name: userHome
+    type: string
+  - default: "true"
+    description: |
+      Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
+    name: enableSymlinkCheck
+    type: string
+  - default: "false"
+    description: Fetch all tags for the repo.
+    name: fetchTags
+    type: string
+  - name: caTrustConfigMapName
+    type: string
+    description: The name of the ConfigMap to read CA bundle data from.
+    default: trusted-ca
+  - name: caTrustConfigMapKey
+    type: string
+    description: The name of the key in the ConfigMap that contains the CA bundle data.
+    default: ca-bundle.crt
+  - name: mergeTargetBranch
+    description: Set to "true" to merge the targetBranch into the checked-out revision.
+    type: string
+    default: "false"
+  - name: targetBranch
+    description: The target branch to merge into the revision (if mergeTargetBranch is true).
+    type: string
+    default: "main"
+  - name: mergeSourceRepoUrl
+    description: |
+      URL of the repository to fetch the target branch from when mergeTargetBranch is true.
+      If empty, uses the same repository (origin). This allows merging a branch from a different repository.
+    type: string
+    default: ""
+  - name: mergeSourceDepth
+    description: |
+      Perform a shallow fetch of the target branch, fetching only the most recent N commits.
+      If empty, fetches the full history of the target branch.
+    type: string
+    default: ""
+  results:
+  - description: The precise commit SHA that was fetched by this Task.
+    name: commit
+  - description: The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters
+    name: short-commit
+  - description: The precise URL that was fetched by this Task.
+    name: url
+  - description: The commit timestamp of the checkout
+    name: commit-timestamp
+  - description: The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.
+    name: CHAINS-GIT_URL
+  - description: The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.
+    name: CHAINS-GIT_COMMIT
+  - name: merged_sha
+    description: The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).
+  steps:
+  - name: clone
+    env:
+    - name: HOME
+      value: $(params.userHome)
+    - name: PARAM_URL
+      value: $(params.url)
+    - name: PARAM_REVISION
+      value: $(params.revision)
+    - name: PARAM_REFSPEC
+      value: $(params.refspec)
+    - name: PARAM_SUBMODULES
+      value: $(params.submodules)
+    - name: PARAM_SUBMODULE_PATHS
+      value: $(params.submodulePaths)
+    - name: PARAM_DEPTH
+      value: $(params.depth)
+    - name: PARAM_SHORT_COMMIT_LENGTH
+      value: $(params.shortCommitLength)
+    - name: PARAM_SSL_VERIFY
+      value: $(params.sslVerify)
+    - name: PARAM_SUBDIRECTORY
+      value: $(params.subdirectory)
+    - name: PARAM_DELETE_EXISTING
+      value: $(params.deleteExisting)
+    - name: PARAM_HTTP_PROXY
+      value: $(params.httpProxy)
+    - name: PARAM_HTTPS_PROXY
+      value: $(params.httpsProxy)
+    - name: PARAM_NO_PROXY
+      value: $(params.noProxy)
+    - name: PARAM_VERBOSE
+      value: $(params.verbose)
+    - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+      value: $(params.sparseCheckoutDirectories)
+    - name: PARAM_USER_HOME
+      value: $(params.userHome)
+    - name: PARAM_FETCH_TAGS
+      value: $(params.fetchTags)
+    - name: PARAM_GIT_INIT_IMAGE
+      value: $(params.gitInitImage)
+    - name: PARAM_MERGE_TARGET_BRANCH
+      value: $(params.mergeTargetBranch)
+    - name: PARAM_TARGET_BRANCH
+      value: $(params.targetBranch)
+    - name: PARAM_MERGE_SOURCE_REPO_URL
+      value: $(params.mergeSourceRepoUrl)
+    - name: PARAM_MERGE_SOURCE_DEPTH
+      value: $(params.mergeSourceDepth)
+    - name: WORKSPACE_OUTPUT_PATH
+      value: $(workspaces.output.path)
+    - name: WORKSPACE_SSH_DIRECTORY_BOUND
+      value: $(workspaces.ssh-directory.bound)
+    - name: WORKSPACE_SSH_DIRECTORY_PATH
+      value: $(workspaces.ssh-directory.path)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+      value: $(workspaces.basic-auth.bound)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+      value: $(workspaces.basic-auth.path)
+    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    computeResources:
+      limits:
+        memory: 2Gi
+      requests:
+        cpu: 350m
+        memory: 2Gi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+      - name: trusted-ca
+        mountPath: /mnt/trusted-ca
+        readOnly: true
+    script: |
+      #!/usr/bin/env sh
+      set -eu
+
+      if [ "${PARAM_VERBOSE}" = "true" ] ; then
+        set -x
+      fi
+
+      if [ -n "${PARAM_GIT_INIT_IMAGE}" ]; then
+        echo "WARNING: provided deprecated gitInitImage parameter has no effect."
+      fi
+
+      if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+        if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+        # Compatibility with kubernetes.io/basic-auth secrets
+        elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
+          HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
+          echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" > "${PARAM_USER_HOME}/.git-credentials"
+          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${PARAM_USER_HOME}/.gitconfig"
+        else
+          echo "Unknown basic-auth workspace format"
+          exit 1
+        fi
+        chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+        chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+      fi
+
+      # Should be called after the gitconfig is copied from the repository secret
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        git config --global http.sslCAInfo "$ca_bundle"
+      fi
+
+      if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+        cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+        chmod 700 "${PARAM_USER_HOME}"/.ssh
+        chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+      fi
+
+      CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+
+      cleandir() {
+        # Delete any existing contents of the repo directory if it exists.
+        #
+        # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
+        # or the root of a mounted volume.
+        if [ -d "${CHECKOUT_DIR}" ] ; then
+          # Delete non-hidden files and directories
+          rm -rf "${CHECKOUT_DIR:?}"/*
+          # Delete files and directories starting with . but excluding ..
+          rm -rf "${CHECKOUT_DIR}"/.[!.]*
+          # Delete files and directories starting with .. plus any other character
+          rm -rf "${CHECKOUT_DIR}"/..?*
+        fi
+      }
+
+      if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
+        cleandir
+      fi
+
+      test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+      test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+      test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+      /ko-app/git-init \
+        -url="${PARAM_URL}" \
+        -revision="${PARAM_REVISION}" \
+        -refspec="${PARAM_REFSPEC}" \
+        -path="${CHECKOUT_DIR}" \
+        -sslVerify="${PARAM_SSL_VERIFY}" \
+        -submodules="${PARAM_SUBMODULES}" \
+        -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
+        -depth="${PARAM_DEPTH}" \
+        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
+        -retryMaxAttempts=10
+      cd "${CHECKOUT_DIR}"
+      RESULT_SHA="$(git rev-parse HEAD)"
+      RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
+
+      if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
+        echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+
+        if [ "${PARAM_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        # Determine if merging from a different repository or the same one
+        if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
+          # Normalize URLs for comparison (remove trailing slashes and .git suffix)
+          normalize_url() {
+            echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
+          }
+
+          NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
+          NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
+
+          if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
+            echo "Merge source URL is the same as origin. Using existing 'origin' remote."
+            MERGE_REMOTE="origin"
+          else
+            echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
+            echo "Adding remote 'merge-source'..."
+            git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
+            MERGE_REMOTE="merge-source"
+          fi
+        else
+          echo "Merging from the same repository (origin)"
+          MERGE_REMOTE="origin"
+        fi
+
+        echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
+        if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
+          retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        else
+          retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        fi
+
+
+        echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
+        git config --global user.email "tekton-git-clone@tekton.dev"
+        git config --global user.name "Tekton Git Clone Task"
+
+      if ! git merge FETCH_HEAD --no-commit --no-ff --allow-unrelated-histories; then
+        echo "ERROR: Merge conflict detected or merge failed before commit." >&2
+        echo "--- Git Status ---"
+        git status
+        echo "------------------"
+        exit 1
+      fi
+
+      # Check if there are changes staged for commit
+      if git diff --staged --quiet; then
+        echo "No diff was found, skipping merge..." >&2
+      else
+        echo "Merge successful (no conflicts found), committing..."
+      if ! git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"; then
+        echo "ERROR: Failed to commit merge." >&2
+        exit 1
+      fi
+        MERGED_SHA=$(git rev-parse HEAD)
+        echo "New HEAD after merge: ${MERGED_SHA}"
+        echo "${MERGED_SHA}" > "$(results.merged_sha.path)"
+      fi
+
+      else
+        echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
+      fi
+      printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+      printf "%s" "${RESULT_SHA}" > "$(results.CHAINS-GIT_COMMIT.path)"
+      printf "%s" "${RESULT_SHA_SHORT}" > "$(results.short-commit.path)"
+      printf "%s" "${PARAM_URL}" > "$(results.url.path)"
+      printf "%s" "${PARAM_URL}" > "$(results.CHAINS-GIT_URL.path)"
+      printf "%s" "$(git log -1 --pretty=%ct)" > "$(results.commit-timestamp.path)"
+
+      if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
+        echo "Fetching tags"
+        retry git fetch --tags
+      fi
+
+  - name: symlink-check
+    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    env:
+    - name: PARAM_ENABLE_SYMLINK_CHECK
+      value: $(params.enableSymlinkCheck)
+    - name: PARAM_SUBDIRECTORY
+      value: $(params.subdirectory)
+    - name: WORKSPACE_OUTPUT_PATH
+      value: $(workspaces.output.path)
+    computeResources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+      check_symlinks() {
+        FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
+        while read -r symlink
+        do
+          target=$(readlink -m "$symlink")
+          if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
+            echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
+            FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
+          fi
+        done < <(find $CHECKOUT_DIR -type l -print)
+        if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ] ; then
+          return 1
+        fi
+      }
+
+      if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ] ; then
+        echo "Running symlink check"
+        check_symlinks
+      fi
+  workspaces:
+  - description: The git repo will be cloned onto the volume backing this Workspace.
+    name: output
+  - description: |
+      A .ssh directory with private key, known_hosts, config, etc. Copied to
+      the user's home before git commands are executed. Used to authenticate
+      with the git remote when performing the clone. Binding a Secret to this
+      Workspace is strongly recommended over other volume types.
+    name: ssh-directory
+    optional: true
+  - description: |
+      A Workspace containing a .gitconfig and .git-credentials file or username and password.
+      These will be copied to the user's home before any git commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to use ssh-directory over basic-auth whenever possible and to bind a
+      Secret to this Workspace over other volume types.
+    name: basic-auth
+    optional: true
+  volumes:
+    - name: trusted-ca
+      configMap:
+        name: $(params.caTrustConfigMapName)
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        optional: true

--- a/task/git-clone/0.2/git-clone.yaml
+++ b/task/git-clone/0.2/git-clone.yaml
@@ -67,21 +67,13 @@ spec:
     description: HTTPS proxy server for SSL requests.
     name: httpsProxy
     type: string
+  - name: logLevel
+    description: Log level for the git-clone command.
+    type: string
+    default: "info"
   - default: ""
     description: Opt out of proxying HTTP/HTTPS requests.
     name: noProxy
-    type: string
-  - default: "false"
-    description: Log the commands that are executed during `git-clone`'s operation.
-    name: verbose
-    type: string
-  - default: ""
-    description: Deprecated. Has no effect. Will be removed in the future.
-    name: gitInitImage
-  - default: /tekton/home
-    description: |
-      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
-    name: userHome
     type: string
   - default: "true"
     description: |
@@ -138,63 +130,55 @@ spec:
   steps:
   - name: clone
     env:
-    - name: HOME
-      value: $(params.userHome)
-    - name: PARAM_URL
+    - name: KBC_GIT_CLONE_URL
       value: $(params.url)
-    - name: PARAM_REVISION
+    - name: KBC_GIT_CLONE_REVISION
       value: $(params.revision)
-    - name: PARAM_REFSPEC
+    - name: KBC_GIT_CLONE_REFSPEC
       value: $(params.refspec)
-    - name: PARAM_SUBMODULES
+    - name: KBC_GIT_CLONE_SUBMODULES
       value: $(params.submodules)
-    - name: PARAM_SUBMODULE_PATHS
+    - name: KBC_GIT_CLONE_SUBMODULE_PATHS
       value: $(params.submodulePaths)
-    - name: PARAM_DEPTH
+    - name: KBC_GIT_CLONE_DEPTH
       value: $(params.depth)
-    - name: PARAM_SHORT_COMMIT_LENGTH
+    - name: KBC_GIT_CLONE_SHORT_COMMIT_LENGTH
       value: $(params.shortCommitLength)
-    - name: PARAM_SSL_VERIFY
+    - name: KBC_GIT_CLONE_SSL_VERIFY
       value: $(params.sslVerify)
-    - name: PARAM_SUBDIRECTORY
+    - name: KBC_GIT_CLONE_SUBDIRECTORY
       value: $(params.subdirectory)
-    - name: PARAM_DELETE_EXISTING
+    - name: KBC_GIT_CLONE_SPARSE_CHECKOUT_DIRECTORIES
+      value: $(params.sparseCheckoutDirectories)
+    - name: KBC_GIT_CLONE_DELETE_EXISTING
       value: $(params.deleteExisting)
+    - name: KBC_GIT_CLONE_ENABLE_SYMLINK_CHECK
+      value: $(params.enableSymlinkCheck)
+    - name: KBC_GIT_CLONE_FETCH_TAGS
+      value: $(params.fetchTags)
+    - name: KBC_GIT_CLONE_MERGE_TARGET_BRANCH
+      value: $(params.mergeTargetBranch)
+    - name: KBC_GIT_CLONE_TARGET_BRANCH
+      value: $(params.targetBranch)
+    - name: KBC_GIT_CLONE_MERGE_SOURCE_REPO_URL
+      value: $(params.mergeSourceRepoUrl)
+    - name: KBC_GIT_CLONE_MERGE_SOURCE_DEPTH
+      value: $(params.mergeSourceDepth)
+    - name: KBC_GIT_CLONE_OUTPUT_DIR
+      value: $(workspaces.output.path)
+    - name: KBC_GIT_CLONE_BASIC_AUTH_DIRECTORY
+      value: $(workspaces.basic-auth.path)
+    - name: KBC_GIT_CLONE_SSH_DIRECTORY
+      value: $(workspaces.ssh-directory.path)
     - name: PARAM_HTTP_PROXY
       value: $(params.httpProxy)
     - name: PARAM_HTTPS_PROXY
       value: $(params.httpsProxy)
     - name: PARAM_NO_PROXY
       value: $(params.noProxy)
-    - name: PARAM_VERBOSE
-      value: $(params.verbose)
-    - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
-      value: $(params.sparseCheckoutDirectories)
-    - name: PARAM_USER_HOME
-      value: $(params.userHome)
-    - name: PARAM_FETCH_TAGS
-      value: $(params.fetchTags)
-    - name: PARAM_GIT_INIT_IMAGE
-      value: $(params.gitInitImage)
-    - name: PARAM_MERGE_TARGET_BRANCH
-      value: $(params.mergeTargetBranch)
-    - name: PARAM_TARGET_BRANCH
-      value: $(params.targetBranch)
-    - name: PARAM_MERGE_SOURCE_REPO_URL
-      value: $(params.mergeSourceRepoUrl)
-    - name: PARAM_MERGE_SOURCE_DEPTH
-      value: $(params.mergeSourceDepth)
-    - name: WORKSPACE_OUTPUT_PATH
-      value: $(workspaces.output.path)
-    - name: WORKSPACE_SSH_DIRECTORY_BOUND
-      value: $(workspaces.ssh-directory.bound)
-    - name: WORKSPACE_SSH_DIRECTORY_PATH
-      value: $(workspaces.ssh-directory.path)
-    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
-      value: $(workspaces.basic-auth.bound)
-    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
-      value: $(workspaces.basic-auth.path)
-    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    - name: KBC_LOG_LEVEL
+      value: $(params.logLevel)
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:dd49bd35038c1cba174e6c166291e5df3d0d5f9be18ed3b2fb852fc6ce3181ed
     computeResources:
       limits:
         memory: 2Gi
@@ -208,211 +192,33 @@ spec:
         mountPath: /mnt/trusted-ca
         readOnly: true
     script: |
-      #!/usr/bin/env sh
-      set -eu
+      #!/usr/bin/env bash
+      set -euo pipefail
 
-      if [ "${PARAM_VERBOSE}" = "true" ] ; then
-        set -x
-      fi
-
-      if [ -n "${PARAM_GIT_INIT_IMAGE}" ]; then
-        echo "WARNING: provided deprecated gitInitImage parameter has no effect."
-      fi
-
-      if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
-        if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
-          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
-          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
-        # Compatibility with kubernetes.io/basic-auth secrets
-        elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
-          HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
-          echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" > "${PARAM_USER_HOME}/.git-credentials"
-          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" > "${PARAM_USER_HOME}/.gitconfig"
-        else
-          echo "Unknown basic-auth workspace format"
-          exit 1
-        fi
-        chmod 400 "${PARAM_USER_HOME}/.git-credentials"
-        chmod 400 "${PARAM_USER_HOME}/.gitconfig"
-      fi
-
-      # Should be called after the gitconfig is copied from the repository secret
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
-        git config --global http.sslCAInfo "$ca_bundle"
-      fi
-
-      if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
-        cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
-        chmod 700 "${PARAM_USER_HOME}"/.ssh
-        chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
-      fi
-
-      CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
-
-      cleandir() {
-        # Delete any existing contents of the repo directory if it exists.
-        #
-        # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
-        # or the root of a mounted volume.
-        if [ -d "${CHECKOUT_DIR}" ] ; then
-          # Delete non-hidden files and directories
-          rm -rf "${CHECKOUT_DIR:?}"/*
-          # Delete files and directories starting with . but excluding ..
-          rm -rf "${CHECKOUT_DIR}"/.[!.]*
-          # Delete files and directories starting with .. plus any other character
-          rm -rf "${CHECKOUT_DIR}"/..?*
-        fi
-      }
-
-      if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
-        cleandir
+        cp -vf "$ca_bundle" /etc/pki/ca-trust/source/anchors
+        update-ca-trust
       fi
 
       test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
       test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
       test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
-      /ko-app/git-init \
-        -url="${PARAM_URL}" \
-        -revision="${PARAM_REVISION}" \
-        -refspec="${PARAM_REFSPEC}" \
-        -path="${CHECKOUT_DIR}" \
-        -sslVerify="${PARAM_SSL_VERIFY}" \
-        -submodules="${PARAM_SUBMODULES}" \
-        -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
-        -depth="${PARAM_DEPTH}" \
-        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
-        -retryMaxAttempts=10
-      cd "${CHECKOUT_DIR}"
-      RESULT_SHA="$(git rev-parse HEAD)"
-      RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
+      RESULT_FILE="$(mktemp)"
+      konflux-build-cli git-clone > "${RESULT_FILE}"
 
-      if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
-        echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+      printf "%s" "$(jq -r '.commit' "${RESULT_FILE}")" > "$(results.commit.path)"
+      printf "%s" "$(jq -r '.shortCommit' "${RESULT_FILE}")" > "$(results.short-commit.path)"
+      printf "%s" "$(jq -r '.url' "${RESULT_FILE}")" > "$(results.url.path)"
+      printf "%s" "$(jq -r '.commitTimestamp' "${RESULT_FILE}")" > "$(results.commit-timestamp.path)"
+      printf "%s" "$(jq -r '."CHAINS-GIT_URL"' "${RESULT_FILE}")" > "$(results.CHAINS-GIT_URL.path)"
+      printf "%s" "$(jq -r '."CHAINS-GIT_COMMIT"' "${RESULT_FILE}")" > "$(results.CHAINS-GIT_COMMIT.path)"
 
-        if [ "${PARAM_DEPTH}" = "1" ]; then
-          echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
-        fi
-
-        if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
-          echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
-        fi
-
-        # Determine if merging from a different repository or the same one
-        if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
-          # Normalize URLs for comparison (remove trailing slashes and .git suffix)
-          normalize_url() {
-            echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
-          }
-
-          NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
-          NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
-
-          if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
-            echo "Merge source URL is the same as origin. Using existing 'origin' remote."
-            MERGE_REMOTE="origin"
-          else
-            echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
-            echo "Adding remote 'merge-source'..."
-            git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
-            MERGE_REMOTE="merge-source"
-          fi
-        else
-          echo "Merging from the same repository (origin)"
-          MERGE_REMOTE="origin"
-        fi
-
-        echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
-        if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
-          retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
-        else
-          retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
-        fi
-
-
-        echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
-        git config --global user.email "tekton-git-clone@tekton.dev"
-        git config --global user.name "Tekton Git Clone Task"
-
-      if ! git merge FETCH_HEAD --no-commit --no-ff --allow-unrelated-histories; then
-        echo "ERROR: Merge conflict detected or merge failed before commit." >&2
-        echo "--- Git Status ---"
-        git status
-        echo "------------------"
-        exit 1
-      fi
-
-      # Check if there are changes staged for commit
-      if git diff --staged --quiet; then
-        echo "No diff was found, skipping merge..." >&2
-      else
-        echo "Merge successful (no conflicts found), committing..."
-      if ! git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"; then
-        echo "ERROR: Failed to commit merge." >&2
-        exit 1
-      fi
-        MERGED_SHA=$(git rev-parse HEAD)
-        echo "New HEAD after merge: ${MERGED_SHA}"
-        echo "${MERGED_SHA}" > "$(results.merged_sha.path)"
-      fi
-
-      else
-        echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
-      fi
-      printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
-      printf "%s" "${RESULT_SHA}" > "$(results.CHAINS-GIT_COMMIT.path)"
-      printf "%s" "${RESULT_SHA_SHORT}" > "$(results.short-commit.path)"
-      printf "%s" "${PARAM_URL}" > "$(results.url.path)"
-      printf "%s" "${PARAM_URL}" > "$(results.CHAINS-GIT_URL.path)"
-      printf "%s" "$(git log -1 --pretty=%ct)" > "$(results.commit-timestamp.path)"
-
-      if [ "${PARAM_FETCH_TAGS}" = "true" ] ; then
-        echo "Fetching tags"
-        retry git fetch --tags
-      fi
-
-  - name: symlink-check
-    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
-    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
-    # the cluster will set imagePullPolicy to IfNotPresent
-    env:
-    - name: PARAM_ENABLE_SYMLINK_CHECK
-      value: $(params.enableSymlinkCheck)
-    - name: PARAM_SUBDIRECTORY
-      value: $(params.subdirectory)
-    - name: WORKSPACE_OUTPUT_PATH
-      value: $(workspaces.output.path)
-    computeResources:
-      limits:
-        memory: 64Mi
-      requests:
-        cpu: 50m
-        memory: 64Mi
-    script: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-
-      CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
-      check_symlinks() {
-        FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
-        while read -r symlink
-        do
-          target=$(readlink -m "$symlink")
-          if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
-            echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
-            FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
-          fi
-        done < <(find $CHECKOUT_DIR -type l -print)
-        if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ] ; then
-          return 1
-        fi
-      }
-
-      if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ] ; then
-        echo "Running symlink check"
-        check_symlinks
+      MERGED_SHA=$(jq -r '.mergedSha // empty' "${RESULT_FILE}")
+      if [ -n "${MERGED_SHA}" ]; then
+        printf "%s" "${MERGED_SHA}" > "$(results.merged_sha.path)"
       fi
   workspaces:
   - description: The git repo will be cloned onto the volume backing this Workspace.

--- a/task/git-clone/0.2/migrations/0.2.sh
+++ b/task/git-clone/0.2/migrations/0.2.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+declare -r pipeline_file=${1:?missing pipeline file}
+
+tasks_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "git-clone" "git-clone-oci-ta" "git-clone-oci-ta-min" "pnc-prebuild-git-clone-oci-ta"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null 2>&1; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#tasks_names[@]} tasks_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#tasks_names[@]} -eq 0 ]; then
+    echo "No git-clone tasks found"
+    exit 0
+fi
+
+for task_name in "${tasks_names[@]}"; do
+    task_name_selector="${tasks_selector} | select(.name == \"${task_name}\")"
+    verbose_val=$(yq -e "${task_name_selector} | .params[] | select(.name == \"verbose\") | .value" "$pipeline_file" 2>/dev/null) || true
+
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param gitInitImage
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param verbose
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param userHome
+    if [ "${verbose_val}" = "true" ]; then
+        pmt modify -f "$pipeline_file" task "$task_name" add-param logLevel "debug"
+    fi
+done

--- a/task/git-clone/0.2/tests/test-git-clone-check-results.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-check-results.yaml
@@ -1,0 +1,81 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-git-clone-check-results
+spec:
+  description: |
+    Test the git-clone task results are correctly populated from kbc JSON output
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/build-definitions
+        - name: revision
+          value: v0.1.5
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: commit
+          value: $(tasks.run-task.results.commit)
+        - name: short-commit
+          value: $(tasks.run-task.results.short-commit)
+        - name: url
+          value: $(tasks.run-task.results.url)
+        - name: commit-timestamp
+          value: $(tasks.run-task.results.commit-timestamp)
+        - name: chains-git-url
+          value: $(tasks.run-task.results.CHAINS-GIT_URL)
+        - name: chains-git-commit
+          value: $(tasks.run-task.results.CHAINS-GIT_COMMIT)
+      taskSpec:
+        params:
+          - name: commit
+          - name: short-commit
+          - name: url
+          - name: commit-timestamp
+          - name: chains-git-url
+          - name: chains-git-commit
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            env:
+              - name: COMMIT
+                value: $(params.commit)
+              - name: SHORT_COMMIT
+                value: $(params.short-commit)
+              - name: URL
+                value: $(params.url)
+              - name: COMMIT_TIMESTAMP
+                value: $(params.commit-timestamp)
+              - name: CHAINS_GIT_URL
+                value: $(params.chains-git-url)
+              - name: CHAINS_GIT_COMMIT
+                value: $(params.chains-git-commit)
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              # commit must be a full 40-char hex SHA
+              [[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]]
+
+              # short-commit must be first 7 chars of commit
+              [ "$SHORT_COMMIT" = "${COMMIT:0:7}" ]
+
+              # url must match what we passed in
+              [ "$URL" = "https://github.com/konflux-ci/build-definitions" ]
+
+              # commit-timestamp must be a numeric Unix timestamp
+              [[ "$COMMIT_TIMESTAMP" =~ ^[0-9]+$ ]]
+
+              # CHAINS results must match their counterparts
+              [ "$CHAINS_GIT_URL" = "$URL" ]
+              [ "$CHAINS_GIT_COMMIT" = "$COMMIT" ]
+      runAfter:
+        - run-task

--- a/task/git-clone/0.2/tests/test-git-clone-custom-subdirectory.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-custom-subdirectory.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-git-clone-with-tag
+  name: test-git-clone-custom-subdirectory
 spec:
   description: |
-    Test the git-clone task with tag
+    Test the git-clone task with a custom subdirectory
   workspaces:
     - name: tests-workspace
   tasks:
@@ -15,8 +15,8 @@ spec:
       params:
         - name: url
           value: https://github.com/konflux-ci/build-definitions
-        - name: revision
-          value: v0.1.5
+        - name: subdirectory
+          value: my-custom-dir
       workspaces:
         - name: output
           workspace: tests-workspace
@@ -29,9 +29,12 @@ spec:
           - name: check-result
             image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
-              files=$(find "$(workspaces.output.path)/source/" -mindepth 1 -maxdepth 1)
-              test -n "$files"
+              # Files should be in the custom subdirectory, not "source"
+              test -d "$(workspaces.output.path)/my-custom-dir/.git"
+              test -f "$(workspaces.output.path)/my-custom-dir/README.md"
+              # Default "source" should not exist
+              test ! -d "$(workspaces.output.path)/source"
       runAfter:
         - run-task

--- a/task/git-clone/0.2/tests/test-git-clone-fail-for-wrong-url.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-fail-for-wrong-url.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-git-clone-fail-for-wrong-url
+  annotations:
+    test/assert-task-failure: "run-task"
+spec:
+  description: |
+    Test the git-clone task with tag
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: https://github.com/user/repo-does-not-exists
+      workspaces:
+        - name: output
+          workspace: tests-workspace

--- a/task/git-clone/0.2/tests/test-git-clone-fetch-tags.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-fetch-tags.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-git-clone-with-tag
+  name: test-git-clone-fetch-tags
 spec:
   description: |
-    Test the git-clone task with tag
+    Test the git-clone task with fetchTags enabled
   workspaces:
     - name: tests-workspace
   tasks:
@@ -15,8 +15,8 @@ spec:
       params:
         - name: url
           value: https://github.com/konflux-ci/build-definitions
-        - name: revision
-          value: v0.1.5
+        - name: fetchTags
+          value: "true"
       workspaces:
         - name: output
           workspace: tests-workspace
@@ -29,9 +29,11 @@ spec:
           - name: check-result
             image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
-              files=$(find "$(workspaces.output.path)/source/" -mindepth 1 -maxdepth 1)
-              test -n "$files"
+              git config --global --add safe.directory "$(workspaces.output.path)/source"
+              cd "$(workspaces.output.path)/source"
+              # Verify that tags were fetched
+              git tag -l | grep -q "v0.1.5"
       runAfter:
         - run-task

--- a/task/git-clone/0.2/tests/test-git-clone-full-depth.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-full-depth.yaml
@@ -2,10 +2,10 @@
 apiVersion: tekton.dev/v1
 kind: Pipeline
 metadata:
-  name: test-git-clone-with-tag
+  name: test-git-clone-full-depth
 spec:
   description: |
-    Test the git-clone task with tag
+    Test the git-clone task with full commit history (depth=0)
   workspaces:
     - name: tests-workspace
   tasks:
@@ -15,8 +15,8 @@ spec:
       params:
         - name: url
           value: https://github.com/konflux-ci/build-definitions
-        - name: revision
-          value: v0.1.5
+        - name: depth
+          value: "0"
       workspaces:
         - name: output
           workspace: tests-workspace
@@ -29,9 +29,13 @@ spec:
           - name: check-result
             image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
             script: |
-              #!/usr/bin/env sh
+              #!/usr/bin/env bash
               set -eux
-              files=$(find "$(workspaces.output.path)/source/" -mindepth 1 -maxdepth 1)
-              test -n "$files"
+              git config --global --add safe.directory "$(workspaces.output.path)/source"
+              cd "$(workspaces.output.path)/source"
+              # Full depth should have more than 1 commit
+              commit_count=$(git rev-list --count HEAD)
+              echo "Commit count: $commit_count"
+              [ "$commit_count" -gt 1 ]
       runAfter:
         - run-task

--- a/task/git-clone/0.2/tests/test-git-clone-merge-target-branch.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-merge-target-branch.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-git-clone-merge-target-branch
+spec:
+  description: |
+    Test the git-clone task with mergeTargetBranch enabled
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: https://github.com/konflux-ci/build-definitions
+        - name: revision
+          value: v0.1.5
+        - name: mergeTargetBranch
+          value: "true"
+        - name: targetBranch
+          value: main
+        - name: depth
+          value: "0"
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+    - name: check-result
+      params:
+        - name: commit
+          value: $(tasks.run-task.results.commit)
+        - name: merged-sha
+          value: $(tasks.run-task.results.merged_sha)
+      taskSpec:
+        params:
+          - name: commit
+          - name: merged-sha
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            env:
+              - name: COMMIT
+                value: $(params.commit)
+              - name: MERGED_SHA
+                value: $(params.merged-sha)
+            script: |
+              #!/usr/bin/env bash
+              set -eux
+
+              TAG_SHA="aab8f135d7b2857463be3a2dec98789363e7087c"
+
+              # commit is the originally checked-out revision (pre-merge)
+              [[ "$COMMIT" =~ ^[0-9a-f]{40}$ ]]
+              [ "$COMMIT" = "$TAG_SHA" ]
+
+              # merged_sha is the merge commit (post-merge), must differ from commit
+              [[ "$MERGED_SHA" =~ ^[0-9a-f]{40}$ ]]
+              [ "$MERGED_SHA" != "$COMMIT" ]
+      runAfter:
+        - run-task

--- a/task/git-clone/0.2/tests/test-git-clone-run-with-tag.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-run-with-tag.yaml
@@ -1,0 +1,37 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-git-clone-with-tag
+spec:
+  description: |
+    Test the git-clone task with tag
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: https://github.com/kelseyhightower/nocode
+        - name: revision
+          value: 1.0.0
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              files=$(find "$(workspaces.output.path)/source/" -mindepth 1 -maxdepth 1)
+              test -n "$files"
+      runAfter:
+        - run-task

--- a/task/git-clone/0.2/tests/test-git-clone-run-without-args.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-run-without-args.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-git-clone-no-args
+spec:
+  description: |
+    Test the git-clone task with no arguments
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-task
+      taskRef:
+        name: git-clone
+      params:
+        - name: url
+          value: https://github.com/kelseyhightower/nocode
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+    - name: check-result
+      workspaces:
+        - name: output
+          workspace: tests-workspace
+      taskSpec:
+        steps:
+          - name: check-result
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+              files=$(find "$(workspaces.output.path)/source/" -mindepth 1 -maxdepth 1)
+              test -n "$files"
+      runAfter:
+        - run-task

--- a/task/git-clone/0.2/tests/test-git-clone-run-without-args.yaml
+++ b/task/git-clone/0.2/tests/test-git-clone-run-without-args.yaml
@@ -14,7 +14,7 @@ spec:
         name: git-clone
       params:
         - name: url
-          value: https://github.com/kelseyhightower/nocode
+          value: https://github.com/konflux-ci/build-definitions
       workspaces:
         - name: output
           workspace: tests-workspace

--- a/task/git-clone/CHANGELOG.md
+++ b/task/git-clone/CHANGELOG.md
@@ -1,15 +1,7 @@
 # Changelog
 
-<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
-
 ## 0.2
 
-- Updated base task to git-clone-oci-ta 0.2.
+- Use git-clone implementation from konflux-build-cli instead of inline Bash.
 - Removed `gitInitImage` (deprecated since 0.1), `verbose` (replaced by `logLevel`), and `userHome` (handled by konflux-build-cli) parameters.
 - Added `logLevel` parameter.
-
-## 0.1
-
-### Added
-
-- The initial version of the `git-clone-oci-ta-min` task!

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2026-08-20T00:00:00Z"
     tekton.dev/categories: Git
     tekton.dev/displayName: pnc prebuild git clone oci trusted artifacts
     tekton.dev/pipelines.minVersion: 0.21.0

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/MIGRATION.md
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/MIGRATION.md
@@ -1,0 +1,11 @@
+# Migration from 0.1 to 0.2
+
+Removed parameters: `gitInitImage`, `verbose`, `userHome`.
+
+New parameter: `logLevel` (default `info`) replaces `verbose`. Use `logLevel: debug` for verbose output.
+
+## Action from users
+
+The migration should be done automatically by renovate.
+For users who don't have automatic updates, remove `gitInitImage`, `verbose`, and `userHome` parameters if present.
+Replace `verbose: "true"` with `logLevel: "debug"` if needed.

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/README.md
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/README.md
@@ -1,0 +1,53 @@
+# pnc-prebuild-git-clone-oci-ta task
+
+The pnc-prebuild-git-clone-oci-ta task will clone a repo from the provided url, apply PNC prebuild modifications (from https://github.com/project-ncl/konflux-tooling) and store it as a trusted artifact in the provided OCI repository. The prebuild modifications create a Containerfile and suitable build script in order for the Java based project to be built within a container given build parameters configured from PNC.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|depth|Perform a shallow clone, fetching only the most recent N commits.|1|false|
+|enableSymlinkCheck|Check symlinks in the repo. If they're pointing outside of the repo, the build will fail. |true|false|
+|fetchTags|Fetch all tags for the repo.|false|false|
+|httpProxy|HTTP proxy server for non-SSL requests.|""|false|
+|httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
+|noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
+|ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
+|ociStorage|The OCI repository where the Trusted Artifacts are stored.||true|
+|refspec|Refspec to fetch before checking out revision.|""|false|
+|revision|Revision to checkout. (branch, tag, sha, ref, etc...)|""|false|
+|shortCommitLength|Length of short commit SHA|7|false|
+|sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
+|sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
+|submodules|Initialize and fetch git submodules.|true|false|
+|targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
+|url|Repository URL to clone from.||true|
+|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
+|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
+|BUILD_SCRIPT|Middleware (Maven/Gradle/Ant/SBT) build script to build the project to embed with the Containerfile||true|
+|BUILD_TOOL|The build tool to use (ant, gradle, maven, sbt).||true|
+|BUILD_TOOL_VERSION|The build tool version to use (e.g. 3.9.5)||true|
+|JAVA_VERSION|Java version to use (7, 8, 9, 11, 17, 21, 22, 23)||true|
+|RECIPE_IMAGE|The image from the build recipe to use||true|
+
+## Results
+|name|description|
+|---|---|
+|CHAINS-GIT_COMMIT|The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|CHAINS-GIT_URL|The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.|
+|commit|The precise commit SHA that was fetched by this Task.|
+|commit-timestamp|The commit timestamp of the checkout|
+|merged_sha|The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).|
+|short-commit|The commit SHA that was fetched by this Task limited to params.shortCommitLength number of characters|
+|url|The precise URL that was fetched by this Task.|
+
+## Workspaces
+|name|description|optional|
+|---|---|---|
+|basic-auth|A Workspace containing a .gitconfig and .git-credentials file or username and password. These will be copied to the user's home before any git commands are run. Any other files in this Workspace are ignored. It is strongly recommended to use ssh-directory over basic-auth whenever possible and to bind a Secret to this Workspace over other volume types. |true|
+|ssh-directory|A .ssh directory with private key, known_hosts, config, etc. Copied to the user's home before git commands are executed. Used to authenticate with the git remote when performing the clone. Binding a Secret to this Workspace is strongly recommended over other volume types. |true|
+
+## Additional info

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/README.md
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/README.md
@@ -12,6 +12,9 @@ The pnc-prebuild-git-clone-oci-ta task will clone a repo from the provided url, 
 |fetchTags|Fetch all tags for the repo.|false|false|
 |httpProxy|HTTP proxy server for non-SSL requests.|""|false|
 |httpsProxy|HTTPS proxy server for SSL requests.|""|false|
+|logLevel|Log level for the git-clone command.|info|false|
+|mergeSourceDepth|Perform a shallow fetch of the target branch, fetching only the most recent N commits. If empty, fetches the full history of the target branch. |""|false|
+|mergeSourceRepoUrl|URL of the repository to fetch the target branch from when mergeTargetBranch is true. If empty, uses the same repository (origin). This allows merging a branch from a different repository. |""|false|
 |mergeTargetBranch|Set to "true" to merge the targetBranch into the checked-out revision.|false|false|
 |noProxy|Opt out of proxying HTTP/HTTPS requests.|""|false|
 |ociArtifactExpiresAfter|Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.|""|false|
@@ -21,11 +24,10 @@ The pnc-prebuild-git-clone-oci-ta task will clone a repo from the provided url, 
 |shortCommitLength|Length of short commit SHA|7|false|
 |sparseCheckoutDirectories|Define the directory patterns to match or exclude when performing a sparse checkout.|""|false|
 |sslVerify|Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.|true|false|
+|submodulePaths|Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched. Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable. |""|false|
 |submodules|Initialize and fetch git submodules.|true|false|
 |targetBranch|The target branch to merge into the revision (if mergeTargetBranch is true).|main|false|
 |url|Repository URL to clone from.||true|
-|userHome|Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user. |/tekton/home|false|
-|verbose|Log the commands that are executed during `git-clone`'s operation.|false|false|
 |BUILD_SCRIPT|Middleware (Maven/Gradle/Ant/SBT) build script to build the project to embed with the Containerfile||true|
 |BUILD_TOOL|The build tool to use (ant, gradle, maven, sbt).||true|
 |BUILD_TOOL_VERSION|The build tool version to use (e.g. 3.9.5)||true|

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/kustomization.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../../git-clone-oci-ta/0.2
+
+patches:
+- path: patch.yaml
+  target:
+    kind: Task

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/migrations/0.2.sh
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/migrations/0.2.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+declare -r pipeline_file=${1:?missing pipeline file}
+
+tasks_names=()
+tasks_selector="(.spec.tasks[], .spec.pipelineSpec.tasks[])"
+
+for task_refname in "git-clone" "git-clone-oci-ta" "git-clone-oci-ta-min" "pnc-prebuild-git-clone-oci-ta"; do
+    task_selector="${tasks_selector} | select(.taskRef.params[] | (.name == \"name\" and .value == \"${task_refname}\"))"
+    if yq -e "$task_selector" "$pipeline_file" >/dev/null 2>&1; then
+        tasks_found="$(yq -e "${task_selector} | .name" "${pipeline_file}")"
+        readarray -t -O ${#tasks_names[@]} tasks_names <<< "${tasks_found}"
+    fi
+done
+
+if [ ${#tasks_names[@]} -eq 0 ]; then
+    echo "No git-clone tasks found"
+    exit 0
+fi
+
+for task_name in "${tasks_names[@]}"; do
+    task_name_selector="${tasks_selector} | select(.name == \"${task_name}\")"
+    verbose_val=$(yq -e "${task_name_selector} | .params[] | select(.name == \"verbose\") | .value" "$pipeline_file" 2>/dev/null) || true
+
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param gitInitImage
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param verbose
+    pmt modify -f "$pipeline_file" task "$task_name" remove-param userHome
+    if [ "${verbose_val}" = "true" ]; then
+        pmt modify -f "$pipeline_file" task "$task_name" add-param logLevel "debug"
+    fi
+done

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/patch.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/patch.yaml
@@ -1,0 +1,73 @@
+- op: replace
+  path: /metadata/name
+  value: pnc-prebuild-git-clone-oci-ta
+- op: replace
+  path: /metadata/annotations/tekton.dev~1displayName
+  value: pnc prebuild git clone oci trusted artifacts
+- op: replace
+  path: /spec/description
+  value: The pnc-prebuild-git-clone-oci-ta task will clone a repo from the provided url, apply
+    PNC prebuild modifications (from https://github.com/project-ncl/konflux-tooling) and store
+    it as a trusted artifact in the provided OCI repository. The prebuild modifications create
+    a Containerfile and suitable build script in order for the Java based project to be built
+    within a container given build parameters configured from PNC.
+
+- op: add
+  path: /spec/params/-
+  value:
+    name: BUILD_SCRIPT
+    description: Middleware (Maven/Gradle/Ant/SBT) build script to build the project to embed with the Containerfile
+    type: string
+- op: add
+  path: /spec/params/-
+  value:
+    name: BUILD_TOOL
+    description: The build tool to use (ant, gradle, maven, sbt).
+    type: string
+- op: add
+  path: /spec/params/-
+  value:
+    name: BUILD_TOOL_VERSION
+    description: The build tool version to use (e.g. 3.9.5)
+    type: string
+- op: add
+  path: /spec/params/-
+  value:
+    name: JAVA_VERSION
+    description: Java version to use (7, 8, 9, 11, 17, 21, 22, 23)
+    type: string
+- op: add
+  path: /spec/params/-
+  value:
+    name: RECIPE_IMAGE
+    description: The image from the build recipe to use
+    type: string
+
+- op: add
+  path: /spec/steps/2
+  value:
+    name: preprocessor
+    image: quay.io/konflux-ci/pnc-konflux-tooling@sha256:8c1c50b01c8dc5e3847f2ace4da8d28d255935b15c14d043bb2e819941697b29
+    securityContext:
+      runAsUser: 0
+    computeResources:
+      limits:
+        cpu: 300m
+        memory: 512Mi
+      requests:
+        cpu: 10m
+        memory: 512Mi
+    args:
+      - prepare
+      - --build-tool-version=$(params.BUILD_TOOL_VERSION)
+      - --java-version=$(params.JAVA_VERSION)
+      - --recipe-image=$(params.RECIPE_IMAGE)
+      - --tooling-image=quay.io/konflux-ci/pnc-konflux-tooling@sha256:8c1c50b01c8dc5e3847f2ace4da8d28d255935b15c14d043bb2e819941697b29
+      - --type=$(params.BUILD_TOOL)
+      - /var/workdir/source
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+    env:
+      - name: BUILD_SCRIPT
+        value: $(params.BUILD_SCRIPT)

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/patch.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/patch.yaml
@@ -44,7 +44,7 @@
     type: string
 
 - op: add
-  path: /spec/steps/2
+  path: /spec/steps/1
   value:
     name: preprocessor
     image: quay.io/konflux-ci/pnc-konflux-tooling@sha256:8c1c50b01c8dc5e3847f2ace4da8d28d255935b15c14d043bb2e819941697b29

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/pnc-prebuild-git-clone-oci-ta.yaml
@@ -49,6 +49,10 @@ spec:
     description: HTTPS proxy server for SSL requests.
     name: httpsProxy
     type: string
+  - default: info
+    description: Log level for the git-clone command.
+    name: logLevel
+    type: string
   - default: ""
     description: |
       Perform a shallow fetch of the target branch, fetching only the most recent N commits.
@@ -117,15 +121,6 @@ spec:
   - description: Repository URL to clone from.
     name: url
     type: string
-  - default: /tekton/home
-    description: |
-      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
-    name: userHome
-    type: string
-  - default: "false"
-    description: Log the commands that are executed during `git-clone`'s operation.
-    name: verbose
-    type: string
   - description: Middleware (Maven/Gradle/Ant/SBT) build script to build the project
       to embed with the Containerfile
     name: BUILD_SCRIPT
@@ -173,196 +168,82 @@ spec:
         cpu: 350m
         memory: 2Gi
     env:
-    - name: HOME
-      value: $(params.userHome)
-    - name: PARAM_URL
+    - name: KBC_GIT_CLONE_URL
       value: $(params.url)
-    - name: PARAM_REVISION
+    - name: KBC_GIT_CLONE_REVISION
       value: $(params.revision)
-    - name: PARAM_REFSPEC
+    - name: KBC_GIT_CLONE_REFSPEC
       value: $(params.refspec)
-    - name: PARAM_SUBMODULES
+    - name: KBC_GIT_CLONE_SUBMODULES
       value: $(params.submodules)
-    - name: PARAM_SUBMODULE_PATHS
+    - name: KBC_GIT_CLONE_SUBMODULE_PATHS
       value: $(params.submodulePaths)
-    - name: PARAM_DEPTH
+    - name: KBC_GIT_CLONE_DEPTH
       value: $(params.depth)
-    - name: PARAM_SHORT_COMMIT_LENGTH
+    - name: KBC_GIT_CLONE_SHORT_COMMIT_LENGTH
       value: $(params.shortCommitLength)
-    - name: PARAM_SSL_VERIFY
+    - name: KBC_GIT_CLONE_SSL_VERIFY
       value: $(params.sslVerify)
+    - name: KBC_GIT_CLONE_SPARSE_CHECKOUT_DIRECTORIES
+      value: $(params.sparseCheckoutDirectories)
+    - name: KBC_GIT_CLONE_ENABLE_SYMLINK_CHECK
+      value: $(params.enableSymlinkCheck)
+    - name: KBC_GIT_CLONE_FETCH_TAGS
+      value: $(params.fetchTags)
+    - name: KBC_GIT_CLONE_MERGE_TARGET_BRANCH
+      value: $(params.mergeTargetBranch)
+    - name: KBC_GIT_CLONE_TARGET_BRANCH
+      value: $(params.targetBranch)
+    - name: KBC_GIT_CLONE_MERGE_SOURCE_REPO_URL
+      value: $(params.mergeSourceRepoUrl)
+    - name: KBC_GIT_CLONE_MERGE_SOURCE_DEPTH
+      value: $(params.mergeSourceDepth)
+    - name: KBC_GIT_CLONE_BASIC_AUTH_DIRECTORY
+      value: $(workspaces.basic-auth.path)
+    - name: KBC_GIT_CLONE_SSH_DIRECTORY
+      value: $(workspaces.ssh-directory.path)
     - name: PARAM_HTTP_PROXY
       value: $(params.httpProxy)
     - name: PARAM_HTTPS_PROXY
       value: $(params.httpsProxy)
     - name: PARAM_NO_PROXY
       value: $(params.noProxy)
-    - name: PARAM_VERBOSE
-      value: $(params.verbose)
-    - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
-      value: $(params.sparseCheckoutDirectories)
-    - name: PARAM_USER_HOME
-      value: $(params.userHome)
-    - name: PARAM_FETCH_TAGS
-      value: $(params.fetchTags)
-    - name: PARAM_MERGE_TARGET_BRANCH
-      value: $(params.mergeTargetBranch)
-    - name: PARAM_TARGET_BRANCH
-      value: $(params.targetBranch)
-    - name: PARAM_MERGE_SOURCE_REPO_URL
-      value: $(params.mergeSourceRepoUrl)
-    - name: PARAM_MERGE_SOURCE_DEPTH
-      value: $(params.mergeSourceDepth)
-    - name: WORKSPACE_SSH_DIRECTORY_BOUND
-      value: $(workspaces.ssh-directory.bound)
-    - name: WORKSPACE_SSH_DIRECTORY_PATH
-      value: $(workspaces.ssh-directory.path)
-    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
-      value: $(workspaces.basic-auth.bound)
-    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
-      value: $(workspaces.basic-auth.path)
-    - name: CHECKOUT_DIR
-      value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    - name: KBC_LOG_LEVEL
+      value: $(params.logLevel)
+    - name: KBC_GIT_CLONE_OUTPUT_DIR
+      value: /var/workdir
+    - name: KBC_GIT_CLONE_SUBDIRECTORY
+      value: source
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:dd49bd35038c1cba174e6c166291e5df3d0d5f9be18ed3b2fb852fc6ce3181ed
     name: clone
     script: |
-      #!/usr/bin/env sh
-      set -eu
+      #!/usr/bin/env bash
+      set -euo pipefail
 
-      if [ "${PARAM_VERBOSE}" = "true" ]; then
-        set -x
-      fi
-
-      if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ]; then
-        if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
-          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
-          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
-        # Compatibility with kubernetes.io/basic-auth secrets
-        elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
-          HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
-          echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" >"${PARAM_USER_HOME}/.git-credentials"
-          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" >"${PARAM_USER_HOME}/.gitconfig"
-        else
-          echo "Unknown basic-auth workspace format"
-          exit 1
-        fi
-        chmod 400 "${PARAM_USER_HOME}/.git-credentials"
-        chmod 400 "${PARAM_USER_HOME}/.gitconfig"
-      fi
-
-      # Should be called after the gitconfig is copied from the repository secret
       ca_bundle=/mnt/trusted-ca/ca-bundle.crt
       if [ -f "$ca_bundle" ]; then
         echo "INFO: Using mounted CA bundle: $ca_bundle"
-        git config --global http.sslCAInfo "$ca_bundle"
-      fi
-
-      if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ]; then
-        cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
-        chmod 700 "${PARAM_USER_HOME}"/.ssh
-        chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        cp -vf "$ca_bundle" /etc/pki/ca-trust/source/anchors
+        update-ca-trust
       fi
 
       test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
       test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
       test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
 
-      /ko-app/git-init \
-        -url="${PARAM_URL}" \
-        -revision="${PARAM_REVISION}" \
-        -refspec="${PARAM_REFSPEC}" \
-        -path="${CHECKOUT_DIR}" \
-        -sslVerify="${PARAM_SSL_VERIFY}" \
-        -submodules="${PARAM_SUBMODULES}" \
-        -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
-        -depth="${PARAM_DEPTH}" \
-        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
-        -retryMaxAttempts=10
-      cd "${CHECKOUT_DIR}"
-      RESULT_SHA="$(git rev-parse HEAD)"
-      RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
+      RESULT_FILE="$(mktemp)"
+      konflux-build-cli git-clone >"${RESULT_FILE}"
 
-      if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
-        echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+      printf "%s" "$(jq -r '.commit' "${RESULT_FILE}")" >"$(results.commit.path)"
+      printf "%s" "$(jq -r '.shortCommit' "${RESULT_FILE}")" >"$(results.short-commit.path)"
+      printf "%s" "$(jq -r '.url' "${RESULT_FILE}")" >"$(results.url.path)"
+      printf "%s" "$(jq -r '.commitTimestamp' "${RESULT_FILE}")" >"$(results.commit-timestamp.path)"
+      printf "%s" "$(jq -r '."CHAINS-GIT_URL"' "${RESULT_FILE}")" >"$(results.CHAINS-GIT_URL.path)"
+      printf "%s" "$(jq -r '."CHAINS-GIT_COMMIT"' "${RESULT_FILE}")" >"$(results.CHAINS-GIT_COMMIT.path)"
 
-        if [ "${PARAM_DEPTH}" = "1" ]; then
-          echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
-        fi
-
-        if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
-          echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
-        fi
-
-        # Determine if merging from a different repository or the same one
-        if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
-          # Normalize URLs for comparison (remove trailing slashes and .git suffix)
-          normalize_url() {
-            echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
-          }
-
-          NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
-          NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
-
-          if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
-            echo "Merge source URL is the same as origin. Using existing 'origin' remote."
-            MERGE_REMOTE="origin"
-          else
-            echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
-            echo "Adding remote 'merge-source'..."
-            git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
-            MERGE_REMOTE="merge-source"
-          fi
-        else
-          echo "Merging from the same repository (origin)"
-          MERGE_REMOTE="origin"
-        fi
-
-        echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
-        if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
-          retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
-        else
-          retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
-        fi
-
-        echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
-        git config --global user.email "tekton-git-clone@tekton.dev"
-        git config --global user.name "Tekton Git Clone Task"
-
-        if ! git merge FETCH_HEAD --no-commit --no-ff --allow-unrelated-histories; then
-          echo "ERROR: Merge conflict detected or merge failed before commit." >&2
-          echo "--- Git Status ---"
-          git status
-          echo "------------------"
-          exit 1
-        fi
-
-        # Check if there are changes staged for commit
-        if git diff --staged --quiet; then
-          echo "No diff was found, skipping merge..." >&2
-        else
-          echo "Merge successful (no conflicts found), committing..."
-          if ! git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"; then
-            echo "ERROR: Failed to commit merge." >&2
-            exit 1
-          fi
-          MERGED_SHA=$(git rev-parse HEAD)
-          echo "New HEAD after merge: ${MERGED_SHA}"
-          echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
-        fi
-
-      else
-        echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
-      fi
-      printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
-      printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"
-      printf "%s" "${RESULT_SHA_SHORT}" >"$(results.short-commit.path)"
-      printf "%s" "${PARAM_URL}" >"$(results.url.path)"
-      printf "%s" "${PARAM_URL}" >"$(results.CHAINS-GIT_URL.path)"
-      printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
-
-      if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
-        echo "Fetching tags"
-        retry git fetch --tags
+      MERGED_SHA=$(jq -r '.mergedSha // empty' "${RESULT_FILE}")
+      if [ -n "${MERGED_SHA}" ]; then
+        printf "%s" "${MERGED_SHA}" >"$(results.merged_sha.path)"
       fi
     securityContext:
       runAsUser: 0
@@ -370,44 +251,6 @@ spec:
     - mountPath: /mnt/trusted-ca
       name: trusted-ca
       readOnly: true
-    - mountPath: /var/workdir
-      name: workdir
-  - computeResources:
-      limits:
-        memory: 64Mi
-      requests:
-        cpu: 50m
-        memory: 64Mi
-    env:
-    - name: PARAM_ENABLE_SYMLINK_CHECK
-      value: $(params.enableSymlinkCheck)
-    - name: CHECKOUT_DIR
-      value: /var/workdir/source
-    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
-    name: symlink-check
-    script: |
-      #!/usr/bin/env bash
-      set -euo pipefail
-
-      check_symlinks() {
-        FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
-        while read -r symlink; do
-          target=$(readlink -m "$symlink")
-          if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
-            echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
-            FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
-          fi
-        done < <(find $CHECKOUT_DIR -type l -print)
-        if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ]; then
-          return 1
-        fi
-      }
-
-      if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ]; then
-        echo "Running symlink check"
-        check_symlinks
-      fi
-    volumeMounts:
     - mountPath: /var/workdir
       name: workdir
   - args:
@@ -449,7 +292,7 @@ spec:
     env:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.ociArtifactExpiresAfter)
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:f53e69930a5c6a6008ea55a29146e4c860ef3d88c390350bada38361b3feeb1a
     name: create-trusted-artifact
     volumeMounts:
     - mountPath: /var/workdir

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/pnc-prebuild-git-clone-oci-ta.yaml
@@ -1,0 +1,486 @@
+# WARNING: This is an auto generated file, do not modify this file directly
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/categories: Git
+    tekton.dev/displayName: pnc prebuild git clone oci trusted artifacts
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
+    tekton.dev/tags: git
+  labels:
+    app.kubernetes.io/version: "0.2"
+  name: pnc-prebuild-git-clone-oci-ta
+spec:
+  description: The pnc-prebuild-git-clone-oci-ta task will clone a repo from the provided
+    url, apply PNC prebuild modifications (from https://github.com/project-ncl/konflux-tooling)
+    and store it as a trusted artifact in the provided OCI repository. The prebuild
+    modifications create a Containerfile and suitable build script in order for the
+    Java based project to be built within a container given build parameters configured
+    from PNC.
+  params:
+  - default: ca-bundle.crt
+    description: The name of the key in the ConfigMap that contains the CA bundle
+      data.
+    name: caTrustConfigMapKey
+    type: string
+  - default: trusted-ca
+    description: The name of the ConfigMap to read CA bundle data from.
+    name: caTrustConfigMapName
+    type: string
+  - default: "1"
+    description: Perform a shallow clone, fetching only the most recent N commits.
+    name: depth
+    type: string
+  - default: "true"
+    description: |
+      Check symlinks in the repo. If they're pointing outside of the repo, the build will fail.
+    name: enableSymlinkCheck
+    type: string
+  - default: "false"
+    description: Fetch all tags for the repo.
+    name: fetchTags
+    type: string
+  - default: ""
+    description: HTTP proxy server for non-SSL requests.
+    name: httpProxy
+    type: string
+  - default: ""
+    description: HTTPS proxy server for SSL requests.
+    name: httpsProxy
+    type: string
+  - default: ""
+    description: |
+      Perform a shallow fetch of the target branch, fetching only the most recent N commits.
+      If empty, fetches the full history of the target branch.
+    name: mergeSourceDepth
+    type: string
+  - default: ""
+    description: |
+      URL of the repository to fetch the target branch from when mergeTargetBranch is true.
+      If empty, uses the same repository (origin). This allows merging a branch from a different repository.
+    name: mergeSourceRepoUrl
+    type: string
+  - default: "false"
+    description: Set to "true" to merge the targetBranch into the checked-out revision.
+    name: mergeTargetBranch
+    type: string
+  - default: ""
+    description: Opt out of proxying HTTP/HTTPS requests.
+    name: noProxy
+    type: string
+  - default: ""
+    description: Expiration date for the trusted artifacts created in the OCI repository.
+      An empty string means the artifacts do not expire.
+    name: ociArtifactExpiresAfter
+    type: string
+  - description: The OCI repository where the Trusted Artifacts are stored.
+    name: ociStorage
+    type: string
+  - default: ""
+    description: Refspec to fetch before checking out revision.
+    name: refspec
+    type: string
+  - default: ""
+    description: Revision to checkout. (branch, tag, sha, ref, etc...)
+    name: revision
+    type: string
+  - default: "7"
+    description: Length of short commit SHA
+    name: shortCommitLength
+    type: string
+  - default: ""
+    description: Define the directory patterns to match or exclude when performing
+      a sparse checkout.
+    name: sparseCheckoutDirectories
+    type: string
+  - default: "true"
+    description: Set the `http.sslVerify` global git config. Setting this to `false`
+      is not advised unless you are sure that you trust your git remote.
+    name: sslVerify
+    type: string
+  - default: ""
+    description: |
+      Comma-separated list of specific submodule paths to initialize and fetch. Only submodules in the specified directories and their subdirectories will be fetched.
+      Empty string fetches all submodules. Parameter "submodules" must be set to "true" to make this parameter applicable.
+    name: submodulePaths
+    type: string
+  - default: "true"
+    description: Initialize and fetch git submodules.
+    name: submodules
+    type: string
+  - default: main
+    description: The target branch to merge into the revision (if mergeTargetBranch
+      is true).
+    name: targetBranch
+    type: string
+  - description: Repository URL to clone from.
+    name: url
+    type: string
+  - default: /tekton/home
+    description: |
+      Absolute path to the user's home directory. Set this explicitly if you are running the image as a non-root user.
+    name: userHome
+    type: string
+  - default: "false"
+    description: Log the commands that are executed during `git-clone`'s operation.
+    name: verbose
+    type: string
+  - description: Middleware (Maven/Gradle/Ant/SBT) build script to build the project
+      to embed with the Containerfile
+    name: BUILD_SCRIPT
+    type: string
+  - description: The build tool to use (ant, gradle, maven, sbt).
+    name: BUILD_TOOL
+    type: string
+  - description: The build tool version to use (e.g. 3.9.5)
+    name: BUILD_TOOL_VERSION
+    type: string
+  - description: Java version to use (7, 8, 9, 11, 17, 21, 22, 23)
+    name: JAVA_VERSION
+    type: string
+  - description: The image from the build recipe to use
+    name: RECIPE_IMAGE
+    type: string
+  results:
+  - description: The precise commit SHA that was fetched by this Task. This result
+      uses Chains type hinting to include in the provenance.
+    name: CHAINS-GIT_COMMIT
+  - description: The precise URL that was fetched by this Task. This result uses Chains
+      type hinting to include in the provenance.
+    name: CHAINS-GIT_URL
+  - description: The Trusted Artifact URI pointing to the artifact with the application
+      source code.
+    name: SOURCE_ARTIFACT
+    type: string
+  - description: The precise commit SHA that was fetched by this Task.
+    name: commit
+  - description: The commit timestamp of the checkout
+    name: commit-timestamp
+  - description: The SHA of the commit after merging the target branch (if the param
+      mergeTargetBranch is true).
+    name: merged_sha
+  - description: The commit SHA that was fetched by this Task limited to params.shortCommitLength
+      number of characters
+    name: short-commit
+  - description: The precise URL that was fetched by this Task.
+    name: url
+  steps:
+  - computeResources:
+      limits:
+        memory: 2Gi
+      requests:
+        cpu: 350m
+        memory: 2Gi
+    env:
+    - name: HOME
+      value: $(params.userHome)
+    - name: PARAM_URL
+      value: $(params.url)
+    - name: PARAM_REVISION
+      value: $(params.revision)
+    - name: PARAM_REFSPEC
+      value: $(params.refspec)
+    - name: PARAM_SUBMODULES
+      value: $(params.submodules)
+    - name: PARAM_SUBMODULE_PATHS
+      value: $(params.submodulePaths)
+    - name: PARAM_DEPTH
+      value: $(params.depth)
+    - name: PARAM_SHORT_COMMIT_LENGTH
+      value: $(params.shortCommitLength)
+    - name: PARAM_SSL_VERIFY
+      value: $(params.sslVerify)
+    - name: PARAM_HTTP_PROXY
+      value: $(params.httpProxy)
+    - name: PARAM_HTTPS_PROXY
+      value: $(params.httpsProxy)
+    - name: PARAM_NO_PROXY
+      value: $(params.noProxy)
+    - name: PARAM_VERBOSE
+      value: $(params.verbose)
+    - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+      value: $(params.sparseCheckoutDirectories)
+    - name: PARAM_USER_HOME
+      value: $(params.userHome)
+    - name: PARAM_FETCH_TAGS
+      value: $(params.fetchTags)
+    - name: PARAM_MERGE_TARGET_BRANCH
+      value: $(params.mergeTargetBranch)
+    - name: PARAM_TARGET_BRANCH
+      value: $(params.targetBranch)
+    - name: PARAM_MERGE_SOURCE_REPO_URL
+      value: $(params.mergeSourceRepoUrl)
+    - name: PARAM_MERGE_SOURCE_DEPTH
+      value: $(params.mergeSourceDepth)
+    - name: WORKSPACE_SSH_DIRECTORY_BOUND
+      value: $(workspaces.ssh-directory.bound)
+    - name: WORKSPACE_SSH_DIRECTORY_PATH
+      value: $(workspaces.ssh-directory.path)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+      value: $(workspaces.basic-auth.bound)
+    - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+      value: $(workspaces.basic-auth.path)
+    - name: CHECKOUT_DIR
+      value: /var/workdir/source
+    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    name: clone
+    script: |
+      #!/usr/bin/env sh
+      set -eu
+
+      if [ "${PARAM_VERBOSE}" = "true" ]; then
+        set -x
+      fi
+
+      if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ]; then
+        if [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" ]; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+        # Compatibility with kubernetes.io/basic-auth secrets
+        elif [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username" ] && [ -f "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password" ]; then
+          HOSTNAME=$(echo $PARAM_URL | awk -F/ '{print $3}')
+          echo "https://$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/username):$(cat ${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/password)@$HOSTNAME" >"${PARAM_USER_HOME}/.git-credentials"
+          echo -e "[credential \"https://$HOSTNAME\"]\n  helper = store" >"${PARAM_USER_HOME}/.gitconfig"
+        else
+          echo "Unknown basic-auth workspace format"
+          exit 1
+        fi
+        chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+        chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+      fi
+
+      # Should be called after the gitconfig is copied from the repository secret
+      ca_bundle=/mnt/trusted-ca/ca-bundle.crt
+      if [ -f "$ca_bundle" ]; then
+        echo "INFO: Using mounted CA bundle: $ca_bundle"
+        git config --global http.sslCAInfo "$ca_bundle"
+      fi
+
+      if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ]; then
+        cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+        chmod 700 "${PARAM_USER_HOME}"/.ssh
+        chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+      fi
+
+      test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+      test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+      test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+      /ko-app/git-init \
+        -url="${PARAM_URL}" \
+        -revision="${PARAM_REVISION}" \
+        -refspec="${PARAM_REFSPEC}" \
+        -path="${CHECKOUT_DIR}" \
+        -sslVerify="${PARAM_SSL_VERIFY}" \
+        -submodules="${PARAM_SUBMODULES}" \
+        -submodulePaths="${PARAM_SUBMODULE_PATHS}" \
+        -depth="${PARAM_DEPTH}" \
+        -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}" \
+        -retryMaxAttempts=10
+      cd "${CHECKOUT_DIR}"
+      RESULT_SHA="$(git rev-parse HEAD)"
+      RESULT_SHA_SHORT="$(git rev-parse --short="${PARAM_SHORT_COMMIT_LENGTH}" HEAD)"
+
+      if [ "${PARAM_MERGE_TARGET_BRANCH}" = "true" ]; then
+        echo "Merge option enabled. Attempting to merge target branch '${PARAM_TARGET_BRANCH}' into HEAD (${RESULT_SHA})."
+
+        if [ "${PARAM_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow clone with depth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        if [ "${PARAM_MERGE_SOURCE_DEPTH}" = "1" ]; then
+          echo "WARNING: Shallow fetch with mergeSourceDepth=1 may cause merge conflicts due to insufficient commit history." >&2
+        fi
+
+        # Determine if merging from a different repository or the same one
+        if [ -n "${PARAM_MERGE_SOURCE_REPO_URL}" ]; then
+          # Normalize URLs for comparison (remove trailing slashes and .git suffix)
+          normalize_url() {
+            echo "$1" | sed -e 's#/$##' -e 's#\.git$##'
+          }
+
+          NORMALIZED_ORIGIN_URL=$(normalize_url "${PARAM_URL}")
+          NORMALIZED_MERGE_URL=$(normalize_url "${PARAM_MERGE_SOURCE_REPO_URL}")
+
+          if [ "${NORMALIZED_ORIGIN_URL}" = "${NORMALIZED_MERGE_URL}" ]; then
+            echo "Merge source URL is the same as origin. Using existing 'origin' remote."
+            MERGE_REMOTE="origin"
+          else
+            echo "Merging from different repository: ${PARAM_MERGE_SOURCE_REPO_URL}"
+            echo "Adding remote 'merge-source'..."
+            git remote add merge-source "${PARAM_MERGE_SOURCE_REPO_URL}"
+            MERGE_REMOTE="merge-source"
+          fi
+        else
+          echo "Merging from the same repository (origin)"
+          MERGE_REMOTE="origin"
+        fi
+
+        echo "Fetching target branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE}..."
+        if [ -n "${PARAM_MERGE_SOURCE_DEPTH}" ]; then
+          retry git fetch --depth="${PARAM_MERGE_SOURCE_DEPTH}" ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        else
+          retry git fetch ${MERGE_REMOTE} "${PARAM_TARGET_BRANCH}"
+        fi
+
+        echo "Merging ${MERGE_REMOTE}/${PARAM_TARGET_BRANCH} into current HEAD..."
+        git config --global user.email "tekton-git-clone@tekton.dev"
+        git config --global user.name "Tekton Git Clone Task"
+
+        if ! git merge FETCH_HEAD --no-commit --no-ff --allow-unrelated-histories; then
+          echo "ERROR: Merge conflict detected or merge failed before commit." >&2
+          echo "--- Git Status ---"
+          git status
+          echo "------------------"
+          exit 1
+        fi
+
+        # Check if there are changes staged for commit
+        if git diff --staged --quiet; then
+          echo "No diff was found, skipping merge..." >&2
+        else
+          echo "Merge successful (no conflicts found), committing..."
+          if ! git commit -m "Merge branch '${PARAM_TARGET_BRANCH}' from ${MERGE_REMOTE} into ${RESULT_SHA}"; then
+            echo "ERROR: Failed to commit merge." >&2
+            exit 1
+          fi
+          MERGED_SHA=$(git rev-parse HEAD)
+          echo "New HEAD after merge: ${MERGED_SHA}"
+          echo "${MERGED_SHA}" >"$(results.merged_sha.path)"
+        fi
+
+      else
+        echo "Merge option disabled. Using checked-out revision ${RESULT_SHA} directly."
+      fi
+      printf "%s" "${RESULT_SHA}" >"$(results.commit.path)"
+      printf "%s" "${RESULT_SHA}" >"$(results.CHAINS-GIT_COMMIT.path)"
+      printf "%s" "${RESULT_SHA_SHORT}" >"$(results.short-commit.path)"
+      printf "%s" "${PARAM_URL}" >"$(results.url.path)"
+      printf "%s" "${PARAM_URL}" >"$(results.CHAINS-GIT_URL.path)"
+      printf "%s" "$(git log -1 --pretty=%ct)" >"$(results.commit-timestamp.path)"
+
+      if [ "${PARAM_FETCH_TAGS}" = "true" ]; then
+        echo "Fetching tags"
+        retry git fetch --tags
+      fi
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /mnt/trusted-ca
+      name: trusted-ca
+      readOnly: true
+    - mountPath: /var/workdir
+      name: workdir
+  - computeResources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
+    env:
+    - name: PARAM_ENABLE_SYMLINK_CHECK
+      value: $(params.enableSymlinkCheck)
+    - name: CHECKOUT_DIR
+      value: /var/workdir/source
+    image: quay.io/konflux-ci/git-clone@sha256:09ac9c14392b5c2b8057f66cc4abfb8ce5d7214706318959d00908923a754434
+    name: symlink-check
+    script: |
+      #!/usr/bin/env bash
+      set -euo pipefail
+
+      check_symlinks() {
+        FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=false
+        while read -r symlink; do
+          target=$(readlink -m "$symlink")
+          if ! [[ "$target" =~ ^$CHECKOUT_DIR ]]; then
+            echo "The cloned repository contains symlink pointing outside of the cloned repository: $symlink"
+            FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO=true
+          fi
+        done < <(find $CHECKOUT_DIR -type l -print)
+        if [ "$FOUND_SYMLINK_POINTING_OUTSIDE_OF_REPO" = true ]; then
+          return 1
+        fi
+      }
+
+      if [ "${PARAM_ENABLE_SYMLINK_CHECK}" = "true" ]; then
+        echo "Running symlink check"
+        check_symlinks
+      fi
+    volumeMounts:
+    - mountPath: /var/workdir
+      name: workdir
+  - args:
+    - prepare
+    - --build-tool-version=$(params.BUILD_TOOL_VERSION)
+    - --java-version=$(params.JAVA_VERSION)
+    - --recipe-image=$(params.RECIPE_IMAGE)
+    - --tooling-image=quay.io/konflux-ci/pnc-konflux-tooling@sha256:8c1c50b01c8dc5e3847f2ace4da8d28d255935b15c14d043bb2e819941697b29
+    - --type=$(params.BUILD_TOOL)
+    - /var/workdir/source
+    computeResources:
+      limits:
+        cpu: 300m
+        memory: 512Mi
+      requests:
+        cpu: 10m
+        memory: 512Mi
+    env:
+    - name: BUILD_SCRIPT
+      value: $(params.BUILD_SCRIPT)
+    image: quay.io/konflux-ci/pnc-konflux-tooling@sha256:8c1c50b01c8dc5e3847f2ace4da8d28d255935b15c14d043bb2e819941697b29
+    name: preprocessor
+    securityContext:
+      runAsUser: 0
+    volumeMounts:
+    - mountPath: /var/workdir
+      name: workdir
+  - args:
+    - create
+    - --store
+    - $(params.ociStorage)
+    - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+    computeResources:
+      limits:
+        memory: 3Gi
+      requests:
+        cpu: "1"
+        memory: 3Gi
+    env:
+    - name: IMAGE_EXPIRES_AFTER
+      value: $(params.ociArtifactExpiresAfter)
+    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+    name: create-trusted-artifact
+    volumeMounts:
+    - mountPath: /var/workdir
+      name: workdir
+    - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+      name: trusted-ca
+      readOnly: true
+      subPath: ca-bundle.crt
+  volumes:
+  - configMap:
+      items:
+      - key: $(params.caTrustConfigMapKey)
+        path: ca-bundle.crt
+      name: $(params.caTrustConfigMapName)
+      optional: true
+    name: trusted-ca
+  - emptyDir: {}
+    name: workdir
+  workspaces:
+  - description: |
+      A Workspace containing a .gitconfig and .git-credentials file or username and password.
+      These will be copied to the user's home before any git commands are run. Any
+      other files in this Workspace are ignored. It is strongly recommended
+      to use ssh-directory over basic-auth whenever possible and to bind a
+      Secret to this Workspace over other volume types.
+    name: basic-auth
+    optional: true
+  - description: |
+      A .ssh directory with private key, known_hosts, config, etc. Copied to
+      the user's home before git commands are executed. Used to authenticate
+      with the git remote when performing the clone. Binding a Secret to this
+      Workspace is strongly recommended over other volume types.
+    name: ssh-directory
+    optional: true

--- a/task/pnc-prebuild-git-clone-oci-ta/CHANGELOG.md
+++ b/task/pnc-prebuild-git-clone-oci-ta/CHANGELOG.md
@@ -1,15 +1,7 @@
 # Changelog
 
-<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
-
 ## 0.2
 
 - Updated base task to git-clone-oci-ta 0.2.
 - Removed `gitInitImage` (deprecated since 0.1), `verbose` (replaced by `logLevel`), and `userHome` (handled by konflux-build-cli) parameters.
 - Added `logLevel` parameter.
-
-## 0.1
-
-### Added
-
-- The initial version of the `git-clone-oci-ta-min` task!


### PR DESCRIPTION
git-clone logic was implemented in Go in the [konflux-build-cli](https://github.com/konflux-ci/konflux-build-cli) repository. 
Use it instead of the original Bash in YAML implementation. 