### PR TITLE
feat(verify-source): add computeResources to slsa-verify step

### DIFF
--- a/task/verify-source/0.1/verify-source.yaml
+++ b/task/verify-source/0.1/verify-source.yaml
@@ -47,6 +47,12 @@ spec:
   steps:
     - name: slsa-verify
       image: quay.io/konflux-ci/git-clone@sha256:aedc5ba99f95c3d77fc256ac01677212c18298373a0b3de3aeabc41ba69cc301
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       env:
         - name: PARAM_URL
           value: $(params.url)


### PR DESCRIPTION
## Summary

Adds `computeResources` to the `slsa-verify` step in `verify-source/0.1`, which had no resource definitions.

### Changes

| Step | Before | After |
|------|--------|-------|
| `slsa-verify` | not set | `memory: 64Mi` req=limit, `cpu: 50m` req, no cpu limit |

### Sizing rationale

Fleet analysis over a 60-day window returned no pod executions for `verify-source` across all 12 Konflux clusters. The task appears to have very low production usage. Floor values (`memory: 64Mi`, `cpu: 50m`) are used, consistent with the approach taken for other low-traffic tasks in this series.

### Policy

The step now satisfies the Konflux compute-resource policy:
- `memory.request == memory.limit`
- `cpu.request` set, no `cpu.limit`

### Related

- Epic: [KONFLUX-11509](https://redhat.atlassian.net/browse/KONFLUX-11509)
- Ticket: [KONFLUX-13066](https://redhat.atlassian.net/browse/KONFLUX-13066)

Assisted-by: CursorAI
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)

[KONFLUX-11509]: https://redhat.atlassian.net/browse/KONFLUX-11509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[KONFLUX-13066]: https://redhat.atlassian.net/browse/KONFLUX-13066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ