### PR TITLE
renovate: fix buildah-remote BUILDER_IMAGE regex

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -292,7 +292,7 @@
         "^task/[\\w-]+/[0-9.]+/[\\w-]+\\.yaml$"
       ],
       "matchStrings": [
-        "value: (?<depName>quay\\.io/konflux-ci/buildah[^:]*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
+        "value: (?<depName>quay\\.io/konflux-ci/konflux-build-cli[^:]*):(?<currentValue>[^@]*)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "autoReplaceStringTemplate": "value: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
       "datasourceTemplate": "docker"


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Fix Renovate regex for buildah-remote BUILDER_IMAGE image rename
<code>🐞 Bug fix</code> <code>⚙️ Configuration changes</code> <code>🕐 Less than 5 minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

The regex is meant to match the value for the BUILDER_IMAGE variable in buildah-remote.yaml.

In buildah version 0.10, this image changed from buildah-task to konflux-build-cli. Update regex accordingly.

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Update Renovate custom regex to match the new konflux-build-cli builder image.
• Restore automated digest/version tracking for BUILDER_IMAGE in task YAMLs.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  R(["Renovate bot"]) --> C["renovate.json"] --> M[["Regex custom manager"]] --> T["task/*/*/*.yaml"] --> I{{"quay.io/konflux-ci/konflux-build-cli"}}
  subgraph Legend
    direction LR
    _svc(["Automation/service"]) ~~~ _cfg["Config file"] ~~~ _mgr[["Parser/manager"]] ~~~ _ext{{"External image"}}
  end
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Backward-compatible regex (match both old and new images)</b></summary>

- ➕ Continues working if some tasks still reference quay.io/konflux-ci/buildah*
- ➕ Reduces risk during transition periods across task versions
- ➖ Slightly more complex regex and potentially broader matching than intended
- ➖ May mask incomplete migrations by keeping both patterns valid

</details>

<details>
<summary><b>2. Use a fixed depNameTemplate instead of capturing depName</b></summary>

- ➕ Less brittle if the image path changes again (only update template)
- ➕ Simplifies the match group to focus on tag/digest
- ➖ Only works if the depName is constant across all matched files
- ➖ Requires ensuring no variants/suffixes are expected in the image name

</details>

**Recommendation:** Current approach is appropriate if the repo has fully moved to konflux-build-cli for buildah-remote tasks. If mixed task versions are expected, consider an alternation regex to match both image names during the transition.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Other</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>renovate.json</strong> <code>Update custom Renovate regex to match konflux-build-cli BUILDER_IMAGE</code> <code>+1/-1</code></summary>

<br/>

>Update custom Renovate regex to match konflux-build-cli BUILDER_IMAGE
>
><pre>
>• Adjust the regex-based custom manager to identify the BUILDER_IMAGE value when it uses quay.io/konflux-ci/konflux-build-cli instead of the previous buildah* image naming. This ensures Renovate continues to extract tag and digest correctly for automated updates.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3574/files#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57'>renovate.json</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>