### PR TITLE
feat(EC-1794): replace ec-defaults ConfigMap with hardcoded bundle ref

### DIFF
--- a/e2e-tests/tests/build/build_templates.go
+++ b/e2e-tests/tests/build/build_templates.go
@@ -45,6 +45,7 @@ var (
 )
 
 const pipelineCompletionRetries = 2
+const verifyECTaskBundle = "quay.io/conforma/tekton-task:konflux@sha256:13375ed6d012614f030d36fa6485c16db1ab1e82d6077d5055c0eb1bfb90b644"
 
 type TestBranches struct {
 	RepoName       string
@@ -569,12 +570,6 @@ var _ = framework.BuildSuiteDescribe("Build templates E2E test", ginkgo.Label("b
 						// to sign and attest the image built in BeforeAll.
 						err = f.AsKubeAdmin.TektonController.AwaitAttestationAndSignature(imageWithDigest, constants.ChainsAttestationTimeout)
 						gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-						cm, err := f.AsKubeAdmin.CommonController.GetConfigMap("ec-defaults", "enterprise-contract-service")
-						gomega.Expect(err).ToNot(gomega.HaveOccurred())
-
-						verifyECTaskBundle := cm.Data["verify_ec_task_bundle"]
-						gomega.Expect(verifyECTaskBundle).ToNot(gomega.BeEmpty())
 
 						publicSecretName := "cosign-public-key"
 						publicKey, err := f.AsKubeAdmin.TektonController.GetTektonChainsPublicKey()

--- a/renovate.json
+++ b/renovate.json
@@ -347,6 +347,16 @@
       "autoReplaceStringTemplate": "image: {{depName}}{{#if newValue}}:{{newValue}}{{/if}}{{#if newDigest}}@{{newDigest}}{{/if}}",
       "datasourceTemplate": "docker",
       "versioningTemplate": "redhat"
+    },
+    {
+      "customType": "regex",
+      "fileMatch": [
+        "\\.go$"
+      ],
+      "matchStrings": [
+        "(?<depName>quay\\.io/conforma/tekton-task):(?<currentValue>[a-zA-Z0-9._-]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "ignorePaths": [


### PR DESCRIPTION
## Summary
- Replace the runtime `GetConfigMap("ec-defaults", ...)` lookup with a pinned package-level constant `verifyECTaskBundle` pointing to `quay.io/conforma/tekton-task:konflux` (tag+digest)
- Remove the local variable declaration and `gomega.Expect` assertion that checked the ConfigMap value

Part of the ec-defaults ConfigMap removal effort.

**Jira:** https://redhat.atlassian.net/browse/EC-1794

## Rollout
This is step 1 of 4 (alongside e2e-tests). Should merge **before** the infra-deployments change that removes the ConfigMap.

## Test plan
- [ ] Existing build templates e2e tests pass with the hardcoded bundle ref
- [ ] No remaining references to `ec-defaults` in this repo

🤖 Generated with [Claude Code](https://claude.ai/claude-code)