### PR TITLE
chore: make konflux-ci/secure-ai-sig owners of ai tasks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -122,11 +122,11 @@
 /task/build-maven-zip-oci-ta    @ligangty @yma96 @Allda @jedinym
 
 # renovate groupName=oci-copy
-/task/oci-copy          @ralphbean @Allda @jedinym
-/task/oci-copy-oci-ta   @ralphbean @Allda @jedinym
+/task/oci-copy          @konflux-ci/secure-ai-sig @Allda @jedinym
+/task/oci-copy-oci-ta   @konflux-ci/secure-ai-sig @Allda @jedinym
 
 # renovate groupName=modelcar-oci
-/task/modelcar-oci-ta   @Victoremepunto @ralphbean @Allda @jedinym
+/task/modelcar-oci-ta   @konflux-ci/secure-ai-sig @Allda @jedinym
 
 # renovate groupName=buildpack
 /task/build-paketo-builder-oci-ta @cmoulliard @Allda @jedinym


### PR DESCRIPTION
For things like https://github.com/konflux-ci/build-definitions/pull/3585 and https://github.com/konflux-ci/build-definitions/pull/3583