### PR TITLE
task(fbc-target-index-pruning-check): add missing cpu requests

### DIFF
--- a/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
+++ b/task/fbc-target-index-pruning-check/0.1/fbc-target-index-pruning-check.yaml
@@ -60,6 +60,7 @@ spec:
           memory: 2Gi
         requests:
           memory: 2Gi
+          cpu: 50m
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -85,6 +86,7 @@ spec:
           memory: 10Gi
         requests:
           memory: 10Gi
+          cpu: 1200m
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
## Summary

Both steps in `fbc-target-index-pruning-check` had memory
`requests == limits` (policy-compliant) but were missing `cpu.request`
entirely, leaving CPU completely unbound.

This PR adds `cpu.request` for both steps, derived from fleet analysis:

| Step | cpu.request (before) | cpu.request (after) | Basis |
|---|---|---|---|
| `pull-rendered-catalog` | (unset) | `50m` | floor — observed max 1m |
| `run-pruning-check` | (unset) | `1200m` | p95 fleet envelope + 5% margin |

Memory limits are unchanged (`2Gi` and `10Gi` respectively) — observed
values are well within existing limits and no reduction is made.

> **Note:** `run-pruning-check` memory max reached ~9Gi on large FBC
> catalogs (~90% of the 10Gi limit). If OOM events are observed on
> heavy workloads, the limit should be revisited upward.

No `oci-ta` variant exists for this task; no generator run needed.

## Motivation

Aligning with the Konflux resource policy:
- `memory.request == memory.limit` ✅ (already set)
- `cpu.request` set ✅ (this PR)
- no `cpu.limit` ✅ (not present)

Related: [KONFLUX-13035](https://redhat.atlassian.net/browse/KONFLUX-13035)
Parent epic: [KONFLUX-11509](https://redhat.atlassian.net/browse/KONFLUX-11509)

Assisted-by: CursorAI
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)

[KONFLUX-13035]: https://redhat.atlassian.net/browse/KONFLUX-13035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ