### PR TITLE
fix(renovate): group all task-runner updates into a single PR

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -272,6 +272,12 @@
         "task/package-operator-package-oci-ta/**",
         "task/package-operator-package/**"
       ]
+    },
+    {
+      "groupName": "task-runner",
+      "matchPackageNames": [
+        "quay.io/konflux-ci/task-runner"
+      ]
     }
   ],
   "postUpdateOptions": [


### PR DESCRIPTION
Add a matchPackageNames rule for quay.io/konflux-ci/task-runner so that updates to this image are consolidated into one PR rather than split across every file-path group that references it.


# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
