### PR TITLE
feat: add dual-compression (zstd:chunked) to buildah task

### DIFF
--- a/pipelines/docker-build-multi-platform-oci-ta/README.md
+++ b/pipelines/docker-build-multi-platform-oci-ta/README.md
@@ -68,11 +68,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.| ""| |
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| ""| '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
+|COMPRESSION_FORMAT| Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.| gzip| |
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |ENV_VARS| Array of --env values ("env=value" strings)| []| |
+|FORCE_COMPRESSION| Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.| false| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
 |HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
@@ -295,6 +297,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah-remote-oci-ta:0.10 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|IMAGES| Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.| |
 |IMAGE_DIGEST| Digest of the image just built| |
 |IMAGE_REF| Image reference of the built image| build-image-index:0.3:IMAGES|
 |IMAGE_URL| Image repository and tag where the built image was pushed| |

--- a/pipelines/docker-build-oci-ta-min/README.md
+++ b/pipelines/docker-build-oci-ta-min/README.md
@@ -59,11 +59,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.| ""| |
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| ""| '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
+|COMPRESSION_FORMAT| Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.| gzip| |
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |ENV_VARS| Array of --env values ("env=value" strings)| []| |
+|FORCE_COMPRESSION| Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.| false| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
 |HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
@@ -235,6 +237,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah-oci-ta-min:0.10 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|IMAGES| Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.| |
 |IMAGE_DIGEST| Digest of the image just built| |
 |IMAGE_REF| Image reference of the built image| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.3:IMAGES|

--- a/pipelines/docker-build-oci-ta/README.md
+++ b/pipelines/docker-build-oci-ta/README.md
@@ -67,11 +67,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.| ""| |
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| ""| '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
+|COMPRESSION_FORMAT| Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.| gzip| |
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |ENV_VARS| Array of --env values ("env=value" strings)| []| |
+|FORCE_COMPRESSION| Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.| false| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
 |HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
@@ -292,6 +294,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah-oci-ta:0.10 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|IMAGES| Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.| |
 |IMAGE_DIGEST| Digest of the image just built| |
 |IMAGE_REF| Image reference of the built image| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.3:IMAGES|

--- a/pipelines/docker-build/README.md
+++ b/pipelines/docker-build/README.md
@@ -66,11 +66,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| ""| '$(params.build-args-file)'|
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.| ""| |
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
+|COMPRESSION_FORMAT| Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.| gzip| |
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |ENV_VARS| Array of --env values ("env=value" strings)| []| |
+|FORCE_COMPRESSION| Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.| false| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
 |HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
@@ -276,6 +278,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah:0.10 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|IMAGES| Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.| |
 |IMAGE_DIGEST| Digest of the image just built| |
 |IMAGE_REF| Image reference of the built image| |
 |IMAGE_URL| Image repository and tag where the built image was pushed| build-image-index:0.3:IMAGES|

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -66,11 +66,13 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.| ""| |
 |CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| ""| '$(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)'|
 |COMMIT_SHA| The image is built from this commit.| ""| '$(tasks.clone-repository.results.commit)'|
+|COMPRESSION_FORMAT| Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.| gzip| |
 |CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
 |CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
 |DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
 |ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
 |ENV_VARS| Array of --env values ("env=value" strings)| []| |
+|FORCE_COMPRESSION| Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.| false| |
 |HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
 |HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| '$(tasks.init.results.http-proxy)'|
 |ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
@@ -220,6 +222,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ### buildah-remote-oci-ta:0.10 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
+|IMAGES| Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.| |
 |IMAGE_DIGEST| Digest of the image just built| |
 |IMAGE_REF| Image reference of the built image| build-image-index:0.3:IMAGES|
 |IMAGE_URL| Image repository and tag where the built image was pushed| |

--- a/task/buildah-oci-ta-min/0.10/README.md
+++ b/task/buildah-oci-ta-min/0.10/README.md
@@ -20,11 +20,13 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |BUILD_TIMESTAMP|Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.|""|false|
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
 |COMMIT_SHA|The image is built from this commit.|""|false|
+|COMPRESSION_FORMAT|Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.|gzip|false|
 |CONTEXT|Path to the directory to use as context.|.|false|
 |CONTEXTUALIZE_SBOM|Determines if SBOM will be contextualized.|true|false|
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |ENV_VARS|Array of --env values ("env=value" strings)|[]|false|
+|FORCE_COMPRESSION|Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.|false|false|
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |HTTP_PROXY|HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.|""|false|
 |ICM_KEEP_COMPAT_LOCATION|Whether to keep compatibility location at /root/buildinfo/ for ICM injection|true|false|
@@ -65,6 +67,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 ## Results
 |name|description|
 |---|---|
+|IMAGES|Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.|
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_REF|Image reference of the built image|
 |IMAGE_URL|Image repository and tag where the built image was pushed|

--- a/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
+++ b/task/buildah-oci-ta-min/0.10/buildah-oci-ta-min.yaml
@@ -6,7 +6,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.5
+    app.kubernetes.io/version: 0.10.6
     build.appstudio.redhat.com/build_type: docker
   name: buildah-oci-ta-min
 spec:
@@ -75,6 +75,13 @@ spec:
     description: The image is built from this commit.
     name: COMMIT_SHA
     type: string
+  - default: gzip
+    description: 'Compression format: gzip (default), zstd-chunked, or dual. In dual
+      mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index
+      (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked
+      modes are experimental and not yet fully supported by the release pipeline.'
+    name: COMPRESSION_FORMAT
+    type: string
   - default: .
     description: Path to the directory to use as context.
     name: CONTEXT
@@ -95,6 +102,11 @@ spec:
     description: Array of --env values ("env=value" strings)
     name: ENV_VARS
     type: array
+  - default: "false"
+    description: Recompress all layers including base image layers, not just layers
+      created by this build. Only applies to zstd-chunked and dual modes.
+    name: FORCE_COMPRESSION
+    type: string
   - default: "false"
     description: Determines if build will be executed without network access.
     name: HERMETIC
@@ -267,6 +279,11 @@ spec:
     name: caTrustConfigMapName
     type: string
   results:
+  - description: Comma-separated image manifest references. In dual mode lists the
+      gzip and zstd child manifest references for Chains provenance; otherwise the
+      single manifest reference.
+    name: IMAGES
+    type: string
   - description: Digest of the image just built
     name: IMAGE_DIGEST
   - description: Image reference of the built image
@@ -297,6 +314,8 @@ spec:
       value: $(params.BUILD_ARGS_FILE)
     - name: BUILD_TIMESTAMP
       value: $(params.BUILD_TIMESTAMP)
+    - name: COMPRESSION_FORMAT
+      value: $(params.COMPRESSION_FORMAT)
     - name: CONTEXT
       value: $(params.CONTEXT)
     - name: CONTEXTUALIZE_SBOM
@@ -625,6 +644,8 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
+    - name: FORCE_COMPRESSION
+      value: $(params.FORCE_COMPRESSION)
     image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: push
     script: |
@@ -650,43 +671,165 @@ spec:
         push_format=docker
       fi
 
-      echo "[$(date --utc -Ins)] Push image with unique tag"
+      # dual requires OCI: the zstd annotation is only valid on OCI manifests
+      if [ "${COMPRESSION_FORMAT}" = "dual" ] && [ "$push_format" != "oci" ]; then
+        echo "ERROR: COMPRESSION_FORMAT=dual requires BUILDAH_FORMAT=oci" >&2
+        exit 1
+      fi
+
+      compression_args=()
+      if [ "${COMPRESSION_FORMAT}" = "zstd-chunked" ]; then
+        compression_args+=(--compression-format zstd:chunked)
+      fi
+      if [ "${FORCE_COMPRESSION}" = "true" ] && [ "${COMPRESSION_FORMAT}" != "gzip" ]; then
+        compression_args+=(--force-compression)
+      fi
+
+      case "${COMPRESSION_FORMAT}" in
+      gzip | zstd-chunked | dual) ;;
+      *)
+        echo "ERROR: unsupported COMPRESSION_FORMAT '${COMPRESSION_FORMAT}'" >&2
+        exit 1
+        ;;
+      esac
 
       buildah_retries=3
+      image_repo="${IMAGE%:*}"
 
-      # Push to a unique tag based on the TaskRun name to avoid race conditions
-      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
-      if ! retry buildah push \
-        --format="$push_format" \
-        --retry "$buildah_retries" \
-        --tls-verify="$TLSVERIFY" \
-        "$IMAGE" \
-        "docker://${IMAGE%:*}:${TASKRUN_NAME}"; then
-        echo "Failed to push image to ${IMAGE%:*}:${TASKRUN_NAME}"
-        exit 1
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        echo "[$(date --utc -Ins)] Push dual-compression per-arch index"
+
+        gzip_tag="${image_repo}:${TASKRUN_NAME}-gzip"
+        gzip_push_args=(
+          --format=oci
+          --retry "$buildah_retries"
+          --tls-verify="$TLSVERIFY"
+          --compression-format gzip
+          --digestfile /tmp/gzip-digest
+        )
+        if [ "${FORCE_COMPRESSION}" = "true" ]; then
+          gzip_push_args+=(--force-compression)
+        fi
+        echo "Pushing gzip variant to ${gzip_tag}"
+        if ! retry buildah push "${gzip_push_args[@]}" "$IMAGE" "docker://${gzip_tag}"; then
+          echo "Failed to push gzip variant to ${gzip_tag}" >&2
+          exit 1
+        fi
+        gzip_digest="$(cat /tmp/gzip-digest)"
+        gzip_ref="${image_repo}@${gzip_digest}"
+
+        zstd_tag="${image_repo}:${TASKRUN_NAME}-zstd"
+        zstd_push_args=(
+          --format=oci
+          --retry "$buildah_retries"
+          --tls-verify="$TLSVERIFY"
+          --compression-format zstd:chunked
+          --digestfile /tmp/zstd-digest
+        )
+        if [ "${FORCE_COMPRESSION}" = "true" ]; then
+          zstd_push_args+=(--force-compression)
+        fi
+        echo "Pushing zstd:chunked variant to ${zstd_tag}"
+        if ! retry buildah push "${zstd_push_args[@]}" "$IMAGE" "docker://${zstd_tag}"; then
+          echo "Failed to push zstd:chunked variant to ${zstd_tag}" >&2
+          exit 1
+        fi
+        zstd_digest="$(cat /tmp/zstd-digest)"
+        zstd_ref="${image_repo}@${zstd_digest}"
+
+        # gzip first in the index for backward compat with older Docker clients
+        per_arch_index="per-arch-index-${TASKRUN_NAME}"
+        echo "Creating per-arch index ${per_arch_index}"
+        buildah manifest create "$per_arch_index"
+        if ! retry buildah manifest add "$per_arch_index" "docker://${gzip_ref}"; then
+          echo "Failed to add gzip variant to ${per_arch_index}" >&2
+          exit 1
+        fi
+        if ! retry buildah manifest add "$per_arch_index" "docker://${zstd_ref}"; then
+          echo "Failed to add zstd variant to ${per_arch_index}" >&2
+          exit 1
+        fi
+
+        buildah manifest inspect "$per_arch_index" >/shared/per-arch-index-manifest.json
+
+        echo "Pushing per-arch index to ${image_repo}:${TASKRUN_NAME}"
+        if ! retry buildah manifest push --all \
+          --format=oci \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          --digestfile "/var/workdir/image-digest" \
+          "$per_arch_index" \
+          "docker://${image_repo}:${TASKRUN_NAME}"; then
+          echo "Failed to push per-arch index to ${image_repo}:${TASKRUN_NAME}" >&2
+          exit 1
+        fi
+
+        echo "Pushing per-arch index to ${IMAGE}"
+        if ! retry buildah manifest push --all \
+          --format=oci \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "$per_arch_index" \
+          "docker://$IMAGE"; then
+          echo "Failed to push per-arch index to $IMAGE" >&2
+          exit 1
+        fi
+
+        index_digest="$(cat "/var/workdir/image-digest")"
+
+        echo -n "$index_digest" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${IMAGE}@${index_digest}" >"$(results.IMAGE_REF.path)"
+        echo -n "${gzip_ref},${zstd_ref}" >"$(results.IMAGES.path)"
+
+        echo -n "$gzip_digest" >/shared/gzip-digest
+        echo -n "$zstd_digest" >/shared/zstd-digest
+        echo -n "$gzip_ref" >/shared/gzip-ref
+        echo -n "$zstd_ref" >/shared/zstd-ref
+        echo
+      else
+        echo "[$(date --utc -Ins)] Push image with unique tag"
+
+        # Push to a unique tag based on the TaskRun name to avoid race conditions
+        echo "Pushing to ${image_repo}:${TASKRUN_NAME}"
+        if ! retry buildah push \
+          --format="$push_format" \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "${compression_args[@]}" \
+          "$IMAGE" \
+          "docker://${image_repo}:${TASKRUN_NAME}"; then
+          echo "Failed to push image to ${image_repo}:${TASKRUN_NAME}" >&2
+          exit 1
+        fi
+
+        echo "[$(date --utc -Ins)] Push image with git revision"
+
+        # Push to a tag based on the git revision
+        echo "Pushing to ${IMAGE}"
+        if ! retry buildah push \
+          --format="$push_format" \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "${compression_args[@]}" \
+          --digestfile "/var/workdir/image-digest" "$IMAGE" \
+          "docker://$IMAGE"; then
+          echo "Failed to push image to $IMAGE" >&2
+          exit 1
+        fi
+
+        tee "$(results.IMAGE_DIGEST.path)" <"/var/workdir"/image-digest
+        echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+        {
+          echo -n "${IMAGE}@"
+          cat "/var/workdir/image-digest"
+        } >"$(results.IMAGE_REF.path)"
+        {
+          echo -n "${IMAGE}@"
+          cat "/var/workdir/image-digest"
+        } >"$(results.IMAGES.path)"
+        echo
       fi
-
-      echo "[$(date --utc -Ins)] Push image with git revision"
-
-      # Push to a tag based on the git revision
-      echo "Pushing to ${IMAGE}"
-      if ! retry buildah push \
-        --format="$push_format" \
-        --retry "$buildah_retries" \
-        --tls-verify="$TLSVERIFY" \
-        --digestfile "/var/workdir/image-digest" "$IMAGE" \
-        "docker://$IMAGE"; then
-        echo "Failed to push image to $IMAGE"
-        exit 1
-      fi
-
-      tee "$(results.IMAGE_DIGEST.path)" <"/var/workdir"/image-digest
-      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-      {
-        echo -n "${IMAGE}@"
-        cat "/var/workdir/image-digest"
-      } >"$(results.IMAGE_REF.path)"
-      echo
 
       # detect if keyless signing is required
       SIGNING_CONFIG='{}'
@@ -754,22 +897,34 @@ spec:
         SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
         export SIGSTORE_ID_TOKEN
 
-        IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
+        # In dual mode, sign all three variants: index, gzip child, zstd child
+        if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+          index_ref="$(cat "$(results.IMAGE_REF.path)")"
+          refs_to_sign=(
+            "$index_ref"
+            "$(cat /shared/gzip-ref)"
+            "$(cat /shared/zstd-ref)"
+          )
+        else
+          refs_to_sign=("$(cat "$(results.IMAGE_REF.path)")")
+        fi
 
         # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-        mkdir -p /tmp/auth && select-oci-auth "${IMAGE_REF}" >/tmp/auth/config.json
+        mkdir -p /tmp/auth && select-oci-auth "${refs_to_sign[0]}" >/tmp/auth/config.json
         export DOCKER_CONFIG=/tmp/auth
 
         echo "[$(date --utc -Ins)] Sign image"
-        echo "Signing image ${IMAGE_REF} using keyless signing"
-        if ! retry cosign sign -y \
-          --rekor-url="${REKOR_URL}" \
-          --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-          --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-          "${IMAGE_REF}"; then
-          echo "Failed to sign image" >&2
-          exit 1
-        fi
+        for ref in "${refs_to_sign[@]}"; do
+          echo "Signing image ${ref} using keyless signing"
+          if ! retry cosign sign -y \
+            --rekor-url="${REKOR_URL}" \
+            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+            "${ref}"; then
+            echo "Failed to sign image ${ref}" >&2
+            exit 1
+          fi
+        done
       elif [ "${configured}" -eq 0 ]; then
         echo "Keyless signing is disabled (none of ${missing} are configured in the konflux-info/cluster-config configmap)"
       else
@@ -909,52 +1064,69 @@ spec:
 
       echo "[$(date --utc -Ins)] Generate SBOM with mobster"
 
-      mobster_args=(
-        generate
-        --output sbom.json
-      )
+      # All compression variants share the same package list; only the digest differs
+      generate_oci_image_sbom() {
+        local output_file="$1"
+        local image_digest="$2"
+        local image_pullspec="$3"
+        local -a args=(generate --output "$output_file")
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          args+=(--skip-validation)
+        fi
+        args+=(
+          oci-image
+          --from-syft "/var/workdir/sbom-image.json"
+          --image-pullspec "$image_pullspec"
+          --image-digest "$image_digest"
+          --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+          --base-image-digest-file "/shared/base_images_digests"
+        )
+        if [ -f "/var/workdir/sbom-source.json" ]; then
+          args+=(--from-syft "/var/workdir/sbom-source.json")
+        fi
+        if [ -f "/var/workdir/sbom-prefetch.json" ]; then
+          args+=(--from-hermeto "/var/workdir/sbom-prefetch.json")
+        fi
+        if [ -n "${TARGET_STAGE}" ]; then
+          args+=(--dockerfile-target "${TARGET_STAGE}")
+        fi
+        for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
+          args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
+        done
+        if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
+          args+=(--contextualize)
+        fi
+        if [ -f "/shared/prefetch-arch" ]; then
+          args+=(--arch "$(cat /shared/prefetch-arch)")
+        fi
+        mobster "${args[@]}"
+      }
 
-      # Validation is a flag for `generate`, not `oci-image`, so we need to
-      # handle it before the oci-image arguments
-      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
-        echo "Skipping SBOM validation"
-        mobster_args+=(--skip-validation)
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        gzip_digest="$(cat /shared/gzip-digest)"
+        zstd_digest="$(cat /shared/zstd-digest)"
+
+        echo "Generating gzip child SBOM (main component digest ${gzip_digest})"
+        generate_oci_image_sbom sbom-gzip.json "$gzip_digest" "$IMAGE"
+
+        echo "Generating zstd child SBOM (main component digest ${zstd_digest})"
+        generate_oci_image_sbom sbom-zstd.json "$zstd_digest" "$IMAGE"
+
+        echo "Generating per-arch index SBOM (main component digest ${IMAGE_DIGEST})"
+        index_args=(generate --output sbom-index.json)
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          index_args+=(--skip-validation)
+        fi
+        index_args+=(
+          oci-index
+          --index-image-pullspec "$IMAGE_URL"
+          --index-image-digest "$IMAGE_DIGEST"
+          --index-manifest-path "/shared/per-arch-index-manifest.json"
+        )
+        mobster "${index_args[@]}"
+      else
+        generate_oci_image_sbom sbom.json "$IMAGE_DIGEST" "$IMAGE_URL"
       fi
-
-      mobster_args+=(
-        oci-image
-        --from-syft "/var/workdir/sbom-image.json"
-        --image-pullspec "$IMAGE_URL"
-        --image-digest "$IMAGE_DIGEST"
-        --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
-        --base-image-digest-file "/shared/base_images_digests"
-      )
-
-      if [ -f "/var/workdir/sbom-source.json" ]; then
-        mobster_args+=(--from-syft "/var/workdir/sbom-source.json")
-      fi
-
-      if [ -f "/var/workdir/sbom-prefetch.json" ]; then
-        mobster_args+=(--from-hermeto "/var/workdir/sbom-prefetch.json")
-      fi
-
-      if [ -n "${TARGET_STAGE}" ]; then
-        mobster_args+=(--dockerfile-target "${TARGET_STAGE}")
-      fi
-
-      for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-        mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
-      done
-
-      if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
-        mobster_args+=(--contextualize)
-      fi
-
-      if [ -f "/shared/prefetch-arch" ]; then
-        mobster_args+=(--arch "$(cat /shared/prefetch-arch)")
-      fi
-
-      mobster "${mobster_args[@]}"
 
       echo "[$(date --utc -Ins)] End prepare-sboms"
     securityContext:
@@ -987,18 +1159,36 @@ spec:
         update-ca-trust
       fi
 
-      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-      mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" >/tmp/auth/config.json
-      export DOCKER_CONFIG=/tmp/auth
-      echo "Pushing sbom to registry"
-      if ! retry cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"; then
-        echo "Failed to push sbom to registry"
-        exit 1
+      # In dual mode each variant gets its own SBOM attached to its own digest
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        index_ref="$(cat "$(results.IMAGE_REF.path)")"
+        sbom_files=(sbom-gzip.json sbom-zstd.json sbom-index.json)
+        sbom_refs=("$(cat /shared/gzip-ref)" "$(cat /shared/zstd-ref)" "$index_ref")
+        primary_sbom=sbom-index.json
+      else
+        image_ref="$(cat "$(results.IMAGE_REF.path)")"
+        sbom_files=(sbom.json)
+        sbom_refs=("$image_ref")
+        primary_sbom=sbom.json
       fi
+
+      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+      mkdir -p /tmp/auth && select-oci-auth "${sbom_refs[0]}" >/tmp/auth/config.json
+      export DOCKER_CONFIG=/tmp/auth
+
+      for i in "${!sbom_files[@]}"; do
+        sbom_file="${sbom_files[$i]}"
+        ref="${sbom_refs[$i]}"
+        echo "Pushing sbom ${sbom_file} to ${ref}"
+        if ! retry cosign attach sbom --sbom "$sbom_file" --type "$SBOM_TYPE" "$ref"; then
+          echo "Failed to push sbom ${sbom_file} to ${ref}" >&2
+          exit 1
+        fi
+      done
 
       # Remove tag from IMAGE while allowing registry to contain a port number.
       sbom_repo="${IMAGE%:*}"
-      sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+      sbom_digest="$(sha256sum "$primary_sbom" | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
 
@@ -1016,8 +1206,6 @@ spec:
         SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
         export SIGSTORE_ID_TOKEN
 
-        IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
-
         ATT_SBOM_TYPE="${SBOM_TYPE}"
         if [ "${ATT_SBOM_TYPE}" = "spdx" ]; then
           # for format cossistency with cyclonedx format, we want to use spdxjson instad of spdx
@@ -1025,16 +1213,20 @@ spec:
           ATT_SBOM_TYPE="spdxjson"
         fi
 
-        echo "[$(date --utc -Ins)] Sign SBOM"
-        echo "Signing and attaching SBOM to ${IMAGE_REF} using keyless signing"
-        if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate sbom.json \
-          --rekor-url="${REKOR_URL}" \
-          --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-          --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-          "${IMAGE_REF}"; then
-          echo "Failed to sign SBOM" >&2
-          exit 1
-        fi
+        for i in "${!sbom_files[@]}"; do
+          sbom_file="${sbom_files[$i]}"
+          ref="${sbom_refs[$i]}"
+          echo "[$(date --utc -Ins)] Sign SBOM"
+          echo "Signing and attaching SBOM ${sbom_file} to ${ref} using keyless signing"
+          if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate "$sbom_file" \
+            --rekor-url="${REKOR_URL}" \
+            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+            "${ref}"; then
+            echo "Failed to sign SBOM ${sbom_file}" >&2
+            exit 1
+          fi
+        done
       fi
 
       echo

--- a/task/buildah-oci-ta-min/CHANGELOG.md
+++ b/task/buildah-oci-ta-min/CHANGELOG.md
@@ -11,6 +11,18 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.6
+
+### Added
+
+- New parameter `COMPRESSION_FORMAT` (gzip | zstd-chunked | dual, default: gzip).
+  In dual mode, both gzip and zstd:chunked variants are pushed and bundled in a
+  per-arch OCI index with gzip first for backward compatibility. Tech preview.
+- New parameter `FORCE_COMPRESSION` (default: false). Recompress all layers
+  including base image layers in zstd-chunked and dual modes.
+- New result `IMAGES`. Comma-separated image manifest references for Chains
+  provenance. In dual mode, lists the gzip and zstd child manifest references.
+
 ## 0.10.5
 
 ### Added

--- a/task/buildah-oci-ta/0.10/README.md
+++ b/task/buildah-oci-ta/0.10/README.md
@@ -20,11 +20,13 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |BUILD_TIMESTAMP|Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.|""|false|
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
 |COMMIT_SHA|The image is built from this commit.|""|false|
+|COMPRESSION_FORMAT|Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.|gzip|false|
 |CONTEXT|Path to the directory to use as context.|.|false|
 |CONTEXTUALIZE_SBOM|Determines if SBOM will be contextualized.|true|false|
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |ENV_VARS|Array of --env values ("env=value" strings)|[]|false|
+|FORCE_COMPRESSION|Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.|false|false|
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |HTTP_PROXY|HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.|""|false|
 |ICM_KEEP_COMPAT_LOCATION|Whether to keep compatibility location at /root/buildinfo/ for ICM injection|true|false|
@@ -65,6 +67,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 ## Results
 |name|description|
 |---|---|
+|IMAGES|Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.|
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_REF|Image reference of the built image|
 |IMAGE_URL|Image repository and tag where the built image was pushed|

--- a/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
+++ b/task/buildah-oci-ta/0.10/buildah-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.5
+    app.kubernetes.io/version: 0.10.6
     build.appstudio.redhat.com/build_type: docker
 spec:
   description: |-
@@ -77,6 +77,14 @@ spec:
       description: The image is built from this commit.
       type: string
       default: ""
+    - name: COMPRESSION_FORMAT
+      description: 'Compression format: gzip (default), zstd-chunked, or dual.
+        In dual mode both gzip and zstd:chunked variants are bundled in a
+        per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci.
+        Tech preview: dual and zstd-chunked modes are experimental and not
+        yet fully supported by the release pipeline.'
+      type: string
+      default: gzip
     - name: CONTEXT
       description: Path to the directory to use as context.
       type: string
@@ -97,6 +105,12 @@ spec:
       description: Array of --env values ("env=value" strings)
       type: array
       default: []
+    - name: FORCE_COMPRESSION
+      description: Recompress all layers including base image layers, not
+        just layers created by this build. Only applies to zstd-chunked and
+        dual modes.
+      type: string
+      default: "false"
     - name: HERMETIC
       description: Determines if build will be executed without network access.
       type: string
@@ -277,6 +291,11 @@ spec:
       type: string
       default: trusted-ca
   results:
+    - name: IMAGES
+      description: Comma-separated image manifest references. In dual mode
+        lists the gzip and zstd child manifest references for Chains provenance;
+        otherwise the single manifest reference.
+      type: string
     - name: IMAGE_DIGEST
       description: Digest of the image just built
     - name: IMAGE_REF
@@ -347,6 +366,8 @@ spec:
         value: $(params.BUILD_ARGS_FILE)
       - name: BUILD_TIMESTAMP
         value: $(params.BUILD_TIMESTAMP)
+      - name: COMPRESSION_FORMAT
+        value: $(params.COMPRESSION_FORMAT)
       - name: CONTEXT
         value: $(params.CONTEXT)
       - name: CONTEXTUALIZE_SBOM
@@ -680,6 +701,8 @@ spec:
           value: $(params.BUILDAH_FORMAT)
         - name: TASKRUN_NAME
           value: $(context.taskRun.name)
+        - name: FORCE_COMPRESSION
+          value: $(params.FORCE_COMPRESSION)
       script: |
         #!/bin/bash
         set -euo pipefail
@@ -703,43 +726,165 @@ spec:
           push_format=docker
         fi
 
-        echo "[$(date --utc -Ins)] Push image with unique tag"
+        # dual requires OCI: the zstd annotation is only valid on OCI manifests
+        if [ "${COMPRESSION_FORMAT}" = "dual" ] && [ "$push_format" != "oci" ]; then
+          echo "ERROR: COMPRESSION_FORMAT=dual requires BUILDAH_FORMAT=oci" >&2
+          exit 1
+        fi
+
+        compression_args=()
+        if [ "${COMPRESSION_FORMAT}" = "zstd-chunked" ]; then
+          compression_args+=(--compression-format zstd:chunked)
+        fi
+        if [ "${FORCE_COMPRESSION}" = "true" ] && [ "${COMPRESSION_FORMAT}" != "gzip" ]; then
+          compression_args+=(--force-compression)
+        fi
+
+        case "${COMPRESSION_FORMAT}" in
+        gzip | zstd-chunked | dual) ;;
+        *)
+          echo "ERROR: unsupported COMPRESSION_FORMAT '${COMPRESSION_FORMAT}'" >&2
+          exit 1
+          ;;
+        esac
 
         buildah_retries=3
+        image_repo="${IMAGE%:*}"
 
-        # Push to a unique tag based on the TaskRun name to avoid race conditions
-        echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
-        if ! retry buildah push \
-          --format="$push_format" \
-          --retry "$buildah_retries" \
-          --tls-verify="$TLSVERIFY" \
-          "$IMAGE" \
-          "docker://${IMAGE%:*}:${TASKRUN_NAME}"; then
-          echo "Failed to push image to ${IMAGE%:*}:${TASKRUN_NAME}"
-          exit 1
+        if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+          echo "[$(date --utc -Ins)] Push dual-compression per-arch index"
+
+          gzip_tag="${image_repo}:${TASKRUN_NAME}-gzip"
+          gzip_push_args=(
+            --format=oci
+            --retry "$buildah_retries"
+            --tls-verify="$TLSVERIFY"
+            --compression-format gzip
+            --digestfile /tmp/gzip-digest
+          )
+          if [ "${FORCE_COMPRESSION}" = "true" ]; then
+            gzip_push_args+=(--force-compression)
+          fi
+          echo "Pushing gzip variant to ${gzip_tag}"
+          if ! retry buildah push "${gzip_push_args[@]}" "$IMAGE" "docker://${gzip_tag}"; then
+            echo "Failed to push gzip variant to ${gzip_tag}" >&2
+            exit 1
+          fi
+          gzip_digest="$(cat /tmp/gzip-digest)"
+          gzip_ref="${image_repo}@${gzip_digest}"
+
+          zstd_tag="${image_repo}:${TASKRUN_NAME}-zstd"
+          zstd_push_args=(
+            --format=oci
+            --retry "$buildah_retries"
+            --tls-verify="$TLSVERIFY"
+            --compression-format zstd:chunked
+            --digestfile /tmp/zstd-digest
+          )
+          if [ "${FORCE_COMPRESSION}" = "true" ]; then
+            zstd_push_args+=(--force-compression)
+          fi
+          echo "Pushing zstd:chunked variant to ${zstd_tag}"
+          if ! retry buildah push "${zstd_push_args[@]}" "$IMAGE" "docker://${zstd_tag}"; then
+            echo "Failed to push zstd:chunked variant to ${zstd_tag}" >&2
+            exit 1
+          fi
+          zstd_digest="$(cat /tmp/zstd-digest)"
+          zstd_ref="${image_repo}@${zstd_digest}"
+
+          # gzip first in the index for backward compat with older Docker clients
+          per_arch_index="per-arch-index-${TASKRUN_NAME}"
+          echo "Creating per-arch index ${per_arch_index}"
+          buildah manifest create "$per_arch_index"
+          if ! retry buildah manifest add "$per_arch_index" "docker://${gzip_ref}"; then
+            echo "Failed to add gzip variant to ${per_arch_index}" >&2
+            exit 1
+          fi
+          if ! retry buildah manifest add "$per_arch_index" "docker://${zstd_ref}"; then
+            echo "Failed to add zstd variant to ${per_arch_index}" >&2
+            exit 1
+          fi
+
+          buildah manifest inspect "$per_arch_index" >/shared/per-arch-index-manifest.json
+
+          echo "Pushing per-arch index to ${image_repo}:${TASKRUN_NAME}"
+          if ! retry buildah manifest push --all \
+            --format=oci \
+            --retry "$buildah_retries" \
+            --tls-verify="$TLSVERIFY" \
+            --digestfile "/var/workdir/image-digest" \
+            "$per_arch_index" \
+            "docker://${image_repo}:${TASKRUN_NAME}"; then
+            echo "Failed to push per-arch index to ${image_repo}:${TASKRUN_NAME}" >&2
+            exit 1
+          fi
+
+          echo "Pushing per-arch index to ${IMAGE}"
+          if ! retry buildah manifest push --all \
+            --format=oci \
+            --retry "$buildah_retries" \
+            --tls-verify="$TLSVERIFY" \
+            "$per_arch_index" \
+            "docker://$IMAGE"; then
+            echo "Failed to push per-arch index to $IMAGE" >&2
+            exit 1
+          fi
+
+          index_digest="$(cat "/var/workdir/image-digest")"
+
+          echo -n "$index_digest" | tee "$(results.IMAGE_DIGEST.path)"
+          echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+          echo -n "${IMAGE}@${index_digest}" >"$(results.IMAGE_REF.path)"
+          echo -n "${gzip_ref},${zstd_ref}" >"$(results.IMAGES.path)"
+
+          echo -n "$gzip_digest" >/shared/gzip-digest
+          echo -n "$zstd_digest" >/shared/zstd-digest
+          echo -n "$gzip_ref" >/shared/gzip-ref
+          echo -n "$zstd_ref" >/shared/zstd-ref
+          echo
+        else
+          echo "[$(date --utc -Ins)] Push image with unique tag"
+
+          # Push to a unique tag based on the TaskRun name to avoid race conditions
+          echo "Pushing to ${image_repo}:${TASKRUN_NAME}"
+          if ! retry buildah push \
+            --format="$push_format" \
+            --retry "$buildah_retries" \
+            --tls-verify="$TLSVERIFY" \
+            "${compression_args[@]}" \
+            "$IMAGE" \
+            "docker://${image_repo}:${TASKRUN_NAME}"; then
+            echo "Failed to push image to ${image_repo}:${TASKRUN_NAME}" >&2
+            exit 1
+          fi
+
+          echo "[$(date --utc -Ins)] Push image with git revision"
+
+          # Push to a tag based on the git revision
+          echo "Pushing to ${IMAGE}"
+          if ! retry buildah push \
+            --format="$push_format" \
+            --retry "$buildah_retries" \
+            --tls-verify="$TLSVERIFY" \
+            "${compression_args[@]}" \
+            --digestfile "/var/workdir/image-digest" "$IMAGE" \
+            "docker://$IMAGE"; then
+            echo "Failed to push image to $IMAGE" >&2
+            exit 1
+          fi
+
+          tee "$(results.IMAGE_DIGEST.path)" <"/var/workdir"/image-digest
+          echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+          {
+            echo -n "${IMAGE}@"
+            cat "/var/workdir/image-digest"
+          } >"$(results.IMAGE_REF.path)"
+          {
+            echo -n "${IMAGE}@"
+            cat "/var/workdir/image-digest"
+          } >"$(results.IMAGES.path)"
+          echo
         fi
-
-        echo "[$(date --utc -Ins)] Push image with git revision"
-
-        # Push to a tag based on the git revision
-        echo "Pushing to ${IMAGE}"
-        if ! retry buildah push \
-          --format="$push_format" \
-          --retry "$buildah_retries" \
-          --tls-verify="$TLSVERIFY" \
-          --digestfile "/var/workdir/image-digest" "$IMAGE" \
-          "docker://$IMAGE"; then
-          echo "Failed to push image to $IMAGE"
-          exit 1
-        fi
-
-        tee "$(results.IMAGE_DIGEST.path)" <"/var/workdir"/image-digest
-        echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-        {
-          echo -n "${IMAGE}@"
-          cat "/var/workdir/image-digest"
-        } >"$(results.IMAGE_REF.path)"
-        echo
 
         # detect if keyless signing is required
         SIGNING_CONFIG='{}'
@@ -807,22 +952,34 @@ spec:
           SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
           export SIGSTORE_ID_TOKEN
 
-          IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
+          # In dual mode, sign all three variants: index, gzip child, zstd child
+          if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+            index_ref="$(cat "$(results.IMAGE_REF.path)")"
+            refs_to_sign=(
+              "$index_ref"
+              "$(cat /shared/gzip-ref)"
+              "$(cat /shared/zstd-ref)"
+            )
+          else
+            refs_to_sign=("$(cat "$(results.IMAGE_REF.path)")")
+          fi
 
           # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-          mkdir -p /tmp/auth && select-oci-auth "${IMAGE_REF}" >/tmp/auth/config.json
+          mkdir -p /tmp/auth && select-oci-auth "${refs_to_sign[0]}" >/tmp/auth/config.json
           export DOCKER_CONFIG=/tmp/auth
 
           echo "[$(date --utc -Ins)] Sign image"
-          echo "Signing image ${IMAGE_REF} using keyless signing"
-          if ! retry cosign sign -y \
-            --rekor-url="${REKOR_URL}" \
-            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-            "${IMAGE_REF}"; then
-            echo "Failed to sign image" >&2
-            exit 1
-          fi
+          for ref in "${refs_to_sign[@]}"; do
+            echo "Signing image ${ref} using keyless signing"
+            if ! retry cosign sign -y \
+              --rekor-url="${REKOR_URL}" \
+              --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+              --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+              "${ref}"; then
+              echo "Failed to sign image ${ref}" >&2
+              exit 1
+            fi
+          done
         elif [ "${configured}" -eq 0 ]; then
           echo "Keyless signing is disabled (none of ${missing} are configured in the konflux-info/cluster-config configmap)"
         else
@@ -953,52 +1110,69 @@ spec:
 
         echo "[$(date --utc -Ins)] Generate SBOM with mobster"
 
-        mobster_args=(
-          generate
-          --output sbom.json
-        )
+        # All compression variants share the same package list; only the digest differs
+        generate_oci_image_sbom() {
+          local output_file="$1"
+          local image_digest="$2"
+          local image_pullspec="$3"
+          local -a args=(generate --output "$output_file")
+          if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+            args+=(--skip-validation)
+          fi
+          args+=(
+            oci-image
+            --from-syft "/var/workdir/sbom-image.json"
+            --image-pullspec "$image_pullspec"
+            --image-digest "$image_digest"
+            --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+            --base-image-digest-file "/shared/base_images_digests"
+          )
+          if [ -f "/var/workdir/sbom-source.json" ]; then
+            args+=(--from-syft "/var/workdir/sbom-source.json")
+          fi
+          if [ -f "/var/workdir/sbom-prefetch.json" ]; then
+            args+=(--from-hermeto "/var/workdir/sbom-prefetch.json")
+          fi
+          if [ -n "${TARGET_STAGE}" ]; then
+            args+=(--dockerfile-target "${TARGET_STAGE}")
+          fi
+          for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
+            args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
+          done
+          if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
+            args+=(--contextualize)
+          fi
+          if [ -f "/shared/prefetch-arch" ]; then
+            args+=(--arch "$(cat /shared/prefetch-arch)")
+          fi
+          mobster "${args[@]}"
+        }
 
-        # Validation is a flag for `generate`, not `oci-image`, so we need to
-        # handle it before the oci-image arguments
-        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
-          echo "Skipping SBOM validation"
-          mobster_args+=(--skip-validation)
+        if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+          gzip_digest="$(cat /shared/gzip-digest)"
+          zstd_digest="$(cat /shared/zstd-digest)"
+
+          echo "Generating gzip child SBOM (main component digest ${gzip_digest})"
+          generate_oci_image_sbom sbom-gzip.json "$gzip_digest" "$IMAGE"
+
+          echo "Generating zstd child SBOM (main component digest ${zstd_digest})"
+          generate_oci_image_sbom sbom-zstd.json "$zstd_digest" "$IMAGE"
+
+          echo "Generating per-arch index SBOM (main component digest ${IMAGE_DIGEST})"
+          index_args=(generate --output sbom-index.json)
+          if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+            index_args+=(--skip-validation)
+          fi
+          index_args+=(
+            oci-index
+            --index-image-pullspec "$IMAGE_URL"
+            --index-image-digest "$IMAGE_DIGEST"
+            --index-manifest-path "/shared/per-arch-index-manifest.json"
+          )
+          mobster "${index_args[@]}"
+        else
+          generate_oci_image_sbom sbom.json "$IMAGE_DIGEST" "$IMAGE_URL"
         fi
-
-        mobster_args+=(
-          oci-image
-          --from-syft "/var/workdir/sbom-image.json"
-          --image-pullspec "$IMAGE_URL"
-          --image-digest "$IMAGE_DIGEST"
-          --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
-          --base-image-digest-file "/shared/base_images_digests"
-        )
-
-        if [ -f "/var/workdir/sbom-source.json" ]; then
-          mobster_args+=(--from-syft "/var/workdir/sbom-source.json")
-        fi
-
-        if [ -f "/var/workdir/sbom-prefetch.json" ]; then
-          mobster_args+=(--from-hermeto "/var/workdir/sbom-prefetch.json")
-        fi
-
-        if [ -n "${TARGET_STAGE}" ]; then
-          mobster_args+=(--dockerfile-target "${TARGET_STAGE}")
-        fi
-
-        for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-          mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
-        done
-
-        if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
-          mobster_args+=(--contextualize)
-        fi
-
-        if [ -f "/shared/prefetch-arch" ]; then
-          mobster_args+=(--arch "$(cat /shared/prefetch-arch)")
-        fi
-
-        mobster "${mobster_args[@]}"
 
         echo "[$(date --utc -Ins)] End prepare-sboms"
       computeResources:
@@ -1038,18 +1212,36 @@ spec:
           update-ca-trust
         fi
 
-        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-        mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" >/tmp/auth/config.json
-        export DOCKER_CONFIG=/tmp/auth
-        echo "Pushing sbom to registry"
-        if ! retry cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"; then
-          echo "Failed to push sbom to registry"
-          exit 1
+        # In dual mode each variant gets its own SBOM attached to its own digest
+        if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+          index_ref="$(cat "$(results.IMAGE_REF.path)")"
+          sbom_files=(sbom-gzip.json sbom-zstd.json sbom-index.json)
+          sbom_refs=("$(cat /shared/gzip-ref)" "$(cat /shared/zstd-ref)" "$index_ref")
+          primary_sbom=sbom-index.json
+        else
+          image_ref="$(cat "$(results.IMAGE_REF.path)")"
+          sbom_files=(sbom.json)
+          sbom_refs=("$image_ref")
+          primary_sbom=sbom.json
         fi
+
+        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+        mkdir -p /tmp/auth && select-oci-auth "${sbom_refs[0]}" >/tmp/auth/config.json
+        export DOCKER_CONFIG=/tmp/auth
+
+        for i in "${!sbom_files[@]}"; do
+          sbom_file="${sbom_files[$i]}"
+          ref="${sbom_refs[$i]}"
+          echo "Pushing sbom ${sbom_file} to ${ref}"
+          if ! retry cosign attach sbom --sbom "$sbom_file" --type "$SBOM_TYPE" "$ref"; then
+            echo "Failed to push sbom ${sbom_file} to ${ref}" >&2
+            exit 1
+          fi
+        done
 
         # Remove tag from IMAGE while allowing registry to contain a port number.
         sbom_repo="${IMAGE%:*}"
-        sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+        sbom_digest="$(sha256sum "$primary_sbom" | cut -d' ' -f1)"
         # The SBOM_BLOB_URL is created by `cosign attach sbom`.
         echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
 
@@ -1067,8 +1259,6 @@ spec:
           SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
           export SIGSTORE_ID_TOKEN
 
-          IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
-
           ATT_SBOM_TYPE="${SBOM_TYPE}"
           if [ "${ATT_SBOM_TYPE}" = "spdx" ]; then
             # for format cossistency with cyclonedx format, we want to use spdxjson instad of spdx
@@ -1076,16 +1266,20 @@ spec:
             ATT_SBOM_TYPE="spdxjson"
           fi
 
-          echo "[$(date --utc -Ins)] Sign SBOM"
-          echo "Signing and attaching SBOM to ${IMAGE_REF} using keyless signing"
-          if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate sbom.json \
-            --rekor-url="${REKOR_URL}" \
-            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-            "${IMAGE_REF}"; then
-            echo "Failed to sign SBOM" >&2
-            exit 1
-          fi
+          for i in "${!sbom_files[@]}"; do
+            sbom_file="${sbom_files[$i]}"
+            ref="${sbom_refs[$i]}"
+            echo "[$(date --utc -Ins)] Sign SBOM"
+            echo "Signing and attaching SBOM ${sbom_file} to ${ref} using keyless signing"
+            if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate "$sbom_file" \
+              --rekor-url="${REKOR_URL}" \
+              --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+              --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+              "${ref}"; then
+              echo "Failed to sign SBOM ${sbom_file}" >&2
+              exit 1
+            fi
+          done
         fi
 
         echo

--- a/task/buildah-oci-ta/CHANGELOG.md
+++ b/task/buildah-oci-ta/CHANGELOG.md
@@ -11,6 +11,18 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.6
+
+### Added
+
+- New parameter `COMPRESSION_FORMAT` (gzip | zstd-chunked | dual, default: gzip).
+  In dual mode, both gzip and zstd:chunked variants are pushed and bundled in a
+  per-arch OCI index with gzip first for backward compatibility. Tech preview.
+- New parameter `FORCE_COMPRESSION` (default: false). Recompress all layers
+  including base image layers in zstd-chunked and dual modes.
+- New result `IMAGES`. Comma-separated image manifest references for Chains
+  provenance. In dual mode, lists the gzip and zstd child manifest references.
+
 ## 0.10.5
 
 ### Added

--- a/task/buildah-remote-oci-ta/0.10/README.md
+++ b/task/buildah-remote-oci-ta/0.10/README.md
@@ -20,11 +20,13 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |BUILD_TIMESTAMP|Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.|""|false|
 |CACHI2_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.|""|false|
 |COMMIT_SHA|The image is built from this commit.|""|false|
+|COMPRESSION_FORMAT|Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.|gzip|false|
 |CONTEXT|Path to the directory to use as context.|.|false|
 |CONTEXTUALIZE_SBOM|Determines if SBOM will be contextualized.|true|false|
 |DOCKERFILE|Path to the Dockerfile to build.|./Dockerfile|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|
 |ENV_VARS|Array of --env values ("env=value" strings)|[]|false|
+|FORCE_COMPRESSION|Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.|false|false|
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |HTTP_PROXY|HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.|""|false|
 |ICM_KEEP_COMPAT_LOCATION|Whether to keep compatibility location at /root/buildinfo/ for ICM injection|true|false|
@@ -67,6 +69,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 ## Results
 |name|description|
 |---|---|
+|IMAGES|Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.|
 |IMAGE_DIGEST|Digest of the image just built|
 |IMAGE_REF|Image reference of the built image|
 |IMAGE_URL|Image repository and tag where the built image was pushed|

--- a/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
+++ b/task/buildah-remote-oci-ta/0.10/buildah-remote-oci-ta.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.5
+    app.kubernetes.io/version: 0.10.6
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote-oci-ta
 spec:
@@ -74,6 +74,13 @@ spec:
     description: The image is built from this commit.
     name: COMMIT_SHA
     type: string
+  - default: gzip
+    description: 'Compression format: gzip (default), zstd-chunked, or dual. In dual
+      mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index
+      (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked
+      modes are experimental and not yet fully supported by the release pipeline.'
+    name: COMPRESSION_FORMAT
+    type: string
   - default: .
     description: Path to the directory to use as context.
     name: CONTEXT
@@ -94,6 +101,11 @@ spec:
     description: Array of --env values ("env=value" strings)
     name: ENV_VARS
     type: array
+  - default: "false"
+    description: Recompress all layers including base image layers, not just layers
+      created by this build. Only applies to zstd-chunked and dual modes.
+    name: FORCE_COMPRESSION
+    type: string
   - default: "false"
     description: Determines if build will be executed without network access.
     name: HERMETIC
@@ -274,6 +286,11 @@ spec:
     name: IMAGE_APPEND_PLATFORM
     type: string
   results:
+  - description: Comma-separated image manifest references. In dual mode lists the
+      gzip and zstd child manifest references for Chains provenance; otherwise the
+      single manifest reference.
+    name: IMAGES
+    type: string
   - description: Digest of the image just built
     name: IMAGE_DIGEST
   - description: Image reference of the built image
@@ -304,6 +321,8 @@ spec:
       value: $(params.BUILD_ARGS_FILE)
     - name: BUILD_TIMESTAMP
       value: $(params.BUILD_TIMESTAMP)
+    - name: COMPRESSION_FORMAT
+      value: $(params.COMPRESSION_FORMAT)
     - name: CONTEXT
       value: $(params.CONTEXT)
     - name: CONTEXTUALIZE_SBOM
@@ -705,6 +724,7 @@ spec:
           -e ANNOTATIONS_FILE="${ANNOTATIONS_FILE@Q}" \
           -e BUILD_ARGS_FILE="${BUILD_ARGS_FILE@Q}" \
           -e BUILD_TIMESTAMP="${BUILD_TIMESTAMP@Q}" \
+          -e COMPRESSION_FORMAT="${COMPRESSION_FORMAT@Q}" \
           -e CONTEXT="${CONTEXT@Q}" \
           -e CONTEXTUALIZE_SBOM="${CONTEXTUALIZE_SBOM@Q}" \
           -e HERMETIC="${HERMETIC@Q}" \
@@ -806,6 +826,8 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
+    - name: FORCE_COMPRESSION
+      value: $(params.FORCE_COMPRESSION)
     image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: push
     script: |
@@ -835,43 +857,165 @@ spec:
         push_format=docker
       fi
 
-      echo "[$(date --utc -Ins)] Push image with unique tag"
+      # dual requires OCI: the zstd annotation is only valid on OCI manifests
+      if [ "${COMPRESSION_FORMAT}" = "dual" ] && [ "$push_format" != "oci" ]; then
+        echo "ERROR: COMPRESSION_FORMAT=dual requires BUILDAH_FORMAT=oci" >&2
+        exit 1
+      fi
+
+      compression_args=()
+      if [ "${COMPRESSION_FORMAT}" = "zstd-chunked" ]; then
+        compression_args+=(--compression-format zstd:chunked)
+      fi
+      if [ "${FORCE_COMPRESSION}" = "true" ] && [ "${COMPRESSION_FORMAT}" != "gzip" ]; then
+        compression_args+=(--force-compression)
+      fi
+
+      case "${COMPRESSION_FORMAT}" in
+      gzip | zstd-chunked | dual) ;;
+      *)
+        echo "ERROR: unsupported COMPRESSION_FORMAT '${COMPRESSION_FORMAT}'" >&2
+        exit 1
+        ;;
+      esac
 
       buildah_retries=3
+      image_repo="${IMAGE%:*}"
 
-      # Push to a unique tag based on the TaskRun name to avoid race conditions
-      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
-      if ! retry buildah push \
-        --format="$push_format" \
-        --retry "$buildah_retries" \
-        --tls-verify="$TLSVERIFY" \
-        "$IMAGE" \
-        "docker://${IMAGE%:*}:${TASKRUN_NAME}"; then
-        echo "Failed to push image to ${IMAGE%:*}:${TASKRUN_NAME}"
-        exit 1
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        echo "[$(date --utc -Ins)] Push dual-compression per-arch index"
+
+        gzip_tag="${image_repo}:${TASKRUN_NAME}-gzip"
+        gzip_push_args=(
+          --format=oci
+          --retry "$buildah_retries"
+          --tls-verify="$TLSVERIFY"
+          --compression-format gzip
+          --digestfile /tmp/gzip-digest
+        )
+        if [ "${FORCE_COMPRESSION}" = "true" ]; then
+          gzip_push_args+=(--force-compression)
+        fi
+        echo "Pushing gzip variant to ${gzip_tag}"
+        if ! retry buildah push "${gzip_push_args[@]}" "$IMAGE" "docker://${gzip_tag}"; then
+          echo "Failed to push gzip variant to ${gzip_tag}" >&2
+          exit 1
+        fi
+        gzip_digest="$(cat /tmp/gzip-digest)"
+        gzip_ref="${image_repo}@${gzip_digest}"
+
+        zstd_tag="${image_repo}:${TASKRUN_NAME}-zstd"
+        zstd_push_args=(
+          --format=oci
+          --retry "$buildah_retries"
+          --tls-verify="$TLSVERIFY"
+          --compression-format zstd:chunked
+          --digestfile /tmp/zstd-digest
+        )
+        if [ "${FORCE_COMPRESSION}" = "true" ]; then
+          zstd_push_args+=(--force-compression)
+        fi
+        echo "Pushing zstd:chunked variant to ${zstd_tag}"
+        if ! retry buildah push "${zstd_push_args[@]}" "$IMAGE" "docker://${zstd_tag}"; then
+          echo "Failed to push zstd:chunked variant to ${zstd_tag}" >&2
+          exit 1
+        fi
+        zstd_digest="$(cat /tmp/zstd-digest)"
+        zstd_ref="${image_repo}@${zstd_digest}"
+
+        # gzip first in the index for backward compat with older Docker clients
+        per_arch_index="per-arch-index-${TASKRUN_NAME}"
+        echo "Creating per-arch index ${per_arch_index}"
+        buildah manifest create "$per_arch_index"
+        if ! retry buildah manifest add "$per_arch_index" "docker://${gzip_ref}"; then
+          echo "Failed to add gzip variant to ${per_arch_index}" >&2
+          exit 1
+        fi
+        if ! retry buildah manifest add "$per_arch_index" "docker://${zstd_ref}"; then
+          echo "Failed to add zstd variant to ${per_arch_index}" >&2
+          exit 1
+        fi
+
+        buildah manifest inspect "$per_arch_index" >/shared/per-arch-index-manifest.json
+
+        echo "Pushing per-arch index to ${image_repo}:${TASKRUN_NAME}"
+        if ! retry buildah manifest push --all \
+          --format=oci \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          --digestfile "/var/workdir/image-digest" \
+          "$per_arch_index" \
+          "docker://${image_repo}:${TASKRUN_NAME}"; then
+          echo "Failed to push per-arch index to ${image_repo}:${TASKRUN_NAME}" >&2
+          exit 1
+        fi
+
+        echo "Pushing per-arch index to ${IMAGE}"
+        if ! retry buildah manifest push --all \
+          --format=oci \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "$per_arch_index" \
+          "docker://$IMAGE"; then
+          echo "Failed to push per-arch index to $IMAGE" >&2
+          exit 1
+        fi
+
+        index_digest="$(cat "/var/workdir/image-digest")"
+
+        echo -n "$index_digest" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${IMAGE}@${index_digest}" >"$(results.IMAGE_REF.path)"
+        echo -n "${gzip_ref},${zstd_ref}" >"$(results.IMAGES.path)"
+
+        echo -n "$gzip_digest" >/shared/gzip-digest
+        echo -n "$zstd_digest" >/shared/zstd-digest
+        echo -n "$gzip_ref" >/shared/gzip-ref
+        echo -n "$zstd_ref" >/shared/zstd-ref
+        echo
+      else
+        echo "[$(date --utc -Ins)] Push image with unique tag"
+
+        # Push to a unique tag based on the TaskRun name to avoid race conditions
+        echo "Pushing to ${image_repo}:${TASKRUN_NAME}"
+        if ! retry buildah push \
+          --format="$push_format" \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "${compression_args[@]}" \
+          "$IMAGE" \
+          "docker://${image_repo}:${TASKRUN_NAME}"; then
+          echo "Failed to push image to ${image_repo}:${TASKRUN_NAME}" >&2
+          exit 1
+        fi
+
+        echo "[$(date --utc -Ins)] Push image with git revision"
+
+        # Push to a tag based on the git revision
+        echo "Pushing to ${IMAGE}"
+        if ! retry buildah push \
+          --format="$push_format" \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "${compression_args[@]}" \
+          --digestfile "/var/workdir/image-digest" "$IMAGE" \
+          "docker://$IMAGE"; then
+          echo "Failed to push image to $IMAGE" >&2
+          exit 1
+        fi
+
+        tee "$(results.IMAGE_DIGEST.path)" <"/var/workdir"/image-digest
+        echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+        {
+          echo -n "${IMAGE}@"
+          cat "/var/workdir/image-digest"
+        } >"$(results.IMAGE_REF.path)"
+        {
+          echo -n "${IMAGE}@"
+          cat "/var/workdir/image-digest"
+        } >"$(results.IMAGES.path)"
+        echo
       fi
-
-      echo "[$(date --utc -Ins)] Push image with git revision"
-
-      # Push to a tag based on the git revision
-      echo "Pushing to ${IMAGE}"
-      if ! retry buildah push \
-        --format="$push_format" \
-        --retry "$buildah_retries" \
-        --tls-verify="$TLSVERIFY" \
-        --digestfile "/var/workdir/image-digest" "$IMAGE" \
-        "docker://$IMAGE"; then
-        echo "Failed to push image to $IMAGE"
-        exit 1
-      fi
-
-      tee "$(results.IMAGE_DIGEST.path)" <"/var/workdir"/image-digest
-      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-      {
-        echo -n "${IMAGE}@"
-        cat "/var/workdir/image-digest"
-      } >"$(results.IMAGE_REF.path)"
-      echo
 
       # detect if keyless signing is required
       SIGNING_CONFIG='{}'
@@ -939,22 +1083,34 @@ spec:
         SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
         export SIGSTORE_ID_TOKEN
 
-        IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
+        # In dual mode, sign all three variants: index, gzip child, zstd child
+        if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+          index_ref="$(cat "$(results.IMAGE_REF.path)")"
+          refs_to_sign=(
+            "$index_ref"
+            "$(cat /shared/gzip-ref)"
+            "$(cat /shared/zstd-ref)"
+          )
+        else
+          refs_to_sign=("$(cat "$(results.IMAGE_REF.path)")")
+        fi
 
         # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-        mkdir -p /tmp/auth && select-oci-auth "${IMAGE_REF}" >/tmp/auth/config.json
+        mkdir -p /tmp/auth && select-oci-auth "${refs_to_sign[0]}" >/tmp/auth/config.json
         export DOCKER_CONFIG=/tmp/auth
 
         echo "[$(date --utc -Ins)] Sign image"
-        echo "Signing image ${IMAGE_REF} using keyless signing"
-        if ! retry cosign sign -y \
-          --rekor-url="${REKOR_URL}" \
-          --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-          --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-          "${IMAGE_REF}"; then
-          echo "Failed to sign image" >&2
-          exit 1
-        fi
+        for ref in "${refs_to_sign[@]}"; do
+          echo "Signing image ${ref} using keyless signing"
+          if ! retry cosign sign -y \
+            --rekor-url="${REKOR_URL}" \
+            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+            "${ref}"; then
+            echo "Failed to sign image ${ref}" >&2
+            exit 1
+          fi
+        done
       elif [ "${configured}" -eq 0 ]; then
         echo "Keyless signing is disabled (none of ${missing} are configured in the konflux-info/cluster-config configmap)"
       else
@@ -1102,52 +1258,69 @@ spec:
 
       echo "[$(date --utc -Ins)] Generate SBOM with mobster"
 
-      mobster_args=(
-        generate
-        --output sbom.json
-      )
+      # All compression variants share the same package list; only the digest differs
+      generate_oci_image_sbom() {
+        local output_file="$1"
+        local image_digest="$2"
+        local image_pullspec="$3"
+        local -a args=(generate --output "$output_file")
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          args+=(--skip-validation)
+        fi
+        args+=(
+          oci-image
+          --from-syft "/var/workdir/sbom-image.json"
+          --image-pullspec "$image_pullspec"
+          --image-digest "$image_digest"
+          --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+          --base-image-digest-file "/shared/base_images_digests"
+        )
+        if [ -f "/var/workdir/sbom-source.json" ]; then
+          args+=(--from-syft "/var/workdir/sbom-source.json")
+        fi
+        if [ -f "/var/workdir/sbom-prefetch.json" ]; then
+          args+=(--from-hermeto "/var/workdir/sbom-prefetch.json")
+        fi
+        if [ -n "${TARGET_STAGE}" ]; then
+          args+=(--dockerfile-target "${TARGET_STAGE}")
+        fi
+        for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
+          args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
+        done
+        if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
+          args+=(--contextualize)
+        fi
+        if [ -f "/shared/prefetch-arch" ]; then
+          args+=(--arch "$(cat /shared/prefetch-arch)")
+        fi
+        mobster "${args[@]}"
+      }
 
-      # Validation is a flag for `generate`, not `oci-image`, so we need to
-      # handle it before the oci-image arguments
-      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
-        echo "Skipping SBOM validation"
-        mobster_args+=(--skip-validation)
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        gzip_digest="$(cat /shared/gzip-digest)"
+        zstd_digest="$(cat /shared/zstd-digest)"
+
+        echo "Generating gzip child SBOM (main component digest ${gzip_digest})"
+        generate_oci_image_sbom sbom-gzip.json "$gzip_digest" "$IMAGE"
+
+        echo "Generating zstd child SBOM (main component digest ${zstd_digest})"
+        generate_oci_image_sbom sbom-zstd.json "$zstd_digest" "$IMAGE"
+
+        echo "Generating per-arch index SBOM (main component digest ${IMAGE_DIGEST})"
+        index_args=(generate --output sbom-index.json)
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          index_args+=(--skip-validation)
+        fi
+        index_args+=(
+          oci-index
+          --index-image-pullspec "$IMAGE_URL"
+          --index-image-digest "$IMAGE_DIGEST"
+          --index-manifest-path "/shared/per-arch-index-manifest.json"
+        )
+        mobster "${index_args[@]}"
+      else
+        generate_oci_image_sbom sbom.json "$IMAGE_DIGEST" "$IMAGE_URL"
       fi
-
-      mobster_args+=(
-        oci-image
-        --from-syft "/var/workdir/sbom-image.json"
-        --image-pullspec "$IMAGE_URL"
-        --image-digest "$IMAGE_DIGEST"
-        --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
-        --base-image-digest-file "/shared/base_images_digests"
-      )
-
-      if [ -f "/var/workdir/sbom-source.json" ]; then
-        mobster_args+=(--from-syft "/var/workdir/sbom-source.json")
-      fi
-
-      if [ -f "/var/workdir/sbom-prefetch.json" ]; then
-        mobster_args+=(--from-hermeto "/var/workdir/sbom-prefetch.json")
-      fi
-
-      if [ -n "${TARGET_STAGE}" ]; then
-        mobster_args+=(--dockerfile-target "${TARGET_STAGE}")
-      fi
-
-      for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-        mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
-      done
-
-      if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
-        mobster_args+=(--contextualize)
-      fi
-
-      if [ -f "/shared/prefetch-arch" ]; then
-        mobster_args+=(--arch "$(cat /shared/prefetch-arch)")
-      fi
-
-      mobster "${mobster_args[@]}"
 
       echo "[$(date --utc -Ins)] End prepare-sboms"
     securityContext:
@@ -1184,18 +1357,36 @@ spec:
         update-ca-trust
       fi
 
-      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-      mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" >/tmp/auth/config.json
-      export DOCKER_CONFIG=/tmp/auth
-      echo "Pushing sbom to registry"
-      if ! retry cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"; then
-        echo "Failed to push sbom to registry"
-        exit 1
+      # In dual mode each variant gets its own SBOM attached to its own digest
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        index_ref="$(cat "$(results.IMAGE_REF.path)")"
+        sbom_files=(sbom-gzip.json sbom-zstd.json sbom-index.json)
+        sbom_refs=("$(cat /shared/gzip-ref)" "$(cat /shared/zstd-ref)" "$index_ref")
+        primary_sbom=sbom-index.json
+      else
+        image_ref="$(cat "$(results.IMAGE_REF.path)")"
+        sbom_files=(sbom.json)
+        sbom_refs=("$image_ref")
+        primary_sbom=sbom.json
       fi
+
+      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+      mkdir -p /tmp/auth && select-oci-auth "${sbom_refs[0]}" >/tmp/auth/config.json
+      export DOCKER_CONFIG=/tmp/auth
+
+      for i in "${!sbom_files[@]}"; do
+        sbom_file="${sbom_files[$i]}"
+        ref="${sbom_refs[$i]}"
+        echo "Pushing sbom ${sbom_file} to ${ref}"
+        if ! retry cosign attach sbom --sbom "$sbom_file" --type "$SBOM_TYPE" "$ref"; then
+          echo "Failed to push sbom ${sbom_file} to ${ref}" >&2
+          exit 1
+        fi
+      done
 
       # Remove tag from IMAGE while allowing registry to contain a port number.
       sbom_repo="${IMAGE%:*}"
-      sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+      sbom_digest="$(sha256sum "$primary_sbom" | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
 
@@ -1213,8 +1404,6 @@ spec:
         SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
         export SIGSTORE_ID_TOKEN
 
-        IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
-
         ATT_SBOM_TYPE="${SBOM_TYPE}"
         if [ "${ATT_SBOM_TYPE}" = "spdx" ]; then
           # for format cossistency with cyclonedx format, we want to use spdxjson instad of spdx
@@ -1222,16 +1411,20 @@ spec:
           ATT_SBOM_TYPE="spdxjson"
         fi
 
-        echo "[$(date --utc -Ins)] Sign SBOM"
-        echo "Signing and attaching SBOM to ${IMAGE_REF} using keyless signing"
-        if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate sbom.json \
-          --rekor-url="${REKOR_URL}" \
-          --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-          --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-          "${IMAGE_REF}"; then
-          echo "Failed to sign SBOM" >&2
-          exit 1
-        fi
+        for i in "${!sbom_files[@]}"; do
+          sbom_file="${sbom_files[$i]}"
+          ref="${sbom_refs[$i]}"
+          echo "[$(date --utc -Ins)] Sign SBOM"
+          echo "Signing and attaching SBOM ${sbom_file} to ${ref} using keyless signing"
+          if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate "$sbom_file" \
+            --rekor-url="${REKOR_URL}" \
+            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+            "${ref}"; then
+            echo "Failed to sign SBOM ${sbom_file}" >&2
+            exit 1
+          fi
+        done
       fi
 
       echo

--- a/task/buildah-remote-oci-ta/CHANGELOG.md
+++ b/task/buildah-remote-oci-ta/CHANGELOG.md
@@ -11,6 +11,18 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.6
+
+### Added
+
+- New parameter `COMPRESSION_FORMAT` (gzip | zstd-chunked | dual, default: gzip).
+  In dual mode, both gzip and zstd:chunked variants are pushed and bundled in a
+  per-arch OCI index with gzip first for backward compatibility. Tech preview.
+- New parameter `FORCE_COMPRESSION` (default: false). Recompress all layers
+  including base image layers in zstd-chunked and dual modes.
+- New result `IMAGES`. Comma-separated image manifest references for Chains
+  provenance. In dual mode, lists the gzip and zstd child manifest references.
+
 ## 0.10.5
 
 ### Added

--- a/task/buildah-remote/0.10/README.md
+++ b/task/buildah-remote/0.10/README.md
@@ -59,6 +59,8 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |SKIP_INJECTIONS|Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.|false|false|
 |LOG_LEVEL|Log level for the build command.|info|false|
 |ALLOW_CROSS_PLATFORM_IMAGES|Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.|false|false|
+|COMPRESSION_FORMAT|Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.|gzip|false|
+|FORCE_COMPRESSION|Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.|false|false|
 |PLATFORM|The platform to build on||true|
 |IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
 
@@ -69,6 +71,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |IMAGE_URL|Image repository and tag where the built image was pushed|
 |IMAGE_REF|Image reference of the built image|
 |SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+|IMAGES|Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.|
 
 ## Workspaces
 |name|description|optional|

--- a/task/buildah-remote/0.10/buildah-remote.yaml
+++ b/task/buildah-remote/0.10/buildah-remote.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.10.5
+    app.kubernetes.io/version: 0.10.6
     build.appstudio.redhat.com/build_type: docker
   name: buildah-remote
 spec:
@@ -256,6 +256,18 @@ spec:
       This option must be used with caution as it may create incompatible images.
     name: ALLOW_CROSS_PLATFORM_IMAGES
     type: string
+  - default: gzip
+    description: 'Compression format: gzip (default), zstd-chunked, or dual. In dual
+      mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index
+      (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked
+      modes are experimental and not yet fully supported by the release pipeline.'
+    name: COMPRESSION_FORMAT
+    type: string
+  - default: "false"
+    description: Recompress all layers including base image layers, not just layers
+      created by this build. Only applies to zstd-chunked and dual modes.
+    name: FORCE_COMPRESSION
+    type: string
   - description: The platform to build on
     name: PLATFORM
     type: string
@@ -274,6 +286,11 @@ spec:
   - description: Reference of SBOM blob digest to enable digest-based verification
       from provenance
     name: SBOM_BLOB_URL
+    type: string
+  - description: Comma-separated image manifest references. In dual mode lists the
+      gzip and zstd child manifest references for Chains provenance; otherwise the
+      single manifest reference.
+    name: IMAGES
     type: string
   stepTemplate:
     computeResources:
@@ -345,6 +362,8 @@ spec:
       value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     - name: RHSM_MOUNT_CA_CERTS
       value: $(params.RHSM_MOUNT_CA_CERTS)
+    - name: COMPRESSION_FORMAT
+      value: $(params.COMPRESSION_FORMAT)
     - name: BUILDER_IMAGE
       value: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     - name: PLATFORM
@@ -707,6 +726,7 @@ spec:
           -e SKIP_INJECTIONS="${SKIP_INJECTIONS@Q}" \
           -e ALLOW_CROSS_PLATFORM_IMAGES="${ALLOW_CROSS_PLATFORM_IMAGES@Q}" \
           -e RHSM_MOUNT_CA_CERTS="${RHSM_MOUNT_CA_CERTS@Q}" \
+          -e COMPRESSION_FORMAT="${COMPRESSION_FORMAT@Q}" \
           -e HOME="${HOME@Q}" \
           -e COMMIT_SHA="${COMMIT_SHA@Q}" \
           -e SOURCE_URL="${SOURCE_URL@Q}" \
@@ -783,6 +803,8 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
+    - name: FORCE_COMPRESSION
+      value: $(params.FORCE_COMPRESSION)
     image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
     name: push
     script: |
@@ -812,45 +834,168 @@ spec:
         push_format=docker
       fi
 
-      echo "[$(date --utc -Ins)] Push image with unique tag"
+      # dual requires OCI: the zstd annotation is only valid on OCI manifests
+      if [ "${COMPRESSION_FORMAT}" = "dual" ] && [ "$push_format" != "oci" ]; then
+        echo "ERROR: COMPRESSION_FORMAT=dual requires BUILDAH_FORMAT=oci" >&2
+        exit 1
+      fi
+
+      compression_args=()
+      if [ "${COMPRESSION_FORMAT}" = "zstd-chunked" ]; then
+        compression_args+=(--compression-format zstd:chunked)
+      fi
+      if [ "${FORCE_COMPRESSION}" = "true" ] && [ "${COMPRESSION_FORMAT}" != "gzip" ]; then
+        compression_args+=(--force-compression)
+      fi
+
+      case "${COMPRESSION_FORMAT}" in
+        gzip|zstd-chunked|dual) ;;
+        *) echo "ERROR: unsupported COMPRESSION_FORMAT '${COMPRESSION_FORMAT}'" >&2; exit 1 ;;
+      esac
 
       buildah_retries=3
+      image_repo="${IMAGE%:*}"
 
-      # Push to a unique tag based on the TaskRun name to avoid race conditions
-      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
-      if ! retry buildah push \
-        --format="$push_format" \
-        --retry "$buildah_retries" \
-        --tls-verify="$TLSVERIFY" \
-        "$IMAGE" \
-        "docker://${IMAGE%:*}:${TASKRUN_NAME}"
-      then
-        echo "Failed to push image to ${IMAGE%:*}:${TASKRUN_NAME}"
-        exit 1
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        echo "[$(date --utc -Ins)] Push dual-compression per-arch index"
+
+        gzip_tag="${image_repo}:${TASKRUN_NAME}-gzip"
+        gzip_push_args=(
+          --format=oci
+          --retry "$buildah_retries"
+          --tls-verify="$TLSVERIFY"
+          --compression-format gzip
+          --digestfile /tmp/gzip-digest
+        )
+        if [ "${FORCE_COMPRESSION}" = "true" ]; then
+          gzip_push_args+=(--force-compression)
+        fi
+        echo "Pushing gzip variant to ${gzip_tag}"
+        if ! retry buildah push "${gzip_push_args[@]}" "$IMAGE" "docker://${gzip_tag}"
+        then
+          echo "Failed to push gzip variant to ${gzip_tag}" >&2
+          exit 1
+        fi
+        gzip_digest="$(cat /tmp/gzip-digest)"
+        gzip_ref="${image_repo}@${gzip_digest}"
+
+        zstd_tag="${image_repo}:${TASKRUN_NAME}-zstd"
+        zstd_push_args=(
+          --format=oci
+          --retry "$buildah_retries"
+          --tls-verify="$TLSVERIFY"
+          --compression-format zstd:chunked
+          --digestfile /tmp/zstd-digest
+        )
+        if [ "${FORCE_COMPRESSION}" = "true" ]; then
+          zstd_push_args+=(--force-compression)
+        fi
+        echo "Pushing zstd:chunked variant to ${zstd_tag}"
+        if ! retry buildah push "${zstd_push_args[@]}" "$IMAGE" "docker://${zstd_tag}"
+        then
+          echo "Failed to push zstd:chunked variant to ${zstd_tag}" >&2
+          exit 1
+        fi
+        zstd_digest="$(cat /tmp/zstd-digest)"
+        zstd_ref="${image_repo}@${zstd_digest}"
+
+        # gzip first in the index for backward compat with older Docker clients
+        per_arch_index="per-arch-index-${TASKRUN_NAME}"
+        echo "Creating per-arch index ${per_arch_index}"
+        buildah manifest create "$per_arch_index"
+        if ! retry buildah manifest add "$per_arch_index" "docker://${gzip_ref}"; then
+          echo "Failed to add gzip variant to ${per_arch_index}" >&2
+          exit 1
+        fi
+        if ! retry buildah manifest add "$per_arch_index" "docker://${zstd_ref}"; then
+          echo "Failed to add zstd variant to ${per_arch_index}" >&2
+          exit 1
+        fi
+
+        buildah manifest inspect "$per_arch_index" > /shared/per-arch-index-manifest.json
+
+        echo "Pushing per-arch index to ${image_repo}:${TASKRUN_NAME}"
+        if ! retry buildah manifest push --all \
+          --format=oci \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          --digestfile "$(workspaces.source.path)/image-digest" \
+          "$per_arch_index" \
+          "docker://${image_repo}:${TASKRUN_NAME}"
+        then
+          echo "Failed to push per-arch index to ${image_repo}:${TASKRUN_NAME}" >&2
+          exit 1
+        fi
+
+        echo "Pushing per-arch index to ${IMAGE}"
+        if ! retry buildah manifest push --all \
+          --format=oci \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "$per_arch_index" \
+          "docker://$IMAGE"
+        then
+          echo "Failed to push per-arch index to $IMAGE" >&2
+          exit 1
+        fi
+
+        index_digest="$(cat "$(workspaces.source.path)/image-digest")"
+
+        echo -n "$index_digest" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${IMAGE}@${index_digest}" > "$(results.IMAGE_REF.path)"
+        echo -n "${gzip_ref},${zstd_ref}" > "$(results.IMAGES.path)"
+
+        echo -n "$gzip_digest" > /shared/gzip-digest
+        echo -n "$zstd_digest" > /shared/zstd-digest
+        echo -n "$gzip_ref" > /shared/gzip-ref
+        echo -n "$zstd_ref" > /shared/zstd-ref
+        echo
+      else
+        echo "[$(date --utc -Ins)] Push image with unique tag"
+
+        # Push to a unique tag based on the TaskRun name to avoid race conditions
+        echo "Pushing to ${image_repo}:${TASKRUN_NAME}"
+        if ! retry buildah push \
+          --format="$push_format" \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "${compression_args[@]}" \
+          "$IMAGE" \
+          "docker://${image_repo}:${TASKRUN_NAME}"
+        then
+          echo "Failed to push image to ${image_repo}:${TASKRUN_NAME}" >&2
+          exit 1
+        fi
+
+        echo "[$(date --utc -Ins)] Push image with git revision"
+
+        # Push to a tag based on the git revision
+        echo "Pushing to ${IMAGE}"
+        if ! retry buildah push \
+          --format="$push_format" \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "${compression_args[@]}" \
+          --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+          "docker://$IMAGE"
+        then
+          echo "Failed to push image to $IMAGE" >&2
+          exit 1
+        fi
+
+        tee "$(results.IMAGE_DIGEST.path)" < "$(workspaces.source.path)"/image-digest
+        echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+        {
+          echo -n "${IMAGE}@"
+          cat "$(workspaces.source.path)/image-digest"
+        } > "$(results.IMAGE_REF.path)"
+        {
+          echo -n "${IMAGE}@"
+          cat "$(workspaces.source.path)/image-digest"
+        } > "$(results.IMAGES.path)"
+        echo
       fi
-
-      echo "[$(date --utc -Ins)] Push image with git revision"
-
-      # Push to a tag based on the git revision
-      echo "Pushing to ${IMAGE}"
-      if ! retry buildah push \
-        --format="$push_format" \
-        --retry "$buildah_retries" \
-        --tls-verify="$TLSVERIFY" \
-        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
-        "docker://$IMAGE"
-      then
-        echo "Failed to push image to $IMAGE"
-        exit 1
-      fi
-
-      tee "$(results.IMAGE_DIGEST.path)" < "$(workspaces.source.path)"/image-digest
-      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-      {
-        echo -n "${IMAGE}@"
-        cat "$(workspaces.source.path)/image-digest"
-      } > "$(results.IMAGE_REF.path)"
-      echo
 
       # detect if keyless signing is required
       SIGNING_CONFIG='{}'
@@ -920,23 +1065,35 @@ spec:
         SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
         export SIGSTORE_ID_TOKEN
 
-        IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
+        # In dual mode, sign all three variants: index, gzip child, zstd child
+        if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+          index_ref="$(cat "$(results.IMAGE_REF.path)")"
+          refs_to_sign=(
+            "$index_ref"
+            "$(cat /shared/gzip-ref)"
+            "$(cat /shared/zstd-ref)"
+          )
+        else
+          refs_to_sign=("$(cat "$(results.IMAGE_REF.path)")")
+        fi
 
         # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-        mkdir -p /tmp/auth && select-oci-auth "${IMAGE_REF}" > /tmp/auth/config.json
+        mkdir -p /tmp/auth && select-oci-auth "${refs_to_sign[0]}" > /tmp/auth/config.json
         export DOCKER_CONFIG=/tmp/auth
 
         echo "[$(date --utc -Ins)] Sign image"
-        echo "Signing image ${IMAGE_REF} using keyless signing"
-        if ! retry cosign sign -y \
-          --rekor-url="${REKOR_URL}" \
-          --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-          --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-          "${IMAGE_REF}"
-        then
-          echo "Failed to sign image" >&2
-          exit 1
-        fi
+        for ref in "${refs_to_sign[@]}"; do
+          echo "Signing image ${ref} using keyless signing"
+          if ! retry cosign sign -y \
+            --rekor-url="${REKOR_URL}" \
+            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+            "${ref}"
+          then
+            echo "Failed to sign image ${ref}" >&2
+            exit 1
+          fi
+        done
       elif [ "${configured}" -eq 0 ]; then
         echo "Keyless signing is disabled (none of ${missing} are configured in the konflux-info/cluster-config configmap)"
       else
@@ -1079,52 +1236,69 @@ spec:
 
       echo "[$(date --utc -Ins)] Generate SBOM with mobster"
 
-      mobster_args=(
-        generate
-        --output sbom.json
-      )
+      # All compression variants share the same package list; only the digest differs
+      generate_oci_image_sbom() {
+        local output_file="$1"
+        local image_digest="$2"
+        local image_pullspec="$3"
+        local -a args=(generate --output "$output_file")
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          args+=(--skip-validation)
+        fi
+        args+=(
+          oci-image
+          --from-syft "$(workspaces.source.path)/sbom-image.json"
+          --image-pullspec "$image_pullspec"
+          --image-digest "$image_digest"
+          --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+          --base-image-digest-file "/shared/base_images_digests"
+        )
+        if [ -f "$(workspaces.source.path)/sbom-source.json" ]; then
+          args+=(--from-syft "$(workspaces.source.path)/sbom-source.json")
+        fi
+        if [ -f "$(workspaces.source.path)/sbom-prefetch.json" ]; then
+          args+=(--from-hermeto "$(workspaces.source.path)/sbom-prefetch.json")
+        fi
+        if [ -n "${TARGET_STAGE}" ]; then
+          args+=(--dockerfile-target "${TARGET_STAGE}")
+        fi
+        for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
+          args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
+        done
+        if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
+          args+=(--contextualize)
+        fi
+        if [ -f "/shared/prefetch-arch" ]; then
+          args+=(--arch "$(cat /shared/prefetch-arch)")
+        fi
+        mobster "${args[@]}"
+      }
 
-      # Validation is a flag for `generate`, not `oci-image`, so we need to
-      # handle it before the oci-image arguments
-      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
-        echo "Skipping SBOM validation"
-        mobster_args+=(--skip-validation)
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        gzip_digest="$(cat /shared/gzip-digest)"
+        zstd_digest="$(cat /shared/zstd-digest)"
+
+        echo "Generating gzip child SBOM (main component digest ${gzip_digest})"
+        generate_oci_image_sbom sbom-gzip.json "$gzip_digest" "$IMAGE"
+
+        echo "Generating zstd child SBOM (main component digest ${zstd_digest})"
+        generate_oci_image_sbom sbom-zstd.json "$zstd_digest" "$IMAGE"
+
+        echo "Generating per-arch index SBOM (main component digest ${IMAGE_DIGEST})"
+        index_args=(generate --output sbom-index.json)
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          index_args+=(--skip-validation)
+        fi
+        index_args+=(
+          oci-index
+          --index-image-pullspec "$IMAGE_URL"
+          --index-image-digest "$IMAGE_DIGEST"
+          --index-manifest-path "/shared/per-arch-index-manifest.json"
+        )
+        mobster "${index_args[@]}"
+      else
+        generate_oci_image_sbom sbom.json "$IMAGE_DIGEST" "$IMAGE_URL"
       fi
-
-      mobster_args+=(
-        oci-image
-        --from-syft "$(workspaces.source.path)/sbom-image.json"
-        --image-pullspec "$IMAGE_URL"
-        --image-digest "$IMAGE_DIGEST"
-        --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
-        --base-image-digest-file "/shared/base_images_digests"
-      )
-
-      if [ -f "$(workspaces.source.path)/sbom-source.json" ]; then
-        mobster_args+=(--from-syft "$(workspaces.source.path)/sbom-source.json")
-      fi
-
-      if [ -f "$(workspaces.source.path)/sbom-prefetch.json" ]; then
-        mobster_args+=(--from-hermeto "$(workspaces.source.path)/sbom-prefetch.json")
-      fi
-
-      if [ -n "${TARGET_STAGE}" ]; then
-        mobster_args+=(--dockerfile-target "${TARGET_STAGE}")
-      fi
-
-      for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-        mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
-      done
-
-      if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
-        mobster_args+=(--contextualize)
-      fi
-
-      if [ -f "/shared/prefetch-arch" ]; then
-        mobster_args+=(--arch "$(cat /shared/prefetch-arch)")
-      fi
-
-      mobster "${mobster_args[@]}"
 
       echo "[$(date --utc -Ins)] End prepare-sboms"
     securityContext:
@@ -1161,19 +1335,37 @@ spec:
         update-ca-trust
       fi
 
-      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-      mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" > /tmp/auth/config.json
-      export DOCKER_CONFIG=/tmp/auth
-      echo "Pushing sbom to registry"
-      if ! retry cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
-      then
-          echo "Failed to push sbom to registry"
-          exit 1
+      # In dual mode each variant gets its own SBOM attached to its own digest
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        index_ref="$(cat "$(results.IMAGE_REF.path)")"
+        sbom_files=(sbom-gzip.json sbom-zstd.json sbom-index.json)
+        sbom_refs=("$(cat /shared/gzip-ref)" "$(cat /shared/zstd-ref)" "$index_ref")
+        primary_sbom=sbom-index.json
+      else
+        image_ref="$(cat "$(results.IMAGE_REF.path)")"
+        sbom_files=(sbom.json)
+        sbom_refs=("$image_ref")
+        primary_sbom=sbom.json
       fi
+
+      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+      mkdir -p /tmp/auth && select-oci-auth "${sbom_refs[0]}" > /tmp/auth/config.json
+      export DOCKER_CONFIG=/tmp/auth
+
+      for i in "${!sbom_files[@]}"; do
+        sbom_file="${sbom_files[$i]}"
+        ref="${sbom_refs[$i]}"
+        echo "Pushing sbom ${sbom_file} to ${ref}"
+        if ! retry cosign attach sbom --sbom "$sbom_file" --type "$SBOM_TYPE" "$ref"
+        then
+            echo "Failed to push sbom ${sbom_file} to ${ref}" >&2
+            exit 1
+        fi
+      done
 
       # Remove tag from IMAGE while allowing registry to contain a port number.
       sbom_repo="${IMAGE%:*}"
-      sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+      sbom_digest="$(sha256sum "$primary_sbom" | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
 
@@ -1192,8 +1384,6 @@ spec:
         SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
         export SIGSTORE_ID_TOKEN
 
-        IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
-
         ATT_SBOM_TYPE="${SBOM_TYPE}"
         if [ "${ATT_SBOM_TYPE}" = "spdx" ]; then
           # for format cossistency with cyclonedx format, we want to use spdxjson instad of spdx
@@ -1201,17 +1391,21 @@ spec:
           ATT_SBOM_TYPE="spdxjson"
         fi
 
-        echo "[$(date --utc -Ins)] Sign SBOM"
-        echo "Signing and attaching SBOM to ${IMAGE_REF} using keyless signing"
-        if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate sbom.json \
-          --rekor-url="${REKOR_URL}" \
-          --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-          --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-          "${IMAGE_REF}"
-        then
-          echo "Failed to sign SBOM" >&2
-          exit 1
-        fi
+        for i in "${!sbom_files[@]}"; do
+          sbom_file="${sbom_files[$i]}"
+          ref="${sbom_refs[$i]}"
+          echo "[$(date --utc -Ins)] Sign SBOM"
+          echo "Signing and attaching SBOM ${sbom_file} to ${ref} using keyless signing"
+          if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate "$sbom_file" \
+            --rekor-url="${REKOR_URL}" \
+            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+            "${ref}"
+          then
+            echo "Failed to sign SBOM ${sbom_file}" >&2
+            exit 1
+          fi
+        done
       fi
 
       echo

--- a/task/buildah-remote/CHANGELOG.md
+++ b/task/buildah-remote/CHANGELOG.md
@@ -11,6 +11,18 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.6
+
+### Added
+
+- New parameter `COMPRESSION_FORMAT` (gzip | zstd-chunked | dual, default: gzip).
+  In dual mode, both gzip and zstd:chunked variants are pushed and bundled in a
+  per-arch OCI index with gzip first for backward compatibility. Tech preview.
+- New parameter `FORCE_COMPRESSION` (default: false). Recompress all layers
+  including base image layers in zstd-chunked and dual modes.
+- New result `IMAGES`. Comma-separated image manifest references for Chains
+  provenance. In dual mode, lists the gzip and zstd child manifest references.
+
 ## 0.10.5
 
 ### Added

--- a/task/buildah/0.10/README.md
+++ b/task/buildah/0.10/README.md
@@ -59,6 +59,8 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |SKIP_INJECTIONS|Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.|false|false|
 |LOG_LEVEL|Log level for the build command.|info|false|
 |ALLOW_CROSS_PLATFORM_IMAGES|Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.|false|false|
+|COMPRESSION_FORMAT|Compression format: gzip (default), zstd-chunked, or dual. In dual mode both gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked modes are experimental and not yet fully supported by the release pipeline.|gzip|false|
+|FORCE_COMPRESSION|Recompress all layers including base image layers, not just layers created by this build. Only applies to zstd-chunked and dual modes.|false|false|
 
 ## Results
 |name|description|
@@ -67,6 +69,7 @@ When prefetch-dependencies task is activated it is using its artifacts to run bu
 |IMAGE_URL|Image repository and tag where the built image was pushed|
 |IMAGE_REF|Image reference of the built image|
 |SBOM_BLOB_URL|Reference of SBOM blob digest to enable digest-based verification from provenance|
+|IMAGES|Comma-separated image manifest references. In dual mode lists the gzip and zstd child manifest references for Chains provenance; otherwise the single manifest reference.|
 
 ## Workspaces
 |name|description|optional|

--- a/task/buildah/0.10/buildah.yaml
+++ b/task/buildah/0.10/buildah.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.10.5"
+    app.kubernetes.io/version: "0.10.6"
     build.appstudio.redhat.com/build_type: "docker"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -243,6 +243,20 @@ spec:
       option must be used with caution as it may create incompatible images.
     type: string
     default: "false"
+  - name: COMPRESSION_FORMAT
+    description: >-
+      Compression format: gzip (default), zstd-chunked, or dual. In dual mode both
+      gzip and zstd:chunked variants are bundled in a per-arch OCI index (gzip
+      first). dual requires BUILDAH_FORMAT=oci. Tech preview: dual and zstd-chunked
+      modes are experimental and not yet fully supported by the release pipeline.
+    type: string
+    default: gzip
+  - name: FORCE_COMPRESSION
+    description: >-
+      Recompress all layers including base image layers, not just layers created by
+      this build. Only applies to zstd-chunked and dual modes.
+    type: string
+    default: "false"
   results:
   - description: Digest of the image just built
     name: IMAGE_DIGEST
@@ -252,6 +266,12 @@ spec:
     name: IMAGE_REF
   - name: SBOM_BLOB_URL
     description: Reference of SBOM blob digest to enable digest-based verification from provenance
+    type: string
+  - name: IMAGES
+    description: >-
+      Comma-separated image manifest references. In dual mode lists the gzip and
+      zstd child manifest references for Chains provenance; otherwise the single
+      manifest reference.
     type: string
   stepTemplate:
     computeResources:
@@ -326,6 +346,8 @@ spec:
       value: $(params.ALLOW_CROSS_PLATFORM_IMAGES)
     - name: RHSM_MOUNT_CA_CERTS
       value: $(params.RHSM_MOUNT_CA_CERTS)
+    - name: COMPRESSION_FORMAT
+      value: $(params.COMPRESSION_FORMAT)
     imagePullPolicy: IfNotPresent
   steps:
   - image: quay.io/konflux-ci/konflux-build-cli:latest@sha256:0415613f955ef8f7c6fc821a6738dcf062d9a3582441042b87a2391c375d7f54
@@ -595,6 +617,8 @@ spec:
       value: $(params.BUILDAH_FORMAT)
     - name: TASKRUN_NAME
       value: $(context.taskRun.name)
+    - name: FORCE_COMPRESSION
+      value: $(params.FORCE_COMPRESSION)
     script: |
       #!/bin/bash
       set -euo pipefail
@@ -618,45 +642,168 @@ spec:
         push_format=docker
       fi
 
-      echo "[$(date --utc -Ins)] Push image with unique tag"
+      # dual requires OCI: the zstd annotation is only valid on OCI manifests
+      if [ "${COMPRESSION_FORMAT}" = "dual" ] && [ "$push_format" != "oci" ]; then
+        echo "ERROR: COMPRESSION_FORMAT=dual requires BUILDAH_FORMAT=oci" >&2
+        exit 1
+      fi
+
+      compression_args=()
+      if [ "${COMPRESSION_FORMAT}" = "zstd-chunked" ]; then
+        compression_args+=(--compression-format zstd:chunked)
+      fi
+      if [ "${FORCE_COMPRESSION}" = "true" ] && [ "${COMPRESSION_FORMAT}" != "gzip" ]; then
+        compression_args+=(--force-compression)
+      fi
+
+      case "${COMPRESSION_FORMAT}" in
+        gzip|zstd-chunked|dual) ;;
+        *) echo "ERROR: unsupported COMPRESSION_FORMAT '${COMPRESSION_FORMAT}'" >&2; exit 1 ;;
+      esac
 
       buildah_retries=3
+      image_repo="${IMAGE%:*}"
 
-      # Push to a unique tag based on the TaskRun name to avoid race conditions
-      echo "Pushing to ${IMAGE%:*}:${TASKRUN_NAME}"
-      if ! retry buildah push \
-        --format="$push_format" \
-        --retry "$buildah_retries" \
-        --tls-verify="$TLSVERIFY" \
-        "$IMAGE" \
-        "docker://${IMAGE%:*}:${TASKRUN_NAME}"
-      then
-        echo "Failed to push image to ${IMAGE%:*}:${TASKRUN_NAME}"
-        exit 1
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        echo "[$(date --utc -Ins)] Push dual-compression per-arch index"
+
+        gzip_tag="${image_repo}:${TASKRUN_NAME}-gzip"
+        gzip_push_args=(
+          --format=oci
+          --retry "$buildah_retries"
+          --tls-verify="$TLSVERIFY"
+          --compression-format gzip
+          --digestfile /tmp/gzip-digest
+        )
+        if [ "${FORCE_COMPRESSION}" = "true" ]; then
+          gzip_push_args+=(--force-compression)
+        fi
+        echo "Pushing gzip variant to ${gzip_tag}"
+        if ! retry buildah push "${gzip_push_args[@]}" "$IMAGE" "docker://${gzip_tag}"
+        then
+          echo "Failed to push gzip variant to ${gzip_tag}" >&2
+          exit 1
+        fi
+        gzip_digest="$(cat /tmp/gzip-digest)"
+        gzip_ref="${image_repo}@${gzip_digest}"
+
+        zstd_tag="${image_repo}:${TASKRUN_NAME}-zstd"
+        zstd_push_args=(
+          --format=oci
+          --retry "$buildah_retries"
+          --tls-verify="$TLSVERIFY"
+          --compression-format zstd:chunked
+          --digestfile /tmp/zstd-digest
+        )
+        if [ "${FORCE_COMPRESSION}" = "true" ]; then
+          zstd_push_args+=(--force-compression)
+        fi
+        echo "Pushing zstd:chunked variant to ${zstd_tag}"
+        if ! retry buildah push "${zstd_push_args[@]}" "$IMAGE" "docker://${zstd_tag}"
+        then
+          echo "Failed to push zstd:chunked variant to ${zstd_tag}" >&2
+          exit 1
+        fi
+        zstd_digest="$(cat /tmp/zstd-digest)"
+        zstd_ref="${image_repo}@${zstd_digest}"
+
+        # gzip first in the index for backward compat with older Docker clients
+        per_arch_index="per-arch-index-${TASKRUN_NAME}"
+        echo "Creating per-arch index ${per_arch_index}"
+        buildah manifest create "$per_arch_index"
+        if ! retry buildah manifest add "$per_arch_index" "docker://${gzip_ref}"; then
+          echo "Failed to add gzip variant to ${per_arch_index}" >&2
+          exit 1
+        fi
+        if ! retry buildah manifest add "$per_arch_index" "docker://${zstd_ref}"; then
+          echo "Failed to add zstd variant to ${per_arch_index}" >&2
+          exit 1
+        fi
+
+        buildah manifest inspect "$per_arch_index" > /shared/per-arch-index-manifest.json
+
+        echo "Pushing per-arch index to ${image_repo}:${TASKRUN_NAME}"
+        if ! retry buildah manifest push --all \
+          --format=oci \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          --digestfile "$(workspaces.source.path)/image-digest" \
+          "$per_arch_index" \
+          "docker://${image_repo}:${TASKRUN_NAME}"
+        then
+          echo "Failed to push per-arch index to ${image_repo}:${TASKRUN_NAME}" >&2
+          exit 1
+        fi
+
+        echo "Pushing per-arch index to ${IMAGE}"
+        if ! retry buildah manifest push --all \
+          --format=oci \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "$per_arch_index" \
+          "docker://$IMAGE"
+        then
+          echo "Failed to push per-arch index to $IMAGE" >&2
+          exit 1
+        fi
+
+        index_digest="$(cat "$(workspaces.source.path)/image-digest")"
+
+        echo -n "$index_digest" | tee "$(results.IMAGE_DIGEST.path)"
+        echo -n "$IMAGE" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${IMAGE}@${index_digest}" > "$(results.IMAGE_REF.path)"
+        echo -n "${gzip_ref},${zstd_ref}" > "$(results.IMAGES.path)"
+
+        echo -n "$gzip_digest" > /shared/gzip-digest
+        echo -n "$zstd_digest" > /shared/zstd-digest
+        echo -n "$gzip_ref" > /shared/gzip-ref
+        echo -n "$zstd_ref" > /shared/zstd-ref
+        echo
+      else
+        echo "[$(date --utc -Ins)] Push image with unique tag"
+
+        # Push to a unique tag based on the TaskRun name to avoid race conditions
+        echo "Pushing to ${image_repo}:${TASKRUN_NAME}"
+        if ! retry buildah push \
+          --format="$push_format" \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "${compression_args[@]}" \
+          "$IMAGE" \
+          "docker://${image_repo}:${TASKRUN_NAME}"
+        then
+          echo "Failed to push image to ${image_repo}:${TASKRUN_NAME}" >&2
+          exit 1
+        fi
+
+        echo "[$(date --utc -Ins)] Push image with git revision"
+
+        # Push to a tag based on the git revision
+        echo "Pushing to ${IMAGE}"
+        if ! retry buildah push \
+          --format="$push_format" \
+          --retry "$buildah_retries" \
+          --tls-verify="$TLSVERIFY" \
+          "${compression_args[@]}" \
+          --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
+          "docker://$IMAGE"
+        then
+          echo "Failed to push image to $IMAGE" >&2
+          exit 1
+        fi
+
+        tee "$(results.IMAGE_DIGEST.path)" < "$(workspaces.source.path)"/image-digest
+        echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
+        {
+          echo -n "${IMAGE}@"
+          cat "$(workspaces.source.path)/image-digest"
+        } > "$(results.IMAGE_REF.path)"
+        {
+          echo -n "${IMAGE}@"
+          cat "$(workspaces.source.path)/image-digest"
+        } > "$(results.IMAGES.path)"
+        echo
       fi
-
-      echo "[$(date --utc -Ins)] Push image with git revision"
-
-      # Push to a tag based on the git revision
-      echo "Pushing to ${IMAGE}"
-      if ! retry buildah push \
-        --format="$push_format" \
-        --retry "$buildah_retries" \
-        --tls-verify="$TLSVERIFY" \
-        --digestfile "$(workspaces.source.path)/image-digest" "$IMAGE" \
-        "docker://$IMAGE"
-      then
-        echo "Failed to push image to $IMAGE"
-        exit 1
-      fi
-
-      tee "$(results.IMAGE_DIGEST.path)" < "$(workspaces.source.path)"/image-digest
-      echo -n "$IMAGE" | tee $(results.IMAGE_URL.path)
-      {
-        echo -n "${IMAGE}@"
-        cat "$(workspaces.source.path)/image-digest"
-      } > "$(results.IMAGE_REF.path)"
-      echo
 
       # detect if keyless signing is required
       SIGNING_CONFIG='{}'
@@ -726,23 +873,35 @@ spec:
         SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
         export SIGSTORE_ID_TOKEN
 
-        IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
+        # In dual mode, sign all three variants: index, gzip child, zstd child
+        if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+          index_ref="$(cat "$(results.IMAGE_REF.path)")"
+          refs_to_sign=(
+            "$index_ref"
+            "$(cat /shared/gzip-ref)"
+            "$(cat /shared/zstd-ref)"
+          )
+        else
+          refs_to_sign=("$(cat "$(results.IMAGE_REF.path)")")
+        fi
 
         # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-        mkdir -p /tmp/auth && select-oci-auth "${IMAGE_REF}" > /tmp/auth/config.json
+        mkdir -p /tmp/auth && select-oci-auth "${refs_to_sign[0]}" > /tmp/auth/config.json
         export DOCKER_CONFIG=/tmp/auth
 
         echo "[$(date --utc -Ins)] Sign image"
-        echo "Signing image ${IMAGE_REF} using keyless signing"
-        if ! retry cosign sign -y \
-          --rekor-url="${REKOR_URL}" \
-          --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-          --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-          "${IMAGE_REF}"
-        then
-          echo "Failed to sign image" >&2
-          exit 1
-        fi
+        for ref in "${refs_to_sign[@]}"; do
+          echo "Signing image ${ref} using keyless signing"
+          if ! retry cosign sign -y \
+            --rekor-url="${REKOR_URL}" \
+            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+            "${ref}"
+          then
+            echo "Failed to sign image ${ref}" >&2
+            exit 1
+          fi
+        done
       elif [ "${configured}" -eq 0 ]; then
         echo "Keyless signing is disabled (none of ${missing} are configured in the konflux-info/cluster-config configmap)"
       else
@@ -883,52 +1042,69 @@ spec:
 
       echo "[$(date --utc -Ins)] Generate SBOM with mobster"
 
-      mobster_args=(
-        generate
-        --output sbom.json
-      )
+      # All compression variants share the same package list; only the digest differs
+      generate_oci_image_sbom() {
+        local output_file="$1"
+        local image_digest="$2"
+        local image_pullspec="$3"
+        local -a args=(generate --output "$output_file")
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          args+=(--skip-validation)
+        fi
+        args+=(
+          oci-image
+          --from-syft "$(workspaces.source.path)/sbom-image.json"
+          --image-pullspec "$image_pullspec"
+          --image-digest "$image_digest"
+          --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
+          --base-image-digest-file "/shared/base_images_digests"
+        )
+        if [ -f "$(workspaces.source.path)/sbom-source.json" ]; then
+          args+=(--from-syft "$(workspaces.source.path)/sbom-source.json")
+        fi
+        if [ -f "$(workspaces.source.path)/sbom-prefetch.json" ]; then
+          args+=(--from-hermeto "$(workspaces.source.path)/sbom-prefetch.json")
+        fi
+        if [ -n "${TARGET_STAGE}" ]; then
+          args+=(--dockerfile-target "${TARGET_STAGE}")
+        fi
+        for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
+          args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
+        done
+        if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
+          args+=(--contextualize)
+        fi
+        if [ -f "/shared/prefetch-arch" ]; then
+          args+=(--arch "$(cat /shared/prefetch-arch)")
+        fi
+        mobster "${args[@]}"
+      }
 
-      # Validation is a flag for `generate`, not `oci-image`, so we need to
-      # handle it before the oci-image arguments
-      if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
-        echo "Skipping SBOM validation"
-        mobster_args+=(--skip-validation)
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        gzip_digest="$(cat /shared/gzip-digest)"
+        zstd_digest="$(cat /shared/zstd-digest)"
+
+        echo "Generating gzip child SBOM (main component digest ${gzip_digest})"
+        generate_oci_image_sbom sbom-gzip.json "$gzip_digest" "$IMAGE"
+
+        echo "Generating zstd child SBOM (main component digest ${zstd_digest})"
+        generate_oci_image_sbom sbom-zstd.json "$zstd_digest" "$IMAGE"
+
+        echo "Generating per-arch index SBOM (main component digest ${IMAGE_DIGEST})"
+        index_args=(generate --output sbom-index.json)
+        if [ "${SBOM_SKIP_VALIDATION}" == "true" ]; then
+          index_args+=(--skip-validation)
+        fi
+        index_args+=(
+          oci-index
+          --index-image-pullspec "$IMAGE_URL"
+          --index-image-digest "$IMAGE_DIGEST"
+          --index-manifest-path "/shared/per-arch-index-manifest.json"
+        )
+        mobster "${index_args[@]}"
+      else
+        generate_oci_image_sbom sbom.json "$IMAGE_DIGEST" "$IMAGE_URL"
       fi
-
-      mobster_args+=(
-        oci-image
-        --from-syft "$(workspaces.source.path)/sbom-image.json"
-        --image-pullspec "$IMAGE_URL"
-        --image-digest "$IMAGE_DIGEST"
-        --parsed-dockerfile-path "/shared/parsed_dockerfile.json"
-        --base-image-digest-file "/shared/base_images_digests"
-      )
-
-      if [ -f "$(workspaces.source.path)/sbom-source.json" ]; then
-        mobster_args+=(--from-syft "$(workspaces.source.path)/sbom-source.json")
-      fi
-
-      if [ -f "$(workspaces.source.path)/sbom-prefetch.json" ]; then
-        mobster_args+=(--from-hermeto "$(workspaces.source.path)/sbom-prefetch.json")
-      fi
-
-      if [ -n "${TARGET_STAGE}" ]; then
-        mobster_args+=(--dockerfile-target "${TARGET_STAGE}")
-      fi
-
-      for ADDITIONAL_BASE_IMAGE in "${ADDITIONAL_BASE_IMAGES[@]}"; do
-        mobster_args+=(--additional-base-image "$ADDITIONAL_BASE_IMAGE")
-      done
-
-      if [ "${CONTEXTUALIZE_SBOM}" == "true" ] && [ "${HERMETIC}" == "false" ]; then
-        mobster_args+=(--contextualize)
-      fi
-
-      if [ -f "/shared/prefetch-arch" ]; then
-        mobster_args+=(--arch "$(cat /shared/prefetch-arch)")
-      fi
-
-      mobster "${mobster_args[@]}"
 
       echo "[$(date --utc -Ins)] End prepare-sboms"
     workingDir: $(workspaces.source.path)
@@ -962,19 +1138,37 @@ spec:
         update-ca-trust
       fi
 
-      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
-      mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" > /tmp/auth/config.json
-      export DOCKER_CONFIG=/tmp/auth
-      echo "Pushing sbom to registry"
-      if ! retry cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
-      then
-          echo "Failed to push sbom to registry"
-          exit 1
+      # In dual mode each variant gets its own SBOM attached to its own digest
+      if [ "${COMPRESSION_FORMAT}" = "dual" ]; then
+        index_ref="$(cat "$(results.IMAGE_REF.path)")"
+        sbom_files=(sbom-gzip.json sbom-zstd.json sbom-index.json)
+        sbom_refs=("$(cat /shared/gzip-ref)" "$(cat /shared/zstd-ref)" "$index_ref")
+        primary_sbom=sbom-index.json
+      else
+        image_ref="$(cat "$(results.IMAGE_REF.path)")"
+        sbom_files=(sbom.json)
+        sbom_refs=("$image_ref")
+        primary_sbom=sbom.json
       fi
+
+      # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+      mkdir -p /tmp/auth && select-oci-auth "${sbom_refs[0]}" > /tmp/auth/config.json
+      export DOCKER_CONFIG=/tmp/auth
+
+      for i in "${!sbom_files[@]}"; do
+        sbom_file="${sbom_files[$i]}"
+        ref="${sbom_refs[$i]}"
+        echo "Pushing sbom ${sbom_file} to ${ref}"
+        if ! retry cosign attach sbom --sbom "$sbom_file" --type "$SBOM_TYPE" "$ref"
+        then
+            echo "Failed to push sbom ${sbom_file} to ${ref}" >&2
+            exit 1
+        fi
+      done
 
       # Remove tag from IMAGE while allowing registry to contain a port number.
       sbom_repo="${IMAGE%:*}"
-      sbom_digest="$(sha256sum sbom.json | cut -d' ' -f1)"
+      sbom_digest="$(sha256sum "$primary_sbom" | cut -d' ' -f1)"
       # The SBOM_BLOB_URL is created by `cosign attach sbom`.
       echo -n "${sbom_repo}@sha256:${sbom_digest}" | tee "$(results.SBOM_BLOB_URL.path)"
 
@@ -993,8 +1187,6 @@ spec:
         SIGSTORE_ID_TOKEN="$(cat /var/run/sigstore/cosign/oidc-token)"
         export SIGSTORE_ID_TOKEN
 
-        IMAGE_REF="$(cat "$(results.IMAGE_REF.path)")"
-
         ATT_SBOM_TYPE="${SBOM_TYPE}"
         if [ "${ATT_SBOM_TYPE}" = "spdx" ]; then
           # for format cossistency with cyclonedx format, we want to use spdxjson instad of spdx
@@ -1002,17 +1194,21 @@ spec:
           ATT_SBOM_TYPE="spdxjson"
         fi
 
-        echo "[$(date --utc -Ins)] Sign SBOM"
-        echo "Signing and attaching SBOM to ${IMAGE_REF} using keyless signing"
-        if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate sbom.json \
-          --rekor-url="${REKOR_URL}" \
-          --fulcio-url="${SIGSTORE_FULCIO_URL}" \
-          --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
-          "${IMAGE_REF}"
-        then
-          echo "Failed to sign SBOM" >&2
-          exit 1
-        fi
+        for i in "${!sbom_files[@]}"; do
+          sbom_file="${sbom_files[$i]}"
+          ref="${sbom_refs[$i]}"
+          echo "[$(date --utc -Ins)] Sign SBOM"
+          echo "Signing and attaching SBOM ${sbom_file} to ${ref} using keyless signing"
+          if ! retry cosign attest -y --type "${ATT_SBOM_TYPE}" --predicate "$sbom_file" \
+            --rekor-url="${REKOR_URL}" \
+            --fulcio-url="${SIGSTORE_FULCIO_URL}" \
+            --oidc-issuer="${SIGSTORE_OIDC_ISSUER}" \
+            "${ref}"
+          then
+            echo "Failed to sign SBOM ${sbom_file}" >&2
+            exit 1
+          fi
+        done
       fi
 
       echo

--- a/task/buildah/CHANGELOG.md
+++ b/task/buildah/CHANGELOG.md
@@ -11,6 +11,18 @@ If that's not something you ever plan to do, consider removing this section.
 
 *Nothing yet.*
 
+## 0.10.6
+
+### Added
+
+- New parameter `COMPRESSION_FORMAT` (gzip | zstd-chunked | dual, default: gzip).
+  In dual mode, both gzip and zstd:chunked variants are pushed and bundled in a
+  per-arch OCI index with gzip first for backward compatibility. Tech preview.
+- New parameter `FORCE_COMPRESSION` (default: false). Recompress all layers
+  including base image layers in zstd-chunked and dual modes.
+- New result `IMAGES`. Comma-separated image manifest references for Chains
+  provenance. In dual mode, lists the gzip and zstd child manifest references.
+
 ## 0.10.5
 
 ### Added


### PR DESCRIPTION
Add COMPRESSION_FORMAT (gzip|zstd-chunked|dual) and FORCE_COMPRESSION params. In dual mode, push gzip and zstd:chunked variants bundled in a per-arch OCI index (gzip first). The IMAGES result exposes both child manifest refs for Chains provenance. SBOM generation, signing, and SBOM attachment run for each variant.

Default stays gzip; dual requires BUILDAH_FORMAT=oci.

Ref: https://github.com/konflux-ci/build-definitions/issues/1264 
Ref: https://github.com/konflux-ci/architecture/blob/main/ADR/0070-dual-compression-for-container-builds.md

