### PR TITLE
task/build-vm-image: add SBOM support (0.2)

### DIFF
--- a/task/build-vm-image/0.2/MIGRATION.md
+++ b/task/build-vm-image/0.2/MIGRATION.md
@@ -6,7 +6,7 @@ Version 0.2 adds SBOM propagation and attachment to disk image artifacts.
 
 The task now downloads the SBOM from the source bootc container image and
 attaches it to the built disk image OCI artifact using cosign. Two new
-steps were added: `sbom-download` and `upload-sbom`.
+steps were added: `download-sbom` and `upload-sbom`.
 
 New optional parameters:
 

--- a/task/build-vm-image/0.2/MIGRATION.md
+++ b/task/build-vm-image/0.2/MIGRATION.md
@@ -24,12 +24,16 @@ New result:
 
 ### Hardening improvements over 0.1
 
-* `validate-bib-config` now uses `set -euo pipefail` (was `set -e`).
+* `validate-bib-config` renamed to `validate-config` — now validates
+  `IMAGE_TYPE`, `STORAGE_DRIVER`, and `SBOM_TYPE` upfront (before the
+  expensive remote build), and uses `set -euo pipefail` (was `set -e`).
+* `BIB_CONFIG_FILE` path traversal guard added (`realpath` check).
 * Pullspec values written to the shared vars file are escaped with
   `printf %q` to prevent shell metacharacter injection when sourced.
 * Pullspec validation character class now includes `._-` and the regex
   logic is no longer inverted (0.1 had a bug where the `!` negation
   made the check a no-op).
+* Base images updated: `task-runner` 1.6.0 → 2.0.0, `buildah` 9.7 → 9.8.
 
 ## Action from users
 

--- a/task/build-vm-image/0.2/MIGRATION.md
+++ b/task/build-vm-image/0.2/MIGRATION.md
@@ -1,0 +1,39 @@
+# Migration from 0.1 to 0.2
+
+Version 0.2 adds SBOM propagation and attachment to disk image artifacts.
+
+## What changed
+
+The task now downloads the SBOM from the source bootc container image and
+attaches it to the built disk image OCI artifact using cosign. Two new
+steps were added: `sbom-download` and `upload-sbom`.
+
+New optional parameters:
+
+* `SBOM_TYPE` (default: `spdx`) — the SBOM format for attachment. Valid
+  values: `spdx`, `cyclonedx`.
+* `SKIP_SBOM_GENERATION` (default: `false`) — skip SBOM propagation
+  entirely. The parameter name follows the convention used by the
+  `buildah` build task; for `build-vm-image`
+  this controls SBOM *propagation* from the source container rather than
+  generation, since the disk image SBOM is downloaded (not generated).
+
+New result:
+
+* `SBOM_BLOB_URL` — digest reference of the attached SBOM blob
+
+### Hardening improvements over 0.1
+
+* `validate-bib-config` now uses `set -euo pipefail` (was `set -e`).
+* Pullspec values written to the shared vars file are escaped with
+  `printf %q` to prevent shell metacharacter injection when sourced.
+* Pullspec validation character class now includes `._-` and the regex
+  logic is no longer inverted (0.1 had a bug where the `!` negation
+  made the check a no-op).
+
+## Action from users
+
+No action required. The new parameters have defaults and the new result is
+not referenced by existing pipelines. SBOM propagation is enabled by default.
+
+To disable SBOM propagation, set `SKIP_SBOM_GENERATION` to `true`.

--- a/task/build-vm-image/0.2/MIGRATION.md
+++ b/task/build-vm-image/0.2/MIGRATION.md
@@ -33,7 +33,7 @@ New result:
 * Pullspec validation character class now includes `._-` and the regex
   logic is no longer inverted (0.1 had a bug where the `!` negation
   made the check a no-op).
-* Base images updated: `task-runner` 1.6.0 → 2.0.0, `buildah` 9.7 → 9.8.
+* Base image updated: `task-runner` 1.8.1 → 2.0.0.
 
 ## Action from users
 

--- a/task/build-vm-image/0.2/README.md
+++ b/task/build-vm-image/0.2/README.md
@@ -1,0 +1,30 @@
+# build-vm-image task
+
+Build disk images using bootc-image-builder. https://github.com/osbuild/bootc-image-builder/
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|PLATFORM|The platform to build on||true|
+|IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
+|OUTPUT_IMAGE|The output manifest list that points to the OCI artifact of the zipped image||true|
+|SOURCE_ARTIFACT|||true|
+|IMAGE_TYPE|The type of VM image to build, valid values are iso, qcow2, gce, vhd and raw||true|
+|BIB_CONFIG_FILE|The config file specifying what to build and the builder to build it with|bib.yaml|false|
+|CONFIG_TOML_FILE|The path for the config.toml file within the source repository|""|false|
+|ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
+|ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
+|SBOM_TYPE|The SBOM format to use for attaching the SBOM to the artifact. Valid values: spdx, cyclonedx.|spdx|false|
+|SKIP_SBOM_GENERATION|Skip SBOM propagation and attachment|false|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the manifest list just built|
+|IMAGE_URL|Image repository where the built manifest list was pushed|
+|IMAGE_REFERENCE|Image reference (IMAGE_URL + IMAGE_DIGEST)|
+|SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+
+
+## Additional info

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -1,0 +1,617 @@
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.2"
+    build.appstudio.redhat.com/build_type: disk-image
+  name: build-vm-image
+spec:
+  description: "Build disk images using bootc-image-builder. https://github.com/osbuild/bootc-image-builder/"
+  params:
+    - description: The platform to build on
+      name: PLATFORM
+      type: string
+    - default: "false"
+      description: Whether to append a sanitized platform architecture on the IMAGE tag
+      name: IMAGE_APPEND_PLATFORM
+      type: string
+    - name: OUTPUT_IMAGE
+      type: string
+      description: The output manifest list that points to the OCI artifact of the zipped image
+    - name: SOURCE_ARTIFACT
+      type: string
+    - name: IMAGE_TYPE
+      type: string
+      description: The type of VM image to build, valid values are iso, qcow2, gce, vhd and raw
+    - name: BIB_CONFIG_FILE
+      default: bib.yaml
+      type: string
+      description: The config file specifying what to build and the builder to build it with
+    - name: CONFIG_TOML_FILE
+      default: ""
+      type: string
+      description: The path for the config.toml file within the source repository
+    - default: etc-pki-entitlement
+      description: Name of secret which contains the entitlement certificates
+      name: ENTITLEMENT_SECRET
+      type: string
+    - default: activation-key
+      description: Name of secret which contains subscription activation key
+      name: ACTIVATION_KEY
+      type: string
+    - name: STORAGE_DRIVER
+      description: Storage driver to configure for buildah
+      type: string
+      default: vfs
+    - name: SBOM_TYPE
+      description: "The SBOM format to use for attaching the SBOM to the artifact. Valid values: spdx, cyclonedx."
+      type: string
+      default: spdx
+    - name: SKIP_SBOM_GENERATION
+      description: Skip SBOM propagation and attachment
+      type: string
+      default: "false"
+  results:
+    - description: Digest of the manifest list just built
+      name: IMAGE_DIGEST
+    - description: Image repository where the built manifest list was pushed
+      name: IMAGE_URL
+    - description: Image reference (IMAGE_URL + IMAGE_DIGEST)
+      name: IMAGE_REFERENCE
+    - description: Reference of SBOM blob digest to enable digest-based verification from provenance
+      name: SBOM_BLOB_URL
+      type: string
+  stepTemplate:
+    env:
+      - name: OUTPUT_IMAGE
+        value: $(params.OUTPUT_IMAGE)
+      - name: BIB_CONFIG_FILE
+        value: $(params.BIB_CONFIG_FILE)
+      - name: CONFIG_TOML_FILE
+        value: $(params.CONFIG_TOML_FILE)
+      - name: IMAGE_TYPE
+        value: $(params.IMAGE_TYPE)
+      - name: ENTITLEMENT_SECRET
+        value: $(params.ENTITLEMENT_SECRET)
+      - name: ACTIVATION_KEY
+        value: $(params.ACTIVATION_KEY)
+      - name: STORAGE_DRIVER
+        value: $(params.STORAGE_DRIVER)
+      - name: BUILDAH_IMAGE
+        value: 'registry.access.redhat.com/ubi9/buildah:9.7-1777422883'
+      - name: PLATFORM
+        value: $(params.PLATFORM)
+      - name: IMAGE_APPEND_PLATFORM
+        value: $(params.IMAGE_APPEND_PLATFORM)
+      - name: SBOM_TYPE
+        value: $(params.SBOM_TYPE)
+      - name: SKIP_SBOM_GENERATION
+        value: $(params.SKIP_SBOM_GENERATION)
+    volumeMounts:
+      - mountPath: "/var/workdir"
+        name: workdir
+      - mountPath: "/var/lib/containers/storage"
+        name: varlibcontainers
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:77563b5fb4b82f9b6a47070ba06e60486567d34e03ea60cd5169be0be53ad5dc
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+    - name: validate-bib-config
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+      script: |-
+        #!/bin/bash
+        set -euo pipefail
+        set -x
+
+        # expects a config file like the following as BIB_CONFIG_FILE
+        #
+        echo -e "BIB_CONFIG_FILE: $BIB_CONFIG_FILE"
+        # # BIB: Bootc Image Builder config
+        # bootc-builder-image: "quay.io/centos-bootc/bootc-image-builder:latest"
+        # source-image: "quay.io/centos-bootc/centos-bootc:stream9"
+        # tagged-as: registry.centos.org/bootc:stream9
+
+        # trim any leading slash.
+        BIB_CONFIG_FILE=${BIB_CONFIG_FILE#/}
+
+        BIB_IMAGE=$(yq -r .bootc-builder-image /var/workdir/source/$BIB_CONFIG_FILE)
+        SOURCE_IMAGE=$(yq -r  .source-image /var/workdir/source/$BIB_CONFIG_FILE)
+        TAGGED_AS=$(yq -r  ".tagged-as // \"${SOURCE_IMAGE}\"" /var/workdir/source/$BIB_CONFIG_FILE)
+
+        # Validate that all keys exist and are plausible pullspecs
+        valid_pullspec_characters="0-9a-zA-Z@:/._-"
+        if [[ "${BIB_IMAGE}" =~ [^$valid_pullspec_characters] ]]; then
+          echo ".bootc-builder-image in $BIB_CONFIG_FILE contains invalid characters"
+          exit 1
+        fi
+        if [[ "${SOURCE_IMAGE}" =~ [^$valid_pullspec_characters] ]]; then
+          echo ".source-image in $BIB_CONFIG_FILE contains invalid characters"
+          exit 1
+        fi
+        if [[ "${TAGGED_AS}" =~ [^$valid_pullspec_characters] ]]; then
+          echo ".tagged-as in $BIB_CONFIG_FILE contains invalid characters"
+          exit 1
+        fi
+
+        # write values to a file in the workspace (printf %q escapes shell metacharacters)
+        printf 'declare BOOTC_BUILDER_IMAGE=%q\n' "${BIB_IMAGE}" > /var/workdir/vars
+        printf 'declare SOURCE_IMAGE=%q\n' "${SOURCE_IMAGE}" >> /var/workdir/vars
+        printf 'declare TAGGED_AS=%q\n' "${TAGGED_AS}" >> /var/workdir/vars
+
+    - name: build
+      image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
+      computeResources:
+        limits:
+          memory: 128Mi
+        requests:
+          cpu: 250m
+          memory: 128Mi
+      script: |-
+        #!/bin/bash
+        set -euo pipefail
+        set -x
+
+        # get values stored from previous task
+        echo "vars file"
+        cat /var/workdir/vars
+        # shellcheck source=/dev/null
+        source /var/workdir/vars
+        echo "Vars:"
+        echo BOOTC_BUILDER_IMAGE $BOOTC_BUILDER_IMAGE
+        echo SOURCE_IMAGE $SOURCE_IMAGE
+        echo TAGGED_AS $TAGGED_AS
+
+        mkdir -p ~/.ssh
+        if [ -e "/ssh/error" ]; then
+          #no server could be provisioned
+          cat /ssh/error
+          exit 1
+        elif [ -e "/ssh/otp" ]; then
+          curl --cacert /ssh/otp-ca -XPOST -d @/ssh/otp $(cat /ssh/otp-server) >~/.ssh/id_rsa
+          echo "" >> ~/.ssh/id_rsa
+        else
+          cp /ssh/id_rsa ~/.ssh
+        fi
+        chmod 0400 ~/.ssh/id_rsa
+        export SSH_HOST=$(cat /ssh/host)
+        export BUILD_DIR=$(cat /ssh/user-dir)
+        export SSH_ARGS=(-o StrictHostKeyChecking=no -o ServerAliveInterval=60 -i ~/.ssh/id_rsa)
+        mkdir -p scripts
+        echo "$BUILD_DIR"
+        ssh -v "${SSH_ARGS[@]}" "$SSH_HOST"  mkdir -p "$BUILD_DIR/workspaces" "$BUILD_DIR/scripts" "$BUILD_DIR/tmp" "$BUILD_DIR/tekton-results" "$BUILD_DIR/entitlement" "$BUILD_DIR/activation-key"
+
+        if [ ! -n "${CONFIG_TOML_FILE}" ]; then
+          echo "No CONFIG_TOML_FILE specified"
+          export CONFIG_TOML_FILE=config.toml
+          if [ -f /var/workdir/source/config.toml ]; then
+            echo "Using the config.toml file found in the repository root!"
+            echo "  Remove the config.toml file or set params.CONFIG_TOML_FILE to another file to prevent using config.toml."
+          else
+            echo "No config.toml file found. Using an empty configuration."
+            touch /var/workdir/source/$CONFIG_TOML_FILE
+          fi
+        fi
+        echo "Using the following config.toml file $CONFIG_TOML_FILE:"
+        cat /var/workdir/source/$CONFIG_TOML_FILE
+
+
+        rsync -e "ssh ${SSH_ARGS[*]}" -ra "/var/workdir/source/$CONFIG_TOML_FILE" "$SSH_HOST:$BUILD_DIR/config.toml"
+        rsync -e "ssh ${SSH_ARGS[*]}" -ra "$HOME/.docker/" "$SSH_HOST:$BUILD_DIR/.docker/"
+        # Rsync activation-key for remote registration or entitlement certificates if provided
+        if [ -e "/activation-key/org" ]; then
+          echo "Syncing activation-key for remote registration"
+          rsync -e "ssh ${SSH_ARGS[*]}" -ra /activation-key/ "$SSH_HOST:$BUILD_DIR/activation-key/"
+        elif [ -d "/entitlement" ] && [ "$(ls -A /entitlement)" ]; then
+          echo "Syncing provided entitlement certificates"
+          rsync -e "ssh ${SSH_ARGS[*]}" -ra /entitlement/ "$SSH_HOST:$BUILD_DIR/entitlement/"
+        fi
+
+        if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+          OUTPUT_IMAGE="${OUTPUT_IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+          export OUTPUT_IMAGE
+        fi
+
+        ARCH=$(sed 's/.*\///' <<<"$PLATFORM")
+        echo "ARCH: '${ARCH}'"
+
+        case "${IMAGE_TYPE}" in
+          iso|qcow2|gce|vhd|raw) ;;
+          *) echo "Invalid IMAGE_TYPE: ${IMAGE_TYPE}. Must be one of: iso, qcow2, gce, vhd, raw." >&2; exit 1 ;;
+        esac
+
+        valid_pullspec_characters="0-9a-zA-Z@:/._-"
+        if [[ "${OUTPUT_IMAGE}" =~ [^$valid_pullspec_characters] ]]; then
+          echo "OUTPUT_IMAGE contains invalid characters" >&2; exit 1
+        fi
+
+        # form the --type arguments
+        IMAGE_TYPE_ARGUMENT=" --type $IMAGE_TYPE "
+
+        # this unquoted heredoc allows expansions for the image name
+        cat >scripts/script-build.sh <<REMOTESSHEOF
+        #!/bin/sh
+        set -euo pipefail
+
+        # this prevents the container from using podman-subscripition-mananger magic,
+        # so that it will use certificates from /etc/pki/entitlements
+        sudo rm /usr/share/containers/mounts.conf
+
+        export BUILD_DIR="$BUILD_DIR"
+        export OUTPUT_IMAGE="$OUTPUT_IMAGE"
+        export BOOTC_BUILDER_IMAGE="$BOOTC_BUILDER_IMAGE"
+        export SOURCE_IMAGE="$SOURCE_IMAGE"
+        export TAGGED_AS="$TAGGED_AS"
+        export IMAGE_TYPE_ARGUMENT="$IMAGE_TYPE_ARGUMENT"
+        export STORAGE_DRIVER="$STORAGE_DRIVER"
+        export BUILDAH_IMAGE="$BUILDAH_IMAGE"
+
+        REMOTESSHEOF
+
+        # import retry function
+        # remove line with bash
+        # shellcheck disable=SC2002
+        cat /usr/bin/retry | sed 1d >> scripts/script-build.sh
+
+        # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
+        cat >>scripts/script-build.sh <<'REMOTESSHEOF'
+
+        mkdir output
+        buildah_retries=3
+
+        # Register with subscription manager if activation key is provided
+        # This happens on the remote VM inside a container to ensure correct architecture-specific repos
+        # We run it in a container (as root) to avoid sudo password requirements
+        if [ -e "$BUILD_DIR/activation-key/org" ] && [ -e "$BUILD_DIR/activation-key/activationkey" ]; then
+          echo "Activation key found, registering with subscription manager on remote VM ($(uname -m))"
+          mkdir -p $BUILD_DIR/entitlement
+          mkdir -p $BUILD_DIR/rhsm-tmp/etc/pki/entitlement
+          mkdir -p $BUILD_DIR/rhsm-tmp/etc/pki/consumer
+
+          export RETRY_MAX_TRIES=6
+          # Run subscription-manager inside a container where we're root (no password needed)
+          if ! retry sudo podman run --rm \
+            -v $BUILD_DIR/activation-key:/activation-key:Z \
+            -v $BUILD_DIR/rhsm-tmp/etc/pki/entitlement:/etc/pki/entitlement:Z \
+            -v $BUILD_DIR/rhsm-tmp/etc/pki/consumer:/etc/pki/consumer:Z \
+            "$BUILDAH_IMAGE" \
+            /bin/bash -c 'subscription-manager register --org "$(cat /activation-key/org)" --activationkey "$(cat /activation-key/activationkey)"'
+          then
+            echo "Subscription-manager register failed on remote VM"
+            exit 1
+          fi
+          unset RETRY_MAX_TRIES
+
+          # Unregister on exit using a container
+          trap 'sudo podman run --rm -v $BUILD_DIR/rhsm-tmp/etc/pki/entitlement:/etc/pki/entitlement:Z -v $BUILD_DIR/rhsm-tmp/etc/pki/consumer:/etc/pki/consumer:Z "$BUILDAH_IMAGE" /bin/bash -c "subscription-manager unregister || true"' EXIT
+
+          # Copy generated certificates to entitlement directory for the build
+          if ! cp $BUILD_DIR/rhsm-tmp/etc/pki/entitlement/*.pem $BUILD_DIR/entitlement/ 2>/dev/null; then
+            echo "Warning: No entitlement certificates found after registration"
+            ls -la $BUILD_DIR/rhsm-tmp/etc/pki/entitlement/ || true
+          fi
+          echo "Entitlement certificates generated on remote VM ($(uname -m))"
+        fi
+
+        # Check if entitlement certificates are available (from activation-key or directly provided)
+        ENTITLEMENT_VOLUME=""
+        if [ -d "$BUILD_DIR/entitlement" ] && [ "$(ls -A $BUILD_DIR/entitlement)" ]; then
+          # Use entitlement certificates (generated from activation-key or directly provided)
+          ENTITLEMENT_VOLUME="-v $BUILD_DIR/entitlement:/etc/pki/entitlement:Z"
+          echo "Using entitlement certificates for the build"
+        fi
+
+        echo "PULLING BUILDER IMAGE"
+        if ! time retry sudo podman pull --authfile=$BUILD_DIR/.docker/config.json --retry "$buildah_retries" $BOOTC_BUILDER_IMAGE
+        then
+            echo "Failed to pull image ${BOOTC_BUILDER_IMAGE} from registry"
+            exit 1
+        fi
+        echo "PULLING IMAGE"
+        if ! time retry sudo podman pull --authfile=$BUILD_DIR/.docker/config.json --retry "$buildah_retries" $SOURCE_IMAGE
+        then
+            echo "Failed to pull image ${SOURCE_IMAGE} from registry"
+            exit 1
+        fi
+        echo "TAGGING IMAGE"
+        time sudo podman tag $SOURCE_IMAGE $TAGGED_AS
+        echo "RUNNING BUILD"
+        echo -e "IMAGE_TYPE_ARGUMENT = $IMAGE_TYPE_ARGUMENT"
+
+        time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
+          -v $BUILD_DIR/config.toml:/config.toml -v $(pwd)/output:/output \
+          -v /var/lib/containers/storage:/var/lib/containers/storage \
+          $ENTITLEMENT_VOLUME \
+          $BOOTC_BUILDER_IMAGE $IMAGE_TYPE_ARGUMENT --local $TAGGED_AS
+
+        time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
+          -v $BUILD_DIR/.docker:/.docker -v $(pwd)/output:/output \
+          -v /var/lib/containers/storage:/var/lib/containers/storage \
+          -v $BUILD_DIR/scripts/script-push.sh:/script-push.sh \
+          -v $BUILD_DIR/tekton-results:/tekton-results \
+          "$BUILDAH_IMAGE" \
+          /script-push.sh
+
+        REMOTESSHEOF
+
+        # script-push.sh script is intended run _inside_ podman on the ssh host and requires sudo
+        # this unquoted heredoc allows expansions for the image name
+        cat >scripts/script-push.sh <<REMOTESSHEOF
+        #!/bin/bash
+        set -ex
+
+        export OUTPUT_IMAGE="$OUTPUT_IMAGE"
+
+        REMOTESSHEOF
+
+        # import retry function
+        # remove line with bash
+        # shellcheck disable=SC2002
+        cat /usr/bin/retry | sed 1d >> scripts/script-push.sh
+
+        # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
+        cat >>scripts/script-push.sh <<'REMOTESSHEOF'
+        dnf -y install buildah skopeo pigz jq
+
+        # Build an image index of length 1 referring to an image manifest with the content
+        buildah manifest create "$OUTPUT_IMAGE"
+
+        # show contents of /output
+        ls -alR /output
+
+        if [ -f "/output/qcow2/disk.qcow2" ]; then
+          echo -e "Found qcow2 image."
+          # don't zip qcow2 images, it is already compressed.
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2.gzip $OUTPUT_IMAGE /output/qcow2/disk.qcow2
+        elif [ -f "/output/image/disk.raw" ]; then
+          echo -e "Found raw image."
+          pigz /output/image/disk.raw
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
+        elif [ -f "/output/bootiso/install.iso" ]; then
+          echo -e "Found iso image."
+          pigz /output/bootiso/install.iso
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
+        elif [ -f "/output/vpc/disk.vhd" ]; then
+          echo -e "Found vhd image."
+          pigz /output/vpc/disk.vhd
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.vhd.gzip $OUTPUT_IMAGE /output/vpc/disk.vhd.gz
+        elif [ -f "/output/gce/image.tar.gz" ]; then
+          echo -e "Found gce image."
+          # already compressed.
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
+        fi
+
+        buildah_retries=3
+        echo "Pushing image $OUTPUT_IMAGE to registry"
+        if ! retry buildah manifest push --digestfile image-digest --authfile /.docker/config.json --retry "$buildah_retries" --all $OUTPUT_IMAGE
+        then
+            echo "Failed to push image ${OUTPUT_IMAGE} to registry"
+            exit 1
+        fi
+
+        # At this point, we have pushed an image index of length 1 to the registry.
+        # Next, extract a reference to the image manifest and expose that, throwing away the image index.
+        IMAGE_INDEX_DIGEST=$(cat image-digest)
+        REPO=${OUTPUT_IMAGE%:*}
+        MANIFEST_DIGEST=$(buildah manifest inspect --authfile /.docker/config.json $REPO@$IMAGE_INDEX_DIGEST | jq -r '.manifests[0].digest')
+
+        # Overwrite the image index pullspec tag with the image manifest one
+        echo "Overwriting image $OUTPUT_IMAGE in registry"
+        if ! retry skopeo copy --authfile /.docker/config.json docker://$REPO@$MANIFEST_DIGEST docker://$OUTPUT_IMAGE
+        then
+            echo "Failed to overwrite image ${OUTPUT_IMAGE} in registry"
+            exit 1
+        fi
+
+        # Finally, record all that in our results
+        echo -n "$OUTPUT_IMAGE" | tee /tekton-results/IMAGE_URL
+        echo $MANIFEST_DIGEST | tee /tekton-results/IMAGE_DIGEST
+        # Saving also these two output in one unique variable. This task is using a matrix reference.
+        # Unfortunately it seems that in Tekton, when using a matrix, each task run is executed in isolation,
+        # and result values can't be dynamically constructed or reused across matrix combinations.
+        # In order to prevent that, we are preparing in the task itself what we'll call as `IMAGE_REFERENCE`
+        # so that we can reference that safely in the pipeline.
+        IMAGE_URL_CLEANED=$(echo -n "$OUTPUT_IMAGE" | tr -d '\n')
+        echo -n "${IMAGE_URL_CLEANED}@${MANIFEST_DIGEST}" | tee /tekton-results/IMAGE_REFERENCE
+        REMOTESSHEOF
+
+
+        # make scripts executable and sync them to the cloud VM.
+        chmod +x scripts/script-build.sh
+        chmod +x scripts/script-push.sh
+        rsync -e "ssh ${SSH_ARGS[*]}" -ra scripts "$SSH_HOST:$BUILD_DIR"
+        rsync -e "ssh ${SSH_ARGS[*]}" -ra /var/workdir/source/ "$SSH_HOST:$BUILD_DIR/workspaces/source/"
+
+        ssh -v "${SSH_ARGS[@]}" "$SSH_HOST" "$BUILD_DIR/scripts/script-build.sh"
+        rsync -e "ssh ${SSH_ARGS[*]}" -ra "$SSH_HOST:$BUILD_DIR/tekton-results/" "/tekton/results/"
+
+      volumeMounts:
+        - mountPath: /ssh
+          name: ssh
+          readOnly: true
+        - mountPath: /entitlement
+          name: etc-pki-entitlement
+        - mountPath: /activation-key
+          name: activation-key
+
+    - name: sbom-download
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 50m
+          memory: 128Mi
+      securityContext:
+        runAsUser: 0
+      script: |-
+        #!/bin/bash
+        set -euo pipefail
+
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM generation"
+          exit 0
+        fi
+
+        case "${SBOM_TYPE}" in
+          spdx|cyclonedx) ;;
+          *) echo "Invalid SBOM_TYPE: ${SBOM_TYPE}. Must be one of: spdx, cyclonedx." >&2; exit 1 ;;
+        esac
+
+        if [ "${IMAGE_APPEND_PLATFORM}" = "true" ]; then
+          OUTPUT_IMAGE="${OUTPUT_IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        fi
+
+        # shellcheck source=/dev/null
+        source /var/workdir/vars
+        ARCH="${PLATFORM##*/}"
+
+        echo "Downloading SBOM from source container: ${SOURCE_IMAGE}"
+
+        mkdir -p /tmp/auth && select-oci-auth "${SOURCE_IMAGE}" > /tmp/auth/config.json
+
+        COSIGN_ARGS=()
+        if DOCKER_CONFIG=/tmp/auth skopeo inspect --raw "docker://${SOURCE_IMAGE}" 2>/dev/null \
+          | jq -e '.manifests' > /dev/null 2>&1; then
+          echo "Source is a multi-arch index, downloading SBOM for linux/${ARCH}"
+          COSIGN_ARGS=(--platform="linux/${ARCH}")
+        fi
+
+        if DOCKER_CONFIG=/tmp/auth retry cosign download sbom "${COSIGN_ARGS[@]}" \
+            "${SOURCE_IMAGE}" > /var/workdir/sbom.json 2>/tmp/cosign-err.log \
+          && jq empty /var/workdir/sbom.json 2>/dev/null; then
+          SBOM_SIZE=$(wc -c < /var/workdir/sbom.json)
+          SBOM_PKGS=$(jq '(.packages // .components // []) | length' /var/workdir/sbom.json 2>/dev/null || echo "unknown")
+          echo "SBOM downloaded successfully (${SBOM_SIZE} bytes, ${SBOM_PKGS} packages)"
+        else
+          echo "WARNING: Failed to download SBOM from source container"
+          cat /tmp/cosign-err.log
+          echo "Generating minimal SBOM placeholder"
+          if ! IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)" 2>/dev/null)"; then
+            echo "WARNING: IMAGE_DIGEST result not available, using 'unknown'"
+            IMAGE_DIGEST="unknown"
+          fi
+          TS="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          if [ "${SBOM_TYPE}" = "cyclonedx" ]; then
+            jq -n \
+              --arg name "${OUTPUT_IMAGE}" \
+              --arg ts "${TS}" \
+              '{
+                bomFormat: "CycloneDX",
+                specVersion: "1.5",
+                version: 1,
+                metadata: {
+                  timestamp: $ts,
+                  tools: [{name: "konflux-ci/build-vm-image-0.2"}],
+                  component: {type: "application", name: $name}
+                },
+                components: []
+              }' > /var/workdir/sbom.json
+          else
+            jq -n \
+              --arg name "${OUTPUT_IMAGE}" \
+              --arg ns "https://konflux-ci.dev/disk-image-sbom/${OUTPUT_IMAGE}@${IMAGE_DIGEST}" \
+              --arg ts "${TS}" \
+              '{
+                spdxVersion: "SPDX-2.3",
+                dataLicense: "CC0-1.0",
+                SPDXID: "SPDXRef-DOCUMENT",
+                name: $name,
+                documentNamespace: $ns,
+                comment: "SBOM download from source container failed. This is a placeholder document with no package data.",
+                creationInfo: {
+                  creators: ["Tool: konflux-ci/build-vm-image-0.2"],
+                  created: $ts,
+                  comment: "placeholder: source SBOM unavailable"
+                },
+                packages: []
+              }' > /var/workdir/sbom.json
+          fi
+        fi
+
+    - name: upload-sbom
+      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      computeResources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 50m
+          memory: 128Mi
+      securityContext:
+        runAsUser: 0
+      script: |-
+        #!/bin/bash
+        set -euo pipefail
+
+        if [ "${SKIP_SBOM_GENERATION}" = "true" ]; then
+          echo "Skipping SBOM upload"
+          echo -n "" | tee "$(results.SBOM_BLOB_URL.path)"
+          exit 0
+        fi
+
+        if [ ! -f /var/workdir/sbom.json ]; then
+          echo "No SBOM file found, skipping upload"
+          echo -n "" | tee "$(results.SBOM_BLOB_URL.path)"
+          exit 0
+        fi
+
+        case "${SBOM_TYPE}" in
+          spdx|cyclonedx) ;;
+          *) echo "Invalid SBOM_TYPE: ${SBOM_TYPE}. Must be one of: spdx, cyclonedx." >&2; exit 1 ;;
+        esac
+
+        if [ "${IMAGE_APPEND_PLATFORM}" = "true" ]; then
+          OUTPUT_IMAGE="${OUTPUT_IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+        fi
+
+        IMAGE_URL="$(cat "$(results.IMAGE_URL.path)")"
+        IMAGE_DIGEST="$(cat "$(results.IMAGE_DIGEST.path)")"
+        IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+
+        mkdir -p /tmp/auth && select-oci-auth "${IMAGE_REF}" > /tmp/auth/config.json
+
+        echo "Attaching SBOM to disk image: ${IMAGE_REF}"
+        if ! DOCKER_CONFIG=/tmp/auth retry cosign attach sbom --sbom /var/workdir/sbom.json --type "${SBOM_TYPE}" "${IMAGE_REF}"; then
+          echo "Failed to attach SBOM to disk image"
+          exit 1
+        fi
+
+        echo "SBOM attached successfully"
+
+        REPO="${OUTPUT_IMAGE%:*}"
+        SBOM_DIGEST=$(sha256sum /var/workdir/sbom.json | awk '{ print $1 }')
+        echo -n "${REPO}@sha256:${SBOM_DIGEST}" | tee "$(results.SBOM_BLOB_URL.path)"
+
+  volumes:
+    - emptyDir: {}
+      name: workdir
+    - emptyDir: {}
+      name: varlibcontainers
+    - name: ssh
+      secret:
+        optional: false
+        secretName: multi-platform-ssh-$(context.taskRun.name)
+    - name: etc-pki-entitlement
+      secret:
+        optional: true
+        secretName: $(params.ENTITLEMENT_SECRET)
+    - name: activation-key
+      secret:
+        optional: true
+        secretName: $(params.ACTIVATION_KEY)

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -95,6 +95,7 @@ spec:
         name: workdir
       - mountPath: "/var/lib/containers/storage"
         name: varlibcontainers
+    imagePullPolicy: IfNotPresent
   steps:
     - name: use-trusted-artifact
       image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:77563b5fb4b82f9b6a47070ba06e60486567d34e03ea60cd5169be0be53ad5dc
@@ -246,7 +247,7 @@ spec:
 
         # this unquoted heredoc allows expansions for the image name
         cat >scripts/script-build.sh <<REMOTESSHEOF
-        #!/bin/sh
+        #!/bin/bash
         set -euo pipefail
 
         # this prevents the container from using podman-subscripition-mananger magic,

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -380,7 +380,7 @@ spec:
         # this unquoted heredoc allows expansions for the image name
         cat >scripts/script-push.sh <<REMOTESSHEOF
         #!/bin/bash
-        set -ex
+        set -euxo pipefail
 
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"
 

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -237,6 +237,11 @@ spec:
           *) echo "Invalid IMAGE_TYPE: ${IMAGE_TYPE}. Must be one of: iso, qcow2, gce, vhd, raw." >&2; exit 1 ;;
         esac
 
+        case "${STORAGE_DRIVER}" in
+          vfs|overlay) ;;
+          *) echo "Invalid STORAGE_DRIVER: ${STORAGE_DRIVER}. Must be one of: vfs, overlay." >&2; exit 1 ;;
+        esac
+
         valid_pullspec_characters="0-9a-zA-Z@:/._-"
         if [[ "${OUTPUT_IMAGE}" =~ [^$valid_pullspec_characters] ]]; then
           echo "OUTPUT_IMAGE contains invalid characters" >&2; exit 1

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -153,6 +153,15 @@ spec:
           echo "BIB_CONFIG_FILE escapes source directory: ${BIB_CONFIG_FILE}" >&2; exit 1
         fi
 
+        if [ -n "${CONFIG_TOML_FILE}" ]; then
+          CONFIG_TOML_FILE_CLEAN="${CONFIG_TOML_FILE#/}"
+          CONFIG_TOML_PATH="/var/workdir/source/${CONFIG_TOML_FILE_CLEAN}"
+          CONFIG_TOML_REAL="$(realpath -m "${CONFIG_TOML_PATH}")"
+          if [[ "${CONFIG_TOML_REAL}" != /var/workdir/source/* ]]; then
+            echo "CONFIG_TOML_FILE escapes source directory: ${CONFIG_TOML_FILE}" >&2; exit 1
+          fi
+        fi
+
         BIB_IMAGE=$(yq -r .bootc-builder-image "${BIB_CONFIG_PATH}")
         SOURCE_IMAGE=$(yq -r .source-image "${BIB_CONFIG_PATH}")
         TAGGED_AS=$(yq -r ".tagged-as // \"${SOURCE_IMAGE}\"" "${BIB_CONFIG_PATH}")

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -132,9 +132,15 @@ spec:
         # trim any leading slash.
         BIB_CONFIG_FILE=${BIB_CONFIG_FILE#/}
 
-        BIB_IMAGE=$(yq -r .bootc-builder-image /var/workdir/source/$BIB_CONFIG_FILE)
-        SOURCE_IMAGE=$(yq -r  .source-image /var/workdir/source/$BIB_CONFIG_FILE)
-        TAGGED_AS=$(yq -r  ".tagged-as // \"${SOURCE_IMAGE}\"" /var/workdir/source/$BIB_CONFIG_FILE)
+        BIB_CONFIG_PATH="/var/workdir/source/${BIB_CONFIG_FILE}"
+        BIB_CONFIG_REAL="$(realpath -m "${BIB_CONFIG_PATH}")"
+        if [[ "${BIB_CONFIG_REAL}" != /var/workdir/source/* ]]; then
+          echo "BIB_CONFIG_FILE escapes source directory: ${BIB_CONFIG_FILE}" >&2; exit 1
+        fi
+
+        BIB_IMAGE=$(yq -r .bootc-builder-image "${BIB_CONFIG_PATH}")
+        SOURCE_IMAGE=$(yq -r .source-image "${BIB_CONFIG_PATH}")
+        TAGGED_AS=$(yq -r ".tagged-as // \"${SOURCE_IMAGE}\"" "${BIB_CONFIG_PATH}")
 
         # Validate that all keys exist and are plausible pullspecs
         valid_pullspec_characters="0-9a-zA-Z@:/._-"
@@ -456,7 +462,7 @@ spec:
         - mountPath: /activation-key
           name: activation-key
 
-    - name: sbom-download
+    - name: download-sbom
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       computeResources:
         limits:

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -81,7 +81,7 @@ spec:
       - name: STORAGE_DRIVER
         value: $(params.STORAGE_DRIVER)
       - name: BUILDAH_IMAGE
-        value: 'registry.access.redhat.com/ubi9/buildah:9.7-1777422883'
+        value: 'registry.access.redhat.com/ubi9/buildah:9.8-1782883468'
       - name: PLATFORM
         value: $(params.PLATFORM)
       - name: IMAGE_APPEND_PLATFORM
@@ -109,7 +109,7 @@ spec:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
     - name: validate-config
-      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
       computeResources:
         limits:
           memory: 64Mi
@@ -468,7 +468,7 @@ spec:
           name: activation-key
 
     - name: download-sbom
-      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
       computeResources:
         limits:
           memory: 256Mi
@@ -558,7 +558,7 @@ spec:
         fi
 
     - name: upload-sbom
-      image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+      image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
       computeResources:
         limits:
           memory: 256Mi

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -108,7 +108,7 @@ spec:
       args:
         - use
         - $(params.SOURCE_ARTIFACT)=/var/workdir/source
-    - name: validate-bib-config
+    - name: validate-config
       image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
       computeResources:
         limits:
@@ -120,6 +120,21 @@ spec:
         #!/bin/bash
         set -euo pipefail
         set -x
+
+        case "${IMAGE_TYPE}" in
+          iso|qcow2|gce|vhd|raw) ;;
+          *) echo "Invalid IMAGE_TYPE: ${IMAGE_TYPE}. Must be one of: iso, qcow2, gce, vhd, raw." >&2; exit 1 ;;
+        esac
+
+        case "${STORAGE_DRIVER}" in
+          vfs|overlay) ;;
+          *) echo "Invalid STORAGE_DRIVER: ${STORAGE_DRIVER}. Must be one of: vfs, overlay." >&2; exit 1 ;;
+        esac
+
+        case "${SBOM_TYPE}" in
+          spdx|cyclonedx) ;;
+          *) echo "Invalid SBOM_TYPE: ${SBOM_TYPE}. Must be one of: spdx, cyclonedx." >&2; exit 1 ;;
+        esac
 
         # expects a config file like the following as BIB_CONFIG_FILE
         #
@@ -237,16 +252,6 @@ spec:
 
         ARCH=$(sed 's/.*\///' <<<"$PLATFORM")
         echo "ARCH: '${ARCH}'"
-
-        case "${IMAGE_TYPE}" in
-          iso|qcow2|gce|vhd|raw) ;;
-          *) echo "Invalid IMAGE_TYPE: ${IMAGE_TYPE}. Must be one of: iso, qcow2, gce, vhd, raw." >&2; exit 1 ;;
-        esac
-
-        case "${STORAGE_DRIVER}" in
-          vfs|overlay) ;;
-          *) echo "Invalid STORAGE_DRIVER: ${STORAGE_DRIVER}. Must be one of: vfs, overlay." >&2; exit 1 ;;
-        esac
 
         valid_pullspec_characters="0-9a-zA-Z@:/._-"
         if [[ "${OUTPUT_IMAGE}" =~ [^$valid_pullspec_characters] ]]; then
@@ -481,11 +486,6 @@ spec:
           exit 0
         fi
 
-        case "${SBOM_TYPE}" in
-          spdx|cyclonedx) ;;
-          *) echo "Invalid SBOM_TYPE: ${SBOM_TYPE}. Must be one of: spdx, cyclonedx." >&2; exit 1 ;;
-        esac
-
         if [ "${IMAGE_APPEND_PLATFORM}" = "true" ]; then
           OUTPUT_IMAGE="${OUTPUT_IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
         fi
@@ -582,11 +582,6 @@ spec:
           echo -n "" | tee "$(results.SBOM_BLOB_URL.path)"
           exit 0
         fi
-
-        case "${SBOM_TYPE}" in
-          spdx|cyclonedx) ;;
-          *) echo "Invalid SBOM_TYPE: ${SBOM_TYPE}. Must be one of: spdx, cyclonedx." >&2; exit 1 ;;
-        esac
 
         if [ "${IMAGE_APPEND_PLATFORM}" = "true" ]; then
           OUTPUT_IMAGE="${OUTPUT_IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"

--- a/task/build-vm-image/0.2/tests/pre-apply-task-hook.sh
+++ b/task/build-vm-image/0.2/tests/pre-apply-task-hook.sh
@@ -2,13 +2,13 @@
 set -euo pipefail
 
 # Patches the build-vm-image task for testing in a kind cluster.
-# Replaces the untestable steps (use-trusted-artifact, validate-bib-config, build)
+# Replaces the untestable steps (use-trusted-artifact, validate-config, build)
 # with lightweight mocks so the real SBOM steps can run against mocked outputs.
 
 TASK_COPY="$1"
 TEST_NS="$2"
 
-export TASK_RUNNER_IMAGE="quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f"
+export TASK_RUNNER_IMAGE="quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b"
 
 # --- Volume fixes ---
 
@@ -36,7 +36,7 @@ yq -i '
   }
 ' "$TASK_COPY"
 
-# 2. Replace validate-bib-config with a mock that writes /var/workdir/vars
+# 2. Replace validate-config with a mock that writes /var/workdir/vars
 export MOCK_VALIDATE_SCRIPT='#!/bin/bash
 set -euo pipefail
 echo "mock: writing test vars to /var/workdir/vars"
@@ -48,8 +48,8 @@ VARS
 cat /var/workdir/vars
 '
 yq -i '
-  (.spec.steps[] | select(.name == "validate-bib-config")) = {
-    "name": "validate-bib-config",
+  (.spec.steps[] | select(.name == "validate-config")) = {
+    "name": "validate-config",
     "image": env(TASK_RUNNER_IMAGE),
     "computeResources": {"limits": {"memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}},
     "script": strenv(MOCK_VALIDATE_SCRIPT)

--- a/task/build-vm-image/0.2/tests/pre-apply-task-hook.sh
+++ b/task/build-vm-image/0.2/tests/pre-apply-task-hook.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+set -euo pipefail
+
+# Patches the build-vm-image task for testing in a kind cluster.
+# Replaces the untestable steps (use-trusted-artifact, validate-bib-config, build)
+# with lightweight mocks so the real SBOM steps can run against mocked outputs.
+
+TASK_COPY="$1"
+TEST_NS="$2"
+
+export TASK_RUNNER_IMAGE="quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f"
+
+# --- Volume fixes ---
+
+# Make the ssh secret optional (it won't exist in kind)
+yq -i '(.spec.volumes[] | select(.name == "ssh")).secret.optional = true' "$TASK_COPY"
+
+# Add trusted-ca volume for kind registry TLS
+yq -i '.spec.volumes += [{"name": "trusted-ca", "configMap": {"name": "trusted-ca", "items": [{"key": "ca-bundle.crt", "path": "ca-bundle.crt"}], "optional": true}}]' "$TASK_COPY"
+
+# Add trusted-ca volumeMount to stepTemplate
+yq -i '.spec.stepTemplate.volumeMounts += [{"name": "trusted-ca", "mountPath": "/etc/pki/tls/certs/ca-custom-bundle.crt", "subPath": "ca-bundle.crt", "readOnly": true}]' "$TASK_COPY"
+
+# --- Step replacements ---
+
+# 1. Replace use-trusted-artifact with a no-op
+export MOCK_UTA_SCRIPT='#!/bin/bash
+echo "mock: trusted artifact step skipped"
+'
+yq -i '
+  (.spec.steps[] | select(.name == "use-trusted-artifact")) = {
+    "name": "use-trusted-artifact",
+    "image": env(TASK_RUNNER_IMAGE),
+    "computeResources": {"limits": {"memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}},
+    "script": strenv(MOCK_UTA_SCRIPT)
+  }
+' "$TASK_COPY"
+
+# 2. Replace validate-bib-config with a mock that writes /var/workdir/vars
+export MOCK_VALIDATE_SCRIPT='#!/bin/bash
+set -euo pipefail
+echo "mock: writing test vars to /var/workdir/vars"
+cat > /var/workdir/vars <<VARS
+declare SOURCE_IMAGE=registry-service.kind-registry/test-source:test
+declare BOOTC_BUILDER_IMAGE=unused
+declare TAGGED_AS=unused
+VARS
+cat /var/workdir/vars
+'
+yq -i '
+  (.spec.steps[] | select(.name == "validate-bib-config")) = {
+    "name": "validate-bib-config",
+    "image": env(TASK_RUNNER_IMAGE),
+    "computeResources": {"limits": {"memory": "64Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}},
+    "script": strenv(MOCK_VALIDATE_SCRIPT)
+  }
+' "$TASK_COPY"
+
+# 3. Replace build with a mock that pushes a dummy artifact and writes results
+export MOCK_BUILD_SCRIPT='#!/bin/bash
+set -euo pipefail
+
+if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
+  OUTPUT_IMAGE="${OUTPUT_IMAGE}-${PLATFORM//[^a-zA-Z0-9]/-}"
+fi
+
+echo "mock: pushing dummy disk image artifact to ${OUTPUT_IMAGE}"
+cd /tmp && echo "test-disk-content" > disk.qcow2
+oras push --no-tty "${OUTPUT_IMAGE}" disk.qcow2
+
+DIGEST=$(oras resolve "${OUTPUT_IMAGE}")
+echo "mock: pushed with digest ${DIGEST}"
+
+echo -n "${OUTPUT_IMAGE}" > /tekton/results/IMAGE_URL
+echo -n "${DIGEST}" > /tekton/results/IMAGE_DIGEST
+echo -n "${OUTPUT_IMAGE}@${DIGEST}" > /tekton/results/IMAGE_REFERENCE
+echo "mock: results written"
+'
+yq -i '
+  (.spec.steps[] | select(.name == "build")) = {
+    "name": "build",
+    "image": env(TASK_RUNNER_IMAGE),
+    "computeResources": {"limits": {"memory": "128Mi"}, "requests": {"cpu": "50m", "memory": "64Mi"}},
+    "script": strenv(MOCK_BUILD_SCRIPT)
+  }
+' "$TASK_COPY"
+
+echo "Task patched for testing"

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-cyclonedx-fallback.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-cyclonedx-fallback.yaml
@@ -22,7 +22,7 @@ spec:
               optional: true
         steps:
           - name: push-source-without-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -81,7 +81,7 @@ spec:
               optional: true
         steps:
           - name: check-cyclonedx-placeholder
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-cyclonedx-fallback.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-cyclonedx-fallback.yaml
@@ -1,0 +1,135 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-build-vm-image-sbom-cyclonedx-fallback
+spec:
+  description: |
+    Test that the build-vm-image task produces a CycloneDX placeholder SBOM
+    when SBOM_TYPE=cyclonedx and the source container has no SBOM attached.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup-source-image
+      taskSpec:
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: push-source-without-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              SOURCE_IMAGE="registry-service.kind-registry/test-source:test"
+
+              echo "Pushing dummy source container image (no SBOM attached)"
+              cd /tmp && echo "source-content-cyclonedx-fallback" > source.txt
+              oras push --no-tty "${SOURCE_IMAGE}" source.txt
+              echo "Setup complete — source image has no SBOM"
+
+    - name: run-build-vm-image
+      taskRef:
+        name: build-vm-image
+      params:
+        - name: PLATFORM
+          value: linux/amd64
+        - name: OUTPUT_IMAGE
+          value: registry-service.kind-registry/test-disk-image:latest
+        - name: SOURCE_ARTIFACT
+          value: unused
+        - name: IMAGE_TYPE
+          value: qcow2
+        - name: SBOM_TYPE
+          value: cyclonedx
+        - name: SKIP_SBOM_GENERATION
+          value: "false"
+      runAfter:
+        - setup-source-image
+
+    - name: verify-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.run-build-vm-image.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.run-build-vm-image.results.IMAGE_DIGEST)
+        - name: SBOM_BLOB_URL
+          value: $(tasks.run-build-vm-image.results.SBOM_BLOB_URL)
+      taskSpec:
+        params:
+          - name: IMAGE_URL
+          - name: IMAGE_DIGEST
+          - name: SBOM_BLOB_URL
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: check-cyclonedx-placeholder
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            env:
+              - name: IMAGE_URL
+                value: $(params.IMAGE_URL)
+              - name: IMAGE_DIGEST
+                value: $(params.IMAGE_DIGEST)
+              - name: SBOM_BLOB_URL
+                value: $(params.SBOM_BLOB_URL)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+              echo "Verifying CycloneDX placeholder SBOM on disk image: ${IMAGE_REF}"
+
+              echo "=== Check 1: SBOM can be downloaded ==="
+              SBOM=$(cosign download sbom "${IMAGE_REF}")
+              echo "${SBOM}" | jq .
+
+              echo "=== Check 2: SBOM is CycloneDX format ==="
+              if ! echo "${SBOM}" | jq -e '.bomFormat == "CycloneDX"' > /dev/null; then
+                echo "FAIL: not a CycloneDX document" && exit 1
+              fi
+              echo "PASS: bomFormat is CycloneDX"
+
+              echo "=== Check 3: CycloneDX specVersion is 1.5 ==="
+              if ! echo "${SBOM}" | jq -e '.specVersion == "1.5"' > /dev/null; then
+                echo "FAIL: specVersion is not 1.5" && exit 1
+              fi
+              echo "PASS: specVersion is 1.5"
+
+              echo "=== Check 4: SBOM has empty components ==="
+              COMP_COUNT=$(echo "${SBOM}" | jq '.components | length')
+              if [ "${COMP_COUNT}" -ne 0 ]; then
+                echo "FAIL: expected 0 components, got ${COMP_COUNT}" && exit 1
+              fi
+              echo "PASS: components array is empty"
+
+              echo "=== Check 5: SBOM_BLOB_URL is non-empty ==="
+              if [ -z "${SBOM_BLOB_URL}" ]; then
+                echo "FAIL: SBOM_BLOB_URL is empty" && exit 1
+              fi
+              echo "PASS: SBOM_BLOB_URL = ${SBOM_BLOB_URL}"
+
+              echo "All checks passed"
+      runAfter:
+        - run-build-vm-image

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-cyclonedx-happy-path.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-cyclonedx-happy-path.yaml
@@ -22,7 +22,7 @@ spec:
               optional: true
         steps:
           - name: push-source-and-attach-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -108,7 +108,7 @@ spec:
               optional: true
         steps:
           - name: check-cyclonedx-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-cyclonedx-happy-path.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-cyclonedx-happy-path.yaml
@@ -1,0 +1,175 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-build-vm-image-sbom-cyclonedx-happy-path
+spec:
+  description: |
+    Test that the build-vm-image task downloads a CycloneDX SBOM from the source
+    container and attaches it to the built disk image artifact.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup-source-image
+      taskSpec:
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: push-source-and-attach-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              SOURCE_IMAGE="registry-service.kind-registry/test-source:test"
+
+              echo "Pushing dummy source container image"
+              cd /tmp && echo "source-content-cdx" > source.txt
+              oras push --no-tty "${SOURCE_IMAGE}" source.txt
+
+              echo "Creating CycloneDX test SBOM with a known component"
+              cat > test-sbom.json <<'EOF'
+              {
+                "bomFormat": "CycloneDX",
+                "specVersion": "1.5",
+                "version": 1,
+                "metadata": {
+                  "timestamp": "2024-01-01T00:00:00Z",
+                  "tools": [{"name": "test-harness"}],
+                  "component": {
+                    "type": "application",
+                    "name": "test-source-cdx"
+                  }
+                },
+                "components": [
+                  {
+                    "type": "library",
+                    "name": "cdx-test-package",
+                    "version": "3.0.0"
+                  }
+                ]
+              }
+              EOF
+
+              echo "Attaching CycloneDX SBOM to source image"
+              cosign attach sbom --sbom test-sbom.json --type cyclonedx "${SOURCE_IMAGE}"
+              echo "Setup complete"
+
+    - name: run-build-vm-image
+      taskRef:
+        name: build-vm-image
+      params:
+        - name: PLATFORM
+          value: linux/amd64
+        - name: OUTPUT_IMAGE
+          value: registry-service.kind-registry/test-disk-image:latest
+        - name: SOURCE_ARTIFACT
+          value: unused
+        - name: IMAGE_TYPE
+          value: qcow2
+        - name: SBOM_TYPE
+          value: cyclonedx
+        - name: SKIP_SBOM_GENERATION
+          value: "false"
+      runAfter:
+        - setup-source-image
+
+    - name: verify-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.run-build-vm-image.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.run-build-vm-image.results.IMAGE_DIGEST)
+        - name: SBOM_BLOB_URL
+          value: $(tasks.run-build-vm-image.results.SBOM_BLOB_URL)
+      taskSpec:
+        params:
+          - name: IMAGE_URL
+          - name: IMAGE_DIGEST
+          - name: SBOM_BLOB_URL
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: check-cyclonedx-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            env:
+              - name: IMAGE_URL
+                value: $(params.IMAGE_URL)
+              - name: IMAGE_DIGEST
+                value: $(params.IMAGE_DIGEST)
+              - name: SBOM_BLOB_URL
+                value: $(params.SBOM_BLOB_URL)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+              echo "Verifying CycloneDX SBOM on disk image: ${IMAGE_REF}"
+
+              echo "=== Check 1: SBOM can be downloaded ==="
+              SBOM=$(cosign download sbom "${IMAGE_REF}")
+              echo "${SBOM}" | jq .
+
+              echo "=== Check 2: SBOM is CycloneDX format ==="
+              if ! echo "${SBOM}" | jq -e '.bomFormat == "CycloneDX"' > /dev/null; then
+                echo "FAIL: not a CycloneDX document" && exit 1
+              fi
+              echo "PASS: bomFormat is CycloneDX"
+
+              echo "=== Check 3: CycloneDX specVersion is 1.5 ==="
+              if ! echo "${SBOM}" | jq -e '.specVersion == "1.5"' > /dev/null; then
+                echo "FAIL: specVersion is not 1.5" && exit 1
+              fi
+              echo "PASS: specVersion is 1.5"
+
+              echo "=== Check 4: SBOM has components ==="
+              COMP_COUNT=$(echo "${SBOM}" | jq '.components | length')
+              if [ "${COMP_COUNT}" -eq 0 ]; then
+                echo "FAIL: SBOM has no components (got placeholder instead of real SBOM?)" && exit 1
+              fi
+              echo "PASS: SBOM has ${COMP_COUNT} component(s)"
+
+              echo "=== Check 5: SBOM contains cdx-test-package ==="
+              if ! echo "${SBOM}" | jq -e '.components[] | select(.name == "cdx-test-package")' > /dev/null; then
+                echo "FAIL: cdx-test-package not found in SBOM" && exit 1
+              fi
+              echo "PASS: cdx-test-package found"
+
+              echo "=== Check 6: SBOM_BLOB_URL is non-empty ==="
+              if [ -z "${SBOM_BLOB_URL}" ]; then
+                echo "FAIL: SBOM_BLOB_URL is empty" && exit 1
+              fi
+              echo "PASS: SBOM_BLOB_URL = ${SBOM_BLOB_URL}"
+
+              echo "=== Check 7: SBOM is not a placeholder ==="
+              TOOLS=$(echo "${SBOM}" | jq -r '(.metadata.tools // [])[] | .name' 2>/dev/null || true)
+              if echo "${TOOLS}" | grep -qi "konflux"; then
+                echo "FAIL: SBOM appears to be a placeholder (tools contain 'konflux')" && exit 1
+              fi
+              echo "PASS: SBOM is not a placeholder"
+
+              echo "All checks passed"
+      runAfter:
+        - run-build-vm-image

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-fallback.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-fallback.yaml
@@ -1,0 +1,139 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-build-vm-image-sbom-fallback
+spec:
+  description: |
+    Test that the build-vm-image task produces a placeholder SBOM with a
+    distinguishing marker when the source container has no SBOM attached.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup-source-image
+      taskSpec:
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: push-source-without-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              SOURCE_IMAGE="registry-service.kind-registry/test-source:test"
+
+              echo "Pushing dummy source container image (no SBOM attached)"
+              cd /tmp && echo "source-content-no-sbom" > source.txt
+              oras push --no-tty "${SOURCE_IMAGE}" source.txt
+              echo "Setup complete — source image has no SBOM"
+
+    - name: run-build-vm-image
+      taskRef:
+        name: build-vm-image
+      params:
+        - name: PLATFORM
+          value: linux/amd64
+        - name: OUTPUT_IMAGE
+          value: registry-service.kind-registry/test-disk-image:latest
+        - name: SOURCE_ARTIFACT
+          value: unused
+        - name: IMAGE_TYPE
+          value: qcow2
+        - name: SBOM_TYPE
+          value: spdx
+        - name: SKIP_SBOM_GENERATION
+          value: "false"
+      runAfter:
+        - setup-source-image
+
+    - name: verify-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.run-build-vm-image.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.run-build-vm-image.results.IMAGE_DIGEST)
+        - name: SBOM_BLOB_URL
+          value: $(tasks.run-build-vm-image.results.SBOM_BLOB_URL)
+      taskSpec:
+        params:
+          - name: IMAGE_URL
+          - name: IMAGE_DIGEST
+          - name: SBOM_BLOB_URL
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: check-placeholder-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            env:
+              - name: IMAGE_URL
+                value: $(params.IMAGE_URL)
+              - name: IMAGE_DIGEST
+                value: $(params.IMAGE_DIGEST)
+              - name: SBOM_BLOB_URL
+                value: $(params.SBOM_BLOB_URL)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+              echo "Verifying placeholder SBOM on disk image: ${IMAGE_REF}"
+
+              echo "=== Check 1: SBOM can be downloaded ==="
+              SBOM=$(cosign download sbom "${IMAGE_REF}")
+              echo "${SBOM}" | jq .
+
+              echo "=== Check 2: SBOM has placeholder comment ==="
+              if ! echo "${SBOM}" | jq -e '.comment' > /dev/null 2>&1; then
+                echo "FAIL: SBOM has no comment field" && exit 1
+              fi
+              COMMENT=$(echo "${SBOM}" | jq -r '.comment')
+              if [[ "${COMMENT}" != *"placeholder"* ]]; then
+                echo "FAIL: comment does not indicate placeholder: ${COMMENT}" && exit 1
+              fi
+              echo "PASS: SBOM comment indicates placeholder"
+
+              echo "=== Check 3: SBOM has empty packages ==="
+              PKG_COUNT=$(echo "${SBOM}" | jq '.packages | length')
+              if [ "${PKG_COUNT}" -ne 0 ]; then
+                echo "FAIL: expected 0 packages, got ${PKG_COUNT}" && exit 1
+              fi
+              echo "PASS: packages array is empty"
+
+              echo "=== Check 4: SBOM_BLOB_URL is non-empty ==="
+              if [ -z "${SBOM_BLOB_URL}" ]; then
+                echo "FAIL: SBOM_BLOB_URL is empty" && exit 1
+              fi
+              echo "PASS: SBOM_BLOB_URL = ${SBOM_BLOB_URL}"
+
+              echo "=== Check 5: SBOM has valid SPDX structure ==="
+              if ! echo "${SBOM}" | jq -e '.spdxVersion == "SPDX-2.3"' > /dev/null; then
+                echo "FAIL: not a valid SPDX 2.3 document" && exit 1
+              fi
+              echo "PASS: valid SPDX 2.3 document"
+
+              echo "All checks passed"
+      runAfter:
+        - run-build-vm-image

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-fallback.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-fallback.yaml
@@ -22,7 +22,7 @@ spec:
               optional: true
         steps:
           - name: push-source-without-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -81,7 +81,7 @@ spec:
               optional: true
         steps:
           - name: check-placeholder-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-happy-path.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-happy-path.yaml
@@ -1,0 +1,165 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-build-vm-image-sbom-happy-path
+spec:
+  description: |
+    Test that the build-vm-image task downloads an SBOM from the source container
+    and attaches it to the built disk image artifact.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup-source-image
+      taskSpec:
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: push-source-and-attach-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              SOURCE_IMAGE="registry-service.kind-registry/test-source:test"
+
+              echo "Pushing dummy source container image"
+              cd /tmp && echo "source-content" > source.txt
+              oras push --no-tty "${SOURCE_IMAGE}" source.txt
+
+              echo "Creating test SBOM with a known package"
+              cat > test-sbom.json <<'EOF'
+              {
+                "spdxVersion": "SPDX-2.3",
+                "dataLicense": "CC0-1.0",
+                "SPDXID": "SPDXRef-DOCUMENT",
+                "name": "test-source-sbom",
+                "documentNamespace": "https://test.example.com/sbom",
+                "creationInfo": {
+                  "creators": ["Tool: test-harness"],
+                  "created": "2024-01-01T00:00:00Z"
+                },
+                "packages": [
+                  {
+                    "SPDXID": "SPDXRef-Package-test",
+                    "name": "test-package",
+                    "versionInfo": "1.0.0",
+                    "downloadLocation": "NOASSERTION",
+                    "supplier": "NOASSERTION"
+                  }
+                ]
+              }
+              EOF
+
+              echo "Attaching SBOM to source image"
+              cosign attach sbom --sbom test-sbom.json --type spdx "${SOURCE_IMAGE}"
+              echo "Setup complete"
+
+    - name: run-build-vm-image
+      taskRef:
+        name: build-vm-image
+      params:
+        - name: PLATFORM
+          value: linux/amd64
+        - name: OUTPUT_IMAGE
+          value: registry-service.kind-registry/test-disk-image:latest
+        - name: SOURCE_ARTIFACT
+          value: unused
+        - name: IMAGE_TYPE
+          value: qcow2
+        - name: SBOM_TYPE
+          value: spdx
+        - name: SKIP_SBOM_GENERATION
+          value: "false"
+      runAfter:
+        - setup-source-image
+
+    - name: verify-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.run-build-vm-image.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.run-build-vm-image.results.IMAGE_DIGEST)
+        - name: SBOM_BLOB_URL
+          value: $(tasks.run-build-vm-image.results.SBOM_BLOB_URL)
+      taskSpec:
+        params:
+          - name: IMAGE_URL
+          - name: IMAGE_DIGEST
+          - name: SBOM_BLOB_URL
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: check-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            env:
+              - name: IMAGE_URL
+                value: $(params.IMAGE_URL)
+              - name: IMAGE_DIGEST
+                value: $(params.IMAGE_DIGEST)
+              - name: SBOM_BLOB_URL
+                value: $(params.SBOM_BLOB_URL)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+              echo "Verifying SBOM on disk image: ${IMAGE_REF}"
+
+              echo "=== Check 1: SBOM can be downloaded ==="
+              SBOM=$(cosign download sbom "${IMAGE_REF}")
+              echo "${SBOM}" | jq .
+
+              echo "=== Check 2: SBOM has packages ==="
+              PKG_COUNT=$(echo "${SBOM}" | jq '.packages | length')
+              if [ "${PKG_COUNT}" -eq 0 ]; then
+                echo "FAIL: SBOM has no packages" && exit 1
+              fi
+              echo "PASS: SBOM has ${PKG_COUNT} package(s)"
+
+              echo "=== Check 3: SBOM contains test-package ==="
+              if ! echo "${SBOM}" | jq -e '.packages[] | select(.name == "test-package")' > /dev/null; then
+                echo "FAIL: test-package not found in SBOM" && exit 1
+              fi
+              echo "PASS: test-package found"
+
+              echo "=== Check 4: SBOM_BLOB_URL is non-empty ==="
+              if [ -z "${SBOM_BLOB_URL}" ]; then
+                echo "FAIL: SBOM_BLOB_URL is empty" && exit 1
+              fi
+              echo "PASS: SBOM_BLOB_URL = ${SBOM_BLOB_URL}"
+
+              echo "=== Check 5: SBOM is not a placeholder ==="
+              if echo "${SBOM}" | jq -e '.comment' > /dev/null 2>&1; then
+                COMMENT=$(echo "${SBOM}" | jq -r '.comment')
+                if [[ "${COMMENT}" == *"placeholder"* ]]; then
+                  echo "FAIL: SBOM is a placeholder" && exit 1
+                fi
+              fi
+              echo "PASS: SBOM is not a placeholder"
+
+              echo "All checks passed"
+      runAfter:
+        - run-build-vm-image

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-happy-path.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-happy-path.yaml
@@ -22,7 +22,7 @@ spec:
               optional: true
         steps:
           - name: push-source-and-attach-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -108,7 +108,7 @@ spec:
               optional: true
         steps:
           - name: check-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-multi-arch-fallback.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-multi-arch-fallback.yaml
@@ -23,7 +23,7 @@ spec:
               optional: true
         steps:
           - name: push-multiarch-source-no-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -129,7 +129,7 @@ spec:
               optional: true
         steps:
           - name: check-placeholder-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-multi-arch-fallback.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-multi-arch-fallback.yaml
@@ -1,0 +1,196 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-build-vm-image-sbom-multi-arch-fallback
+spec:
+  description: |
+    Test that the build-vm-image task correctly detects a multi-arch source image
+    (passes --platform to cosign) but falls back to a placeholder SBOM when no
+    SBOM is attached to the per-arch manifest.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup-source-image
+      taskSpec:
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: push-multiarch-source-no-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              REPO="registry-service.kind-registry/test-source"
+
+              echo "=== Pushing per-arch images (no SBOM on either) ==="
+              cd /tmp
+              echo "amd64-content-no-sbom" > amd64.txt
+              oras push --no-tty "${REPO}:amd64" amd64.txt
+              AMD64_DIGEST=$(oras resolve "${REPO}:amd64")
+              echo "amd64 digest: ${AMD64_DIGEST}"
+
+              echo "arm64-content-no-sbom" > arm64.txt
+              oras push --no-tty "${REPO}:arm64" arm64.txt
+              ARM64_DIGEST=$(oras resolve "${REPO}:arm64")
+              echo "arm64 digest: ${ARM64_DIGEST}"
+
+              echo "=== Creating OCI image index ==="
+              cat > index.json <<EOF
+              {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                  {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "${AMD64_DIGEST}",
+                    "size": $(skopeo inspect --raw "docker://${REPO}@${AMD64_DIGEST}" | wc -c),
+                    "platform": { "architecture": "amd64", "os": "linux" }
+                  },
+                  {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "${ARM64_DIGEST}",
+                    "size": $(skopeo inspect --raw "docker://${REPO}@${ARM64_DIGEST}" | wc -c),
+                    "platform": { "architecture": "arm64", "os": "linux" }
+                  }
+                ]
+              }
+              EOF
+              cat index.json
+
+              REGISTRY="registry-service.kind-registry"
+              INDEX_CT="application/vnd.oci.image.index.v1+json"
+              curl -fsSL -X PUT \
+                -H "Content-Type: ${INDEX_CT}" \
+                -d @index.json \
+                "https://${REGISTRY}/v2/test-source/manifests/test" \
+                --cacert /etc/pki/tls/certs/ca-custom-bundle.crt || \
+              curl -fsSL -X PUT \
+                -H "Content-Type: ${INDEX_CT}" \
+                -d @index.json \
+                "http://${REGISTRY}/v2/test-source/manifests/test"
+
+              echo "=== Verifying index ==="
+              skopeo inspect --raw "docker://${REPO}:test" | jq .
+
+              echo "Setup complete — multi-arch index with no SBOM on any manifest"
+
+    - name: run-build-vm-image
+      taskRef:
+        name: build-vm-image
+      params:
+        - name: PLATFORM
+          value: linux/amd64
+        - name: OUTPUT_IMAGE
+          value: registry-service.kind-registry/test-disk-image:latest
+        - name: SOURCE_ARTIFACT
+          value: unused
+        - name: IMAGE_TYPE
+          value: qcow2
+        - name: SBOM_TYPE
+          value: spdx
+        - name: SKIP_SBOM_GENERATION
+          value: "false"
+      runAfter:
+        - setup-source-image
+
+    - name: verify-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.run-build-vm-image.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.run-build-vm-image.results.IMAGE_DIGEST)
+        - name: SBOM_BLOB_URL
+          value: $(tasks.run-build-vm-image.results.SBOM_BLOB_URL)
+      taskSpec:
+        params:
+          - name: IMAGE_URL
+          - name: IMAGE_DIGEST
+          - name: SBOM_BLOB_URL
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: check-placeholder-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            env:
+              - name: IMAGE_URL
+                value: $(params.IMAGE_URL)
+              - name: IMAGE_DIGEST
+                value: $(params.IMAGE_DIGEST)
+              - name: SBOM_BLOB_URL
+                value: $(params.SBOM_BLOB_URL)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+              echo "Verifying placeholder SBOM on disk image: ${IMAGE_REF}"
+
+              echo "=== Check 1: SBOM can be downloaded ==="
+              SBOM=$(cosign download sbom "${IMAGE_REF}")
+              echo "${SBOM}" | jq .
+
+              echo "=== Check 2: SBOM is SPDX format ==="
+              if ! echo "${SBOM}" | jq -e '.spdxVersion == "SPDX-2.3"' > /dev/null; then
+                echo "FAIL: not an SPDX-2.3 document" && exit 1
+              fi
+              echo "PASS: spdxVersion is SPDX-2.3"
+
+              echo "=== Check 3: SBOM has empty packages (placeholder) ==="
+              PKG_COUNT=$(echo "${SBOM}" | jq '.packages | length')
+              if [ "${PKG_COUNT}" -ne 0 ]; then
+                echo "FAIL: expected 0 packages in placeholder, got ${PKG_COUNT}" && exit 1
+              fi
+              echo "PASS: packages array is empty"
+
+              echo "=== Check 4: SBOM_BLOB_URL is non-empty ==="
+              if [ -z "${SBOM_BLOB_URL}" ]; then
+                echo "FAIL: SBOM_BLOB_URL is empty" && exit 1
+              fi
+              echo "PASS: SBOM_BLOB_URL = ${SBOM_BLOB_URL}"
+
+              echo "=== Check 5: SBOM is a placeholder ==="
+              IS_PLACEHOLDER=false
+              if echo "${SBOM}" | jq -e '.comment' > /dev/null 2>&1; then
+                COMMENT=$(echo "${SBOM}" | jq -r '.comment')
+                if [[ "${COMMENT}" == *"placeholder"* ]]; then
+                  IS_PLACEHOLDER=true
+                fi
+              fi
+              if echo "${SBOM}" | jq -e '.creationInfo.comment' > /dev/null 2>&1; then
+                CREATION_COMMENT=$(echo "${SBOM}" | jq -r '.creationInfo.comment')
+                if [[ "${CREATION_COMMENT}" == *"placeholder"* ]]; then
+                  IS_PLACEHOLDER=true
+                fi
+              fi
+              if [ "${IS_PLACEHOLDER}" != "true" ]; then
+                echo "FAIL: SBOM should be a placeholder but has no placeholder marker" && exit 1
+              fi
+              echo "PASS: SBOM is a placeholder (multi-arch detection ran but no SBOM found)"
+
+              echo "All checks passed — multi-arch fallback to placeholder works correctly"
+      runAfter:
+        - run-build-vm-image

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-multi-arch.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-multi-arch.yaml
@@ -1,0 +1,222 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-build-vm-image-sbom-multi-arch
+spec:
+  description: |
+    Test that the build-vm-image task resolves a multi-arch image index to the
+    per-arch manifest before downloading the SBOM. The SBOM is attached only to
+    the per-arch manifest (not the index), matching real Konflux behavior.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: setup-source-image
+      taskSpec:
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: push-multiarch-source
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              REPO="registry-service.kind-registry/test-source"
+
+              echo "=== Pushing per-arch images ==="
+              cd /tmp
+              echo "amd64-content" > amd64.txt
+              oras push --no-tty "${REPO}:amd64" amd64.txt
+              AMD64_DIGEST=$(oras resolve "${REPO}:amd64")
+              echo "amd64 digest: ${AMD64_DIGEST}"
+
+              echo "arm64-content" > arm64.txt
+              oras push --no-tty "${REPO}:arm64" arm64.txt
+              ARM64_DIGEST=$(oras resolve "${REPO}:arm64")
+              echo "arm64 digest: ${ARM64_DIGEST}"
+
+              echo "=== Creating OCI image index ==="
+              cat > index.json <<EOF
+              {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.index.v1+json",
+                "manifests": [
+                  {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "${AMD64_DIGEST}",
+                    "size": $(skopeo inspect --raw "docker://${REPO}@${AMD64_DIGEST}" | wc -c),
+                    "platform": { "architecture": "amd64", "os": "linux" }
+                  },
+                  {
+                    "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                    "digest": "${ARM64_DIGEST}",
+                    "size": $(skopeo inspect --raw "docker://${REPO}@${ARM64_DIGEST}" | wc -c),
+                    "platform": { "architecture": "arm64", "os": "linux" }
+                  }
+                ]
+              }
+              EOF
+              cat index.json
+
+              # Push the index manifest directly via the registry API
+              INDEX_CT="application/vnd.oci.image.index.v1+json"
+              REGISTRY="registry-service.kind-registry"
+              curl -fsSL -X PUT \
+                -H "Content-Type: ${INDEX_CT}" \
+                -d @index.json \
+                "https://${REGISTRY}/v2/test-source/manifests/test" \
+                --cacert /etc/pki/tls/certs/ca-custom-bundle.crt || \
+              curl -fsSL -X PUT \
+                -H "Content-Type: ${INDEX_CT}" \
+                -d @index.json \
+                "http://${REGISTRY}/v2/test-source/manifests/test"
+
+              echo "=== Verifying index ==="
+              skopeo inspect --raw "docker://${REPO}:test" | jq .
+
+              echo "=== Attaching SBOM to amd64 manifest only ==="
+              cat > test-sbom.json <<'SBOM_EOF'
+              {
+                "spdxVersion": "SPDX-2.3",
+                "dataLicense": "CC0-1.0",
+                "SPDXID": "SPDXRef-DOCUMENT",
+                "name": "test-multiarch-sbom",
+                "documentNamespace": "https://test.example.com/multiarch-sbom",
+                "creationInfo": {
+                  "creators": ["Tool: test-harness"],
+                  "created": "2024-01-01T00:00:00Z"
+                },
+                "packages": [
+                  {
+                    "SPDXID": "SPDXRef-Package-multiarch-test",
+                    "name": "multiarch-test-package",
+                    "versionInfo": "2.0.0",
+                    "downloadLocation": "NOASSERTION",
+                    "supplier": "NOASSERTION"
+                  }
+                ]
+              }
+              SBOM_EOF
+
+              cosign attach sbom --sbom test-sbom.json --type spdx "${REPO}@${AMD64_DIGEST}"
+              echo "SBOM attached to amd64 manifest (not index)"
+
+              echo "=== Verify: index-level SBOM should NOT exist ==="
+              INDEX_DIGEST=$(oras resolve "${REPO}:test")
+              if cosign download sbom "${REPO}@${INDEX_DIGEST}" 2>/dev/null; then
+                echo "WARNING: index has its own SBOM (unexpected but not fatal)"
+              else
+                echo "OK: no SBOM at index level — task must resolve to per-arch"
+              fi
+
+              echo "Setup complete"
+
+    - name: run-build-vm-image
+      taskRef:
+        name: build-vm-image
+      params:
+        - name: PLATFORM
+          value: linux/amd64
+        - name: OUTPUT_IMAGE
+          value: registry-service.kind-registry/test-disk-image:latest
+        - name: SOURCE_ARTIFACT
+          value: unused
+        - name: IMAGE_TYPE
+          value: qcow2
+        - name: SBOM_TYPE
+          value: spdx
+        - name: SKIP_SBOM_GENERATION
+          value: "false"
+      runAfter:
+        - setup-source-image
+
+    - name: verify-sbom
+      params:
+        - name: IMAGE_URL
+          value: $(tasks.run-build-vm-image.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.run-build-vm-image.results.IMAGE_DIGEST)
+        - name: SBOM_BLOB_URL
+          value: $(tasks.run-build-vm-image.results.SBOM_BLOB_URL)
+      taskSpec:
+        params:
+          - name: IMAGE_URL
+          - name: IMAGE_DIGEST
+          - name: SBOM_BLOB_URL
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: check-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            env:
+              - name: IMAGE_URL
+                value: $(params.IMAGE_URL)
+              - name: IMAGE_DIGEST
+                value: $(params.IMAGE_DIGEST)
+              - name: SBOM_BLOB_URL
+                value: $(params.SBOM_BLOB_URL)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+              echo "Verifying SBOM on disk image: ${IMAGE_REF}"
+
+              echo "=== Check 1: SBOM can be downloaded ==="
+              SBOM=$(cosign download sbom "${IMAGE_REF}")
+              echo "${SBOM}" | jq .
+
+              echo "=== Check 2: SBOM has packages ==="
+              PKG_COUNT=$(echo "${SBOM}" | jq '.packages | length')
+              if [ "${PKG_COUNT}" -eq 0 ]; then
+                echo "FAIL: SBOM has no packages (index-level stub?)" && exit 1
+              fi
+              echo "PASS: SBOM has ${PKG_COUNT} package(s)"
+
+              echo "=== Check 3: SBOM contains multiarch-test-package ==="
+              if ! echo "${SBOM}" | jq -e '.packages[] | select(.name == "multiarch-test-package")' > /dev/null; then
+                echo "FAIL: multiarch-test-package not found — task did not resolve per-arch manifest" && exit 1
+              fi
+              echo "PASS: multiarch-test-package found (per-arch resolution worked)"
+
+              echo "=== Check 4: SBOM_BLOB_URL is non-empty ==="
+              if [ -z "${SBOM_BLOB_URL}" ]; then
+                echo "FAIL: SBOM_BLOB_URL is empty" && exit 1
+              fi
+              echo "PASS: SBOM_BLOB_URL = ${SBOM_BLOB_URL}"
+
+              echo "=== Check 5: SBOM is not a placeholder ==="
+              if echo "${SBOM}" | jq -e '.comment' > /dev/null 2>&1; then
+                COMMENT=$(echo "${SBOM}" | jq -r '.comment')
+                if [[ "${COMMENT}" == *"placeholder"* ]]; then
+                  echo "FAIL: SBOM is a placeholder — per-arch resolution failed" && exit 1
+                fi
+              fi
+              echo "PASS: SBOM is not a placeholder"
+
+              echo "All checks passed — multi-arch index resolution works correctly"
+      runAfter:
+        - run-build-vm-image

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-multi-arch.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-multi-arch.yaml
@@ -23,7 +23,7 @@ spec:
               optional: true
         steps:
           - name: push-multiarch-source
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -165,7 +165,7 @@ spec:
               optional: true
         steps:
           - name: check-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-skip.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-skip.yaml
@@ -50,7 +50,7 @@ spec:
               optional: true
         steps:
           - name: check-no-sbom
-            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
             volumeMounts:
               - name: trusted-ca
                 mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-skip.yaml
+++ b/task/build-vm-image/0.2/tests/test-build-vm-image-sbom-skip.yaml
@@ -1,0 +1,85 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-build-vm-image-sbom-skip
+spec:
+  description: |
+    Test that the build-vm-image task skips SBOM propagation when
+    SKIP_SBOM_GENERATION is set to true, and produces an empty SBOM_BLOB_URL.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: run-build-vm-image
+      taskRef:
+        name: build-vm-image
+      params:
+        - name: PLATFORM
+          value: linux/amd64
+        - name: OUTPUT_IMAGE
+          value: registry-service.kind-registry/test-disk-image:latest
+        - name: SOURCE_ARTIFACT
+          value: unused
+        - name: IMAGE_TYPE
+          value: qcow2
+        - name: SBOM_TYPE
+          value: spdx
+        - name: SKIP_SBOM_GENERATION
+          value: "true"
+
+    - name: verify-skip
+      params:
+        - name: SBOM_BLOB_URL
+          value: $(tasks.run-build-vm-image.results.SBOM_BLOB_URL)
+        - name: IMAGE_URL
+          value: $(tasks.run-build-vm-image.results.IMAGE_URL)
+        - name: IMAGE_DIGEST
+          value: $(tasks.run-build-vm-image.results.IMAGE_DIGEST)
+      taskSpec:
+        params:
+          - name: SBOM_BLOB_URL
+          - name: IMAGE_URL
+          - name: IMAGE_DIGEST
+        volumes:
+          - name: trusted-ca
+            configMap:
+              name: trusted-ca
+              items:
+                - key: ca-bundle.crt
+                  path: ca-bundle.crt
+              optional: true
+        steps:
+          - name: check-no-sbom
+            image: quay.io/konflux-ci/task-runner:1.6.0@sha256:1abfe4e50d4e961d0fd9790202565f93ee650fe8dfc50932c94989acba10485f
+            volumeMounts:
+              - name: trusted-ca
+                mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+                subPath: ca-bundle.crt
+                readOnly: true
+            env:
+              - name: SBOM_BLOB_URL
+                value: $(params.SBOM_BLOB_URL)
+              - name: IMAGE_URL
+                value: $(params.IMAGE_URL)
+              - name: IMAGE_DIGEST
+                value: $(params.IMAGE_DIGEST)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              echo "=== Check 1: SBOM_BLOB_URL is empty ==="
+              if [ -n "${SBOM_BLOB_URL}" ]; then
+                echo "FAIL: SBOM_BLOB_URL should be empty but got: ${SBOM_BLOB_URL}" && exit 1
+              fi
+              echo "PASS: SBOM_BLOB_URL is empty"
+
+              echo "=== Check 2: No SBOM attached to disk image ==="
+              IMAGE_REF="${IMAGE_URL}@${IMAGE_DIGEST}"
+              if cosign download sbom "${IMAGE_REF}" > /dev/null 2>&1; then
+                echo "FAIL: SBOM should not be attached when SKIP_SBOM_GENERATION=true" && exit 1
+              fi
+              echo "PASS: No SBOM attached to disk image"
+
+              echo "All checks passed"
+      runAfter:
+        - run-build-vm-image

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
+
+## Unreleased
+
+<!--
+When you make changes without bumping the version right away, document them here.
+If that's not something you ever plan to do, consider removing this section.
+-->
+
+*Nothing yet.*
+
+## 0.2
+
+### Added
+
+- Started tracking changes in this file.
+- SBOM support: download source container SBOM and attach it to the disk image artifact.
+- New params: `SBOM_TYPE`, `SKIP_SBOM_GENERATION`.
+- New result: `SBOM_BLOB_URL`.
+- Multi-arch image index resolution for per-arch SBOM download.


### PR DESCRIPTION
## Summary

Adds `build-vm-image` task version 0.2 with SBOM support for disk images.

Disk images built by `build-vm-image` are 1:1 filesystem conversions of bootc container images (via bootc-image-builder). Since the source container already has a full SBOM (generated by the `buildah` task via syft+mobster), this task downloads that SBOM and attaches it to the disk image OCI artifact.

### Changes from 0.1

- **3 new steps**: `sbom-download`, `upload-sbom`, `report-sbom-url`
- **New params**: `SBOM_TYPE` (default: spdx), `SKIP_SBOM_GENERATION` (default: false)
- **New result**: `SBOM_BLOB_URL`
- Resolves multi-arch image indexes to per-arch manifests before downloading SBOMs (index-level SBOMs only contain image metadata, not package-level data)
- Follows the same `cosign attach sbom` + `SBOM_BLOB_URL` pattern used by `buildah`, `oci-copy`, and `modelcar-oci-ta` tasks
- SBOM steps use `runAsUser: 0`, consistent with `buildah-remote`

### Why

Enterprise Contract policies currently exclude `sbom.found` for disk images as a workaround. This closes that gap so the exclusion can be removed.

### Testing

Tested end-to-end via git resolvers:
- bootc MR → konflux-data pipeline → this task (0.2)
- SBOM download, attach, and result reporting all validated against RHELAI disk image builds

Includes `MIGRATION.md` and `README.md`.