### PR TITLE
Don't force migration to modify pipelines

### DIFF
--- a/hack/validate-migration.sh
+++ b/hack/validate-migration.sh
@@ -123,7 +123,7 @@ list_preprocessed_pipelines() {
 # Only the pipelines included in the build pipeline config are checked.
 # This function checks two aspects:
 # - whether the migration file exits successfully or not.
-# - whether the migration file modifies a pipeline. If nothing changed, it is treated a failure.
+# - whether the migration file modifies a pipeline. If nothing changed, it is logged as informational.
 # The modified pipeline is saved into a separate file with suffix '.modified'.
 check_apply_on_pipelines() {
     local -r migration_file=$1
@@ -159,7 +159,7 @@ check_apply_on_pipelines() {
         )
         info "${FUNCNAME[0]}: migration file does not modify any of pipelines ${pl_names[*]}"
     fi
-    if [ -n "$failed" ] || [ -z "$updated" ]; then
+    if [ -n "$failed" ]; then
         return 1
     else
         return 0
@@ -336,9 +336,8 @@ check_apply_in_real_cluster() {
     apply_logfile=$(mktemp --suffix="-${FUNCNAME[0]}")
     modified_pipeline_files=$(find "${WORK_DIR}/pipelines" -type f -name "*.modified")
     if [ -z "$modified_pipeline_files" ]; then
-        error "No modified pipeline file is found."
-        error "Please check if migrations work correctly to update pipelines."
-        exit 1
+        info "No modified pipeline file is found. Skipping in-cluster validation."
+        return 0
     fi
     while read -r pl_file; do
         info "apply pipeline with migrations in namespace ${K8S_TEST_NS}: ${pl_file}"


### PR DESCRIPTION
Migration validation currently fails if the migration hasn't made an actual change.

However, there's a possible use case for a migration to do an update only conditionally and thus sometimes do not do an update leading to a validation failure.
