### PR TITLE
fix(build-vm-image): expand IMAGE_TYPE validation to all BIB types

### DIFF
--- a/task/build-vm-image/0.2/README.md
+++ b/task/build-vm-image/0.2/README.md
@@ -9,7 +9,7 @@ Build disk images using bootc-image-builder. https://github.com/osbuild/bootc-im
 |IMAGE_APPEND_PLATFORM|Whether to append a sanitized platform architecture on the IMAGE tag|false|false|
 |OUTPUT_IMAGE|The output manifest list that points to the OCI artifact of the zipped image||true|
 |SOURCE_ARTIFACT|||true|
-|IMAGE_TYPE|The type of VM image to build, valid values are iso, qcow2, gce, vhd and raw||true|
+|IMAGE_TYPE|The type of VM image to build, valid values are ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, vhd and vmdk||true|
 |BIB_CONFIG_FILE|The config file specifying what to build and the builder to build it with|bib.yaml|false|
 |CONFIG_TOML_FILE|The path for the config.toml file within the source repository|""|false|
 |ENTITLEMENT_SECRET|Name of secret which contains the entitlement certificates|etc-pki-entitlement|false|

--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -5,7 +5,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.2.1"
+    app.kubernetes.io/version: "0.2.2"
     build.appstudio.redhat.com/build_type: disk-image
   name: build-vm-image
 spec:
@@ -25,7 +25,7 @@ spec:
       type: string
     - name: IMAGE_TYPE
       type: string
-      description: The type of VM image to build, valid values are ami, anaconda-iso, bootc-installer, gce, iso, qcow2, raw, vhd and vmdk
+      description: The type of VM image to build, valid values are ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, vhd and vmdk
     - name: BIB_CONFIG_FILE
       default: bib.yaml
       type: string
@@ -122,8 +122,8 @@ spec:
         set -x
 
         case "${IMAGE_TYPE}" in
-          ami|anaconda-iso|bootc-installer|gce|iso|qcow2|raw|vhd|vmdk) ;;
-          *) echo "Invalid IMAGE_TYPE: ${IMAGE_TYPE}. Must be one of: ami, anaconda-iso, bootc-installer, gce, iso, qcow2, raw, vhd, vmdk." >&2; exit 1 ;;
+          ami|anaconda-iso|bootc-installer|gce|iso|ova|pxe-tar-xz|qcow2|raw|vhd|vmdk) ;;
+          *) echo "Invalid IMAGE_TYPE: ${IMAGE_TYPE}. Must be one of: ami, anaconda-iso, bootc-installer, gce, iso, ova, pxe-tar-xz, qcow2, raw, vhd, vmdk." >&2; exit 1 ;;
         esac
 
         case "${STORAGE_DRIVER}" in
@@ -388,6 +388,7 @@ spec:
         set -euxo pipefail
 
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"
+        export IMAGE_TYPE="$IMAGE_TYPE"
 
         REMOTESSHEOF
 
@@ -398,7 +399,7 @@ spec:
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-push.sh <<'REMOTESSHEOF'
-        dnf -y install buildah skopeo pigz jq
+        dnf -y install buildah skopeo pigz jq tar xz
 
         # Build an image index of length 1 referring to an image manifest with the content
         buildah manifest create "$OUTPUT_IMAGE"
@@ -426,6 +427,39 @@ spec:
           echo -e "Found gce image."
           # already compressed.
           buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
+        elif [ -f "/output/vmdk/disk.vmdk" ]; then
+          echo -e "Found vmdk image."
+          pigz /output/vmdk/disk.vmdk
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.vmdk.gzip $OUTPUT_IMAGE /output/vmdk/disk.vmdk.gz
+        elif [ -f "/output/archive/image.ova" ]; then
+          echo -e "Found ova image."
+          pigz /output/archive/image.ova
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.ova.gzip $OUTPUT_IMAGE /output/archive/image.ova.gz
+        # NOTE: pxe-tar-xz handling covers two different bootc-image-builder versions:
+        #
+        # 1. New image-builder multicall binary (osbuild/image-builder):
+        #    Exports the "xz" pipeline → /output/xz/pxe.tar.xz (pre-compressed)
+        #    No container builds exist for this variant yet (as of July 2026).
+        #
+        # 2. Old bootc-image-builder (osbuild/bootc-image-builder, archived June 2026):
+        #    Exports the "bootc-pxe-tree" pipeline → /output/bootc-pxe-tree/ which is
+        #    a raw directory tree containing vmlinuz, initrd.img, rootfs.img, EFI/,
+        #    grub.cfg, and README. This is what current BIB containers actually produce.
+        #    The task must create the tar.xz archive itself before pushing.
+        #
+        # Check for the new pre-compressed output first, fall back to creating
+        # the archive from the old raw tree.
+        elif [ -f "/output/xz/pxe.tar.xz" ]; then
+          echo -e "Found pxe-tar-xz image (new image-builder)."
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/xz/pxe.tar.xz
+        elif [ -d "/output/bootc-pxe-tree" ]; then
+          echo -e "Found pxe tree directory (old BIB), creating tar.xz archive."
+          tar -cJf /output/bootc-pxe-tree.tar.xz -C /output/bootc-pxe-tree .
+          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/bootc-pxe-tree.tar.xz
+        else
+          echo "No output artifact found for IMAGE_TYPE=${IMAGE_TYPE}. Check BIB output in /output." >&2
+          ls -alR /output >&2
+          exit 1
         fi
 
         buildah_retries=3

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -9,11 +9,15 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
+*Nothing yet.*
+
+## 0.2.2
+
 ### Fixed
 
-- Added `ami`, `anaconda-iso`, `bootc-installer`, and `vmdk` to `IMAGE_TYPE` validation allowlist.
-  The `ami` type was rejected despite being a valid bootc-image-builder output type, breaking AWS
-  disk image builds.
+- Expanded `IMAGE_TYPE` validation to support all bootc-image-builder types: `ami`, `anaconda-iso`, `bootc-installer`, `gce`, `iso`, `ova`, `pxe-tar-xz`, `qcow2`, `raw`, `vhd`, `vmdk`. The `ami` type was rejected despite being a valid bootc-image-builder output type, breaking AWS disk image builds.
+- Added push-script handling for `vmdk`, `ova`, and `pxe-tar-xz` output artifacts.
+- Added explicit failure when no output artifact is found, instead of silently pushing an empty manifest.
 
 ## 0.2.1
 


### PR DESCRIPTION
## Summary

The `build-vm-image` v0.2 task rejected valid bootc-image-builder (BIB) image types and lacked push-script handling for several output formats. Expand the `IMAGE_TYPE` validation allowlist to cover all BIB-supported types, add artifact push logic for `vmdk`, `ova`, and `pxe-tar-xz` and add an explicit failure path when no output artifact is found.

## Key Changes

- Expand `IMAGE_TYPE` validation to accept all BIB types: `ami`, `anaconda-iso`, `bootc-installer`, `gce`, `iso`, `ova`, `pxe-tar-xz`, `qcow2`, `raw`, `vhd`, `vmdk`
- Add push-script handling for `vmdk` (pigz-compressed), `ova` (pigz-compressed), and `pxe-tar-xz` (supports both old BIB raw tree export and future image-builder multicall pre-compressed output)
- Add a catch-all `else` branch that fails explicitly with diagnostic output instead of silently pushing an empty manifest
- Install `tar` and `xz` packages in the push script for pxe-tar-xz archive creation