### PR TITLE
bump sbom-syft-generate memory limit to 16Gi

### DIFF
--- a/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.9/buildah-oci-ta.yaml
@@ -1283,7 +1283,7 @@ spec:
       computeResources:
         limits:
           cpu: 1100m
-          memory: 4Gi
+          memory: 16Gi
         requests:
           cpu: 1100m
           memory: 4Gi

--- a/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.9/buildah-remote-oci-ta.yaml
@@ -1359,7 +1359,7 @@ spec:
   - computeResources:
       limits:
         cpu: 1100m
-        memory: 4Gi
+        memory: 16Gi
       requests:
         cpu: 1100m
         memory: 4Gi

--- a/task/buildah-remote/0.9/buildah-remote.yaml
+++ b/task/buildah-remote/0.9/buildah-remote.yaml
@@ -1331,7 +1331,7 @@ spec:
   - computeResources:
       limits:
         cpu: 1100m
-        memory: 4Gi
+        memory: 16Gi
       requests:
         cpu: 1100m
         memory: 4Gi

--- a/task/buildah/0.9/buildah.yaml
+++ b/task/buildah/0.9/buildah.yaml
@@ -1139,7 +1139,7 @@ spec:
     image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
     computeResources:
       limits:
-        memory: 4Gi
+        memory: 16Gi
         cpu: 1100m
       requests:
         memory: 4Gi


### PR DESCRIPTION
Downstream teams work around this today with per-repo `taskRunSpecs` overrides (e.g. [opendatahub-io/base-containers#220](https://github.com/opendatahub-io/base-containers/pull/220)).

Closes #3537