### PR TITLE
fix: add missing image types to build-vm-image 0.2 validation

### DIFF
--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -25,7 +25,7 @@ spec:
       type: string
     - name: IMAGE_TYPE
       type: string
-      description: The type of VM image to build, valid values are iso, qcow2, gce, vhd and raw
+      description: The type of VM image to build, valid values are ami, anaconda-iso, bootc-installer, gce, iso, qcow2, raw, vhd and vmdk
     - name: BIB_CONFIG_FILE
       default: bib.yaml
       type: string
@@ -122,8 +122,8 @@ spec:
         set -x
 
         case "${IMAGE_TYPE}" in
-          iso|qcow2|gce|vhd|raw) ;;
-          *) echo "Invalid IMAGE_TYPE: ${IMAGE_TYPE}. Must be one of: iso, qcow2, gce, vhd, raw." >&2; exit 1 ;;
+          ami|anaconda-iso|bootc-installer|gce|iso|qcow2|raw|vhd|vmdk) ;;
+          *) echo "Invalid IMAGE_TYPE: ${IMAGE_TYPE}. Must be one of: ami, anaconda-iso, bootc-installer, gce, iso, qcow2, raw, vhd, vmdk." >&2; exit 1 ;;
         esac
 
         case "${STORAGE_DRIVER}" in

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -9,7 +9,11 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
-*Nothing yet.*
+### Fixed
+
+- Added `ami`, `anaconda-iso`, `bootc-installer`, and `vmdk` to `IMAGE_TYPE` validation allowlist.
+  The `ami` type was rejected despite being a valid bootc-image-builder output type, breaking AWS
+  disk image builds.
 
 ## 0.2.1
 


### PR DESCRIPTION
## Summary

- The `IMAGE_TYPE` validation introduced in `build-vm-image` 0.2 only allowed `iso`, `qcow2`, `gce`, `vhd`, and `raw`
- Add all valid [bootc-image-builder](https://github.com/osbuild/bootc-image-builder) output types to the allowlist: `ami`, `anaconda-iso`, `bootc-installer`, `vmdk`
- Update param description and error message to list all valid types

## Test plan

- [ ] Verify `ami` image type is accepted by the validation step
- [ ] Verify invalid types are still rejected

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)