### PR TITLE
Release git-clone task 0.2.1

### DIFF
--- a/task/git-clone-oci-ta-min/0.2/git-clone-oci-ta-min.yaml
+++ b/task/git-clone-oci-ta-min/0.2/git-clone-oci-ta-min.yaml
@@ -9,7 +9,7 @@ metadata:
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: git
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: 0.2.1
   name: git-clone-oci-ta-min
 spec:
   description: The git-clone-oci-ta Task will clone a repo from the provided url and
@@ -196,7 +196,7 @@ spec:
       value: /var/workdir
     - name: KBC_GIT_CLONE_SUBDIRECTORY
       value: source
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:dd49bd35038c1cba174e6c166291e5df3d0d5f9be18ed3b2fb852fc6ce3181ed
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:b960a0972b6628b13b4fb4e803e16c427f0066f079a0d2cba6d47d81750a9eaa
     name: clone
     script: |
       #!/usr/bin/env bash

--- a/task/git-clone-oci-ta-min/CHANGELOG.md
+++ b/task/git-clone-oci-ta-min/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 <!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
 
+## 0.2.1
+
+- `refspec` parameter should now accept multiple refspecs separated by whitespace like in git-clone 0.1 [konflux-build-cli#155](https://github.com/konflux-ci/konflux-build-cli/issues/155)
+- Fix handling of whitespaces in gitconfig which should fix most of the issues with basic-auth [konflux-build-cli#159](https://github.com/konflux-ci/konflux-build-cli/pull/159)
+
 ## 0.2
 
 - Updated base task to git-clone-oci-ta 0.2.

--- a/task/git-clone-oci-ta/0.2/git-clone-oci-ta.yaml
+++ b/task/git-clone-oci-ta/0.2/git-clone-oci-ta.yaml
@@ -10,7 +10,7 @@ metadata:
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: git
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: 0.2.1
 spec:
   description: The git-clone-oci-ta Task will clone a repo from the provided
     url and store it as a trusted artifact in the provided OCI repository.
@@ -174,7 +174,7 @@ spec:
       optional: true
   steps:
     - name: clone
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:dd49bd35038c1cba174e6c166291e5df3d0d5f9be18ed3b2fb852fc6ce3181ed
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:b960a0972b6628b13b4fb4e803e16c427f0066f079a0d2cba6d47d81750a9eaa
       volumeMounts:
         - mountPath: /mnt/trusted-ca
           name: trusted-ca

--- a/task/git-clone-oci-ta/CHANGELOG.md
+++ b/task/git-clone-oci-ta/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1
+
+- `refspec` parameter should now accept multiple refspecs separated by whitespace like in git-clone 0.1 [konflux-build-cli#155](https://github.com/konflux-ci/konflux-build-cli/issues/155)
+- Fix handling of whitespaces in gitconfig which should fix most of the issues with basic-auth [konflux-build-cli#159](https://github.com/konflux-ci/konflux-build-cli/pull/159)
+
 ## 0.2
 
 - Use git-clone implementation from konflux-build-cli instead of inline Bash.

--- a/task/git-clone/0.2/git-clone.yaml
+++ b/task/git-clone/0.2/git-clone.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.2.1"
   annotations:
     tekton.dev/categories: Git
     tekton.dev/displayName: git clone
@@ -178,7 +178,7 @@ spec:
       value: $(params.noProxy)
     - name: KBC_LOG_LEVEL
       value: $(params.logLevel)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:dd49bd35038c1cba174e6c166291e5df3d0d5f9be18ed3b2fb852fc6ce3181ed
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:b960a0972b6628b13b4fb4e803e16c427f0066f079a0d2cba6d47d81750a9eaa
     computeResources:
       limits:
         memory: 2Gi

--- a/task/git-clone/CHANGELOG.md
+++ b/task/git-clone/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1
+
+- `refspec` parameter should now accept multiple refspecs separated by whitespace like in git-clone 0.1 [konflux-build-cli#155](https://github.com/konflux-ci/konflux-build-cli/issues/155)
+- Fix handling of whitespaces in gitconfig which should fix most of the issues with basic-auth [konflux-build-cli#159](https://github.com/konflux-ci/konflux-build-cli/pull/159)
+
 ## 0.2
 
 - Use git-clone implementation from konflux-build-cli instead of inline Bash.

--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/pnc-prebuild-git-clone-oci-ta.yaml
@@ -9,7 +9,7 @@ metadata:
     tekton.dev/platforms: linux/amd64,linux/s390x,linux/ppc64le,linux/arm64
     tekton.dev/tags: git
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: 0.2.1
   name: pnc-prebuild-git-clone-oci-ta
 spec:
   description: The pnc-prebuild-git-clone-oci-ta task will clone a repo from the provided
@@ -216,7 +216,7 @@ spec:
       value: /var/workdir
     - name: KBC_GIT_CLONE_SUBDIRECTORY
       value: source
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:dd49bd35038c1cba174e6c166291e5df3d0d5f9be18ed3b2fb852fc6ce3181ed
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:b960a0972b6628b13b4fb4e803e16c427f0066f079a0d2cba6d47d81750a9eaa
     name: clone
     script: |
       #!/usr/bin/env bash

--- a/task/pnc-prebuild-git-clone-oci-ta/CHANGELOG.md
+++ b/task/pnc-prebuild-git-clone-oci-ta/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1
+
+- `refspec` parameter should now accept multiple refspecs separated by whitespace like in git-clone 0.1 [konflux-build-cli#155](https://github.com/konflux-ci/konflux-build-cli/issues/155)
+- Fix handling of whitespaces in gitconfig which should fix most of the issues with basic-auth [konflux-build-cli#159](https://github.com/konflux-ci/konflux-build-cli/pull/159)
+
 ## 0.2
 
 - Updated base task to git-clone-oci-ta 0.2.


### PR DESCRIPTION
New version of konflux-build-cli includes two fixes for git-clone.
See CHANGELOGs.