### PR TITLE
fix: use per-command RETRY_MAX_TRIES override in build-vm-image

### DIFF
--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -315,7 +315,6 @@ spec:
           mkdir -p $BUILD_DIR/rhsm-tmp/etc/pki/entitlement
           mkdir -p $BUILD_DIR/rhsm-tmp/etc/pki/consumer
 
-          export RETRY_MAX_TRIES=6
           # Run subscription-manager inside a container where we're root (no password needed)
           if ! retry sudo podman run --rm \
             -v $BUILD_DIR/activation-key:/activation-key:Z \
@@ -327,7 +326,6 @@ spec:
             echo "Subscription-manager register failed on remote VM"
             exit 1
           fi
-          unset RETRY_MAX_TRIES
 
           # Unregister on exit using a container
           trap 'sudo podman run --rm -v $BUILD_DIR/rhsm-tmp/etc/pki/entitlement:/etc/pki/entitlement:Z -v $BUILD_DIR/rhsm-tmp/etc/pki/consumer:/etc/pki/consumer:Z "$BUILDAH_IMAGE" /bin/bash -c "subscription-manager unregister || true"' EXIT


### PR DESCRIPTION
## Summary
Follow the established retry pattern from `buildah-remote`: let the imported retry function's own defaults apply, and use a per-command env prefix (`RETRY_MAX_TRIES=6 retry ...`) for the subscription-manager call instead of `export`/`unset` which breaks under `set -u`.

## Root cause
The `export RETRY_MAX_TRIES=6` + `unset RETRY_MAX_TRIES` pair around subscription-manager registration removes the variable entirely. Under `set -euo pipefail`, subsequent `retry` calls (`podman pull`) fail with `RETRY_MAX_TRIES: unbound variable`.

The imported `retry` function already sets its own default (`: "${RETRY_MAX_TRIES=10}"`), so no manual export/unset is needed — just override per-command when a different value is desired, as `buildah-remote` does with `RETRY_STOP_IF_STDERR_MATCHES`.

## Test plan
- [ ] Verify disk image builds with activation-key pass end-to-end

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>