### PR TITLE
ART-21342: expose EFFECTIVE_TIME param in enterprise-contract pipeline

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -82,7 +82,8 @@ spec:
       default: "true"
     - name: EFFECTIVE_TIME
       type: string
-      description: Run policy checks with the provided time.
+      description: Run policy checks with the provided time. Expects a
+        RFC3339 formatted value, e.g. "2026-06-24T00:00:00Z"
       default: "now"
   results:
     - name: TEST_OUTPUT

--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -80,6 +80,10 @@ spec:
         Setting to false is useful on specific conditions but will always mark the integration test as successful and
         humans will tend to ignore the test results if they failed. Use with caution.
       default: "true"
+    - name: EFFECTIVE_TIME
+      type: string
+      description: Run policy checks with the provided time.
+      default: "now"
   results:
     - name: TEST_OUTPUT
       value: "$(tasks.verify.results.TEST_OUTPUT)"
@@ -137,6 +141,8 @@ spec:
           value: "$(params.SINGLE_COMPONENT)"
         - name: SINGLE_COMPONENT_CUSTOM_RESOURCE
           value: "$(params.SINGLE_COMPONENT_CUSTOM_RESOURCE)"
+        - name: EFFECTIVE_TIME
+          value: "$(params.EFFECTIVE_TIME)"
       taskRef:
         resolver: bundles
         params:


### PR DESCRIPTION
## Summary

- Expose the `EFFECTIVE_TIME` parameter in the `enterprise-contract` pipeline, passing it through to the `verify-enterprise-contract` task
- The underlying `verify-enterprise-contract` task already supports this parameter (passed as `--effective-time` to ec-cli), but the pipeline did not expose it

## Motivation

Build systems need to evaluate EC policies as of a future date -- specifically the scheduled release ship date -- so that rules with upcoming `effective_on` dates are caught during build time, before they become enforced at release time.

Without this pass-through, callers have no way to override the evaluation time and policies are always checked against "now".

Relates to https://redhat.atlassian.net/browse/ART-20711 and https://redhat.atlassian.net/browse/EC-1910

## Changes

- Added `EFFECTIVE_TIME` pipeline param (type: string, default: `"now"`)
- Wired it through to the `verify` task params

Default behavior is unchanged -- existing callers that do not set `EFFECTIVE_TIME` will continue to use `"now"`.

## Test plan

- Verify existing EC pipeline runs still pass (default "now" behavior unchanged)
- Verify that passing a future date string causes ec-cli to evaluate time-gated rules accordingly
