### PR TITLE
fix: drop RETRY_MAX_TRIES override in build-vm-image

### DIFF
--- a/task/build-vm-image/0.2/build-vm-image.yaml
+++ b/task/build-vm-image/0.2/build-vm-image.yaml
@@ -315,7 +315,6 @@ spec:
           mkdir -p $BUILD_DIR/rhsm-tmp/etc/pki/entitlement
           mkdir -p $BUILD_DIR/rhsm-tmp/etc/pki/consumer
 
-          export RETRY_MAX_TRIES=6
           # Run subscription-manager inside a container where we're root (no password needed)
           if ! retry sudo podman run --rm \
             -v $BUILD_DIR/activation-key:/activation-key:Z \
@@ -327,7 +326,6 @@ spec:
             echo "Subscription-manager register failed on remote VM"
             exit 1
           fi
-          unset RETRY_MAX_TRIES
 
           # Unregister on exit using a container
           trap 'sudo podman run --rm -v $BUILD_DIR/rhsm-tmp/etc/pki/entitlement:/etc/pki/entitlement:Z -v $BUILD_DIR/rhsm-tmp/etc/pki/consumer:/etc/pki/consumer:Z "$BUILDAH_IMAGE" /bin/bash -c "subscription-manager unregister || true"' EXIT


### PR DESCRIPTION
Use the default retry count like every other task in the catalog. The export/unset pattern was unique to this task and broke under set -u after the task-runner migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
