### PR TITLE
feat(slack-webhook-notification): add computeResources to send-message

### DIFF
--- a/task/slack-webhook-notification-oci-ta/0.1/slack-webhook-notification-oci-ta.yaml
+++ b/task/slack-webhook-notification-oci-ta/0.1/slack-webhook-notification-oci-ta.yaml
@@ -252,6 +252,12 @@ spec:
         data=$(jq --compact-output --null-input --arg message "$slack_message" '{text: $message}')
 
         curl -X POST -H 'Content-type: application/json' --data "${data}" "$WEBHOOK_URL"
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       securityContext:
         runAsNonRoot: false
         runAsUser: 0

--- a/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
+++ b/task/slack-webhook-notification/0.1/slack-webhook-notification.yaml
@@ -44,6 +44,12 @@ spec:
   steps:
     - name: send-message
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       securityContext:
         runAsUser: 0
         runAsNonRoot: false


### PR DESCRIPTION
## Summary

Adds `computeResources` to the `send-message` step in `slack-webhook-notification/0.1`, which had no resource definitions, and regenerates `slack-webhook-notification-oci-ta/0.1` accordingly.

### Changes

| Step | Before | After |
|------|--------|-------|
| `send-message` | not set | `memory: 64Mi` req=limit, `cpu: 50m` req, no cpu limit |

### Sizing rationale

Fleet analysis over a 60-day window:

| Variant | Clusters with data | Pod executions | mem_max | mem_p95 |
|---|---|---|---|---|
| `slack-webhook-notification` (base) | 3 of 12 | 65 | 3 MB | 1 MB |
| `slack-webhook-notification-oci-ta` | 0 of 12 | 0 | — | — |

The `send-message` step makes a simple HTTP POST to a Slack webhook. Observed memory max is 3 MB across all clusters — well within the 64Mi floor value. Floor values (`memory: 64Mi`, `cpu: 50m`) are used for consistency with other low-traffic tasks in this series.

### Policy

Both the base task and the regenerated oci-ta variant now satisfy the Konflux compute-resource policy:
- `memory.request == memory.limit`
- `cpu.request` set, no `cpu.limit`

### Note on `use-trusted-artifact`

The `use-trusted-artifact` injected step in the oci-ta variant does not receive `computeResources` because the generator (`task-generator/trusted-artifacts/ta.go`) does not emit them for that step. This is a generator-level gap and is out of scope for this PR.

### Related

- Epic: [KONFLUX-11509](https://redhat.atlassian.net/browse/KONFLUX-11509)
- Ticket: [KONFLUX-13058](https://redhat.atlassian.net/browse/KONFLUX-13058)

Assisted-by: CursorAI
Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)

[KONFLUX-11509]: https://redhat.atlassian.net/browse/KONFLUX-11509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ