### PR TITLE
Revert mistaken SOURCE_ARTIFACT output from oci-copy-oci-ta

### DIFF
--- a/task/oci-copy-oci-ta/0.2/README.md
+++ b/task/oci-copy-oci-ta/0.2/README.md
@@ -22,7 +22,6 @@ Copy content from arbitrary urls into the OCI registry. Downloads and pushes fil
 |IMAGE_REF|Image reference of the built image|
 |IMAGE_URL|Repository where the artifact was pushed|
 |SBOM_BLOB_URL|Link to the SBOM blob pushed to the registry.|
-|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to downloaded model files.|
 
 
 ## Additional info

--- a/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
+++ b/task/oci-copy-oci-ta/0.2/oci-copy-oci-ta.yaml
@@ -65,8 +65,6 @@ spec:
       description: Repository where the artifact was pushed
     - name: SBOM_BLOB_URL
       description: Link to the SBOM blob pushed to the registry.
-    - name: SOURCE_ARTIFACT
-      description: The Trusted Artifact URI pointing to downloaded model files.
   volumes:
     - name: varlibcontainers
       emptyDir: {}
@@ -541,50 +539,6 @@ spec:
         capabilities:
           add:
             - SETFCAP
-    - name: populate-model-source
-      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
-      workingDir: /var/workdir
-      script: |
-        #!/bin/bash
-        set -euo pipefail
-
-        mkdir -p /var/workdir/model-source
-        select-oci-auth "${IMAGE}" >auth.json
-        REPO=${IMAGE%:*}
-
-        shopt -s nullglob
-        varfiles=(/var/workdir/vars/*)
-        shopt -u nullglob
-
-        if [ "${#varfiles[@]}" -eq 0 ]; then
-          echo "No artifacts to include in SOURCE_ARTIFACT"
-          exit 0
-        fi
-
-        for varfile in "${varfiles[@]}"; do
-          # shellcheck source=/dev/null
-          source "$varfile"
-          output_path="/var/workdir/model-source/${OCI_FILENAME}"
-          mkdir -p "$(dirname "${output_path}")"
-          retry oras blob fetch --registry-config auth.json "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}" >"${output_path}"
-          echo "${OCI_ARTIFACT_DIGEST}  ${output_path}" | sha256sum --check --quiet
-        done
-    - name: create-trusted-artifact
-      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
-      args:
-        - create
-        - --store
-        - $(params.IMAGE).source
-        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/model-source
-      env:
-        - name: IMAGE_EXPIRES_AFTER
-          value: $(params.IMAGE_EXPIRES_AFTER)
-      computeResources:
-        limits:
-          memory: 4Gi
-        requests:
-          cpu: "2"
-          memory: 4Gi
     - name: sbom-generate
       image: quay.io/konflux-ci/mobster:1.2.0-1774868067@sha256:2e00c2f0aeff55713150b51822013327ea0e0d75b8164a52f837fb297c17703d
       workingDir: /var/workdir

--- a/task/oci-copy-oci-ta/0.2/recipe.yaml
+++ b/task/oci-copy-oci-ta/0.2/recipe.yaml
@@ -9,56 +9,6 @@ addParams:
       hours, days, and weeks, respectively.
     type: string
     default: ""
-addResult:
-  - name: SOURCE_ARTIFACT
-    description: The Trusted Artifact URI pointing to downloaded model files.
-additionalSteps:
-  - at: 3
-    name: populate-model-source
-    image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
-    workingDir: /var/workdir
-    script: |
-      #!/bin/bash
-      set -euo pipefail
-
-      mkdir -p /var/workdir/model-source
-      select-oci-auth "${IMAGE}" >auth.json
-      REPO=${IMAGE%:*}
-
-      shopt -s nullglob
-      varfiles=(/var/workdir/vars/*)
-      shopt -u nullglob
-
-      if [ "${#varfiles[@]}" -eq 0 ]; then
-        echo "No artifacts to include in SOURCE_ARTIFACT"
-        exit 0
-      fi
-
-      for varfile in "${varfiles[@]}"; do
-        # shellcheck source=/dev/null
-        source "$varfile"
-        output_path="/var/workdir/model-source/${OCI_FILENAME}"
-        mkdir -p "$(dirname "${output_path}")"
-        retry oras blob fetch --registry-config auth.json "${REPO}@sha256:${OCI_ARTIFACT_DIGEST}" >"${output_path}"
-        echo "${OCI_ARTIFACT_DIGEST}  ${output_path}" | sha256sum --check --quiet
-      done
-  - at: 4
-    name: create-trusted-artifact
-    image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:fb7ce11be542bc524be2c5ea78fd73c87a8a8cbf333905fcdf8b7cb700ad178a
-    args:
-      - create
-      - --store
-      - $(params.IMAGE).source
-      - $(results.SOURCE_ARTIFACT.path)=/var/workdir/model-source
-    env:
-      - name: IMAGE_EXPIRES_AFTER
-        value: $(params.IMAGE_EXPIRES_AFTER)
-    computeResources:
-      limits:
-        memory: 4Gi
-      requests:
-        cpu: "2"
-        memory: 4Gi
 removeWorkspaces:
   - source
 replacements:


### PR DESCRIPTION
## Summary

Remove the mistaken `SOURCE_ARTIFACT` output work from `oci-copy-oci-ta:0.2`. That logic was accidentally included in #3583 and is unused, breaks model builds, and does not serve the intended Snyk use case.

## Context

#3583 was opened to fix missing OCI labels on ModelCar images. It also picked up earlier work from the closed #3509 (`add source artifact for snyk scans`), which added to `oci-copy-oci-ta`:

- a new `SOURCE_ARTIFACT` **result**
- a `populate-model-source` step that re-fetches blobs from the registry
- a `create-trusted-artifact` step to publish downloaded model files

That oci-copy work was not part of the label fix and should not have landed with #3583.

## Why this was a mistake

1. **Nothing consumes it** — no pipeline references `$(tasks.oci-copy.results.SOURCE_ARTIFACT)`. For example, `models-united` still passes `$(tasks.clone-repository.results.SOURCE_ARTIFACT)` to `sast-snyk-check`.
2. **It breaks builds** — `populate-model-source` runs `oras blob fetch` without `--output` or `--descriptor`, causing:
   ```
   Error: either `--output` or `--descriptor` must be provided
   ```
3. **It does not match the stated goal** — `sast-snyk-check-oci-ta` runs `snyk code test` on application source code, not on downloaded model weights (`safetensors`, etc.).

## Changes

Remove from `task/oci-copy-oci-ta/0.2/`:

- `SOURCE_ARTIFACT` result
- `populate-model-source` step
- `create-trusted-artifact` step for model files
- Related recipe/README entries

**Kept unchanged:**

- `SOURCE_ARTIFACT` **param** (input from `git-clone`) used by `use-trusted-artifact`
- `IMAGE_EXPIRES_AFTER` param (still passed by downstream pipelines)

## Impact

- Model oci-copy pipelines should no longer fail in `populate-model-source`.
