### PR TITLE
fix: update fips stepaction

### DIFF
--- a/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
+++ b/stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
@@ -21,7 +21,7 @@ spec:
   results:
     - name: TEST_OUTPUT
       description: Tekton task test output.
-  image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+  image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
   securityContext:
     capabilities:
       add:


### PR DESCRIPTION
Updated fips stepaction to use konflux-test:v1.5.1 with check-payload 0.3.15.
