### PR TITLE
e2e: update the checked symlink error message

### DIFF
--- a/e2e-tests/tests/build/build_templates.go
+++ b/e2e-tests/tests/build/build_templates.go
@@ -814,7 +814,7 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", ginkgo.Label("b
 			component, err := f.AsKubeAdmin.HasController.GetComponent(symlinkComponentName, testNamespace)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			gomega.Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", "", "",
-				f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 0}, nil)).Should(gomega.MatchError(gomega.ContainSubstring("cloned repository contains symlink pointing outside of the cloned repository")))
+				f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 0}, nil)).Should(gomega.MatchError(gomega.ContainSubstring("symlink check: found 1 symlink(s) pointing outside the directory")))
 		})
 
 	})


### PR DESCRIPTION
From current e2e run, it looks like the error msgs are these:

    time="2026-06-25T09:57:58Z" level=error msg="Symlink points outside directory: /workspace/output/source/os-release-symlink -> /usr/lib/os-release"
    time="2026-06-25T09:57:58Z" level=fatal msg="symlink check: found 1 symlink(s) pointing outside the directory"

But the e2e code checks for "cloned repository contains symlink pointing outside of the cloned repository". The problem seems to be the update from git clone task version 1 to version 2, which changed the err message. The update happened in https://github.com/konflux-ci/build-definitions/commit/fadae822ef69f4e5db5c7ce86913277a1294510e

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
