### PR TITLE
task/buildah*: restore cachi2.env mount

### DIFF
--- a/task/buildah-min/0.10/buildah-min.yaml
+++ b/task/buildah-min/0.10/buildah-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.3
+    app.kubernetes.io/version: 0.10.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-min
 spec:
@@ -371,7 +371,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: build
     script: |
       #!/bin/bash
@@ -584,7 +584,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-min/CHANGELOG.md
+++ b/task/buildah-min/CHANGELOG.md
@@ -18,6 +18,17 @@ If that's not something you ever plan to do, consider removing this section.
 - Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
   which don't match build host architecture.
 
+### Changed
+
+- When used with prefetch-dependencies >= 0.3.1, no longer edits RUN instructions
+  in order to set the prefetch environment variables. Instead, sets the variables
+  using buildah `--mount` + `--secret` flags. Details in [konflux-build-cli#151].
+  Fixes [#1200].
+  - As a side effect, also no longer mounts the `/cachi2/cachi2.env` file,
+    whose only purpose was to enable the automatic setting of prefetch variables.
+
+[konflux-build-cli#151]: https://github.com/konflux-ci/konflux-build-cli/pull/151
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-min/CHANGELOG.md
+++ b/task/buildah-min/CHANGELOG.md
@@ -11,6 +11,15 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.4
+
+### Fixed
+
+- Restores the `/cachi2/cachi2.env` mount that version 0.10.3 removed.
+  Despite being an undocumented implementation detail, some builds use
+  the presence of this file as an indicator that the build is hermetic.
+  Enable them to do so for the time being.
+
 ## 0.10.3
 
 ### Added

--- a/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.3
+    app.kubernetes.io/version: 0.10.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-oci-ta-min
 spec:
@@ -394,7 +394,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: build
     script: |
       #!/bin/bash
@@ -614,7 +614,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -18,6 +18,17 @@ If that's not something you ever plan to do, consider removing this section.
 - Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
   which don't match build host architecture.
 
+### Changed
+
+- When used with prefetch-dependencies >= 0.3.1, no longer edits RUN instructions
+  in order to set the prefetch environment variables. Instead, sets the variables
+  using buildah `--mount` + `--secret` flags. Details in [konflux-build-cli#151].
+  Fixes [#1200].
+  - As a side effect, also no longer mounts the `/cachi2/cachi2.env` file,
+    whose only purpose was to enable the automatic setting of prefetch variables.
+
+[konflux-build-cli#151]: https://github.com/konflux-ci/konflux-build-cli/pull/151
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,15 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.4
+
+### Fixed
+
+- Restores the `/cachi2/cachi2.env` mount that version 0.10.3 removed.
+  Despite being an undocumented implementation detail, some builds use
+  the presence of this file as an indicator that the build is hermetic.
+  Enable them to do so for the time being.
+
 ## 0.10.3
 
 ### Added

--- a/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.3
+    app.kubernetes.io/version: 0.10.4
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -408,7 +408,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: build
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
       args:
         - --build-args
         - $(params.BUILD_ARGS[*])
@@ -651,7 +651,7 @@ spec:
             - SETFCAP
         runAsUser: 0
     - name: push
-      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+      image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
       workingDir: /var/workdir
       volumeMounts:
         - mountPath: /var/lib/containers

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -18,6 +18,17 @@ If that's not something you ever plan to do, consider removing this section.
 - Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
   which don't match build host architecture.
 
+### Changed
+
+- When used with prefetch-dependencies >= 0.3.1, no longer edits RUN instructions
+  in order to set the prefetch environment variables. Instead, sets the variables
+  using buildah `--mount` + `--secret` flags. Details in [konflux-build-cli#151].
+  Fixes [#1200].
+  - As a side effect, also no longer mounts the `/cachi2/cachi2.env` file,
+    whose only purpose was to enable the automatic setting of prefetch variables.
+
+[konflux-build-cli#151]: https://github.com/konflux-ci/konflux-build-cli/pull/151
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -11,6 +11,15 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.4
+
+### Fixed
+
+- Restores the `/cachi2/cachi2.env` mount that version 0.10.3 removed.
+  Despite being an undocumented implementation detail, some builds use
+  the presence of this file as an indicator that the build is hermetic.
+  Enable them to do so for the time being.
+
 ## 0.10.3
 
 ### Added

--- a/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.3
+    app.kubernetes.io/version: 0.10.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -347,7 +347,7 @@ spec:
     - name: YUM_REPOS_D_TARGET
       value: $(params.YUM_REPOS_D_TARGET)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
+      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -408,7 +408,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: build
     script: |-
       #!/bin/bash
@@ -794,7 +794,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -18,6 +18,17 @@ If that's not something you ever plan to do, consider removing this section.
 - Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
   which don't match build host architecture.
 
+### Changed
+
+- When used with prefetch-dependencies >= 0.3.1, no longer edits RUN instructions
+  in order to set the prefetch environment variables. Instead, sets the variables
+  using buildah `--mount` + `--secret` flags. Details in [konflux-build-cli#151].
+  Fixes [#1200].
+  - As a side effect, also no longer mounts the `/cachi2/cachi2.env` file,
+    whose only purpose was to enable the automatic setting of prefetch variables.
+
+[konflux-build-cli#151]: https://github.com/konflux-ci/konflux-build-cli/pull/151
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -11,6 +11,15 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.4
+
+### Fixed
+
+- Restores the `/cachi2/cachi2.env` mount that version 0.10.3 removed.
+  Despite being an undocumented implementation detail, some builds use
+  the presence of this file as an indicator that the build is hermetic.
+  Enable them to do so for the time being.
+
 ## 0.10.3
 
 ### Added

--- a/task/buildah-remote/0.10/buildah-remote.yaml
+++ b/task/buildah-remote/0.10/buildah-remote.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.3
+    app.kubernetes.io/version: 0.10.4
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -338,7 +338,7 @@ spec:
     - name: ALLOW_CROSS_PLATFORM_IMAGES
       value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     - name: BUILDER_IMAGE
-      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
+      value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     - name: PLATFORM
       value: $(params.PLATFORM)
     - name: IMAGE_APPEND_PLATFORM
@@ -385,7 +385,7 @@ spec:
       value: $(params.SOURCE_DATE_EPOCH)
     - name: BUILDAH_REWRITE_TIMESTAMP
       value: $(params.REWRITE_TIMESTAMP)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: build
     script: |-
       #!/bin/bash
@@ -771,7 +771,7 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: push
     script: |
       #!/bin/bash

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -18,6 +18,17 @@ If that's not something you ever plan to do, consider removing this section.
 - Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
   which don't match build host architecture.
 
+### Changed
+
+- When used with prefetch-dependencies >= 0.3.1, no longer edits RUN instructions
+  in order to set the prefetch environment variables. Instead, sets the variables
+  using buildah `--mount` + `--secret` flags. Details in [konflux-build-cli#151].
+  Fixes [#1200].
+  - As a side effect, also no longer mounts the `/cachi2/cachi2.env` file,
+    whose only purpose was to enable the automatic setting of prefetch variables.
+
+[konflux-build-cli#151]: https://github.com/konflux-ci/konflux-build-cli/pull/151
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -11,6 +11,15 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.4
+
+### Fixed
+
+- Restores the `/cachi2/cachi2.env` mount that version 0.10.3 removed.
+  Despite being an undocumented implementation detail, some builds use
+  the presence of this file as an indicator that the build is hermetic.
+  Enable them to do so for the time being.
+
 ## 0.10.3
 
 ### Added

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.10.3"
+    app.kubernetes.io/version: "0.10.4"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -320,7 +320,7 @@ spec:
       value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     imagePullPolicy: IfNotPresent
   steps:
-  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:eaf4bcc55d4753eb0776b9bf61257edb5661b1a574268ef41e8bccb348112dad
+  - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: build
     computeResources:
       limits:
@@ -569,7 +569,7 @@ spec:
     workingDir: $(workspaces.source.path)
 
   - name: push
-    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:7881de18a51416bb20548a23897225a14f4301c78663531d8c78b7f8af249747
+    image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     computeResources:
       limits:
         memory: 4Gi

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -18,6 +18,17 @@ If that's not something you ever plan to do, consider removing this section.
 - Added new parameter ALLOW_CROSS_PLATFORM_IMAGES to allow usage of parent images
   which don't match build host architecture.
 
+### Changed
+
+- When used with prefetch-dependencies >= 0.3.1, no longer edits RUN instructions
+  in order to set the prefetch environment variables. Instead, sets the variables
+  using buildah `--mount` + `--secret` flags. Details in [konflux-build-cli#151].
+  Fixes [#1200].
+  - As a side effect, also no longer mounts the `/cachi2/cachi2.env` file,
+    whose only purpose was to enable the automatic setting of prefetch variables.
+
+[konflux-build-cli#151]: https://github.com/konflux-ci/konflux-build-cli/pull/151
+
 ## 0.10.2
 
 ### Fixed

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -11,6 +11,15 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.4
+
+### Fixed
+
+- Restores the `/cachi2/cachi2.env` mount that version 0.10.3 removed.
+  Despite being an undocumented implementation detail, some builds use
+  the presence of this file as an indicator that the build is hermetic.
+  Enable them to do so for the time being.
+
 ## 0.10.3
 
 ### Added


### PR DESCRIPTION
Update the konflux-build-cli image to bring in
https://github.com/konflux-ci/konflux-build-cli/pull/162,
which restores the cachi2.env mount.

Motivation documented in that PR and in the updated changelog

---

Also update the changelog for 0.10.3 to mention a change that was previously undocumented