### PR TITLE
task(fips-operator-bundle-check{,-oci-ta}): fix resource policy

### DIFF
--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -143,7 +143,6 @@ spec:
         echo "${images_processed_template/\[%s]/[$digests_processed_string]}" >/tekton/home/images_processed.txt
       computeResources:
         limits:
-          cpu: "1"
           memory: 12Gi
         requests:
           cpu: "1"
@@ -158,7 +157,6 @@ spec:
           value: $(params.MAX_PARALLEL)
       computeResources:
         limits:
-          cpu: "8"
           memory: 12Gi
         requests:
           cpu: "8"
@@ -184,3 +182,9 @@ spec:
           echo "Task was skipped. Exiting"
           exit 0
         fi
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -33,7 +33,6 @@ spec:
       computeResources:
         limits:
           memory: 12Gi
-          cpu: '1'
         requests:
           memory: 12Gi
           cpu: '1'
@@ -129,7 +128,6 @@ spec:
       computeResources:
         limits:
           memory: 12Gi
-          cpu: '8'
         requests:
           memory: 12Gi
           cpu: '8'
@@ -148,6 +146,12 @@ spec:
 
     - name: parse-images-processed-result
       image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          memory: 64Mi
+          cpu: 50m
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
## Summary

Fix two Konflux resource policy violations and add a missing
`computeResources` block in `task/fips-operator-bundle-check/0.1` and
its generated oci-ta variant.

## Changes

| Task | Step | Field | Before | After |
|---|---|---|---|---|
| base + oci-ta | `get-unique-related-images` | cpu limit | `'1'` | **removed** |
| base + oci-ta | `fips-operator-check-step-action` | cpu limit | `'8'` | **removed** |
| base + oci-ta | `parse-images-processed-result` | memory limit | *(unset)* | **64Mi** |
| base + oci-ta | `parse-images-processed-result` | memory request | *(unset)* | **64Mi** |
| base + oci-ta | `parse-images-processed-result` | cpu request | *(unset)* | **50m** |

Memory values for `get-unique-related-images` and
`fips-operator-check-step-action` are **unchanged** (12Gi req=limit).

## Rationale

**CPU limit removal** — Konflux resource policy requires `cpu.request`
to be set and explicitly forbids `cpu.limit`. Both `get-unique-related-images`
and `fips-operator-check-step-action` had identical values in both
`requests` and `limits` for CPU, violating this policy. The `requests`
values are preserved; only the `limits` entries are removed.

**`parse-images-processed-result` resources added** — This step had no
`computeResources` block at all, leaving it entirely unbound. It is a
lightweight result-parsing shell script; floor values
(`memory: 64Mi` req=limit, `cpu: 50m` req only) are applied, consistent
with the floor used for similar lightweight steps across the task fleet.

**Memory unchanged** — Existing 12Gi memory limits on the two heavier
steps already satisfy `memory.request == memory.limit`. Fleet analysis
was run but observed values are well below the current limits; no
reduction is made at this time.

**`use-trusted-artifact` (oci-ta)** — No `computeResources` added. The
`hack/generate-ta-tasks.sh` generator does not yet support configurable
`computeResources` for the injected `use-trusted-artifact` step; adding
it manually would cause the *Check Trusted Artifact variants* CI check
to fail.

Related: KONFLUX-13036, [KONFLUX-13037](https://redhat.atlassian.net/browse/KONFLUX-13037)
Parent epic: [KONFLUX-11509](https://redhat.atlassian.net/browse/KONFLUX-11509)

Assisted-by: CursorAI
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)

[KONFLUX-13037]: https://redhat.atlassian.net/browse/KONFLUX-13037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ