### PR TITLE
feat(run-opm-command-oci-ta): add computeResources to all steps

### DIFF
--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -75,10 +75,10 @@ spec:
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       computeResources:
         requests:
-          memory: 64Mi
+          memory: 4Gi
           cpu: 50m
         limits:
-          memory: 64Mi
+          memory: 4Gi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -338,10 +338,10 @@ spec:
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       computeResources:
         requests:
-          memory: 64Mi
+          memory: 3Gi
           cpu: 50m
         limits:
-          memory: 64Mi
+          memory: 3Gi
       when:
         - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
           operator: in

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -73,11 +73,23 @@ spec:
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: run-opm-with-user-args
       image: quay.io/konflux-ci/operator-sdk-builder:latest@sha256:2737ff035f3a6d94e189cd31e7653998525c52f4d4db994ba1874a3a74bb4912
+      computeResources:
+        requests:
+          memory: 512Mi
+          cpu: 100m
+        limits:
+          memory: 512Mi
       workingDir: /var/workdir/source
       results:
         - name: skip_create_trusted_artifact
@@ -133,6 +145,12 @@ spec:
         - $(params.OPM_ARGS[*])
     - name: convert-image-tags-to-digests
       image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 250m
+        limits:
+          memory: 64Mi
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0
@@ -278,6 +296,12 @@ spec:
         convert_tags_to_digests
     - name: replace-related-images-pullspec-in-file
       image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0
@@ -312,6 +336,12 @@ spec:
           replace_mirror_pullspec_with_source "${IDMS_PATH_PARAM}" "${FILE_TO_UPDATE_PULLSPEC_PATH}"
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       when:
         - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
           operator: in

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -77,8 +77,8 @@ spec:
         limits:
           memory: 4Gi
         requests:
-          memory: 4Gi
           cpu: 50m
+          memory: 4Gi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -88,8 +88,8 @@ spec:
         limits:
           memory: 512Mi
         requests:
-          memory: 512Mi
           cpu: 100m
+          memory: 512Mi
       workingDir: /var/workdir/source
       results:
         - name: skip_create_trusted_artifact
@@ -149,8 +149,8 @@ spec:
         limits:
           memory: 64Mi
         requests:
-          memory: 64Mi
           cpu: 250m
+          memory: 64Mi
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0
@@ -300,8 +300,8 @@ spec:
         limits:
           memory: 64Mi
         requests:
-          memory: 64Mi
           cpu: 50m
+          memory: 64Mi
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0
@@ -340,8 +340,8 @@ spec:
         limits:
           memory: 3Gi
         requests:
-          memory: 3Gi
           cpu: 50m
+          memory: 3Gi
       when:
         - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
           operator: in

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -74,22 +74,22 @@ spec:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       computeResources:
+        limits:
+          memory: 4Gi
         requests:
           memory: 4Gi
           cpu: 50m
-        limits:
-          memory: 4Gi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: run-opm-with-user-args
       image: quay.io/konflux-ci/operator-sdk-builder:latest@sha256:2737ff035f3a6d94e189cd31e7653998525c52f4d4db994ba1874a3a74bb4912
       computeResources:
+        limits:
+          memory: 512Mi
         requests:
           memory: 512Mi
           cpu: 100m
-        limits:
-          memory: 512Mi
       workingDir: /var/workdir/source
       results:
         - name: skip_create_trusted_artifact
@@ -146,11 +146,11 @@ spec:
     - name: convert-image-tags-to-digests
       image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
       computeResources:
+        limits:
+          memory: 64Mi
         requests:
           memory: 64Mi
           cpu: 250m
-        limits:
-          memory: 64Mi
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0
@@ -297,11 +297,11 @@ spec:
     - name: replace-related-images-pullspec-in-file
       image: quay.io/konflux-ci/konflux-test:v1.5.0@sha256:fbd5ad045b902065990218922aa6f343e8eb5fd039ecd445bc54819b8e968c3e
       computeResources:
+        limits:
+          memory: 64Mi
         requests:
           memory: 64Mi
           cpu: 50m
-        limits:
-          memory: 64Mi
       workingDir: /var/workdir/source
       securityContext:
         runAsUser: 0
@@ -337,11 +337,11 @@ spec:
     - name: create-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       computeResources:
+        limits:
+          memory: 3Gi
         requests:
           memory: 3Gi
           cpu: 50m
-        limits:
-          memory: 3Gi
       when:
         - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
           operator: in

--- a/task/run-opm-command-oci-ta/CHANGELOG.md
+++ b/task/run-opm-command-oci-ta/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
+
+## Unreleased
+
+<!--
+When you make changes without bumping the version right away, document them here.
+If that's not something you ever plan to do, consider removing this section.
+-->
+
+### Fixed
+
+- Added computeResources to all steps.
+
+## 0.1
+
+### Added
+
+- The initial version of the `run-opm-command-oci-ta` task!

--- a/task/run-opm-command-oci-ta/CHANGELOG.md
+++ b/task/run-opm-command-oci-ta/CHANGELOG.md
@@ -9,7 +9,7 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
-### Fixed
+### Added
 
 - Added computeResources to all steps.
 


### PR DESCRIPTION
## What

Adds `computeResources` to all five steps in
`task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml`.
No `computeResources` were defined anywhere in the task, leaving all
steps unconstrained.

## Changes

| Step | Before | After (mem req=limit) | After (CPU req) | Change type |
|---|---|---|---|---|
| `use-trusted-artifact` | MISSING | **4Gi** | **50m** | New — aligned to existing TA step convention |
| `run-opm-with-user-args` | MISSING | **512Mi** | **100m** | New — data-backed from fleet P95 |
| `convert-image-tags-to-digests` | MISSING | **64Mi** | **250m** | New — data-backed from fleet P95 |
| `replace-related-images-pullspec-in-file` | MISSING | **64Mi** | **50m** | New — floor values (low fleet usage) |
| `create-trusted-artifact` | MISSING | **3Gi** | **50m** | New — aligned to existing TA step convention |

## Sizing rationale

Fleet analysis across all 12 Konflux clusters over a 60-day window
(12,613 pod executions), using **P95 + 5% margin** as the base metric.
The absolute maximum is noted for context but is not used for sizing —
outlier spikes are deliberately excluded so that default limits don't
over-provision every execution for rare heavy runs. Tenants whose
workloads regularly exceed the proposed limits should use
[pipeline-level compute resource overrides](https://konflux.pages.redhat.com/docs/users/building/overriding-compute-resources.html).

**run-opm-with-user-args (512Mi / 100m):**
The step runs `opm` to render OCI-based file-based catalogs (FBCs).
Memory P95 is 431Mi on `stone-prd-rh01` (driven by large OCP catalog
renders from `rh-openshift-gitops-tenant`), with a 626Mi absolute max.
P95 + 5% margin = 453Mi → rounded up to the next standard value: **512Mi**.
CPU P95 is 78m (+5% → 82m), rounded to **100m**.

**convert-image-tags-to-digests (64Mi / 250m):**
Memory is very low (P95 ≤ 13Mi across all clusters → 64Mi floor).
CPU P95 is 204m on `stone-prod-p02` (+5% → 214m), driven by parallel
`skopeo inspect` calls resolving image tags to digests. Rounded to
**250m**.

**use-trusted-artifact (4Gi / 50m) and create-trusted-artifact (3Gi / 50m):**
These values follow the established convention for Trusted Artifact
steps across the repository (see PR [#3405](https://github.com/konflux-ci/build-definitions/pull/3405)).
CPU P95 ≤ 42m across all clusters → floor value of **50m** applied.

**replace-related-images-pullspec-in-file (64Mi / 50m):**
Memory P95 ≤ 8Mi and CPU P95 ≤ 1m across all clusters — floor values
applied.

## Policy

All steps comply with the project compute resource policy:

* `memory.request == memory.limit`
* `cpu.request` set on every step
* No `cpu.limit`

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAgent@Cursor.com

Made with [Cursor](https://cursor.com)