### PR TITLE
chore: remove invalid users from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -110,7 +110,7 @@
 /task/eaas-provision-space                                  @konflux-ci/eaas-maintainers
 
 # renovate groupName=build-vm-image
-/task/build-vm-image    @Victoremepunto @arewm @brianwcook @ralphbean @scoheb
+/task/build-vm-image    @Victoremepunto @arewm @ralphbean @scoheb
 
 # renovate groupName=opm
 /task/operator-sdk-generate-bundle  @gurnben
@@ -118,8 +118,8 @@
 /task/opm-render-bundles            @gurnben
 
 # renovate groupName=maven
-/task/build-maven-zip           @ligangty @yma96 @Allda @jedinym
-/task/build-maven-zip-oci-ta    @ligangty @yma96 @Allda @jedinym
+/task/build-maven-zip           @Allda @jedinym
+/task/build-maven-zip-oci-ta    @Allda @jedinym
 
 # renovate groupName=oci-copy
 /task/oci-copy          @konflux-ci/secure-ai-sig @Allda @jedinym


### PR DESCRIPTION
## Summary
- Remove `@brianwcook` from `build-vm-image` — has only read access, not write (required for code ownership)
- Remove `@ligangty` from `build-maven-zip` — no access to the repo
- Remove `@yma96` from `build-maven-zip` — GitHub user does not exist

Verified all remaining users and teams via the GitHub API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)