### PR TITLE
CI: fix mount path for redhat-appstudio push secret

### DIFF
--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -111,7 +111,7 @@ spec:
                 git config --global --add safe.directory "$PWD"
                 ./hack/build-and-push.sh
               volumeMounts:
-                - mountPath: /tekton/home/.docker/config.json
+                - mountPath: /home/taskuser/.docker/config.json
                   subPath: .dockerconfigjson
                   name: quay-secret
             - name: update-acceptable-bundles


### PR DESCRIPTION
The push pipeline was failing to push task bundles to quay.io/redhat-appstudio-tekton-catalog.

In 59e0093ac9a40909e797ebd0131383985a3058d0, the image that runs the relevant step changed to the task-runner image. The new image has HOME=/home/taskuser, whereas the previous one had HOME=/tekton/home. Commands were not finding the injected .docker/config.json and failing with unauthorized errors.

Fix the mount path to match the new $HOME.
