### PR TITLE
Remove latest tag for images using :latest@digest pattern

### DIFF
--- a/task-generator/trusted-artifacts/golden/buildah/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/buildah/ta.yaml
@@ -130,7 +130,7 @@ spec:
       - mountPath: /var/workdir
         name: workdir
   steps:
-  - image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved
+  - image: quay.io/konflux-ci/build-trusted-artifacts@sha256:resolved
     name: use-trusted-artifact
     args:
       - use

--- a/task-generator/trusted-artifacts/golden/git-clone/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/git-clone/ta.yaml
@@ -251,7 +251,7 @@ spec:
       fi
 
   - name: create-trusted-artifact
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:existing
+    image: quay.io/konflux-ci/build-trusted-artifacts@sha256:existing
     env:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.ociArtifactExpiresAfter)

--- a/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/prefetch-dependencies/ta.yaml
@@ -75,7 +75,7 @@ spec:
       requests:
         cpu: 50m
         memory: 64Mi
-  - image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved
+  - image: quay.io/konflux-ci/build-trusted-artifacts@sha256:resolved
     name: use-trusted-artifact
     args:
       - use
@@ -157,7 +157,7 @@ spec:
         -name hermeto.repo \
         -execdir mv {} cachi2.repo \;
 
-  - image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved
+  - image: quay.io/konflux-ci/build-trusted-artifacts@sha256:resolved
     name: create-trusted-artifact
     env:
     - name: IMAGE_EXPIRES_AFTER

--- a/task-generator/trusted-artifacts/golden/sast-snyk-check/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/sast-snyk-check/ta.yaml
@@ -61,7 +61,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:resolved
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task-generator/trusted-artifacts/golden/source-build/ta.yaml
+++ b/task-generator/trusted-artifacts/golden/source-build/ta.yaml
@@ -53,7 +53,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:resolved
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task-generator/trusted-artifacts/main.go
+++ b/task-generator/trusted-artifacts/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"strings"
 )
 
 func main() {
@@ -26,7 +25,7 @@ func main() {
 	if _, err := os.Stat(taTaskPath); err == nil {
 		existing := expectValue(readTask(taTaskPath))
 		for _, step := range existing.Spec.Steps {
-			if strings.Contains(step.Image, "/build-trusted-artifacts:") {
+			if isBuildTrustedArtifactsImage(step.Image) {
 				image = step.Image
 				break
 			}

--- a/task-generator/trusted-artifacts/main_test.go
+++ b/task-generator/trusted-artifacts/main_test.go
@@ -19,7 +19,7 @@ func TestGolden(t *testing.T) {
 	}
 
 	resolveImage = func() string {
-		return "quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:resolved"
+		return "quay.io/konflux-ci/build-trusted-artifacts@sha256:resolved"
 	}
 
 	for _, dir := range dirs {
@@ -40,7 +40,7 @@ func TestGolden(t *testing.T) {
 			image = "" // force resolve
 			if dir.Name() == "git-clone" {
 				// use existing, simulates image being set from main from the parsed Task Step
-				image = "quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:existing"
+				image = "quay.io/konflux-ci/build-trusted-artifacts@sha256:existing"
 			}
 
 			if err := perform(task, recipe); err != nil {

--- a/task-generator/trusted-artifacts/ta.go
+++ b/task-generator/trusted-artifacts/ta.go
@@ -15,6 +15,8 @@ import (
 	resource "k8s.io/apimachinery/pkg/api/resource"
 )
 
+const buildTrustedArtifactsRepo = "quay.io/konflux-ci/build-trusted-artifacts"
+
 var (
 	image = ""
 
@@ -26,9 +28,18 @@ var (
 			panic(err)
 		}
 
-		return "quay.io/konflux-ci/build-trusted-artifacts:latest@" + desc.Digest.String()
+		return "quay.io/konflux-ci/build-trusted-artifacts@" + desc.Digest.String()
 	}
 )
+
+func isBuildTrustedArtifactsImage(imageRef string) bool {
+	ref, err := name.ParseReference(imageRef)
+	if err != nil {
+		return false
+	}
+
+	return ref.Context().String() == buildTrustedArtifactsRepo
+}
 
 func ensureImage() {
 	if image != "" {

--- a/task-generator/trusted-artifacts/ta_test.go
+++ b/task-generator/trusted-artifacts/ta_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestIsBuildTrustedArtifactsImage(t *testing.T) {
+	tests := []struct {
+		image string
+		want  bool
+	}{
+		{
+			image: "quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476",
+			want:  true,
+		},
+		{
+			image: "quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476",
+			want:  true,
+		},
+		{
+			image: "quay.io/konflux-ci/buildah-task@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709",
+			want:  false,
+		},
+		{
+			image: "quay.io/konflux-ci/build-trusted-artifacts:latest",
+			want:  true,
+		},
+		{
+			image: "not-an-image-reference",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.image, func(t *testing.T) {
+			if got := isBuildTrustedArtifactsImage(tt.image); got != tt.want {
+				t.Fatalf("isBuildTrustedArtifactsImage(%q) = %v, want %v", tt.image, got, tt.want)
+			}
+		})
+	}
+}

--- a/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
@@ -100,7 +100,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      image: quay.io/redhat-appstudio/build-trusted-artifacts@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task/build-image-index-min/0.2/build-image-index-min.yaml
+++ b/task/build-image-index-min/0.2/build-image-index-min.yaml
@@ -105,7 +105,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
+    image: quay.io/konflux-ci/buildah-task@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
     name: build
     script: |
       #!/bin/bash

--- a/task/build-image-index-min/0.3/build-image-index-min.yaml
+++ b/task/build-image-index-min/0.3/build-image-index-min.yaml
@@ -93,7 +93,7 @@ spec:
       requests:
         cpu: 100m
         memory: 256Mi
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:b296232c9b0d478c0bd1f48911ead97cd786eebdc737b877797564567fda8eae
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:b296232c9b0d478c0bd1f48911ead97cd786eebdc737b877797564567fda8eae
     name: build
     script: |
       #!/bin/bash

--- a/task/build-image-index/0.2/build-image-index.yaml
+++ b/task/build-image-index/0.2/build-image-index.yaml
@@ -97,7 +97,7 @@ spec:
         mountPath: /mnt/trusted-ca
         readOnly: true
   steps:
-  - image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
+  - image: quay.io/konflux-ci/buildah-task@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build

--- a/task/build-image-index/0.3/build-image-index.yaml
+++ b/task/build-image-index/0.3/build-image-index.yaml
@@ -87,7 +87,7 @@ spec:
         mountPath: /mnt/trusted-ca
         readOnly: true
   steps:
-  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:b296232c9b0d478c0bd1f48911ead97cd786eebdc737b877797564567fda8eae
+  - image: quay.io/konflux-ci/konflux-build-cli@sha256:b296232c9b0d478c0bd1f48911ead97cd786eebdc737b877797564567fda8eae
     # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
     # the cluster will set imagePullPolicy to IfNotPresent
     name: build

--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -97,7 +97,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:0aecefdc3714304547e5f4eb90320b32595832e644ca61f605b73b594e021f4b
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:0aecefdc3714304547e5f4eb90320b32595832e644ca61f605b73b594e021f4b
       args:
         - use
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2

--- a/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
+++ b/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
@@ -130,14 +130,14 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:4689f88dd253bd1feebf57f1a76a5a751880f739000719cd662bbdc76990a7fd
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - args:
         - "$(params.BUILD_ARGS[*])"
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
+      image: quay.io/konflux-ci/buildah-task@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
       name: "run-script"
       script: |-
         #!/usr/bin/env bash
@@ -457,7 +457,7 @@ spec:
         requests:
           cpu: "1"
           memory: 1Gi
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
+      image: quay.io/konflux-ci/buildah-task@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
       name: inject-sbom-and-push
       env:
         - name: TASKRUN_NAME

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -82,7 +82,7 @@ spec:
         name: varlibcontainers
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:77563b5fb4b82f9b6a47070ba06e60486567d34e03ea60cd5169be0be53ad5dc
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:77563b5fb4b82f9b6a47070ba06e60486567d34e03ea60cd5169be0be53ad5dc
       computeResources:
         limits:
           memory: 64Mi
@@ -142,7 +142,7 @@ spec:
         echo "declare TAGGED_AS=${TAGGED_AS}" >> /var/workdir/vars
 
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
+      image: quay.io/konflux-ci/buildah-task@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
       computeResources:
         limits:
           memory: 128Mi

--- a/task/buildah-min/0.10/buildah-min.yaml
+++ b/task/buildah-min/0.10/buildah-min.yaml
@@ -364,7 +364,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: build
     script: |
       #!/bin/bash
@@ -576,7 +576,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
@@ -343,7 +343,7 @@ spec:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+    image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
     name: use-trusted-artifact
     volumeMounts:
     - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -387,7 +387,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: build
     script: |
       #!/bin/bash
@@ -606,7 +606,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
@@ -389,7 +389,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -400,7 +400,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+      image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -642,7 +642,7 @@ spec:
             - SETFCAP
         runAsUser: 0
     - name: push
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+      image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
@@ -340,7 +340,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+      value: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -357,7 +357,7 @@ spec:
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     computeResources: {}
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+    image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
     name: use-trusted-artifact
     volumeMounts:
     - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -401,7 +401,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: build
     script: |-
       #!/bin/bash
@@ -785,7 +785,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote/0.10/buildah-remote.yaml
+++ b/task/buildah-remote/0.10/buildah-remote.yaml
@@ -331,7 +331,7 @@ spec:
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+      value: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -378,7 +378,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: build
     script: |-
       #!/bin/bash
@@ -762,7 +762,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -313,7 +313,7 @@ spec:
       value: $(params.SKIP_INJECTIONS)
     imagePullPolicy: IfNotPresent
   steps:
-  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+  - image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     name: build
     computeResources:
       limits:
@@ -561,7 +561,7 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: push
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
+    image: quay.io/konflux-ci/konflux-build-cli@sha256:949367ed2d1d2b9d8c23a5b26a9314eb28a01036a7e48496d38ec56cc720e06d
     computeResources:
       limits:
         memory: 4Gi

--- a/task/fbc-fips-check-matrix-based-oci-ta/0.1/fbc-fips-check-matrix-based-oci-ta.yaml
+++ b/task/fbc-fips-check-matrix-based-oci-ta/0.1/fbc-fips-check-matrix-based-oci-ta.yaml
@@ -41,7 +41,7 @@ spec:
         name: workdir
   steps:
     - name: use-buckets-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       args:
         - use
         - $(params.BUCKETS_ARTIFACT)=/var/workdir/buckets

--- a/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
+++ b/task/fbc-fips-check-oci-ta/0.1/fbc-fips-check-oci-ta.yaml
@@ -43,7 +43,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task/fbc-fips-prepare-oci-ta/0.1/fbc-fips-prepare-oci-ta.yaml
+++ b/task/fbc-fips-prepare-oci-ta/0.1/fbc-fips-prepare-oci-ta.yaml
@@ -55,7 +55,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -480,7 +480,7 @@ spec:
         echo "Done!"
 
     - name: create-buckets-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       args:
         - create
         - --store

--- a/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
+++ b/task/fips-operator-bundle-check-oci-ta/0.1/fips-operator-bundle-check-oci-ta.yaml
@@ -49,7 +49,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task/git-clone-oci-ta-min/0.1/git-clone-oci-ta-min.yaml
+++ b/task/git-clone-oci-ta-min/0.1/git-clone-oci-ta-min.yaml
@@ -404,7 +404,7 @@ spec:
     env:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.ociArtifactExpiresAfter)
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+    image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
     name: create-trusted-artifact
     volumeMounts:
     - mountPath: /var/workdir

--- a/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.1/git-clone-oci-ta.yaml
@@ -421,7 +421,7 @@ spec:
           cpu: 50m
           memory: 64Mi
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
       args:
         - create
         - --store

--- a/task/ko-oci-ta/0.1/ko-oci-ta.yaml
+++ b/task/ko-oci-ta/0.1/ko-oci-ta.yaml
@@ -90,7 +90,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
       computeResources:
         requests:
           memory: 4Gi
@@ -106,7 +106,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/ko-builder:latest@sha256:6dd07b33afbf322122524cd0b5e69bbe4b3fa260467947e0b822dc6524744cbd
+      image: quay.io/konflux-ci/ko-builder@sha256:6dd07b33afbf322122524cd0b5e69bbe4b3fa260467947e0b822dc6524744cbd
       workingDir: /var/workdir/source
       computeResources:
         requests:

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -137,7 +137,7 @@ spec:
         subPath: ca-bundle.crt
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
       computeResources:
         requests:
           memory: 64Mi

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -88,7 +88,7 @@ spec:
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
             args:
               - create
               - --store
@@ -101,7 +101,7 @@ spec:
         - name: SOURCE_ARTIFACT
           value: $(tasks.mock-trusted-artifact.results.SOURCE_ARTIFACT)
         - name: BASE_IMAGE
-          value: "registry.access.redhat.com/ubi9/ubi:latest@sha256:b68c21b2dd3e72abcf2f8dcfc77580e4030564d1243bfcb7cd64ccc5aa3e0a25"
+          value: "registry.access.redhat.com/ubi9/ubi@sha256:b68c21b2dd3e72abcf2f8dcfc77580e4030564d1243bfcb7cd64ccc5aa3e0a25"
         - name: PLATFORM
           value: linux/s390x
         - name: IMAGE_APPEND_PLATFORM

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -88,7 +88,7 @@ spec:
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
             args:
               - create
               - --store

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -88,7 +88,7 @@ spec:
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
             args:
               - create
               - --store

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -90,7 +90,7 @@ spec:
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
             args:
               - create
               - --store

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -88,7 +88,7 @@ spec:
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
             args:
               - create
               - --store

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -87,7 +87,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:4f97e1f367f2b79afaceb1606f4b9b9f2b10afb21577a552f3e743154917dda8
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:4f97e1f367f2b79afaceb1606f4b9b9f2b10afb21577a552f3e743154917dda8
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -570,7 +570,7 @@ spec:
           echo "${OCI_ARTIFACT_DIGEST}  ${output_path}" | sha256sum --check --quiet
         done
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
       args:
         - create
         - --store

--- a/task/oci-copy-oci-ta/0.2/recipe.yaml
+++ b/task/oci-copy-oci-ta/0.2/recipe.yaml
@@ -44,7 +44,7 @@ additionalSteps:
       done
   - at: 4
     name: create-trusted-artifact
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
+    image: quay.io/konflux-ci/build-trusted-artifacts@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
     args:
       - create
       - --store

--- a/task/package-operator-package-oci-ta/0.1/package-operator-package-oci-ta.yaml
+++ b/task/package-operator-package-oci-ta/0.1/package-operator-package-oci-ta.yaml
@@ -63,7 +63,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:77563b5fb4b82f9b6a47070ba06e60486567d34e03ea60cd5169be0be53ad5dc
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:77563b5fb4b82f9b6a47070ba06e60486567d34e03ea60cd5169be0be53ad5dc
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.1/pnc-prebuild-git-clone-oci-ta.yaml
@@ -449,7 +449,7 @@ spec:
     env:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.ociArtifactExpiresAfter)
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+    image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
     name: create-trusted-artifact
     volumeMounts:
     - mountPath: /var/workdir

--- a/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
+++ b/task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
@@ -111,7 +111,7 @@ spec:
   - args:
     - use
     - $(params.SOURCE_ARTIFACT)=/var/workdir/source
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:5307eb0dd71e493851632526497b85640efe46cf2e1934856724489260c968ae
+    image: quay.io/konflux-ci/build-trusted-artifacts@sha256:5307eb0dd71e493851632526497b85640efe46cf2e1934856724489260c968ae
     name: use-trusted-artifact
   - computeResources:
       limits:
@@ -212,7 +212,7 @@ spec:
     env:
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.ociArtifactExpiresAfter)
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:5307eb0dd71e493851632526497b85640efe46cf2e1934856724489260c968ae
+    image: quay.io/konflux-ci/build-trusted-artifacts@sha256:5307eb0dd71e493851632526497b85640efe46cf2e1934856724489260c968ae
     name: create-trusted-artifact
   volumes:
   - name: activation-key

--- a/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
+++ b/task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
@@ -147,7 +147,7 @@ spec:
           cpu: 50m
           memory: 64Mi
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:5307eb0dd71e493851632526497b85640efe46cf2e1934856724489260c968ae
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:5307eb0dd71e493851632526497b85640efe46cf2e1934856724489260c968ae
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -236,7 +236,7 @@ spec:
           cpu: "1"
           memory: 3Gi
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:5307eb0dd71e493851632526497b85640efe46cf2e1934856724489260c968ae
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:5307eb0dd71e493851632526497b85640efe46cf2e1934856724489260c968ae
       args:
         - create
         - --store

--- a/task/push-dockerfile-oci-ta/0.3/push-dockerfile-oci-ta.yaml
+++ b/task/push-dockerfile-oci-ta/0.3/push-dockerfile-oci-ta.yaml
@@ -78,7 +78,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
+++ b/task/run-opm-command-oci-ta/0.1/run-opm-command-oci-ta.yaml
@@ -72,12 +72,12 @@ spec:
         subPath: ca-bundle.crt
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: run-opm-with-user-args
-      image: quay.io/konflux-ci/operator-sdk-builder:latest@sha256:2737ff035f3a6d94e189cd31e7653998525c52f4d4db994ba1874a3a74bb4912
+      image: quay.io/konflux-ci/operator-sdk-builder@sha256:2737ff035f3a6d94e189cd31e7653998525c52f4d4db994ba1874a3a74bb4912
       workingDir: /var/workdir/source
       results:
         - name: skip_create_trusted_artifact
@@ -311,7 +311,7 @@ spec:
           echo "Replacing pullspecs in '${FILE_TO_UPDATE_PULLSPEC_PATH}' using '${IDMS_PATH_PARAM}'."
           replace_mirror_pullspec_with_source "${IDMS_PATH_PARAM}" "${FILE_TO_UPDATE_PULLSPEC_PATH}"
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
       when:
         - input: "$(steps.run-opm-with-user-args.results.skip_create_trusted_artifact)"
           operator: in

--- a/task/run-opm-command-oci-ta/0.1/tests/test-convert-tags-already-digested.yaml
+++ b/task/run-opm-command-oci-ta/0.1/tests/test-convert-tags-already-digested.yaml
@@ -70,7 +70,7 @@ spec:
               echo "Created catalog with digest-based images:"
               cat "$(workspaces.tests-workspace.path)/source/.konflux/catalog/test-operator/catalog.json"
           - name: create-trusted-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
             args:
               - create
               - --store
@@ -131,7 +131,7 @@ spec:
               readOnly: true
         steps:
           - name: fetch-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
             args:
               - use
               - $(params.SOURCE_ARTIFACT)=$(workspaces.tests-workspace.path)/output

--- a/task/run-opm-command-oci-ta/0.1/tests/test-convert-tags-disabled.yaml
+++ b/task/run-opm-command-oci-ta/0.1/tests/test-convert-tags-disabled.yaml
@@ -70,7 +70,7 @@ spec:
               echo "Created catalog with tagged images:"
               cat "$(workspaces.tests-workspace.path)/source/.konflux/catalog/test-operator/catalog.json"
           - name: create-trusted-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
             args:
               - create
               - --store
@@ -131,7 +131,7 @@ spec:
               readOnly: true
         steps:
           - name: fetch-artifact
-            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
+            image: quay.io/konflux-ci/build-trusted-artifacts@sha256:a246cf2267fe6fa68ae8885c6ca4141923edca3ccf9b56838d1ebe369d31b46d
             args:
               - use
               - $(params.SOURCE_ARTIFACT)=$(workspaces.tests-workspace.path)/output

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -108,7 +108,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -119,7 +119,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: run-script
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
+      image: quay.io/konflux-ci/buildah-task@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /mnt/trusted-ca
@@ -242,7 +242,7 @@ spec:
           add:
             - SETFCAP
     - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:adf22f3ec90bfa3f7e2c832a7d52febd1ea31aa9fff6db21324c965d7d622327
       args:
         - create
         - --store

--- a/task/slack-webhook-notification-oci-ta/0.1/slack-webhook-notification-oci-ta.yaml
+++ b/task/slack-webhook-notification-oci-ta/0.1/slack-webhook-notification-oci-ta.yaml
@@ -60,7 +60,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
+++ b/task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
@@ -86,7 +86,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
@@ -189,7 +189,7 @@ spec:
           cpu: 50m
           memory: 128Mi
     - name: build
-      image: quay.io/konflux-ci/source-container-build:latest@sha256:a8416f792207e4b9b8bfea1c9b86ad54ae7bc28384d14de0726cced3dee01ae5
+      image: quay.io/konflux-ci/source-container-build@sha256:a8416f792207e4b9b8bfea1c9b86ad54ae7bc28384d14de0726cced3dee01ae5
       workingDir: /var/workdir
       env:
         - name: SOURCE_DIR

--- a/task/source-build/0.3/source-build.yaml
+++ b/task/source-build/0.3/source-build.yaml
@@ -178,7 +178,7 @@ spec:
         fi
 
     - name: build
-      image: quay.io/konflux-ci/source-container-build:latest@sha256:a8416f792207e4b9b8bfea1c9b86ad54ae7bc28384d14de0726cced3dee01ae5
+      image: quay.io/konflux-ci/source-container-build@sha256:a8416f792207e4b9b8bfea1c9b86ad54ae7bc28384d14de0726cced3dee01ae5
       # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
       # the cluster will set imagePullPolicy to IfNotPresent
       computeResources:

--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -69,7 +69,7 @@ spec:
         name: workdir
   steps:
     - name: use-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:27ddb820f0d30609dcb8de88219309edbced429896324e474f494470c2f003fb
+      image: quay.io/konflux-ci/build-trusted-artifacts@sha256:27ddb820f0d30609dcb8de88219309edbced429896324e474f494470c2f003fb
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source

--- a/task/validate-fbc/0.1/validate-fbc.yaml
+++ b/task/validate-fbc/0.1/validate-fbc.yaml
@@ -508,7 +508,7 @@ spec:
         requests:
           cpu: 100m
           memory: 256Mi
-      image: quay.io/konflux-ci/oras:latest@sha256:76d221b871642154f32151797186430a9cb8b46a194221870c2a87b1a0b916ff
+      image: quay.io/konflux-ci/oras@sha256:76d221b871642154f32151797186430a9cb8b46a194221870c2a87b1a0b916ff
       script: |
         #!/usr/bin/env bash
         set -euo pipefail
@@ -530,7 +530,7 @@ spec:
         requests:
           cpu: 100m
           memory: 256Mi
-      image: quay.io/konflux-ci/oras:latest@sha256:76d221b871642154f32151797186430a9cb8b46a194221870c2a87b1a0b916ff
+      image: quay.io/konflux-ci/oras@sha256:76d221b871642154f32151797186430a9cb8b46a194221870c2a87b1a0b916ff
       script: |
         #!/usr/bin/env bash
         set -euo pipefail


### PR DESCRIPTION
Having the latest tag make k8s set the imagepullpolicy to always which cause the pull to not leverage node cache.

 Update the trusted-artifacts generator so it can reuse an existing pinned build-trusted-artifacts image when regenerating tasks. The old logic only matched references containing "/build-trusted-artifacts:",
 which broke after switching to digest-only pullspecs (...@sha256:...). It now parses each step image with go-containerregistry and checks whether the repository is quay.io/konflux-ci/build-trusted-artifacts, so
 both legacy tag+digest and new digest-only formats are recognized and the existing digest is preserved instead of being re-resolved from :latest

[KFLUXINFRA-3096](https://redhat.atlassian.net/browse/KFLUXINFRA-3096)


[KFLUXINFRA-3096]: https://redhat.atlassian.net/browse/KFLUXINFRA-3096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ