### PR TITLE
fix: determine scenarios to run in task-switchboard instead of passing `changed_files`

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -188,8 +188,8 @@ spec:
             value: $(context.pipelineRun.name)
           - name: revision
             value: "{{revision}}"
-          - name: changed_files
-            value: "$(tasks.task-switchboard.results.changed_files)"
+          - name: scenarios
+            value: "$(tasks.task-switchboard.results.scenarios)"
         runAfter:
           - build-bundles
         taskRef:

--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -26,9 +26,9 @@ spec:
       type: string
     - name: revision
       type: string
-    - name: changed_files
+    - name: scenarios
       type: string
-      default: ""
+      default: "basic"
   workspaces:
     - name: source
       description: Workspace containing the cloned repository
@@ -92,8 +92,8 @@ spec:
         value: "$(params.ec_pipelines_repo_url)"
       - name: EC_PIPELINES_REPO_REVISION
         value: "$(params.ec_pipelines_repo_revision)"
-      - name: PR_CHANGED_FILES
-        value: "$(params.changed_files)"
+      - name: SCENARIOS
+        value: "$(params.scenarios)"
       - name: TEKTON_CHAINS_NS
         value: "openshift-pipelines"
     - name: capture-log

--- a/.tekton/tasks/task-switchboard.yaml
+++ b/.tekton/tasks/task-switchboard.yaml
@@ -9,8 +9,7 @@ metadata:
     tekton.dev/displayName: Task Switchboard
     tekton.dev/platforms: "linux/amd64"
 spec:
-  description: "Computes a set of expressions based on the changed files in the
-  pipeline, used to determine which tasks to run"
+  description: "Computes a set of expressions based on the changed files in the pipeline, used to determine which tasks to run"
   params:
     - name: revision
       type: string
@@ -23,7 +22,7 @@ spec:
       type: array
     - name: run-e2e
       type: string
-    - name: changed_files
+    - name: scenarios
       type: string
   steps:
     - name: evaluate
@@ -71,7 +70,6 @@ spec:
           # StdOut is "execute_e2e" or "dont_execute_e2e" based on files changed in pr
           # shellcheck disable=SC2086
           .tekton/scripts/determine-if-e2e-execution-needed.py --changed_files ${changed_files} | tr -d '\n' | tee "$(results.run-e2e.path)"
-          echo "${changed_files}" | tr -d '\n' | tee "$(results.changed_files.path)"
         else
           ec opa eval --v1-compatible --data "${rules}" --input \
           <(gh pr view "https://github.com/konflux-ci/build-definitions/pull/${pr_number}" --json files --jq '[.files.[].path']) \
@@ -83,6 +81,20 @@ spec:
           # StdOut is "execute_e2e" or "dont_execute_e2e" based on files changed in pr
           .tekton/scripts/determine-if-e2e-execution-needed.py --pr_number "${pr_number}" | tr -d '\n' | tee "$(results.run-e2e.path)"
 
-          changed_files=$(gh pr view "https://github.com/konflux-ci/build-definitions/pull/${pr_number}" --json files --jq '[.files.[].path'] | jq -r 'join(" ")')
-          echo "${changed_files}" | tr -d '\n' | tee "$(results.changed_files.path)"
+          changed_files=$(gh pr view "https://github.com/konflux-ci/build-definitions/pull/${pr_number}" --json files --jq '.files.[].path' | tr '\n' ' ')
+        fi
+
+        # Check if any hermetic-related files are changed
+        is_hermetic_change=0
+        for file in ${changed_files}; do
+          if [[ "${file}" == "task/buildah"* || "${file}" == "task/prefetch-dependencies"* || "${file}" == "external-task/prefetch-dependencies"* ]]; then
+            is_hermetic_change=1
+            break
+          fi
+        done
+        # set scenarios result to hermetic or basic based on the files changed
+        if [[ "$is_hermetic_change" -eq 1 ]]; then
+            echo -n "hermetic" | tee "$(results.scenarios.path)"
+        else
+            echo -n "basic" | tee "$(results.scenarios.path)"
         fi

--- a/e2e-tests/tests/build/build_templates_scenarios.go
+++ b/e2e-tests/tests/build/build_templates_scenarios.go
@@ -309,26 +309,13 @@ func GetComponentScenarioDetailsFromGitUrl(gitUrl string) ComponentScenarioSpec 
 	return ComponentScenarioSpec{}
 }
 
-// this function returns true if hermeto related files changed, otherwise false
-func DoesHermetoChanged(changedFilesStr string) bool {
-	isHermetoChanged := false
-	changedFiles := strings.Split(changedFilesStr, " ")
-	for _, filePath := range changedFiles {
-		if strings.HasPrefix(filePath, "task/buildah") || strings.HasPrefix(filePath, "task/prefetch-dependencies") {
-			isHermetoChanged = true
-			break
-		}
-	}
-	return isHermetoChanged
-}
-
 // this function returns which scenarios to execute based on changed_files in PR
 func GetScenarios() []string {
-	changedFiles := utils.GetEnv(PR_CHANGED_FILES_ENV, "")
-	if changedFiles == "" {
-		fmt.Println("ChangedFiles is empty")
+	scenarios := utils.GetEnv(SCENARIOS_ENV, "")
+	if scenarios == "" {
+		fmt.Println("scenarios is empty")
 		return componentUrls
-	} else if DoesHermetoChanged(changedFiles) {
+	} else if scenarios == "hermetic" {
 		fmt.Println("Hermeto related files changed, running hermetic scenarios as well")
 		return append(basicScenarioUrls, hermeticScenarioUrls...)
 	} else {

--- a/e2e-tests/tests/build/const.go
+++ b/e2e-tests/tests/build/const.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	COMPONENT_REPO_URLS_ENV string = "COMPONENT_REPO_URLS"
-	PR_CHANGED_FILES_ENV    string = "PR_CHANGED_FILES"
+	SCENARIOS_ENV           string = "SCENARIOS"
 
 	containerImageSource             = "quay.io/redhat-appstudio-qe/busybox-loop@sha256:f698f1f2cf641fe9176d2a277c9052d872f6b1c39e56248a1dd259b96281dda9"
 	gitRepoContainsSymlinkBranchName = "symlink"


### PR DESCRIPTION
when we had large number of files changed in a PR, `changed_files` task result was exceeding result limit of 4096 bytes and causing the task `task-switchboard` fail silently without any error like [here](https://github.com/konflux-ci/build-definitions/runs/82950147883)
This change will address the issue and we will determine the scenarios to run in e2e-tests side using a single string `hermetic` setting in the task result of `task-switchboard`  and passing the same to `e2e-tests` task

Fixes: https://redhat.atlassian.net/browse/STONEBLD-4863
