### PR TITLE
buildah: add option to allow crossplatfrom parent images

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -56,6 +56,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_BASE_IMAGES| Additional base image references to include to the SBOM. Array of image_reference_with_digest strings| []| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| ""| |
+|ALLOW_CROSS_PLATFORM_IMAGES| Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.| false| |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| ""| |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|

--- a/pipelines/docker-build-oci-ta-min/README.md
+++ b/pipelines/docker-build-oci-ta-min/README.md
@@ -47,6 +47,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_BASE_IMAGES| Additional base image references to include to the SBOM. Array of image_reference_with_digest strings| []| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| ""| |
+|ALLOW_CROSS_PLATFORM_IMAGES| Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.| false| |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| ""| |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -55,6 +55,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_BASE_IMAGES| Additional base image references to include to the SBOM. Array of image_reference_with_digest strings| []| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| ""| |
+|ALLOW_CROSS_PLATFORM_IMAGES| Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.| false| |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| ""| |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -55,6 +55,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_BASE_IMAGES| Additional base image references to include to the SBOM. Array of image_reference_with_digest strings| []| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| ""| |
+|ALLOW_CROSS_PLATFORM_IMAGES| Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.| false| |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| ""| |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -54,6 +54,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |ADDITIONAL_BASE_IMAGES| Additional base image references to include to the SBOM. Array of image_reference_with_digest strings| []| |
 |ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
 |ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| ""| |
+|ALLOW_CROSS_PLATFORM_IMAGES| Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.| false| |
 |ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
 |ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| ""| |
 |BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| |

--- a/task/buildah-min/0.10/README.md
+++ b/task/buildah-min/0.10/README.md
@@ -60,6 +60,8 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |SOURCE_DATE_EPOCH|Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.|""|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
 |SKIP_INJECTIONS|Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.|false|false|
+|LOG_LEVEL|Log level for the build command.|info|false|
+|ALLOW_CROSS_PLATFORM_IMAGES|Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah-min/0.10/buildah-min.yaml
+++ b/task/buildah-min/0.10/buildah-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.2
+    app.kubernetes.io/version: 0.10.3
     build.appstudio.redhat.com/build_type: docker
   name: buildah-min
 spec:
@@ -246,6 +246,11 @@ spec:
     description: Log level for the build command.
     name: LOG_LEVEL
     type: string
+  - default: "false"
+    description: Allows to use parent images that don't match the build host architecture.
+      This option must be used with caution as it may create incompatible images.
+    name: ALLOW_CROSS_PLATFORM_IMAGES
+    type: string
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -323,6 +328,8 @@ spec:
       value: $(params.SBOM_SKIP_VALIDATION)
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - mountPath: /shared
@@ -364,7 +371,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
     name: build
     script: |
       #!/bin/bash
@@ -528,6 +535,7 @@ spec:
           --ulimits nofile=4096:4096
           --src-tls-verify="$TLSVERIFY"
           --dest-tls-verify="$TLSVERIFY"
+          --allow-cross-platform-images="$ALLOW_CROSS_PLATFORM_IMAGES"
           "$@"  # --annotations, --labels, --envs, --build-args
       )
 

--- a/task/buildah-min/CHANGELOG.md
+++ b/task/buildah-min/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.3
+
+### Added
+
+- Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
+  which don't match build host architecture.
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-oci-ta-min/0.10/README.md
+++ b/task/buildah-oci-ta-min/0.10/README.md
@@ -11,6 +11,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|ALLOW_CROSS_PLATFORM_IMAGES|Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.|false|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
@@ -31,6 +32,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|LOG_LEVEL|Log level for the build command.|info|false|
 |NO_PROXY|Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.|""|false|
 |OMIT_HISTORY|Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.|false|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|

--- a/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.2
+    app.kubernetes.io/version: 0.10.3
     build.appstudio.redhat.com/build_type: docker
   name: buildah-oci-ta-min
 spec:
@@ -33,6 +33,11 @@ spec:
     description: Comma separated list of extra capabilities to add when running 'buildah
       build'
     name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Allows to use parent images that don't match the build host architecture.
+      This option must be used with caution as it may create incompatible images.
+    name: ALLOW_CROSS_PLATFORM_IMAGES
     type: string
   - default: []
     description: Additional key=value annotations that should be applied to the image
@@ -278,6 +283,8 @@ spec:
       value: $(params.ADDITIONAL_SECRET)
     - name: ADD_CAPABILITIES
       value: $(params.ADD_CAPABILITIES)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
     - name: BUILD_ARGS_FILE
@@ -387,7 +394,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
     name: build
     script: |
       #!/bin/bash
@@ -551,6 +558,7 @@ spec:
         --ulimits nofile=4096:4096
         --src-tls-verify="$TLSVERIFY"
         --dest-tls-verify="$TLSVERIFY"
+        --allow-cross-platform-images="$ALLOW_CROSS_PLATFORM_IMAGES"
         "$@" # --annotations, --labels, --envs, --build-args
       )
 

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.3
+
+### Added
+
+- Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
+  which don't match build host architecture.
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-oci-ta/0.10/README.md
+++ b/task/buildah-oci-ta/0.10/README.md
@@ -11,6 +11,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|ALLOW_CROSS_PLATFORM_IMAGES|Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.|false|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|

--- a/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.2
+    app.kubernetes.io/version: 0.10.3
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -34,6 +34,12 @@ spec:
         running 'buildah build'
       type: string
       default: ""
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      description: Allows to use parent images that don't match the build
+        host architecture. This option must be used with caution as it may
+        create incompatible images.
+      type: string
+      default: "false"
     - name: ANNOTATIONS
       description: Additional key=value annotations that should be applied
         to the image
@@ -327,6 +333,8 @@ spec:
         value: $(params.ADDITIONAL_SECRET)
       - name: ADD_CAPABILITIES
         value: $(params.ADD_CAPABILITIES)
+      - name: ALLOW_CROSS_PLATFORM_IMAGES
+        value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
       - name: ANNOTATIONS_FILE
         value: $(params.ANNOTATIONS_FILE)
       - name: BUILD_ARGS_FILE
@@ -400,7 +408,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -609,6 +617,7 @@ spec:
           --ulimits nofile=4096:4096
           --src-tls-verify="$TLSVERIFY"
           --dest-tls-verify="$TLSVERIFY"
+          --allow-cross-platform-images="$ALLOW_CROSS_PLATFORM_IMAGES"
           "$@" # --annotations, --labels, --envs, --build-args
         )
 

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.3
+
+### Added
+
+- Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
+  which don't match build host architecture.
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-remote-oci-ta/0.10/README.md
+++ b/task/buildah-remote-oci-ta/0.10/README.md
@@ -11,6 +11,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |ADDITIONAL_BASE_IMAGES|Additional base image references to include to the SBOM. Array of image_reference_with_digest strings|[]|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |ADD_CAPABILITIES|Comma separated list of extra capabilities to add when running 'buildah build'|""|false|
+|ALLOW_CROSS_PLATFORM_IMAGES|Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.|false|false|
 |ANNOTATIONS|Additional key=value annotations that should be applied to the image|[]|false|
 |ANNOTATIONS_FILE|Path to a file with additional key=value annotations that should be applied to the image|""|false|
 |BUILDAH_FORMAT|The format for the resulting image's mediaType. Valid values are oci (default) or docker.|oci|false|
@@ -31,6 +32,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |IMAGE_EXPIRES_AFTER|Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.|""|false|
 |INHERIT_BASE_IMAGE_LABELS|Determines if the image inherits the base image labels.|true|false|
 |LABELS|Additional key=value labels that should be applied to the image|[]|false|
+|LOG_LEVEL|Log level for the build command.|info|false|
 |NO_PROXY|Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.|""|false|
 |OMIT_HISTORY|Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.|false|false|
 |PREFETCH_INPUT|In case it is not empty, the prefetched content should be made available to the build.|""|false|

--- a/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.2
+    app.kubernetes.io/version: 0.10.3
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -32,6 +32,11 @@ spec:
     description: Comma separated list of extra capabilities to add when running 'buildah
       build'
     name: ADD_CAPABILITIES
+    type: string
+  - default: "false"
+    description: Allows to use parent images that don't match the build host architecture.
+      This option must be used with caution as it may create incompatible images.
+    name: ALLOW_CROSS_PLATFORM_IMAGES
     type: string
   - default: []
     description: Additional key=value annotations that should be applied to the image
@@ -285,6 +290,8 @@ spec:
       value: $(params.ADDITIONAL_SECRET)
     - name: ADD_CAPABILITIES
       value: $(params.ADD_CAPABILITIES)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     - name: ANNOTATIONS_FILE
       value: $(params.ANNOTATIONS_FILE)
     - name: BUILD_ARGS_FILE
@@ -340,7 +347,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -401,7 +408,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
     name: build
     script: |-
       #!/bin/bash
@@ -635,6 +642,7 @@ spec:
         --ulimits nofile=4096:4096
         --src-tls-verify="$TLSVERIFY"
         --dest-tls-verify="$TLSVERIFY"
+        --allow-cross-platform-images="$ALLOW_CROSS_PLATFORM_IMAGES"
         "$@" # --annotations, --labels, --envs, --build-args
       )
 
@@ -682,6 +690,7 @@ spec:
           --tmpfs /run/secrets \
           -e ADDITIONAL_SECRET="${ADDITIONAL_SECRET@Q}" \
           -e ADD_CAPABILITIES="${ADD_CAPABILITIES@Q}" \
+          -e ALLOW_CROSS_PLATFORM_IMAGES="${ALLOW_CROSS_PLATFORM_IMAGES@Q}" \
           -e ANNOTATIONS_FILE="${ANNOTATIONS_FILE@Q}" \
           -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
           -e BUILD_TIMESTAMP="${BUILD_TIMESTAMP@Q}" \

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.3
+
+### Added
+
+- Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
+  which don't match build host architecture.
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-remote/0.10/README.md
+++ b/task/buildah-remote/0.10/README.md
@@ -56,6 +56,8 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |SOURCE_DATE_EPOCH|Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.|""|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
 |SKIP_INJECTIONS|Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.|false|false|
+|LOG_LEVEL|Log level for the build command.|info|false|
+|ALLOW_CROSS_PLATFORM_IMAGES|Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.|false|false|
 |PLATFORM|The platform to build on||true|
 |IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
 

--- a/task/buildah-remote/0.10/buildah-remote.yaml
+++ b/task/buildah-remote/0.10/buildah-remote.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.2
+    app.kubernetes.io/version: 0.10.3
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -245,6 +245,11 @@ spec:
     description: Log level for the build command.
     name: LOG_LEVEL
     type: string
+  - default: "false"
+    description: Allows to use parent images that don't match the build host architecture.
+      This option must be used with caution as it may create incompatible images.
+    name: ALLOW_CROSS_PLATFORM_IMAGES
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -330,8 +335,10 @@ spec:
       value: $(params.SBOM_SKIP_VALIDATION)
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -378,7 +385,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
     name: build
     script: |-
       #!/bin/bash
@@ -612,6 +619,7 @@ spec:
           --ulimits nofile=4096:4096
           --src-tls-verify="$TLSVERIFY"
           --dest-tls-verify="$TLSVERIFY"
+          --allow-cross-platform-images="$ALLOW_CROSS_PLATFORM_IMAGES"
           "$@"  # --annotations, --labels, --envs, --build-args
       )
 
@@ -686,6 +694,7 @@ spec:
           -e CONTEXTUALIZE_SBOM="${CONTEXTUALIZE_SBOM@Q}" \
           -e SBOM_SKIP_VALIDATION="${SBOM_SKIP_VALIDATION@Q}" \
           -e SKIP_INJECTIONS="${SKIP_INJECTIONS@Q}" \
+          -e ALLOW_CROSS_PLATFORM_IMAGES="${ALLOW_CROSS_PLATFORM_IMAGES@Q}" \
           -e HOME="${HOME@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e SOURCE_URL="${SOURCE_URL@Q}" \

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.3
+
+### Added
+
+- Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
+  which don't match build host architecture.
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah/0.10/README.md
+++ b/task/buildah/0.10/README.md
@@ -56,6 +56,8 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |SOURCE_DATE_EPOCH|Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.|""|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
 |SKIP_INJECTIONS|Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.|false|false|
+|LOG_LEVEL|Log level for the build command.|info|false|
+|ALLOW_CROSS_PLATFORM_IMAGES|Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.|false|false|
 
 ## Results
 |name|description|

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.10.2"
+    app.kubernetes.io/version: "0.10.3"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -232,6 +232,11 @@ spec:
     description: Log level for the build command.
     type: string
     default: info
+  - name: ALLOW_CROSS_PLATFORM_IMAGES
+    description: Allows to use parent images that don't match the build host architecture. This
+      option must be used with caution as it may create incompatible images.
+    type: string
+    default: "false"
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -311,9 +316,11 @@ spec:
       value: $(params.SBOM_SKIP_VALIDATION)
     - name: SKIP_INJECTIONS
       value: $(params.SKIP_INJECTIONS)
+    - name: ALLOW_CROSS_PLATFORM_IMAGES
+      value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     imagePullPolicy: IfNotPresent
   steps:
-  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
     name: build
     computeResources:
       limits:
@@ -517,6 +524,7 @@ spec:
           --ulimits nofile=4096:4096
           --src-tls-verify="$TLSVERIFY"
           --dest-tls-verify="$TLSVERIFY"
+          --allow-cross-platform-images="$ALLOW_CROSS_PLATFORM_IMAGES"
           "$@"  # --annotations, --labels, --envs, --build-args
       )
 

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.3
+
+### Added
+
+- Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
+  which don't match build host architecture.
+
 ## 0.10.2
 
 ### Fixed


### PR DESCRIPTION
New task option ALLOW_CROSS_PLATFORM_IMAGES allows user to use images which doen't match platform of the build host.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
