### PR TITLE
feat(tkn-bundle): add computeResources to all steps

### DIFF
--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -195,6 +195,12 @@ spec:
         fi
 
         printf "%s\n" "${FILES[@]}" >"${TASK_FILE}"
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
     - name: build
       image: quay.io/konflux-ci/task-runner:1.5.0@sha256:200019314a50be5b6dd06f362c794c92a700583a522c5eee9a41e3eab7f706c5
       workingDir: /var/workdir
@@ -388,5 +394,11 @@ spec:
         # cleanup task file
         # shellcheck disable=SC2153
         [[ -f "${TASK_FILE}" ]] && rm -f "${TASK_FILE}"
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
       securityContext:
         runAsUser: 0

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -66,6 +66,12 @@ spec:
       value: $(params.STEPS_IMAGE)
     - name: STEPS_IMAGE_STEP_NAMES
       value: $(params.STEPS_IMAGE_STEP_NAMES)
+    computeResources:
+      requests:
+        memory: 64Mi
+        cpu: 50m
+      limits:
+        memory: 64Mi
     script: |
       #!/bin/env bash
       set -o errexit
@@ -190,6 +196,12 @@ spec:
       value: $(params.URL)
     - name: REVISION
       value: $(params.REVISION)
+    computeResources:
+      requests:
+        memory: 64Mi
+        cpu: 50m
+      limits:
+        memory: 64Mi
     script: |
       #!/bin/env bash
 

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -67,10 +67,10 @@ spec:
     - name: STEPS_IMAGE_STEP_NAMES
       value: $(params.STEPS_IMAGE_STEP_NAMES)
     computeResources:
-      requests:
-        memory: 64Mi
-        cpu: 50m
       limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
         memory: 64Mi
     script: |
       #!/bin/env bash
@@ -197,10 +197,10 @@ spec:
     - name: REVISION
       value: $(params.REVISION)
     computeResources:
-      requests:
-        memory: 64Mi
-        cpu: 50m
       limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
         memory: 64Mi
     script: |
       #!/bin/env bash

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -59,6 +59,12 @@ spec:
   steps:
   - image: quay.io/konflux-ci/konflux-test:v1.4.52@sha256:deabe80a01dca3a8a0edb709324e30cbf0baa176f7a181bbb695323f506f7aac
     name: modify-task-files
+    computeResources:
+      limits:
+        memory: 64Mi
+      requests:
+        cpu: 50m
+        memory: 64Mi
     env:
     - name: CONTEXT
       value: $(params.CONTEXT)
@@ -66,12 +72,6 @@ spec:
       value: $(params.STEPS_IMAGE)
     - name: STEPS_IMAGE_STEP_NAMES
       value: $(params.STEPS_IMAGE_STEP_NAMES)
-    computeResources:
-      limits:
-        memory: 64Mi
-      requests:
-        cpu: 50m
-        memory: 64Mi
     script: |
       #!/bin/env bash
       set -o errexit


### PR DESCRIPTION
## Summary

Adds `computeResources` (memory request = limit, CPU request only) to all
hand-editable steps in `tkn-bundle/0.2` and its generated OCI-TA variant,
in compliance with the Konflux resource policy.

### Fleet analysis

| Variant | Clusters with data | Pod executions | Window |
|---|---|---|---|
| `tkn-bundle` (base) | 0 / 12 | 0 | 60 days |
| `tkn-bundle-oci-ta` | 4 / 12 | 173 | up to 9.4 days |

All steps showed P95 memory ≤ 8 MB and P95 CPU ≤ 2m across clusters,
well below the floor values. Floor values (64Mi / 50m) are applied
throughout. Full analysis: [KONFLUX-13063](https://redhat.atlassian.net/browse/KONFLUX-13063).

### Changes

| Task | Step | Memory req=limit | CPU request |
|---|---|---|---|
| `tkn-bundle` | `modify-task-files` | 64Mi | 50m |
| `tkn-bundle` | `build` | 64Mi | 50m |
| `tkn-bundle-oci-ta` | `modify-task-files` | 64Mi | 50m |
| `tkn-bundle-oci-ta` | `build` | 64Mi | 50m |

### Note on `use-trusted-artifact` (OCI-TA variant)

`tkn-bundle-oci-ta` is a **generated** task (`recipe.yaml` +
`hack/generate-ta-tasks.sh`). The generator injects the
`use-trusted-artifact` step but does not currently support
propagating `computeResources` for it. Manually adding them would
cause the "Check Trusted Artifact variants" CI check to fail (the
generator re-run would strip them). This generator gap is tracked in
[#3405](https://github.com/konflux-ci/build-definitions/pull/3405).

### Policy compliance

- ✅ `memory.request == memory.limit` for all changed steps
- ✅ `cpu.request` set, no `cpu.limit`
- ✅ OCI-TA YAML regenerated via `hack/generate-ta-tasks.sh`

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAgent@Cursor.com

Made with [Cursor](https://cursor.com)

[KONFLUX-13063]: https://redhat.atlassian.net/browse/KONFLUX-13063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ