### PR TITLE
[KONFLUX-13286] Replace appstudio-utils with task-runner in ec-checks

### DIFF
--- a/.tekton/tasks/ec-checks.yaml
+++ b/.tekton/tasks/ec-checks.yaml
@@ -22,7 +22,7 @@ spec:
         value: /tekton/home
   steps:
   - name: gather-tasks
-    image: quay.io/konflux-ci/appstudio-utils:48c311af02858e2422d6229600e9959e496ddef1@sha256:91ddd999271f65d8ec8487b10f3dd378f81aa894e11b9af4d10639fd52bba7e8
+    image: quay.io/konflux-ci/task-runner:1.7.0
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     workingDir: $(workspaces.source.path)/source


### PR DESCRIPTION
  ## Summary
  - Replace `quay.io/konflux-ci/appstudio-utils` with `quay.io/konflux-ci/task-runner:1.7.0` in `.tekton/tasks/ec-checks.yaml`
  - The `appstudio-utils` image is being decommissioned ,`task-runner` is the replacement.
 
Issue: [KONFLUX-13286](https://issues.redhat.com/browse/KONFLUX-13286)

[KONFLUX-13286]: https://redhat.atlassian.net/browse/KONFLUX-13286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ