### PR TITLE
fix(run-script-oci-ta): right-size computeResources per fleet data

### DIFF
--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -105,10 +105,10 @@ spec:
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
       computeResources:
         requests:
-          memory: 64Mi
+          memory: 4Gi
           cpu: 50m
         limits:
-          memory: 64Mi
+          memory: 4Gi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -266,7 +266,7 @@ spec:
           value: $(params.ociArtifactExpiresAfter)
       computeResources:
         requests:
-          memory: 64Mi
+          memory: 3Gi
           cpu: 50m
         limits:
-          memory: 64Mi
+          memory: 3Gi

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -92,12 +92,6 @@ spec:
     - name: varlibcontainers
       emptyDir: {}
   stepTemplate:
-    computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        cpu: "1"
-        memory: 1Gi
     env:
       - name: SCRIPT
         value: $(params.SCRIPT)
@@ -109,6 +103,12 @@ spec:
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -120,6 +120,12 @@ spec:
           subPath: ca-bundle.crt
     - name: run-script
       image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
+      computeResources:
+        requests:
+          memory: 5Gi
+          cpu: 1500m
+        limits:
+          memory: 5Gi
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca
@@ -259,8 +265,8 @@ spec:
         - name: IMAGE_EXPIRES_AFTER
           value: $(params.ociArtifactExpiresAfter)
       computeResources:
-        limits:
-          memory: 3Gi
         requests:
-          cpu: "1"
-          memory: 3Gi
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -104,11 +104,11 @@ spec:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
       computeResources:
+        limits:
+          memory: 4Gi
         requests:
           memory: 4Gi
           cpu: 50m
-        limits:
-          memory: 4Gi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -121,11 +121,11 @@ spec:
     - name: run-script
       image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
       computeResources:
+        limits:
+          memory: 5Gi
         requests:
           memory: 5Gi
           cpu: 1500m
-        limits:
-          memory: 5Gi
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca
@@ -265,8 +265,8 @@ spec:
         - name: IMAGE_EXPIRES_AFTER
           value: $(params.ociArtifactExpiresAfter)
       computeResources:
+        limits:
+          memory: 3Gi
         requests:
           memory: 3Gi
           cpu: 50m
-        limits:
-          memory: 3Gi

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -107,8 +107,8 @@ spec:
         limits:
           memory: 4Gi
         requests:
-          memory: 4Gi
           cpu: 50m
+          memory: 4Gi
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -124,8 +124,8 @@ spec:
         limits:
           memory: 5Gi
         requests:
-          memory: 5Gi
           cpu: 1500m
+          memory: 5Gi
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca
@@ -268,5 +268,5 @@ spec:
         limits:
           memory: 3Gi
         requests:
-          memory: 3Gi
           cpu: 50m
+          memory: 3Gi


### PR DESCRIPTION
## What

Right-sizes `computeResources` on all three steps in
`task/run-script-oci-ta/0.1/run-script-oci-ta.yaml`, fixing three
policy violations in the existing partial configuration.

## Changes

| Step | Before (mem req / limit) | Before (CPU req) | After (mem req=limit) | After (CPU req) | Change type |
|---|---|---|---|---|---|
| `use-trusted-artifact` | 1Gi (stepTemplate) / 4Gi (stepTemplate) | 1 (stepTemplate) | **4Gi** | **50m** | Policy fix: req→limit aligned; memory limit unchanged |
| `run-script` | 1Gi (stepTemplate) / 4Gi (stepTemplate) | 1 (stepTemplate) | **5Gi** | **1500m** | Data-backed increase from fleet P95 |
| `create-trusted-artifact` | 1Gi (stepTemplate) / 3Gi (per-step) | 1 (per-step) | **3Gi** | **50m** | Policy fix: req→limit aligned; memory limit unchanged |

## Policy violations fixed

1. **`stepTemplate` had `memory.request (1Gi) != memory.limit (4Gi)`** — removed
   the `stepTemplate.computeResources` block entirely and replaced with
   per-step values so each step is sized independently.
2. **`use-trusted-artifact` and `create-trusted-artifact` inherited mismatched req/limit** —
   these steps were already running with 4Gi and 3Gi memory limits respectively
   (via stepTemplate / per-step override). This PR makes `req=limit` explicit at those
   same values — no memory limit change, just a policy alignment.
3. **`run-script` was under-provisioned** — inherited the 4Gi limit despite
   a fleet P95 of 4351 MB on `stone-prd-rh01` (driven by
   `clair-in-ci-db-hermetic` fetching a large Clair vulnerability DB).
   Raised to **5Gi** to cover the fleet P95 envelope.
4. **CPU was set to `"1"` on all steps** (from stepTemplate/per-step) with no data
   backing — updated from fleet P95.

## Sizing rationale

Fleet analysis across all 12 Konflux clusters over a 60-day window
(**6,989 pod executions**), using **P95 + 5% margin** as the base metric.

**run-script (5Gi / 1500m):**
Memory P95 is 4351 MB on `stone-prd-rh01` (driven by
`clair-in-ci-db-hermetic` / `rhtap-integration-tenant` fetching a large
vulnerability DB), with a 10,022 MB absolute max.
P95 + 5% margin = 4568 MB ≈ 4.46 GiB → rounded up to **5Gi**.
CPU P95 is 1284m on `stone-prd-rh01` → +5% = 1348m → rounded to **1500m**.

**use-trusted-artifact (4Gi / 50m) and create-trusted-artifact (3Gi / 50m):**
These values were already the effective production limits (via stepTemplate
and per-step overrides). The change aligns `requests == limits` at those
existing values. CPU P95 ≤ 42m across all clusters → floor value of **50m** applied.

## Policy

All steps comply with the project compute resource policy:

* `memory.request == memory.limit`
* `cpu.request` set on every step
* No `cpu.limit`

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAgent@Cursor.com

Made with [Cursor](https://cursor.com)