### PR TITLE
buildah*/0.10: add RHSM_MOUNT_CA_CERTS param

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -90,7 +90,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
-|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -90,6 +90,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build-oci-ta-min/README.md
+++ b/pipelines/docker-build-oci-ta-min/README.md
@@ -79,6 +79,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build-oci-ta-min/README.md
+++ b/pipelines/docker-build-oci-ta-min/README.md
@@ -79,7 +79,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
-|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -87,7 +87,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
-|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -87,6 +87,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -86,6 +86,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -86,7 +86,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
-|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -88,7 +88,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
-|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -88,6 +88,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
 |PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
 |REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.| auto| |
 |SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
 |SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
 |SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |

--- a/task/buildah-oci-ta-min/0.10/README.md
+++ b/task/buildah-oci-ta-min/0.10/README.md
@@ -40,7 +40,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
 |PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|caching-ca-bundle|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
-|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.|auto|false|
 |SBOM_SKIP_VALIDATION|Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.|true|false|
 |SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|

--- a/task/buildah-oci-ta-min/0.10/README.md
+++ b/task/buildah-oci-ta-min/0.10/README.md
@@ -40,6 +40,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
 |PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|caching-ca-bundle|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
 |SBOM_SKIP_VALIDATION|Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.|true|false|
 |SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|

--- a/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.4
+    app.kubernetes.io/version: 0.10.5
     build.appstudio.redhat.com/build_type: docker
   name: buildah-oci-ta-min
 spec:
@@ -166,7 +166,8 @@ spec:
     type: string
   - default: auto
     description: Mount /etc/rhsm/ca from the host machine into the build. Valid values
-      are 'always', 'auto' (default), 'never'.
+      are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and
+      ACTIVATION_KEY or ENTITLEMENT_SECRET is set.
     name: RHSM_MOUNT_CA_CERTS
     type: string
   - default: "true"

--- a/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
@@ -164,6 +164,11 @@ spec:
       if SOURCE_DATE_EPOCH is not defined.
     name: REWRITE_TIMESTAMP
     type: string
+  - default: auto
+    description: Mount /etc/rhsm/ca from the host machine into the build. Valid values
+      are 'always', 'auto' (default), 'never'.
+    name: RHSM_MOUNT_CA_CERTS
+    type: string
   - default: "true"
     description: Flag to enable or disable SBOM validation before save. Validation
       is optional - use this if you are experiencing performance issues.
@@ -307,6 +312,8 @@ spec:
       value: $(params.LOG_LEVEL)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: RHSM_MOUNT_CA_CERTS
+      value: $(params.RHSM_MOUNT_CA_CERTS)
     - name: SBOM_SKIP_VALIDATION
       value: $(params.SBOM_SKIP_VALIDATION)
     - name: SBOM_SOURCE_SCAN_ENABLED
@@ -515,6 +522,9 @@ spec:
         elif find /entitlement -name "*.pem" >/dev/null; then
           rhsm_args+=(--rhsm-entitlements=/entitlement)
         fi
+      fi
+      if [ "${RHSM_MOUNT_CA_CERTS}" != "auto" ]; then
+        rhsm_args+=(--rhsm-mount-ca-certs="$RHSM_MOUNT_CA_CERTS")
       fi
 
       # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.5
+
+### Added
+
+- Added a new parameter RHSM_MOUNT_CA_CERTS to allow setting [konflux-build-cli]'s
+  `--rhsm-mount-ca-certs` option.
+
 ## 0.10.4
 
 ### Fixed

--- a/task/buildah-oci-ta/0.10/README.md
+++ b/task/buildah-oci-ta/0.10/README.md
@@ -40,7 +40,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
 |PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|caching-ca-bundle|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
-|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.|auto|false|
 |SBOM_SKIP_VALIDATION|Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.|true|false|
 |SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|

--- a/task/buildah-oci-ta/0.10/README.md
+++ b/task/buildah-oci-ta/0.10/README.md
@@ -40,6 +40,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
 |PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|caching-ca-bundle|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
 |SBOM_SKIP_VALIDATION|Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.|true|false|
 |SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|

--- a/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.4
+    app.kubernetes.io/version: 0.10.5
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -171,7 +171,8 @@ spec:
       default: "false"
     - name: RHSM_MOUNT_CA_CERTS
       description: Mount /etc/rhsm/ca from the host machine into the build.
-        Valid values are 'always', 'auto' (default), 'never'.
+        Valid values are 'always', 'auto' (default), 'never'. Only effective
+        if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.
       type: string
       default: auto
     - name: SBOM_SKIP_VALIDATION

--- a/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
@@ -169,6 +169,11 @@ spec:
         Does nothing if SOURCE_DATE_EPOCH is not defined.
       type: string
       default: "false"
+    - name: RHSM_MOUNT_CA_CERTS
+      description: Mount /etc/rhsm/ca from the host machine into the build.
+        Valid values are 'always', 'auto' (default), 'never'.
+      type: string
+      default: auto
     - name: SBOM_SKIP_VALIDATION
       description: Flag to enable or disable SBOM validation before save.
         Validation is optional - use this if you are experiencing performance
@@ -357,6 +362,8 @@ spec:
         value: $(params.LOG_LEVEL)
       - name: PRIVILEGED_NESTED
         value: $(params.PRIVILEGED_NESTED)
+      - name: RHSM_MOUNT_CA_CERTS
+        value: $(params.RHSM_MOUNT_CA_CERTS)
       - name: SBOM_SKIP_VALIDATION
         value: $(params.SBOM_SKIP_VALIDATION)
       - name: SBOM_SOURCE_SCAN_ENABLED
@@ -574,6 +581,9 @@ spec:
           elif find /entitlement -name "*.pem" >/dev/null; then
             rhsm_args+=(--rhsm-entitlements=/entitlement)
           fi
+        fi
+        if [ "${RHSM_MOUNT_CA_CERTS}" != "auto" ]; then
+          rhsm_args+=(--rhsm-mount-ca-certs="$RHSM_MOUNT_CA_CERTS")
         fi
 
         # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.5
+
+### Added
+
+- Added a new parameter RHSM_MOUNT_CA_CERTS to allow setting [konflux-build-cli]'s
+  `--rhsm-mount-ca-certs` option.
+
 ## 0.10.4
 
 ### Fixed

--- a/task/buildah-remote-oci-ta/0.10/README.md
+++ b/task/buildah-remote-oci-ta/0.10/README.md
@@ -40,7 +40,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
 |PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|caching-ca-bundle|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
-|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.|auto|false|
 |SBOM_SKIP_VALIDATION|Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.|true|false|
 |SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|

--- a/task/buildah-remote-oci-ta/0.10/README.md
+++ b/task/buildah-remote-oci-ta/0.10/README.md
@@ -40,6 +40,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |PROXY_CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the proxy CA bundle data.|ca-bundle.crt|false|
 |PROXY_CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read proxy CA bundle data from.|caching-ca-bundle|false|
 |REWRITE_TIMESTAMP|Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.|false|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
 |SBOM_SKIP_VALIDATION|Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.|true|false|
 |SBOM_SOURCE_SCAN_ENABLED|Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.|true|false|
 |SBOM_SYFT_SELECT_CATALOGERS|Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection|""|false|

--- a/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.4
+    app.kubernetes.io/version: 0.10.5
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -165,7 +165,8 @@ spec:
     type: string
   - default: auto
     description: Mount /etc/rhsm/ca from the host machine into the build. Valid values
-      are 'always', 'auto' (default), 'never'.
+      are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and
+      ACTIVATION_KEY or ENTITLEMENT_SECRET is set.
     name: RHSM_MOUNT_CA_CERTS
     type: string
   - default: "true"

--- a/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
@@ -163,6 +163,11 @@ spec:
       if SOURCE_DATE_EPOCH is not defined.
     name: REWRITE_TIMESTAMP
     type: string
+  - default: auto
+    description: Mount /etc/rhsm/ca from the host machine into the build. Valid values
+      are 'always', 'auto' (default), 'never'.
+    name: RHSM_MOUNT_CA_CERTS
+    type: string
   - default: "true"
     description: Flag to enable or disable SBOM validation before save. Validation
       is optional - use this if you are experiencing performance issues.
@@ -314,6 +319,8 @@ spec:
       value: $(params.LOG_LEVEL)
     - name: PRIVILEGED_NESTED
       value: $(params.PRIVILEGED_NESTED)
+    - name: RHSM_MOUNT_CA_CERTS
+      value: $(params.RHSM_MOUNT_CA_CERTS)
     - name: SBOM_SKIP_VALIDATION
       value: $(params.SBOM_SKIP_VALIDATION)
     - name: SBOM_SOURCE_SCAN_ENABLED
@@ -600,6 +607,9 @@ spec:
           rhsm_args+=(--rhsm-entitlements=/entitlement)
         fi
       fi
+      if [ "${RHSM_MOUNT_CA_CERTS}" != "auto" ]; then
+        rhsm_args+=(--rhsm-mount-ca-certs="$RHSM_MOUNT_CA_CERTS")
+      fi
 
       # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
       declare IMAGE
@@ -702,6 +712,7 @@ spec:
           -e INHERIT_BASE_IMAGE_LABELS="${INHERIT_BASE_IMAGE_LABELS@Q}" \
           -e KBC_LOG_LEVEL="${KBC_LOG_LEVEL@Q}" \
           -e PRIVILEGED_NESTED="${PRIVILEGED_NESTED@Q}" \
+          -e RHSM_MOUNT_CA_CERTS="${RHSM_MOUNT_CA_CERTS@Q}" \
           -e SBOM_SKIP_VALIDATION="${SBOM_SKIP_VALIDATION@Q}" \
           -e SBOM_SOURCE_SCAN_ENABLED="${SBOM_SOURCE_SCAN_ENABLED@Q}" \
           -e SBOM_SYFT_SELECT_CATALOGERS="${SBOM_SYFT_SELECT_CATALOGERS@Q}" \

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.5
+
+### Added
+
+- Added a new parameter RHSM_MOUNT_CA_CERTS to allow setting [konflux-build-cli]'s
+  `--rhsm-mount-ca-certs` option.
+
 ## 0.10.4
 
 ### Fixed

--- a/task/buildah-remote/0.10/README.md
+++ b/task/buildah-remote/0.10/README.md
@@ -21,6 +21,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |ENV_VARS|Array of --env values ("env=value" strings)|[]|false|

--- a/task/buildah-remote/0.10/README.md
+++ b/task/buildah-remote/0.10/README.md
@@ -21,7 +21,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
-|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.|auto|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |ENV_VARS|Array of --env values ("env=value" strings)|[]|false|

--- a/task/buildah-remote/0.10/buildah-remote.yaml
+++ b/task/buildah-remote/0.10/buildah-remote.yaml
@@ -72,6 +72,11 @@ spec:
     description: Name of secret which contains subscription activation key
     name: ACTIVATION_KEY
     type: string
+  - default: auto
+    description: Mount /etc/rhsm/ca from the host machine into the build. Valid values
+      are 'always', 'auto' (default), 'never'.
+    name: RHSM_MOUNT_CA_CERTS
+    type: string
   - default: does-not-exist
     description: Name of a secret which will be made available to the build with 'buildah
       build --secret' at /run/secrets/$ADDITIONAL_SECRET
@@ -337,6 +342,8 @@ spec:
       value: $(params.SKIP_INJECTIONS)
     - name: ALLOW_CROSS_PLATFORM_IMAGES
       value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
+    - name: RHSM_MOUNT_CA_CERTS
+      value: $(params.RHSM_MOUNT_CA_CERTS)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     - name: PLATFORM
@@ -577,6 +584,9 @@ spec:
           rhsm_args+=(--rhsm-entitlements=/entitlement)
         fi
       fi
+      if [ "${RHSM_MOUNT_CA_CERTS}" != "auto" ]; then
+        rhsm_args+=(--rhsm-mount-ca-certs="$RHSM_MOUNT_CA_CERTS")
+      fi
 
       # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.
       declare IMAGE
@@ -695,6 +705,7 @@ spec:
           -e SBOM_SKIP_VALIDATION="${SBOM_SKIP_VALIDATION@Q}" \
           -e SKIP_INJECTIONS="${SKIP_INJECTIONS@Q}" \
           -e ALLOW_CROSS_PLATFORM_IMAGES="${ALLOW_CROSS_PLATFORM_IMAGES@Q}" \
+          -e RHSM_MOUNT_CA_CERTS="${RHSM_MOUNT_CA_CERTS@Q}" \
           -e HOME="${HOME@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e SOURCE_URL="${SOURCE_URL@Q}" \

--- a/task/buildah-remote/0.10/buildah-remote.yaml
+++ b/task/buildah-remote/0.10/buildah-remote.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.4
+    app.kubernetes.io/version: 0.10.5
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -74,7 +74,8 @@ spec:
     type: string
   - default: auto
     description: Mount /etc/rhsm/ca from the host machine into the build. Valid values
-      are 'always', 'auto' (default), 'never'.
+      are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and
+      ACTIVATION_KEY or ENTITLEMENT_SECRET is set.
     name: RHSM_MOUNT_CA_CERTS
     type: string
   - default: does-not-exist

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.5
+
+### Added
+
+- Added a new parameter RHSM_MOUNT_CA_CERTS to allow setting [konflux-build-cli]'s
+  `--rhsm-mount-ca-certs` option.
+
 ## 0.10.4
 
 ### Fixed

--- a/task/buildah/0.10/README.md
+++ b/task/buildah/0.10/README.md
@@ -21,6 +21,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |ENV_VARS|Array of --env values ("env=value" strings)|[]|false|

--- a/task/buildah/0.10/README.md
+++ b/task/buildah/0.10/README.md
@@ -21,7 +21,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |TARGET_STAGE|Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |ACTIVATION_KEY|Name of secret which contains subscription activation key|activation-key|false|
-|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'.|auto|false|
+|RHSM_MOUNT_CA_CERTS|Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.|auto|false|
 |ADDITIONAL_SECRET|Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET|does-not-exist|false|
 |BUILD_ARGS|Array of --build-arg values ("arg=value" strings)|[]|false|
 |ENV_VARS|Array of --env values ("env=value" strings)|[]|false|

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.10.4"
+    app.kubernetes.io/version: "0.10.5"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -68,7 +68,8 @@ spec:
     type: string
   - default: auto
     description: Mount /etc/rhsm/ca from the host machine into the build. Valid values
-      are 'always', 'auto' (default), 'never'.
+      are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and
+      ACTIVATION_KEY or ENTITLEMENT_SECRET is set.
     name: RHSM_MOUNT_CA_CERTS
     type: string
   - name: ADDITIONAL_SECRET

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -66,6 +66,11 @@ spec:
     default: activation-key
     description: Name of secret which contains subscription activation key
     type: string
+  - default: auto
+    description: Mount /etc/rhsm/ca from the host machine into the build. Valid values
+      are 'always', 'auto' (default), 'never'.
+    name: RHSM_MOUNT_CA_CERTS
+    type: string
   - name: ADDITIONAL_SECRET
     description: Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET
     type: string
@@ -318,6 +323,8 @@ spec:
       value: $(params.SKIP_INJECTIONS)
     - name: ALLOW_CROSS_PLATFORM_IMAGES
       value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
+    - name: RHSM_MOUNT_CA_CERTS
+      value: $(params.RHSM_MOUNT_CA_CERTS)
     imagePullPolicy: IfNotPresent
   steps:
   - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
@@ -481,6 +488,9 @@ spec:
         elif find /entitlement -name "*.pem" > /dev/null; then
           rhsm_args+=(--rhsm-entitlements=/entitlement)
         fi
+      fi
+      if [ "${RHSM_MOUNT_CA_CERTS}" != "auto" ]; then
+        rhsm_args+=(--rhsm-mount-ca-certs="$RHSM_MOUNT_CA_CERTS")
       fi
 
       # Prevent ShellCheck from giving a warning because 'image' is defined and 'IMAGE' is not.

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -11,6 +11,13 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.5
+
+### Added
+
+- Added a new parameter RHSM_MOUNT_CA_CERTS to allow setting [konflux-build-cli]'s
+  `--rhsm-mount-ca-certs` option.
+
 ## 0.10.4
 
 ### Fixed


### PR DESCRIPTION
Expose the `--rhsm-mount-ca-certs` option to Task consumers. This is a prerequisite to fix KFLUXSPRT-8389.

The MintMaker image [installs](https://github.com/konflux-ci/mintmaker-renovate-image/blob/ed85567f7a10f71828c0927a070a8f9d02ef9591/Dockerfile#L144-L145) the `subscription-manager-rhsm-certificates` package so that its CA certificates are made available to builds at runtime under `/etc/rhsm/ca`. [konflux-build-cli](https://github.com/konflux-ci/konflux-build-cli/blob/main/README.md#konflux-build-tasks-cli) introduced a new behavior of [mounting](https://github.com/konflux-ci/konflux-build-cli/blob/8bfe33041d7d7213c31bb28d583cedb32ed6f931/pkg/commands/build.go#L1576) at that directory at every `RUN` instruction, which causes the MintMaker Dockerfile to write files to the mount instead of the container filesystem. This parameter allows consumers to opt out of this automatic mount of `/etc/rhsm/ca` during `RUN` instructions so that CA certificates can persist in the resulting image.