### PR TITLE
Bugfix/ocp 5.0 prev version cross major boundary

### DIFF
--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -149,11 +149,7 @@ spec:
         if [[ "${unreleased_pkg_count}" -gt 0 ]]; then
           echo "One or more packages in the FBC fragment were not found in the target index."
 
-          # Derive previous minor version from target_ocp_version
-          major_ocp_version=$(echo "${target_ocp_version#v}" | awk -F'.' '{print $1}')
-          minor_ocp_version=$(echo "${target_ocp_version#v}" | awk -F'.' '{print $2}')
-          prev_minor_version=$(("${minor_ocp_version}" - 1))
-          prev_ocp_version="v${major_ocp_version}.${prev_minor_version}"
+          prev_ocp_version=$(get_prev_ocp_version "${target_ocp_version}")
           echo "Using the previous catalog OCP version to check for unreleased bundles: ${prev_ocp_version}"
           target_index_url="${target_index_repo_reg}:${prev_ocp_version}"
         fi

--- a/task/fbc-fips-check-oci-ta/CHANGELOG.md
+++ b/task/fbc-fips-check-oci-ta/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
+
+## 0.1
+
+### Added
+
+- Initial version of `fbc-fips-check-oci-ta` task
+- Trusted Artifacts (`SOURCE_ARTIFACT`) variant of FBC fragment FIPS checking with `check-payload`
+- Scans relatedImages from unreleased operator bundles in an FBC fragment image
+- Parameters include `MAX_PARALLEL` and `image-mirror-set-path` for mirror resolution
+
+### Note
+
+This is the Trusted Artifacts variant of `fbc-fips-check` (`fbc-fips-check` uses a workspace source instead of `SOURCE_ARTIFACT`).

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -149,11 +149,7 @@ spec:
         if [[ "${unreleased_pkg_count}" -gt 0 ]]; then
           echo "One or more packages in the FBC fragment were not found in the target index."
 
-          # Derive previous minor version from target_ocp_version
-          major_ocp_version=$(echo "${target_ocp_version#v}" | awk -F'.' '{print $1}')
-          minor_ocp_version=$(echo "${target_ocp_version#v}" | awk -F'.' '{print $2}')
-          prev_minor_version=$(("${minor_ocp_version}" - 1))
-          prev_ocp_version="v${major_ocp_version}.${prev_minor_version}"
+          prev_ocp_version=$(get_prev_ocp_version "${target_ocp_version}")
           echo "Using the previous catalog OCP version to check for unreleased bundles: ${prev_ocp_version}"
           target_index_url="${target_index_repo_reg}:${prev_ocp_version}"
         fi

--- a/task/fbc-fips-check/CHANGELOG.md
+++ b/task/fbc-fips-check/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+## Unreleased
+
+### Fixed
+
+- Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
+
+## 0.1
+
+### Added
+
+- Initial version of `fbc-fips-check` task
+- FBC fragment FIPS checking with `check-payload` for unreleased operator bundles
+- Legacy bundle exemption for qualifying Red Hat subscriptions when the bundle predates the FIPS requirement date (January 31, 2025), unless the bundle explicitly claims FIPS compliance
+- Parameters include `MAX_PARALLEL` and `image-mirror-set-path` for mirror resolution
+
+### Note
+
+Workspace-source variant; the Trusted Artifacts equivalent is `fbc-fips-check-oci-ta`.

--- a/task/fbc-fips-prepare-oci-ta/0.1/fbc-fips-prepare-oci-ta.yaml
+++ b/task/fbc-fips-prepare-oci-ta/0.1/fbc-fips-prepare-oci-ta.yaml
@@ -164,11 +164,7 @@ spec:
         if [[ "${unreleased_pkg_count}" -gt 0 ]]; then
           echo "One or more packages in the FBC fragment were not found in the target index."
 
-          # Derive previous minor version from target_ocp_version
-          major_ocp_version=$(echo "${target_ocp_version#v}" | awk -F'.' '{print $1}')
-          minor_ocp_version=$(echo "${target_ocp_version#v}" | awk -F'.' '{print $2}')
-          prev_minor_version=$(("${minor_ocp_version}" - 1))
-          prev_ocp_version="v${major_ocp_version}.${prev_minor_version}"
+          prev_ocp_version=$(get_prev_ocp_version "${target_ocp_version}")
           echo "Using the previous catalog OCP version to check for unreleased bundles: ${prev_ocp_version}"
           target_index_url="${target_index_repo_reg}:${prev_ocp_version}"
         fi

--- a/task/fbc-fips-prepare-oci-ta/CHANGELOG.md
+++ b/task/fbc-fips-prepare-oci-ta/CHANGELOG.md
@@ -2,12 +2,9 @@
 
 ## Unreleased
 
-<!--
-When you make changes without bumping the version right away, document them here.
-If that's not something you ever plan to do, consider removing this section.
--->
+### Fixed
 
-*Nothing yet.*
+- Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
 
 ## 0.1
 


### PR DESCRIPTION
Replace the ad-hoc 4-line minor-version arithmetic with a call to the
shared get_prev_ocp_version helper now available in utils.sh (konflux-test
v1.5.0). The helper correctly handles the v5.0 → v4.22 cross-major boundary
that the old arithmetic produced as v5.-1.

Refers to [KONFLUX-13978](https://redhat.atlassian.net/browse/KONFLUX-13978)



[KONFLUX-13978]: https://redhat.atlassian.net/browse/KONFLUX-13978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ