### PR TITLE
Fix validation of olm.csv.metadata for OCP 5.x versions 

### DIFF
--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -219,6 +219,7 @@ spec:
         image_with_digest=$(cat /shared/image_with_digest)
         base_image_with_digest=$(cat /shared/base_image_with_digest)
         base_image_repository=$(cat /shared/base_image_repository)
+        note=""
 
         declare -a ALLOWED_BASE_IMAGES=(
           "registry.redhat.io/openshift4/ose-operator-registry"
@@ -429,7 +430,7 @@ spec:
           OCP_BUNDLE_METADATA_THRESHOLD_MINOR=17
           OCP_BUNDLE_METADATA_FORMAT="olm.bundle.object"
 
-          if [[ "${OCP_VER_MAJOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MAJOR}" ]] && [[ "${OCP_VER_MINOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MINOR}" ]]; then
+          if [[ "${OCP_VER_MAJOR}" -gt "${OCP_BUNDLE_METADATA_THRESHOLD_MAJOR}" ]] || [[ "${OCP_VER_MAJOR}" -eq "${OCP_BUNDLE_METADATA_THRESHOLD_MAJOR}" && "${OCP_VER_MINOR}" -ge "${OCP_BUNDLE_METADATA_THRESHOLD_MINOR}" ]]; then
              OCP_BUNDLE_METADATA_FORMAT="olm.csv.metadata"
           fi
 
@@ -489,6 +490,9 @@ spec:
         fi
 
         if [ $TESTPASSED == false ]; then
+          if [ -z "$note" ]; then
+            note="Step extract-and-validate failed: Validation checks failed. For details, check Tekton task log."
+          fi
           ERROR_OUTPUT=$(make_result_json -r FAILURE -f $failure_num -s $((check_num - failure_num)) -t "$note")
           echo -n "${ERROR_OUTPUT}" | tee "$(results.TEST_OUTPUT.path)"
         else


### PR DESCRIPTION
Currently olm.csv.metadata is validated for 4.17+ versions using AND logic, which incorrectly fails for 5.x versions (e.g., 5.0, 5.1) since their minor version is less than 17. Fixed the condition to use OR logic to properly handle both 4.17+ and all 5.x+ versions.

Also fixed the unbound variable error for 'note' by initializing it and providing a fallback message when validation fails.

Refers to [KONFLUX-14143](https://redhat.atlassian.net/browse/KONFLUX-14143)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.


[KONFLUX-14143]: https://redhat.atlassian.net/browse/KONFLUX-14143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ