### PR TITLE
fix(modelcar-oci-ta): raise create-modelcar-base-image memory to 512Mi

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -191,10 +191,10 @@ spec:
       image: quay.io/konflux-ci/release-service-utils:2f93b7ed6a2099e7187bb110a6b95caac3b8bdbc
       computeResources:
         requests:
-          memory: 64Mi
+          memory: 512Mi
           cpu: 50m
         limits:
-          memory: 64Mi
+          memory: 512Mi
       workingDir: /var/workdir
       script: |
         #!/bin/bash


### PR DESCRIPTION
The create-modelcar-base-image step runs oras copy --to-oci-layout to pull a full base image. The 64Mi floor value set in cd975229 is insufficient, causing OOMKilled in CI. Raise to 512Mi to match the copy-model-files step.

Assisted-by: Claude Opus 4.6 <noreply@anthropic.com>

