### PR TITLE
Replace deprecated buildah-task image with task-runner image

### DIFF
--- a/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
+++ b/task/build-paketo-builder-oci-ta/0.2/build-paketo-builder-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, buildpack, paketo, konflux
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.2.1"
     build.appstudio.redhat.com/build_type: pack
 spec:
   description: |-
@@ -138,7 +138,10 @@ spec:
         - $(params.CACHI2_ARTIFACT)=/var/workdir/cachi2
     - args:
         - "$(params.BUILD_ARGS[*])"
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
+      image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
+      env:
+      - name: HOME
+        value: /root
       name: "run-script"
       script: |-
         #!/usr/bin/env bash
@@ -230,7 +233,7 @@ spec:
         # import retry function
         # remove line with bash
         # shellcheck disable=SC2002
-        cat /usr/bin/retry | sed 1d >> scripts/script-build.sh
+        cat /usr/local/bin/retry | sed 1d >> scripts/script-build.sh
 
         cat >>scripts/script-build.sh <<'REMOTESSHEOF'
 
@@ -363,6 +366,7 @@ spec:
         rsync -ra "$SSH_HOST:$BUILD_DIR/volumes/shared/"  "/shared/"
         rsync -ra "$SSH_HOST:$BUILD_DIR/results/"         "/tekton/results/"
       securityContext:
+        runAsUser: 0
         capabilities:
           add:
             - SETFCAP
@@ -458,11 +462,13 @@ spec:
         requests:
           cpu: "1"
           memory: 1Gi
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:27400eaf836985bcc35182d62d727629f061538f61603c05b85d5d99bfa7da2d
+      image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
       name: inject-sbom-and-push
       env:
         - name: TASKRUN_NAME
           value: $(context.taskRun.name)
+        - name: HOME
+          value: /root
       script: |
         #!/bin/bash
         set -e

--- a/task/build-vm-image/0.1/build-vm-image.yaml
+++ b/task/build-vm-image/0.1/build-vm-image.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1"
+    app.kubernetes.io/version: "0.1.1"
     build.appstudio.redhat.com/build_type: disk-image
   name: build-vm-image
 spec:
@@ -143,13 +143,18 @@ spec:
         echo "declare TAGGED_AS=${TAGGED_AS}" >> /var/workdir/vars
 
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
+      image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
       computeResources:
         limits:
           memory: 128Mi
         requests:
           cpu: 250m
           memory: 128Mi
+      env:
+      - name: HOME
+        value: /root
+      securityContext:
+        runAsUser: 0
       script: |-
         #!/bin/bash
         set -o verbose
@@ -244,7 +249,7 @@ spec:
         # import retry function
         # remove line with bash
         # shellcheck disable=SC2002
-        cat /usr/bin/retry | sed 1d >> scripts/script-build.sh
+        cat /usr/local/bin/retry | sed 1d >> scripts/script-build.sh
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-build.sh <<'REMOTESSHEOF'
@@ -340,7 +345,7 @@ spec:
         # import retry function
         # remove line with bash
         # shellcheck disable=SC2002
-        cat /usr/bin/retry | sed 1d >> scripts/script-push.sh
+        cat /usr/local/bin/retry | sed 1d >> scripts/script-push.sh
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-push.sh <<'REMOTESSHEOF'

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.2"
+    app.kubernetes.io/version: "0.2.1"
     build.appstudio.redhat.com/build_type: disk-image
   name: build-vm-image
 spec:
@@ -187,13 +187,18 @@ spec:
         printf 'declare TAGGED_AS=%q\n' "${TAGGED_AS}" >> /var/workdir/vars
 
     - name: build
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:4c470b5a153c4acd14bf4f8731b5e36c61d7faafe09c2bf376bb81ce84aa5709
+      image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
       computeResources:
         limits:
           memory: 128Mi
         requests:
           cpu: 250m
           memory: 128Mi
+      env:
+      - name: HOME
+        value: /root
+      securityContext:
+        runAsUser: 0
       script: |-
         #!/bin/bash
         set -euo pipefail
@@ -293,7 +298,7 @@ spec:
         # import retry function
         # remove line with bash
         # shellcheck disable=SC2002
-        cat /usr/bin/retry | sed 1d >> scripts/script-build.sh
+        cat /usr/local/bin/retry | sed 1d >> scripts/script-build.sh
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-build.sh <<'REMOTESSHEOF'
@@ -389,7 +394,7 @@ spec:
         # import retry function
         # remove line with bash
         # shellcheck disable=SC2002
-        cat /usr/bin/retry | sed 1d >> scripts/script-push.sh
+        cat /usr/local/bin/retry | sed 1d >> scripts/script-push.sh
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-push.sh <<'REMOTESSHEOF'

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -11,6 +11,12 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.2.1
+
+### Changed
+
+- Replaced deprecated `quay.io/konflux-ci/buildah-task` image with `quay.io/konflux-ci/task-runner`.
+
 ## 0.2
 
 ### Added

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1.1"
+    app.kubernetes.io/version: "0.1.2"
 spec:
   description: |-
     This task allows to run an script stored on the git repository and stores the resultant directory
@@ -120,7 +120,7 @@ spec:
           readOnly: true
           subPath: ca-bundle.crt
     - name: run-script
-      image: quay.io/konflux-ci/buildah-task:latest@sha256:c8d667a4efa2f05e73e2ac36b55928633d78857589165bd919d2628812d7ffcb
+      image: quay.io/konflux-ci/task-runner:2.1.0@sha256:c34c933c269e2401bb042fe69e2999cf288331b6586d4f4eca9c845270d9b1f9
       computeResources:
         limits:
           memory: 5Gi
@@ -135,6 +135,8 @@ spec:
         - mountPath: /var/lib/containers
           name: varlibcontainers
       env:
+        - name: HOME
+          value: /root
         - name: PARAM_ENABLE_SYMLINK_CHECK
           value: $(params.enableSymlinkCheck)
         - name: SCRIPT
@@ -245,6 +247,7 @@ spec:
         # fix permissions after running the script.
         chown -R root:root "$REAL_ARTIFACT_PATH"
       securityContext:
+        runAsUser: 0
         capabilities:
           add:
             - SETFCAP

--- a/task/run-script-oci-ta/CHANGELOG.md
+++ b/task/run-script-oci-ta/CHANGELOG.md
@@ -11,6 +11,12 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.1.2
+
+### Changed
+
+- Replaced deprecated `quay.io/konflux-ci/buildah-task` image with `quay.io/konflux-ci/task-runner`.
+
 ## 0.1.1
 
 ### Added


### PR DESCRIPTION
Replace deprecated `buildah-task` image with `task-runner` image.
The change includes the following tasks:
- build-paketo-builder-oci-ta
- build-vm-image
- run-script-oci-ta