### PR TITLE
Fix CODEOWNERS for Vanguard team

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,8 +37,8 @@
 /task/generate-labels   @konflux-ci/build-maintainers @ralphbean
 
 # renovate groupName=ec
-/task/tkn-bundle                    @konflux-ci/ec @amisstea @avi-biton @gbenhaim @yftacherzog
-/task/tkn-bundle-oci-ta             @konflux-ci/ec @amisstea @avi-biton @gbenhaim @yftacherzog
+/task/tkn-bundle                    @konflux-ci/ec @konflux-ci/Vanguard @gbenhaim
+/task/tkn-bundle-oci-ta             @konflux-ci/ec @konflux-ci/Vanguard @gbenhaim
 /pipelines/enterprise-contract.yaml @konflux-ci/ec
 /.tekton/tasks/ec-checks.yaml       @konflux-ci/ec
 
@@ -96,18 +96,18 @@
 /task/ecosystem-cert-preflight-checks   @acornett21 @bcrochet @komish @skattoju @caxu-rh
 
 # renovate groupName=vanguard
-/external-task/rpms-signature-scan          @amisstea @avi-biton @gbenhaim @yftacherzog
-/task/build-helm-chart-oci-ta               @amisstea @avi-biton @gbenhaim @yftacherzog
-/pipelines/tekton-bundle-builder            @konflux-ci/ec @amisstea @avi-biton @gbenhaim @yftacherzog
-/pipelines/tekton-bundle-builder-oci-ta     @konflux-ci/ec @amisstea @avi-biton @gbenhaim @yftacherzog
+/external-task/rpms-signature-scan          @konflux-ci/Vanguard @gbenhaim
+/task/build-helm-chart-oci-ta               @konflux-ci/Vanguard @gbenhaim
+/pipelines/tekton-bundle-builder            @konflux-ci/ec @konflux-ci/Vanguard @gbenhaim
+/pipelines/tekton-bundle-builder-oci-ta     @konflux-ci/ec @konflux-ci/Vanguard @gbenhaim
 
 # renovate groupName=eaas
-/stepactions/eaas-copy-secrets-to-ephemeral-cluster         @konflux-ci/eaas-maintainers
-/stepactions/eaas-create-ephemeral-cluster-hypershift-aws   @konflux-ci/eaas-maintainers
-/stepactions/eaas-get-ephemeral-cluster-credentials         @konflux-ci/eaas-maintainers
-/stepactions/eaas-get-latest-openshift-version-by-prefix    @konflux-ci/eaas-maintainers
-/stepactions/eaas-get-supported-ephemeral-cluster-versions  @konflux-ci/eaas-maintainers
-/task/eaas-provision-space                                  @konflux-ci/eaas-maintainers
+/stepactions/eaas-copy-secrets-to-ephemeral-cluster         @konflux-ci/Vanguard
+/stepactions/eaas-create-ephemeral-cluster-hypershift-aws   @konflux-ci/Vanguard
+/stepactions/eaas-get-ephemeral-cluster-credentials         @konflux-ci/Vanguard
+/stepactions/eaas-get-latest-openshift-version-by-prefix    @konflux-ci/Vanguard
+/stepactions/eaas-get-supported-ephemeral-cluster-versions  @konflux-ci/Vanguard
+/task/eaas-provision-space                                  @konflux-ci/Vanguard
 
 # renovate groupName=build-vm-image
 /task/build-vm-image    @Victoremepunto @arewm @ralphbean @scoheb


### PR DESCRIPTION
Remove the individual owners so access can be managed using the team.

The eaas-maintainers team is obsolete. Vanguard maintains these tasks and stepactions.