### PR TITLE
build: move more build tasks to external tasks

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -3,8 +3,17 @@
 *   @konflux-ci/build-maintainers
 
 # renovate groupName=build
-/external-task/init                         @konflux-ci/build-maintainers
+/external-task/apply-tags                   @konflux-ci/build-maintainers
 /task/apply-tags                            @konflux-ci/build-maintainers
+/external-task/init                         @konflux-ci/build-maintainers
+/external-task/push-dockerfile              @konflux-ci/build-maintainers
+/task/push-dockerfile                       @konflux-ci/build-maintainers
+/external-task/push-dockerfile-oci-ta       @konflux-ci/build-maintainers
+/task/push-dockerfile-oci-ta                @konflux-ci/build-maintainers
+/external-task/source-build                 @konflux-ci/build-maintainers @Allda @jedinym
+/task/source-build                          @konflux-ci/build-maintainers @Allda @jedinym
+/external-task/source-build-oci-ta          @konflux-ci/build-maintainers @Allda @jedinym
+/task/source-build-oci-ta                   @konflux-ci/build-maintainers @Allda @jedinym
 /task/build-image-index                     @konflux-ci/build-maintainers @Allda @jedinym
 /task/build-image-index-min                 @konflux-ci/build-maintainers @Allda @jedinym
 /task/build-image-manifest                  @konflux-ci/build-maintainers @Allda @jedinym
@@ -17,20 +26,19 @@
 /task/git-clone-oci-ta                      @konflux-ci/build-maintainers
 /task/git-clone-oci-ta-min                  @konflux-ci/build-maintainers
 /task/pnc-prebuild-git-clone-oci-ta         @konflux-ci/build-maintainers
-/task/push-dockerfile                       @konflux-ci/build-maintainers
-/task/push-dockerfile-oci-ta                @konflux-ci/build-maintainers
 /task/show-sbom                             @konflux-ci/build-maintainers @Allda @jedinym
 /task/slack-webhook-notification            @konflux-ci/build-maintainers
 /task/slack-webhook-notification-oci-ta     @konflux-ci/build-maintainers
-/task/source-build                          @konflux-ci/build-maintainers @Allda @jedinym
-/task/source-build-oci-ta                   @konflux-ci/build-maintainers @Allda @jedinym
 /task/summary                               @konflux-ci/build-maintainers
 /task/update-infra-deployments              @konflux-ci/build-maintainers
 
 # renovate groupName=build-prefetch
-/task/prefetch-dependencies             @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
-/task/prefetch-dependencies-oci-ta      @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
-/task/prefetch-dependencies-oci-ta-min  @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
+/external-task/prefetch-dependencies             @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
+/task/prefetch-dependencies                      @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
+/external-task/prefetch-dependencies-oci-ta      @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
+/task/prefetch-dependencies-oci-ta               @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
+/external-task/prefetch-dependencies-oci-ta-min  @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
+/task/prefetch-dependencies-oci-ta-min           @konflux-ci/build-maintainers @a-ovchinnikov @brunoapimentel @eskultety @taylormadore
 
 # renovate groupName=build
 /task/generate-labels   @konflux-ci/build-maintainers @ralphbean

--- a/external-task/apply-tags/0.3/apply-tags.yaml
+++ b/external-task/apply-tags/0.3/apply-tags.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:3ab844157eccd68e95e4852adc06c3c4ea674edb7865a474b0a898227f2893d6

--- a/external-task/apply-tags/README.md
+++ b/external-task/apply-tags/README.md
@@ -1,0 +1,5 @@
+# apply-tags
+
+⚠️ This task is maintained externally in the [Build Pipeline Tasks](https://github.com/konflux-ci/build-pipeline-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/external-task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
+++ b/external-task/prefetch-dependencies-oci-ta-min/0.3/prefetch-dependencies-oci-ta-min.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta-min:0.3.2@sha256:7f344093a3387d05eeedad1f929743e197212b50ee95ceaebdc74bbe5df05d03

--- a/external-task/prefetch-dependencies-oci-ta-min/README.md
+++ b/external-task/prefetch-dependencies-oci-ta-min/README.md
@@ -1,0 +1,5 @@
+# prefetch-dependencies-oci-ta-min
+
+⚠️ This task is maintained externally in the [Build Pipeline Tasks](https://github.com/konflux-ci/build-pipeline-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/external-task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
+++ b/external-task/prefetch-dependencies-oci-ta/0.3/prefetch-dependencies-oci-ta.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3.2@sha256:389aea03a065e8118d36b7acb85b05cd13f6750e7e10ff8a85f270ee65b0167b

--- a/external-task/prefetch-dependencies-oci-ta/README.md
+++ b/external-task/prefetch-dependencies-oci-ta/README.md
@@ -1,0 +1,5 @@
+# prefetch-dependencies-oci-ta
+
+⚠️ This task is maintained externally in the [Build Pipeline Tasks](https://github.com/konflux-ci/build-pipeline-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/external-task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
+++ b/external-task/prefetch-dependencies/0.3/prefetch-dependencies.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies:0.3.2@sha256:c36c18cdb3e923dd4a0860d6b3d550473b29c7a999a1a26492b6ee948f0bf677

--- a/external-task/prefetch-dependencies/README.md
+++ b/external-task/prefetch-dependencies/README.md
@@ -1,0 +1,5 @@
+# prefetch-dependencies
+
+⚠️ This task is maintained externally in the [Build Pipeline Tasks](https://github.com/konflux-ci/build-pipeline-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/external-task/push-dockerfile-oci-ta/0.3/push-dockerfile-oci-ta.yaml
+++ b/external-task/push-dockerfile-oci-ta/0.3/push-dockerfile-oci-ta.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3.1@sha256:5a6cbebd89e5bc163b38231859767f7f6a0dd66cf1333699574379f062731183

--- a/external-task/push-dockerfile-oci-ta/README.md
+++ b/external-task/push-dockerfile-oci-ta/README.md
@@ -1,0 +1,5 @@
+# push-dockerfile-oci-ta
+
+⚠️ This task is maintained externally in the [Build Pipeline Tasks](https://github.com/konflux-ci/build-pipeline-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/external-task/push-dockerfile/0.3/push-dockerfile.yaml
+++ b/external-task/push-dockerfile/0.3/push-dockerfile.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.3.1@sha256:0b11148d49d2fd94c9f148828d752ca526380fefcb88772127e683538ab5e248

--- a/external-task/push-dockerfile/README.md
+++ b/external-task/push-dockerfile/README.md
@@ -1,0 +1,5 @@
+# push-dockerfile
+
+⚠️ This task is maintained externally in the [Build Pipeline Tasks](https://github.com/konflux-ci/build-pipeline-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/external-task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
+++ b/external-task/source-build-oci-ta/0.3/source-build-oci-ta.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:7c5575ac8e292f27f57716c021ab0324460dc958e73946724c588c5228e5f372

--- a/external-task/source-build-oci-ta/README.md
+++ b/external-task/source-build-oci-ta/README.md
@@ -1,0 +1,5 @@
+# source-build-oci-ta
+
+⚠️ This task is maintained externally in the [Build Pipeline Tasks](https://github.com/konflux-ci/build-pipeline-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/external-task/source-build/0.3/source-build.yaml
+++ b/external-task/source-build/0.3/source-build.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-source-build:0.3@sha256:e1e625218212c94f8426f0c6367390281d628a6d4a1e3adb2b18a9cf1b62a947

--- a/external-task/source-build/README.md
+++ b/external-task/source-build/README.md
@@ -1,0 +1,5 @@
+# source-build
+
+⚠️ This task is maintained externally in the [Build Pipeline Tasks](https://github.com/konflux-ci/build-pipeline-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/renovate.json
+++ b/renovate.json
@@ -27,7 +27,12 @@
     {
       "groupName": "build",
       "matchFileNames": [
+        "external-task/apply-tags/**",
         "external-task/init/**",
+        "external-task/push-dockerfile-oci-ta/**",
+        "external-task/push-dockerfile/**",
+        "external-task/source-build-oci-ta/**",
+        "external-task/source-build/**",
         "task/apply-tags/**",
         "task/build-image-index-min/**",
         "task/build-image-index/**",
@@ -56,6 +61,9 @@
     {
       "groupName": "build-prefetch",
       "matchFileNames": [
+        "external-task/prefetch-dependencies-oci-ta-min/**",
+        "external-task/prefetch-dependencies-oci-ta/**",
+        "external-task/prefetch-dependencies/**",
         "task/prefetch-dependencies-oci-ta-min/**",
         "task/prefetch-dependencies-oci-ta/**",
         "task/prefetch-dependencies/**"


### PR DESCRIPTION
Deleted more build tasks from the `task` directory, added them as external tasks and updated CODEOWNERS and renovate.json

Digests in the external task directory are from:
- https://quay.io/repository/konflux-ci/tekton-catalog/task-apply-tags?tab=tags&tag=latest
- https://quay.io/repository/konflux-ci/tekton-catalog/task-prefetch-dependencies?tab=tags&tag=latest
- https://quay.io/repository/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta?tab=tags&tag=latest
- https://quay.io/repository/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta-min?tab=tags&tag=latest
- https://quay.io/repository/konflux-ci/tekton-catalog/task-source-build?tab=tags&tag=latest
- https://quay.io/repository/konflux-ci/tekton-catalog/task-source-build-oci-ta?tab=tags&tag=latest
- https://quay.io/repository/konflux-ci/tekton-catalog/task-push-dockerfile?tab=tags&tag=latest
- https://quay.io/repository/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta?tab=tags&tag=latest
