### PR TITLE
fix(opm-get-bundle-version): add computeResources, upgrade API version

### DIFF
--- a/task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
+++ b/task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: tekton.dev/v1beta1
+apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   name: opm-get-bundle-version
@@ -21,6 +21,12 @@ spec:
   steps:
     - name: opm-render-bundle
       image: "registry.redhat.io/openshift4/ose-operator-registry:latest@sha256:fb659a4c2942db5f1073c6b66be5c7ac2e4aed30432cce4aff08b9d5874010e9"
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       securityContext:
         runAsUser: 0
       env:
@@ -32,6 +38,12 @@ spec:
         opm render "${BUNDLE_IMAGE}" > "$(workspaces.workspace.path)/bundle.json"
     - name: jq-get-olm-package-version
       image: "quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea"
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       securityContext:
         runAsUser: 0
         runAsNonRoot: false


### PR DESCRIPTION
## What

Adds `computeResources` to both steps in
`task/opm-get-bundle-version/0.1/opm-get-bundle-version.yaml` and
upgrades the `apiVersion` from `tekton.dev/v1beta1` to `tekton.dev/v1`.

## Changes

| Step | Before | After |
|------|--------|-------|
| `opm-render-bundle` | MISSING | `memory: 64Mi` req=limit, `cpu: 50m` req |
| `jq-get-olm-package-version` | MISSING | `memory: 64Mi` req=limit, `cpu: 50m` req |

`apiVersion`: `tekton.dev/v1beta1` → `tekton.dev/v1`

## Sizing rationale

Fleet analysis across all Konflux clusters over a 60-day window returned
no execution data for this task, indicating negligible production usage.
Floor values (`memory: 64Mi` request=limit, `cpu: 50m` request) are
applied as the minimum safe baseline. These can be tuned upward once
real usage data is available.

The `apiVersion` upgrade to `tekton.dev/v1` is required to use the
`computeResources` field (the `v1beta1` equivalent `resources` is
deprecated) and aligns this task with the rest of the catalogue.

## Policy

All steps comply with the project compute resource policy:
- `memory.request == memory.limit`
- `cpu.request` set on every step
- No `cpu.limit`

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAgent@Cursor.com

Made with [Cursor](https://cursor.com)