### PR TITLE
Bugfix/remove build type label

### DIFF
--- a/task/build-image-index-min/0.2/build-image-index-min.yaml
+++ b/task/build-image-index-min/0.2/build-image-index-min.yaml
@@ -7,7 +7,6 @@ metadata:
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: "0.2"
-    build.appstudio.redhat.com/build_type: docker
   name: build-image-index-min
 spec:
   description: This takes existing Image Manifests and combines them in an Image Index.

--- a/task/build-image-index-min/0.3/build-image-index-min.yaml
+++ b/task/build-image-index-min/0.3/build-image-index-min.yaml
@@ -7,7 +7,6 @@ metadata:
     tekton.dev/tags: image-build, konflux
   labels:
     app.kubernetes.io/version: "0.3"
-    build.appstudio.redhat.com/build_type: docker
   name: build-image-index-min
 spec:
   description: This takes existing Image Manifests and combines them in an Image Index.

--- a/task/build-image-index/0.2/build-image-index.yaml
+++ b/task/build-image-index/0.2/build-image-index.yaml
@@ -3,7 +3,6 @@ kind: Task
 metadata:
   labels:
     app.kubernetes.io/version: "0.2"
-    build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, konflux"

--- a/task/build-image-index/0.3/build-image-index.yaml
+++ b/task/build-image-index/0.3/build-image-index.yaml
@@ -3,7 +3,6 @@ kind: Task
 metadata:
   labels:
     app.kubernetes.io/version: "0.3"
-    build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, konflux"


### PR DESCRIPTION
# Remove `build_type: docker` from `build-image-index`

## Summary

Remove `build.appstudio.redhat.com/build_type: docker` from `build-image-index` (0.2 and 0.3). This task only assembles a multi-arch index from existing manifests; it is not a container build. The label caused Conforma to treat modelcar pipelines as docker builds and apply the wrong required-task policy.

## Problem

Modelcar pipelines (`modelcar-oci-ta` → `build-image-index`) fail release Conforma with:

- `tasks.required_tasks_found`: one of `buildah`, `buildah-remote`, `buildah-oci-ta`, `buildah-remote-oci-ta` is missing
- `tasks.required_tasks_found`: `deprecated-image-check` is missing

`rhtap-ec-policy` already defines **`pipeline-required-tasks.modelcar`** (init, git-clone-oci-ta, modelcar-oci-ta, sast-snyk-check-oci-ta) without buildah or deprecated-image-check.

Conforma picks required tasks from **build tasks** in the attestation using `build.appstudio.redhat.com/build_type` ([`policy/lib/tekton/pipeline.rego`](https://github.com/conforma/policy/blob/main/policy/lib/tekton/pipeline.rego)). When build tasks have different types, it **unions** the requirement sets.

| Task | Role | Previous `build_type` |
|------|------|------------------------|
| `modelcar-oci-ta` | Builds the modelcar image | `modelcar` |
| `build-image-index` | Combines manifests into an index | `docker` |

`build-image-index` outputs `IMAGE_URL` / `IMAGE_DIGEST`, so it counts as a build task. With `build_type: docker`, Conforma merges **modelcar + docker** rules and enforces docker requirements (buildah, deprecated-image-check) on a non-docker pipeline.

`pipelines.openshift.io/runtime: modelcar` on the Pipeline does **not** override this; task-level `build_type` wins.

## Why remove the label (not set it to `modelcar`)

- `build-image-index` is **shared** (docker, modelcar, disk-image, etc.). A global `build_type: modelcar` would misclassify every consumer.
- Index assembly is not a modelcar or docker **build**; the typed build is `modelcar-oci-ta` or `buildah-*`.
- **Docker pipelines**: still get `docker` from `buildah-*` only → union stays `{docker}`.
- **Modelcar pipelines** (after catalog rollout): only `modelcar-oci-ta` contributes `modelcar` → correct policy applies.

## Changes

- `task/build-image-index/0.2/build-image-index.yaml` — remove `build.appstudio.redhat.com/build_type: docker`
- `task/build-image-index/0.3/build-image-index.yaml` — same
