### PR TITLE
Set expiry date for older version of build-image-index

### DIFF
--- a/task/build-image-index-min/0.2/build-image-index-min.yaml
+++ b/task/build-image-index-min/0.2/build-image-index-min.yaml
@@ -3,6 +3,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2026-08-30T00:00:00Z"
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:

--- a/task/build-image-index/0.2/build-image-index.yaml
+++ b/task/build-image-index/0.2/build-image-index.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "image-build, konflux"
+    build.appstudio.redhat.com/expires-on: "2026-08-30T00:00:00Z"
   name: build-image-index
 spec:
   description: |-


### PR DESCRIPTION
the 0.3 version is out for a while, I just forgot to do this step of the process.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
