### PR TITLE
Serialize push pipeline to prevent data-acceptable-bundles race

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -8,6 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/on-target-branch: "main"
     pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, task/buildah-remote/0.8/buildah-remote.yaml, task/build-image-index/0.3/build-image-index.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml, task/apply-tags/0.2/apply-tags.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
+    pipelinesascode.tekton.dev/concurrency: "1"
 spec:
   params:
     - name: git-url


### PR DESCRIPTION
When multiple commits land on main in quick succession, concurrent
pipeline runs race to update the `data-acceptable-bundles` `:latest` tag.
Intermediate images can end up as `:latest` without a durable numbered
tag, and Quay's 14-day tag expiration GCs them. Downstream consumers
pinned by digest then break with 404s.

For example, digest `sha256:d65342bb1a08...` was `:latest` from
`04:50:37` to `16:41:28 UTC` on May 26, but never received a numbered
tag. After `:latest` moved on, Quay garbage collected it. This broke
the reference pinned in [konflux-ci/konflux-ci#6993](https://github.com/konflux-ci/konflux-ci/pull/6993).

Setting `pipelinesascode.tekton.dev/concurrency: "1"` serializes runs
so each one reads the previous run's `:latest` as input and produces
a single output with both a numbered tag and `:latest` pointing to the
same digest.

**Note:**
This serializes the entire push pipeline, not just the `data-acceptable-bundles` step: the task and pipeline bundle builds (`konflux-ci/tekton-catalog`, `redhat-appstudio-tekton-catalog`) are also serialized. 
Those bundles are tagged by commit SHA, not by timestamp, so they don't have the same race condition.
The only impact is slightly slower throughput when multiple commits land on main in quick succession.