### PR TITLE
task/buildah*: fix labels.json for quoted labels

### DIFF
--- a/task/buildah-min/0.10/buildah-min.yaml
+++ b/task/buildah-min/0.10/buildah-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.1
+    app.kubernetes.io/version: 0.10.2
     build.appstudio.redhat.com/build_type: docker
   name: buildah-min
 spec:
@@ -364,7 +364,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: build
     script: |
       #!/bin/bash
@@ -576,7 +576,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-min/CHANGELOG.md
+++ b/task/buildah-min/CHANGELOG.md
@@ -11,6 +11,16 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.2
+
+### Fixed
+
+- The injected `labels.json` file will now better match the actual image labels
+  in cases when the containerfile includes quoted `LABEL` values. This is a result
+  of [dockerfile-json#16].
+
+[dockerfile-json#16]: https://github.com/konflux-ci/dockerfile-json/pull/16
+
 ## 0.10.1
 
 ### Changed

--- a/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.1
+    app.kubernetes.io/version: 0.10.2
     build.appstudio.redhat.com/build_type: docker
   name: buildah-oci-ta-min
 spec:
@@ -387,7 +387,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: build
     script: |
       #!/bin/bash
@@ -606,7 +606,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,16 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.2
+
+### Fixed
+
+- The injected `labels.json` file will now better match the actual image labels
+  in cases when the containerfile includes quoted `LABEL` values. This is a result
+  of [dockerfile-json#16].
+
+[dockerfile-json#16]: https://github.com/konflux-ci/dockerfile-json/pull/16
+
 ## 0.10.1
 
 ### Changed

--- a/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.1
+    app.kubernetes.io/version: 0.10.2
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -400,7 +400,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -642,7 +642,7 @@ spec:
             - SETFCAP
         runAsUser: 0
     - name: push
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -11,6 +11,16 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.2
+
+### Fixed
+
+- The injected `labels.json` file will now better match the actual image labels
+  in cases when the containerfile includes quoted `LABEL` values. This is a result
+  of [dockerfile-json#16].
+
+[dockerfile-json#16]: https://github.com/konflux-ci/dockerfile-json/pull/16
+
 ## 0.10.1
 
 ### Changed

--- a/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.1
+    app.kubernetes.io/version: 0.10.2
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -340,7 +340,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -401,7 +401,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: build
     script: |-
       #!/bin/bash
@@ -785,7 +785,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -11,6 +11,16 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.2
+
+### Fixed
+
+- The injected `labels.json` file will now better match the actual image labels
+  in cases when the containerfile includes quoted `LABEL` values. This is a result
+  of [dockerfile-json#16].
+
+[dockerfile-json#16]: https://github.com/konflux-ci/dockerfile-json/pull/16
+
 ## 0.10.1
 
 ### Changed

--- a/task/buildah-remote/0.10/buildah-remote.yaml
+++ b/task/buildah-remote/0.10/buildah-remote.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.1
+    app.kubernetes.io/version: 0.10.2
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -331,7 +331,7 @@ spec:
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -378,7 +378,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: build
     script: |-
       #!/bin/bash
@@ -762,7 +762,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -11,6 +11,16 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.2
+
+### Fixed
+
+- The injected `labels.json` file will now better match the actual image labels
+  in cases when the containerfile includes quoted `LABEL` values. This is a result
+  of [dockerfile-json#16].
+
+[dockerfile-json#16]: https://github.com/konflux-ci/dockerfile-json/pull/16
+
 ## 0.10.1
 
 ### Changed

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.10.1"
+    app.kubernetes.io/version: "0.10.2"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -313,7 +313,7 @@ spec:
       value: $(params.SKIP_INJECTIONS)
     imagePullPolicy: IfNotPresent
   steps:
-  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     name: build
     computeResources:
       limits:
@@ -561,7 +561,7 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: push
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:88395b2e3aba44a15f8ab4e12d63e81db215dc72a799200a3b560a55f30c631c
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
     computeResources:
       limits:
         memory: 4Gi

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -11,6 +11,16 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.2
+
+### Fixed
+
+- The injected `labels.json` file will now better match the actual image labels
+  in cases when the containerfile includes quoted `LABEL` values. This is a result
+  of [dockerfile-json#16].
+
+[dockerfile-json#16]: https://github.com/konflux-ci/dockerfile-json/pull/16
+
 ## 0.10.1
 
 ### Changed


### PR DESCRIPTION
Do so by updating the konflux-build-cli image, which comes with an updated version of the dockerfile-json dependency, which fixed the handling of quoted values in
https://github.com/konflux-ci/dockerfile-json/pull/16
