### PR TITLE
task(generate-labels): set floor computeResources for render step

### DIFF
--- a/task/generate-labels/0.1/generate-labels.yaml
+++ b/task/generate-labels/0.1/generate-labels.yaml
@@ -1,4 +1,4 @@
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
@@ -53,6 +53,12 @@ spec:
   steps:
     - name: render
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       env:
       - name: SOURCE_DATE_EPOCH
         value: "$(params.source-date-epoch)"


### PR DESCRIPTION
## Summary

The `render` step in the `generate-labels` task had no `computeResources`
defined, leaving resource requests and limits unset — a policy violation.

This PR adds floor values for the step:

| Step | memory.request | memory.limit | cpu.request | cpu.limit |
|------|----------------|--------------|-------------|-----------|
| `render` | `64Mi` | `64Mi` | `50m` | _(not set)_ |

**Policy alignment:**
- `memory.request == memory.limit` (floor value — step is extremely lightweight)
- `cpu.request` set to floor value
- No `cpu.limit` (per Konflux resource policy)

There is no OCI-TA variant for this task, so no generated file changes are needed.

Part of the broader effort to ensure all task steps have explicit resource
requests and limits defined.

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAI
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)