### PR TITLE
task(summary): set floor computeResources for appstudio-summary step

### DIFF
--- a/task/summary/0.2/summary.yaml
+++ b/task/summary/0.2/summary.yaml
@@ -28,6 +28,12 @@ spec:
   steps:
     - name: appstudio-summary
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       env:


### PR DESCRIPTION
## Summary

The `appstudio-summary` step in the `summary` task had no `computeResources`
defined, leaving resource requests and limits unset — a policy violation.

This PR adds floor values for the step:

| Step | memory.request | memory.limit | cpu.request | cpu.limit |
|------|----------------|--------------|-------------|-----------|
| `appstudio-summary` | `64Mi` | `64Mi` | `50m` | _(not set)_ |

**Policy alignment:**
- `memory.request == memory.limit` (floor value — step is extremely lightweight)
- `cpu.request` set to floor value
- No `cpu.limit` (per Konflux resource policy)

There is no OCI-TA variant for this task, so no generated file changes are needed.

Part of the broader effort to ensure all task steps have explicit resource
requests and limits defined.

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAI
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)