### PR TITLE
CI: drop the MIGRATION.md check

### DIFF
--- a/.tekton/pull-request.yaml
+++ b/.tekton/pull-request.yaml
@@ -211,37 +211,6 @@ spec:
         workspaces:
           - name: source
             workspace: workspace
-      - name: check-task-migration-md
-        when:
-          - input: "tasks"
-            operator: "in"
-            values: ["$(tasks.task-switchboard.results.bindings[*])"]
-        runAfter:
-          - task-switchboard
-        taskSpec:
-          steps:
-            - name: check-task-migration-md
-              image: registry.redhat.io/openshift4/ose-tools-rhel8:v4.12@sha256:c24dbe19be6cd9b2a8ab9a76f50607b123b75fcf8a3aeeed45ac91a7bde107a0
-              workingDir: $(workspaces.source.path)/source
-              script: |
-                #!/usr/bin/env bash
-                EXIT=0
-                for TASK_DIR in $(ls task); do
-                  # Do not check on initial version of task
-                  for VERSION in $(ls -d task/$TASK_DIR/*/ | sort --version-sort | tail -n+2); do
-                    MIGRATION_FILE=${VERSION}MIGRATION.md
-                    if [ ! -f $MIGRATION_FILE ]; then
-                       echo "Missing file $MIGRATION_FILE"
-                       EXIT=1
-                    fi
-                  done
-                done
-                exit $EXIT
-          workspaces:
-            - name: source
-        workspaces:
-          - name: source
-            workspace: workspace
     finally:
       - name: e2e-cleanup
         when:

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ The StepActions can be found in the `stepactions` directory. StepActions are not
 When a task update changes the interface (e.g., change of parameters, workspaces or results names), a new version of the task should be created.
 We restructure the task definitions so that each version is maintained in its own directory. Instead of a single flat task file, the task is now versioned by placing its YAML into a version-specific folder.
 Within the newly versioned YAMLs a label should be added to the task's metadata for identifying the specific version of the task.
-The folder with the new version must contain `MIGRATION.md` with instructions on how to update the current pipeline file in user's `.tekton` folder.
 Since tasks are now organized by version, any pipelines that reference these tasks must be updated to point to the newly versioned path.
 
 If the task update affects the results which are checked by [e2e tests](https://github.com/konflux-ci/e2e-tests/tree/main),
@@ -322,10 +321,10 @@ pipelines according to the task updates. By creating migrations, task
 maintainers are able to add/remove/update task parameters, change task
 execution order, add/remove mandatory tasks to/from pipelines, etc.
 
-Historically, task maintainers write `MIGRATION.md` to notify users what changes
-have to be made to the pipeline. This mechanism is not deprecated. Besides
-writing the document, it is also recommended to write a migration script so that the
-updates can be applied to user pipelines automatically, that is done by the
+Historically, task maintainers would write `MIGRATION.md` to notify users what changes
+have to be made to the pipeline. This mechanism is deprecated in favor of `CHANGELOG.md`.
+Besides updating the changelog, it is also recommended to write a migration script so that
+the updates can be applied to user pipelines automatically, that is done by the
 [pipeline-migration-tool](https://github.com/konflux-ci/pipeline-migration-tool).
 
 Task migrations are Bash scripts defined in version-specific task


### PR DESCRIPTION
The MIGRATION.md files are no longer the primary mechanism to communicate changes in task versions to users. That role now belongs to CHANGELOG.md.

Decentralized task repos do not have the checks for MIGRATION.md existence anymore and, as explained in ADR 57 [1], they are not expected to be used anymore.

Remove the CI check that requires MIGRATION.md files and the related text in the README. We already have CI checks for CHANGELOG.md presence (though they are warning-level checks at the moment), as well as AI agent rules that AI review should enforce.

Also note that MintMaker will not be trying to link MIGRATION.md files anymore after https://github.com/konflux-ci/mintmaker/pull/569.

[1]: https://github.com/konflux-ci/architecture/blob/main/ADR/0054-task-versioning.md#mintmaker-dont-assume-each-xy-version-has-a-migrationmd
