### PR TITLE
feat(update-infra-deployments): add computeResources to all steps

### DIFF
--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -52,6 +52,12 @@ spec:
       env:
         - name: TASKRUN_NAME
           value: $(context.taskRun.name)
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       script: |
         #!/bin/bash
         set -euo pipefail
@@ -144,6 +150,12 @@ spec:
           value: $(params.ORIGIN_REPO)
         - name: GIT_IMAGE
           value: $(params.GIT_IMAGE)
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       script: |
         if [ -n "${GIT_IMAGE}" ]; then
           echo "WARNING: provided deprecated GIT_IMAGE parameter has no effect."
@@ -163,6 +175,12 @@ spec:
           value: $(params.SCRIPT)
         - name: SCRIPT_IMAGE
           value: $(params.SCRIPT_IMAGE)
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       script: |
         if [ -n "${SCRIPT_IMAGE}" ]; then
           echo "WARNING: provided deprecated SCRIPT_IMAGE parameter has no effect."
@@ -179,6 +197,12 @@ spec:
       env:
         - name: GIT_IMAGE
           value: $(params.GIT_IMAGE)
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       script: |
         if [ -n "${GIT_IMAGE}" ]; then
           echo "WARNING: provided deprecated GIT_IMAGE parameter has no effect."
@@ -220,6 +244,12 @@ spec:
           value: $(params.REVISION)
         - name: TARGET_GH_REPO
           value: "$(params.TARGET_GH_REPO)"
+      computeResources:
+        requests:
+          memory: 64Mi
+          cpu: 50m
+        limits:
+          memory: 64Mi
       script: |
         #!/usr/bin/env python3
         import json


### PR DESCRIPTION
## Summary

Adds `computeResources` (memory request = limit, CPU request only) to all
5 steps in `update-infra-deployments/0.1`, in compliance with the Konflux
resource policy.

### Fleet analysis

| Variant | Clusters with data | Pod executions | Window |
|---|---|---|---|
| `update-infra-deployments` | 3 / 12 | 47 | up to 9.4 days |

All observed steps showed P95 memory ≤ 1 MB and P95 CPU = 0m.
Two steps (`race-condition-update-check`, `create-mr`) had no observability
data at all. Floor values (64Mi / 50m) are applied throughout.
Full analysis: [KONFLUX-13065](https://redhat.atlassian.net/browse/KONFLUX-13065).

### Changes

| Step | Memory req=limit | CPU request | Rationale |
|---|---|---|---|
| `race-condition-update-check` | 64Mi | 50m | No observability data |
| `git-clone-infra-deployments` | 64Mi | 50m | Floor (P95 = 0 MB) |
| `run-update-script` | 64Mi | 50m | Floor (P95 = 1 MB) |
| `get-diff-files` | 64Mi | 50m | Floor (P95 = 1 MB) |
| `create-mr` | 64Mi | 50m | No observability data |

### Policy compliance

- ✅ `memory.request == memory.limit` for all steps
- ✅ `cpu.request` set, no `cpu.limit`
- ✅ No OCI-TA variant exists for this task

Signed-off-by: Subrata Modak <smodak@redhat.com>
Assisted-by: CursorAgent@Cursor.com

Made with [Cursor](https://cursor.com)

[KONFLUX-13065]: https://redhat.atlassian.net/browse/KONFLUX-13065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ