### PR TITLE
fix: decoupled the e2e-tests task from the build-bundles task

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -191,7 +191,7 @@ spec:
           - name: changed_files
             value: "$(tasks.task-switchboard.results.changed_files)"
         runAfter:
-          - build-bundles
+          - task-switchboard
         taskRef:
           name: e2e-test
         workspaces:


### PR DESCRIPTION
- e2e-tests now runs after task-switchboard, which always runs
- e2e-tests will execute independently based on its own when condition
- If build-bundles is skipped, e2e-tests can still run (as long as its when condition is met)

Assisted-by: Claude

