### PR TITLE
fix: update fips tasks for check-payload 0.3.14

### DIFF
--- a/task/fbc-fips-check-matrix-based-oci-ta/0.1/fbc-fips-check-matrix-based-oci-ta.yaml
+++ b/task/fbc-fips-check-matrix-based-oci-ta/0.1/fbc-fips-check-matrix-based-oci-ta.yaml
@@ -111,7 +111,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 6660aed5c5388fade0f433c14d41c5d4e073d07a
+            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fbc-fips-check-matrix-based-oci-ta/CHANGELOG.md
+++ b/task/fbc-fips-check-matrix-based-oci-ta/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## Unreleased
 
-<!--
-When you make changes without bumping the version right away, document them here.
-If that's not something you ever plan to do, consider removing this section.
--->
+### Fixed
 
-*Nothing yet.*
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 
 ## 0.1
 

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -325,7 +325,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 6660aed5c5388fade0f433c14d41c5d4e073d07a
+            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fbc-fips-check-oci-ta/CHANGELOG.md
+++ b/task/fbc-fips-check-oci-ta/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 
 ## 0.1
 

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -314,7 +314,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 6660aed5c5388fade0f433c14d41c5d4e073d07a
+            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 

--- a/task/fbc-fips-check/CHANGELOG.md
+++ b/task/fbc-fips-check/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 
 ## 0.1
 

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -168,7 +168,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 6660aed5c5388fade0f433c14d41c5d4e073d07a
+            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git

--- a/task/fips-operator-bundle-check-oci-ta/CHANGELOG.md
+++ b/task/fips-operator-bundle-check-oci-ta/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
+
+## 0.1
+
+### Added
+
+- Initial version of `fips-operator-bundle-check-oci-ta` task
+- Trusted Artifacts (`SOURCE_ARTIFACT`) variant of single operator bundle FIPS checking with `check-payload`
+- Scans relatedImages from the operator bundle image
+- Expects an image digest mirror set at `.tekton/images-mirror-set.yaml` when mirroring is required
+
+### Note
+
+This is the Trusted Artifacts variant of `fips-operator-bundle-check`.

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -142,7 +142,7 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 6660aed5c5388fade0f433c14d41c5d4e073d07a
+            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 

--- a/task/fips-operator-bundle-check/CHANGELOG.md
+++ b/task/fips-operator-bundle-check/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
+
+## 0.1
+
+### Added
+
+- Initial version of `fips-operator-bundle-check` task
+- Single operator bundle FIPS checking with `check-payload`
+- Scans relatedImages from the operator bundle image
+- Expects an image digest mirror set at `.tekton/images-mirror-set.yaml` when mirroring is required
+
+### Note
+
+Workspace-source variant; the Trusted Artifacts equivalent is `fips-operator-bundle-check-oci-ta`.


### PR DESCRIPTION
Updated fips tasks to use updated stepaction for check-payload 0.3.14.

Closes: [KFLUXSPRT-7801](https://redhat.atlassian.net/browse/KFLUXSPRT-7801)


[KFLUXSPRT-7801]: https://redhat.atlassian.net/browse/KFLUXSPRT-7801?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ