### PR TITLE
task/buildah*: update konflux-build-cli

### DIFF
--- a/task/buildah-min/0.10/buildah-min.yaml
+++ b/task/buildah-min/0.10/buildah-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.10"
+    app.kubernetes.io/version: 0.10.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-min
 spec:
@@ -364,7 +364,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: build
     script: |
       #!/bin/bash
@@ -576,7 +576,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-min/CHANGELOG.md
+++ b/task/buildah-min/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.1
+
+### Changed
+
+- Updated the image that runs the `build` and `push` steps.
+  Notably, the new image comes with Buildah `v1.44.0`.
+
 ## 0.10
 
 This version introduces [konflux-build-cli]. The `build` step replaces most of the Bash with

--- a/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.10"
+    app.kubernetes.io/version: 0.10.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-oci-ta-min
 spec:
@@ -387,7 +387,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: build
     script: |
       #!/bin/bash
@@ -606,7 +606,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.1
+
+### Changed
+
+- Updated the image that runs the `build` and `push` steps.
+  Notably, the new image comes with Buildah `v1.44.0`.
+
 ## 0.10
 
 This version introduces [konflux-build-cli]. The `build` step replaces most of the Bash with

--- a/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.10"
+    app.kubernetes.io/version: 0.10.1
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -400,7 +400,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -642,7 +642,7 @@ spec:
             - SETFCAP
         runAsUser: 0
     - name: push
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.1
+
+### Changed
+
+- Updated the image that runs the `build` and `push` steps.
+  Notably, the new image comes with Buildah `v1.44.0`.
+
 ## 0.10
 
 This version introduces [konflux-build-cli]. The `build` step replaces most of the Bash with

--- a/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.10"
+    app.kubernetes.io/version: 0.10.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -340,7 +340,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -401,7 +401,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: build
     script: |-
       #!/bin/bash
@@ -785,7 +785,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.1
+
+### Changed
+
+- Updated the image that runs the `build` and `push` steps.
+  Notably, the new image comes with Buildah `v1.44.0`.
+
 ## 0.10
 
 This version introduces [konflux-build-cli]. The `build` step replaces most of the Bash with

--- a/task/buildah-remote/0.10/buildah-remote.yaml
+++ b/task/buildah-remote/0.10/buildah-remote.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.10"
+    app.kubernetes.io/version: 0.10.1
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -331,7 +331,7 @@ spec:
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -378,7 +378,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: build
     script: |-
       #!/bin/bash
@@ -762,7 +762,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.1
+
+### Changed
+
+- Updated the image that runs the `build` and `push` steps.
+  Notably, the new image comes with Buildah `v1.44.0`.
+
 ## 0.10
 
 This version introduces [konflux-build-cli]. The `build` step replaces most of the Bash with

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.10"
+    app.kubernetes.io/version: "0.10.1"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -313,7 +313,7 @@ spec:
       value: $(params.SKIP_INJECTIONS)
     imagePullPolicy: IfNotPresent
   steps:
-  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     name: build
     computeResources:
       limits:
@@ -561,7 +561,7 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: push
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
     computeResources:
       limits:
         memory: 4Gi

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.1
+
+### Changed
+
+- Updated the image that runs the `build` and `push` steps.
+  Notably, the new image comes with Buildah `v1.44.0`.
+
 ## 0.10
 
 This version introduces [konflux-build-cli]. The `build` step replaces most of the Bash with


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Bump konflux-build-cli image digest for buildah Tekton tasks (0.10.1)
<code>⚙️ Configuration changes</code> <code>📝 Documentation</code> <code>🕐 10-20 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

The new image is based on task-runner 1.8.1 [1]
and comes with buildah v1.44.0 [2].

We do not expect breaking changes.

[1]: https://github.com/konflux-ci/task-runner/blob/main/CHANGELOG.md#181
[2]: https://github.com/podman-container-tools/buildah/releases/tag/v1.44.0

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Bump konflux-build-cli image digest across buildah* Tekton tasks.
• Update task versions to 0.10.1 and document the Buildah v1.44.0 refresh.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  P["PR: update buildah tasks"] --> T["Buildah Tekton tasks"] --> I["konflux-build-cli digest"] --> B["Buildah v1.44.0"] --> C["Task CHANGELOG 0.10.1"]
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Use a versioned tag instead of latest@sha</b></summary>

- ➕ More human-readable upgrades (e.g., konflux-build-cli:vX.Y)
- ➕ Can simplify automated update tooling and auditing
- ➖ Loses the immutability guarantee of a digest unless tags are strictly managed
- ➖ May reduce reproducibility if tags are moved/reused

</details>

<details>
<summary><b>2. Centralize the builder image in a shared param/include</b></summary>

- ➕ Single place to update the digest for all buildah* tasks
- ➕ Reduces risk of tasks drifting to different toolchain versions
- ➖ Requires repo conventions/support for shared includes/templating
- ➖ May reduce per-task autonomy if different tasks need different builders

</details>

**Recommendation:** The current approach (pinning an immutable image digest and bumping task versions/changelogs) is the safest and most reproducible for CI. If digest bumps become frequent and error-prone, consider centralizing the digest definition to avoid repeated edits across multiple task variants.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (6)</summary>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Add 0.10.1 release notes for image refresh</code> <code>+7/-0</code></summary>

<br/>

>Add 0.10.1 release notes for image refresh
>
><pre>
>• Adds a 0.10.1 entry noting the updated build-step image and that it includes Buildah v1.44.0.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-0c73bb7b0db22e147534c4aa67c2dce9be27249863eb49dc0ff609763eccf16d'>task/buildah-min/CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Add 0.10.1 release notes for image refresh</code> <code>+7/-0</code></summary>

<br/>

>Add 0.10.1 release notes for image refresh
>
><pre>
>• Adds a 0.10.1 entry noting the updated build-step image and that it includes Buildah v1.44.0.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-953e1500c3121452856ce00da3aa3952f70dfd5deeaebcf9f8b2a1d40e5e8a3e'>task/buildah-oci-ta-min/CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Add 0.10.1 release notes for image refresh</code> <code>+7/-0</code></summary>

<br/>

>Add 0.10.1 release notes for image refresh
>
><pre>
>• Adds a 0.10.1 entry noting the updated build-step image and that it includes Buildah v1.44.0.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-9f50e2d9524fad943dd0312dd468f54c4dc26f22ea6de34030f32e8d2bfcfde0'>task/buildah-oci-ta/CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Add 0.10.1 release notes for image refresh</code> <code>+7/-0</code></summary>

<br/>

>Add 0.10.1 release notes for image refresh
>
><pre>
>• Adds a 0.10.1 entry noting the updated build-step image and that it includes Buildah v1.44.0.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-5bd4ae2fde33e7f17fb0cf1c447de327377702fcdd5c275d5ab542cb396f99db'>task/buildah-remote-oci-ta/CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Add 0.10.1 release notes for image refresh</code> <code>+7/-0</code></summary>

<br/>

>Add 0.10.1 release notes for image refresh
>
><pre>
>• Adds a 0.10.1 entry noting the updated build-step image and that it includes Buildah v1.44.0.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-e3ccf85de2e866ac67040fadeeca1d11cef74a63bdc14ee283a7d2ec23dbb0bf'>task/buildah-remote/CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>CHANGELOG.md</strong> <code>Add 0.10.1 release notes for image refresh</code> <code>+7/-0</code></summary>

<br/>

>Add 0.10.1 release notes for image refresh
>
><pre>
>• Adds a 0.10.1 entry noting the updated build-step image and that it includes Buildah v1.44.0.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-764ea52bebafc4c67aee75f7081ec669ed6463f9420733e1fe4e3c354ab56c37'>task/buildah/CHANGELOG.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (6)</summary>

<blockquote>
<details>
<summary><strong>buildah-min.yaml</strong> <code>Bump task version and builder image digest</code> <code>+3/-3</code></summary>

<br/>

>Bump task version and builder image digest
>
><pre>
>• Updates the task label version to 0.10.1 and refreshes the konflux-build-cli image digest used by the build and push steps.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-af9fca8c65856b2e2834db9e8bcdc770df5e025876c8037e7a03b77f87e74cf7'>task/buildah-min/0.10/buildah-min.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>buildah-oci-ta-min.yaml</strong> <code>Bump task version and builder image digest</code> <code>+3/-3</code></summary>

<br/>

>Bump task version and builder image digest
>
><pre>
>• Updates the task label version to 0.10.1 and refreshes the konflux-build-cli image digest used by the build and push steps.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-b5da2f1a20ad5639823f7c79d3f394748e5b68a459952d575923cdc0632d36ba'>task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>buildah-oci-ta.yaml</strong> <code>Bump task version and builder image digest</code> <code>+3/-3</code></summary>

<br/>

>Bump task version and builder image digest
>
><pre>
>• Updates the task label version to 0.10.1 and refreshes the konflux-build-cli image digest used by the build and push steps.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-f9ce7b8482d2a45dbc86ca2508198e31fe675a982259f80062749b09bdf4e748'>task/buildah-oci-ta/0.10/buildah-oci-ta.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>buildah-remote-oci-ta.yaml</strong> <code>Bump task version and builder image digest/param</code> <code>+4/-4</code></summary>

<br/>

>Bump task version and builder image digest/param
>
><pre>
>• Updates the task label version to 0.10.1 and refreshes the konflux-build-cli image digest, including the BUILDER_IMAGE parameter and the build/push step images.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-de3306ee1f339b575231205e44762b3f3a1cace2ecda0f6b94bc5ad830841308'>task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>buildah-remote.yaml</strong> <code>Bump task version and builder image digest/param</code> <code>+4/-4</code></summary>

<br/>

>Bump task version and builder image digest/param
>
><pre>
>• Updates the task label version to 0.10.1 and refreshes the konflux-build-cli image digest, including the BUILDER_IMAGE parameter and the build/push step images.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-a4f9bd454a283233aea50d6dbb2e416c854b52d647db961575919aad6aa34ba2'>task/buildah-remote/0.10/buildah-remote.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>buildah.yaml</strong> <code>Bump task version and builder image digest</code> <code>+3/-3</code></summary>

<br/>

>Bump task version and builder image digest
>
><pre>
>• Updates the task label version to 0.10.1 and refreshes the konflux-build-cli image digest used by the build and push steps.
></pre>
>
><a href='https://github.com/konflux-ci/build-definitions/pull/3575/files#diff-16a7bff43e721703b373b38a7e22fae5ef03fb39c1665bd104f202eaad3f9116'>task/buildah/0.10/buildah.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>