### PR TITLE
feat(oci-copy): add missing computeResources to unset steps in oci-copy/0.2

### DIFF
--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -119,6 +119,12 @@ spec:
           echo "Wrote /var/workdir/vars/$varfile with contents:"
           cat "/var/workdir/vars/$varfile"
         done
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
     - name: oci-copy
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       workingDir: /var/workdir
@@ -557,6 +563,12 @@ spec:
           --image-pullspec "$IMAGE_URL" \
           --image-digest "$IMAGE_DIGEST" \
           --sbom-type "$SBOM_TYPE"
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
     - name: upload-sbom
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       workingDir: /var/workdir
@@ -564,6 +576,12 @@ spec:
         # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
         mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" >/tmp/auth/config.json
         DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       securityContext:
         runAsNonRoot: false
         runAsUser: 0
@@ -577,3 +595,9 @@ spec:
         SBOM_DIGEST=$(sha256sum sbom.json | awk '{ print $1 }')
         echo "Found that ${SBOM_DIGEST} is the SBOM digest"
         echo -n "${REPO}@sha256:${SBOM_DIGEST}" | tee $(results.SBOM_BLOB_URL.path)
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -64,6 +64,12 @@ spec:
   steps:
     - name: prepare
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       script: |
         #!/bin/bash
         set -eu
@@ -514,6 +520,12 @@ spec:
       workingDir: $(workspaces.source.path)
     - name: sbom-generate
       image: quay.io/konflux-ci/mobster:1.2.0-1774868067@sha256:2e00c2f0aeff55713150b51822013327ea0e0d75b8164a52f837fb297c17703d
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       script: |
         #!/bin/bash
         set -euo pipefail
@@ -533,6 +545,12 @@ spec:
       workingDir: $(workspaces.source.path)
     - name: upload-sbom
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       securityContext:
         runAsUser: 0
         runAsNonRoot: false
@@ -543,6 +561,12 @@ spec:
         DOCKER_CONFIG=/tmp/auth cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
     - name: report-sbom-url
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       script: |
         #!/bin/bash
         REPO=${IMAGE%:*}

--- a/task/oci-copy/0.2/oci-copy.yaml
+++ b/task/oci-copy/0.2/oci-copy.yaml
@@ -65,10 +65,10 @@ spec:
     - name: prepare
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       computeResources:
-        requests:
-          memory: 64Mi
-          cpu: 50m
         limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
           memory: 64Mi
       script: |
         #!/bin/bash
@@ -521,10 +521,10 @@ spec:
     - name: sbom-generate
       image: quay.io/konflux-ci/mobster:1.2.0-1774868067@sha256:2e00c2f0aeff55713150b51822013327ea0e0d75b8164a52f837fb297c17703d
       computeResources:
-        requests:
-          memory: 64Mi
-          cpu: 50m
         limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
           memory: 64Mi
       script: |
         #!/bin/bash
@@ -546,10 +546,10 @@ spec:
     - name: upload-sbom
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       computeResources:
-        requests:
-          memory: 64Mi
-          cpu: 50m
         limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
           memory: 64Mi
       securityContext:
         runAsUser: 0
@@ -562,10 +562,10 @@ spec:
     - name: report-sbom-url
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       computeResources:
-        requests:
-          memory: 64Mi
-          cpu: 50m
         limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
           memory: 64Mi
       script: |
         #!/bin/bash


### PR DESCRIPTION
## Summary

Adds `computeResources` to the four steps in `oci-copy/0.2` that had no resource definitions, and regenerates `oci-copy-oci-ta/0.2` accordingly.

### Changes

| Step | Before | After |
|------|--------|-------|
| `prepare` | not set | `memory: 64Mi` req=limit, `cpu: 50m` req |
| `oci-copy` | `memory: 4Gi` req=limit, `cpu: 2` req | **unchanged** (already compliant) |
| `sbom-generate` | not set | `memory: 64Mi` req=limit, `cpu: 50m` req |
| `upload-sbom` | not set | `memory: 64Mi` req=limit, `cpu: 50m` req |
| `report-sbom-url` | not set | `memory: 64Mi` req=limit, `cpu: 50m` req |

The `oci-copy` step already satisfied the policy (`memory.request == memory.limit`, `cpu.request` set, no `cpu.limit`) and is untouched.

### Sizing rationale

Fleet analysis over a 60-day window returned no pod executions for the base `oci-copy` task across all 12 clusters, and only 26 executions (2.5 days of coverage, single cluster) for the oci-ta variant. The sample is too sparse to drive data-backed sizing. Floor values (`memory: 64Mi`, `cpu: 50m`) are used for all newly-added steps, consistent with the approach taken for other low-traffic tasks in this series.

### Policy

All steps now satisfy the Konflux compute-resource policy:
- `memory.request == memory.limit` per step
- `cpu.request` set, no `cpu.limit`

### Note on `use-trusted-artifact`

The `use-trusted-artifact` step injected by the trusted-artifact generator does not receive `computeResources` because the generator (`task-generator/trusted-artifacts/ta.go`) does not emit them for that step. This is a generator-level gap and is out of scope for this PR.

### Related

- Epic: [KONFLUX-11509](https://redhat.atlassian.net/browse/KONFLUX-11509)
- Ticket: [KONFLUX-13044](https://redhat.atlassian.net/browse/KONFLUX-13044) / [KONFLUX-13045](https://redhat.atlassian.net/browse/KONFLUX-13045)

Assisted-by: CursorAI
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)

[KONFLUX-11509]: https://redhat.atlassian.net/browse/KONFLUX-11509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ