### PR TITLE
fix: update apply-tags reference to 0.3 in push PipelineRun

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     pipelinesascode.tekton.dev/on-event: "push"
     pipelinesascode.tekton.dev/on-target-branch: "main"
-    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, task/buildah-remote/0.10/buildah-remote.yaml, task/build-image-index/0.3/build-image-index.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml, task/apply-tags/0.2/apply-tags.yaml]"
+    pipelinesascode.tekton.dev/task: "[task/update-infra-deployments/0.1/update-infra-deployments.yaml, task/git-clone/0.1/git-clone.yaml, task/buildah-remote/0.10/buildah-remote.yaml, task/build-image-index/0.3/build-image-index.yaml, task/slack-webhook-notification/0.1/slack-webhook-notification.yaml, .tekton/tasks/ec-checks.yaml, task/apply-tags/0.3/apply-tags.yaml]"
     pipelinesascode.tekton.dev/max-keep-runs: "5"
 spec:
   params:


### PR DESCRIPTION
## Summary
- The `apply-tags/0.2` task was archived in 3fbad427, which moved the files to `archived-tasks/` and left a symlink at `task/apply-tags/0.2`
- GitHub's Contents API does not follow symlinks — it sees the symlink as a blob, not a directory — so Pipelines-as-Code gets a 404 when fetching `task/apply-tags/0.2/apply-tags.yaml`
- Updated `.tekton/push.yaml` to reference `task/apply-tags/0.3/apply-tags.yaml` (the current non-archived version)

Fixes #3590

## Test plan
- [ ] CI push pipeline should no longer 404 on the apply-tags task fetch

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)