### PR TITLE
Update FIPS-* tasks to use konflux-test v1.5.1 and pin step action

### DIFF
--- a/task/fbc-fips-check-matrix-based-oci-ta/0.1/fbc-fips-check-matrix-based-oci-ta.yaml
+++ b/task/fbc-fips-check-matrix-based-oci-ta/0.1/fbc-fips-check-matrix-based-oci-ta.yaml
@@ -47,7 +47,7 @@ spec:
         - $(params.BUCKETS_ARTIFACT)=/var/workdir/buckets
 
     - name: prepare-bucket-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       env:
         - name: BUCKET_INDEX
           value: $(params.BUCKET_INDEX)
@@ -111,13 +111,13 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
+            value: e96f4c79387f635a1a49cb3298541ab25b3ddada
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git
 
     - name: output-results
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       env:
         - name: BUCKET_INDEX
           value: $(params.BUCKET_INDEX)

--- a/task/fbc-fips-check-matrix-based-oci-ta/CHANGELOG.md
+++ b/task/fbc-fips-check-matrix-based-oci-ta/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 
 ## 0.1

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -48,7 +48,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -325,12 +325,12 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
+            value: e96f4c79387f635a1a49cb3298541ab25b3ddada
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       env:
         - name: STEP_ACTION_TEST_OUTPUT
           value: $(steps.fips-operator-check-step-action.results.TEST_OUTPUT)

--- a/task/fbc-fips-check-oci-ta/CHANGELOG.md
+++ b/task/fbc-fips-check-oci-ta/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 
 ## 0.1
 

--- a/task/fbc-fips-check/0.1/fbc-fips-check.yaml
+++ b/task/fbc-fips-check/0.1/fbc-fips-check.yaml
@@ -38,7 +38,7 @@ spec:
       description: Images processed in the task.
   steps:
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       computeResources:
         requests:
           memory: 6Gi
@@ -314,12 +314,12 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
+            value: e96f4c79387f635a1a49cb3298541ab25b3ddada
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       computeResources:
         requests:
           memory: 64Mi

--- a/task/fbc-fips-check/CHANGELOG.md
+++ b/task/fbc-fips-check/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 - Replace the ad-hoc 4-line minor-version arithmetic with a call to the shared `get_prev_ocp_version()` helper now available in `utils.sh` (`konflux-test:v1.5.0`). The helper correctly handles the v5.0 → v4.22 cross-major boundary.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -54,7 +54,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       env:
         - name: IMAGE_URL
           value: $(params.image-url)
@@ -166,12 +166,12 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
+            value: e96f4c79387f635a1a49cb3298541ab25b3ddada
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
         resolver: git
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       script: |
         #!/usr/bin/env bash
         set -euo pipefail

--- a/task/fips-operator-bundle-check-oci-ta/CHANGELOG.md
+++ b/task/fips-operator-bundle-check-oci-ta/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 
 ## 0.1

--- a/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
+++ b/task/fips-operator-bundle-check/0.1/fips-operator-bundle-check.yaml
@@ -29,7 +29,7 @@ spec:
       description: Images processed in the task.
   steps:
     - name: get-unique-related-images
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       computeResources:
         limits:
           memory: 12Gi
@@ -140,12 +140,12 @@ spec:
           - name: url
             value: https://github.com/konflux-ci/build-definitions
           - name: revision
-            value: 9eddeafc3de7e609e087f3e04010383ba3979c4f
+            value: e96f4c79387f635a1a49cb3298541ab25b3ddada
           - name: pathInRepo
             value: stepactions/fips-operator-check-step-action/0.1/fips-operator-check-step-action.yaml
 
     - name: parse-images-processed-result
-      image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      image: quay.io/konflux-ci/konflux-test:v1.5.1@sha256:e6b090c515168c8ed0fa932ffe0ac6f27dbc1ea41fdb2fe83cfcaa7829b910bd
       computeResources:
         limits:
           memory: 64Mi

--- a/task/fips-operator-bundle-check/CHANGELOG.md
+++ b/task/fips-operator-bundle-check/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.15`.
 - Updated the `fips-operator-check-step-action` revision parameter to use `check-payload` release `0.3.14`.
 
 ## 0.1


### PR DESCRIPTION
# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
