### PR TITLE
CLOUDDST-32791: Add fbc-inject-lifecycle to FBC pipeline

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -52,6 +52,7 @@
 /external-task/fbc-fips-check-matrix-based-oci-ta        @konflux-ci/operator-foundry
 /external-task/fbc-fips-check-oci-ta                     @konflux-ci/operator-foundry
 /external-task/fbc-fips-prepare-oci-ta                   @konflux-ci/operator-foundry
+/external-task/fbc-inject-lifecycle-oci-ta               @konflux-ci/operator-foundry
 /external-task/fbc-target-index-pruning-check            @konflux-ci/operator-foundry
 /external-task/run-opm-command-oci-ta                    @konflux-ci/operator-foundry
 /task/sbom-json-check                                    @Allda @jedinym

--- a/external-task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
+++ b/external-task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:a636970f2f7ff1c8156ad92e3c6bde96ce532a3195b24cc3ed4025d7d609e6eb

--- a/external-task/fbc-inject-lifecycle-oci-ta/README.md
+++ b/external-task/fbc-inject-lifecycle-oci-ta/README.md
@@ -1,0 +1,5 @@
+# fbc-inject-lifecycle-oci-ta
+
+⚠️ This task is maintained externally in the [konflux-operator-tasks](https://github.com/konflux-ci/konflux-operator-tasks) repository.
+
+For issues, contributions, or documentation, please refer to the upstream repository.

--- a/external-task/validate-fbc/0.2/validate-fbc.yaml
+++ b/external-task/validate-fbc/0.2/validate-fbc.yaml
@@ -1,0 +1,1 @@
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-validate-fbc:0.2@sha256:8988a61a5680521d583dc3a4c7d378529337ac99cf521e38a2786b99824f64f6

--- a/pipelines/fbc-builder/README.md
+++ b/pipelines/fbc-builder/README.md
@@ -7,20 +7,20 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 ## Parameters
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
-|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| build-images:0.10:BUILD_ARGS|
+|build-args| Array of --build-arg values ("arg=value" strings) for buildah| []| fbc-inject-lifecycle:0.1:BUILD_ARGS ; build-images:0.10:BUILD_ARGS|
 |build-args-file| Path to a file with build arguments for buildah, see https://www.mankier.com/1/buildah-build#--build-arg-file| | build-images:0.10:BUILD_ARGS_FILE|
 |build-image-index| Add built image into an OCI image index| true| build-image-index:0.3:ALWAYS_BUILD_INDEX|
 |build-platforms| List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.| ['linux/x86_64']| |
 |build-source-image| Build a source image.| false| |
-|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| build-images:0.10:DOCKERFILE|
+|dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| fbc-inject-lifecycle:0.1:DOCKERFILE ; build-images:0.10:DOCKERFILE|
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|
 |git-url| Source Repository URL| None| clone-repository:0.2:url|
 |hermetic| Execute the build with network isolation| true| build-images:0.10:HERMETIC|
-|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; run-opm-command:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.10:IMAGE_EXPIRES_AFTER|
+|image-expires-after| Image tag expiration time, time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| | clone-repository:0.2:ociArtifactExpiresAfter ; fbc-inject-lifecycle:0.1:ociArtifactExpiresAfter ; run-opm-command:0.1:ociArtifactExpiresAfter ; prefetch-dependencies:0.3:ociArtifactExpiresAfter ; build-images:0.10:IMAGE_EXPIRES_AFTER|
 |omit-history| When "true", omit the build history (history timestamps, layer metadata, etc.) from the resulting image.| false| build-images:0.10:OMIT_HISTORY|
-|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; run-opm-command:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-images:0.10:IMAGE ; build-image-index:0.3:IMAGE|
-|path-context| Path to the source code of an application's component from where to build image.| .| build-images:0.10:CONTEXT|
+|output-image| Fully Qualified Output Image| None| clone-repository:0.2:ociStorage ; fbc-inject-lifecycle:0.1:ociStorage ; run-opm-command:0.1:ociStorage ; prefetch-dependencies:0.3:ociStorage ; build-images:0.10:IMAGE ; build-image-index:0.3:IMAGE|
+|path-context| Path to the source code of an application's component from where to build image.| .| fbc-inject-lifecycle:0.1:CONTEXT ; build-images:0.10:CONTEXT|
 |prefetch-input| Build dependencies to be prefetched| | prefetch-dependencies:0.3:input ; build-images:0.10:PREFETCH_INPUT|
 |revision| Revision of the Source Repository| | clone-repository:0.2:revision|
 |rewrite-timestamp| When "true", clamp file modification times in the image layers to at most source-date-epoch. Does nothing unless source-date-epoch is set.| false| build-images:0.10:REWRITE_TIMESTAMP|
@@ -127,6 +127,17 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |image-digest| Image digest to scan.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
 |image-mirror-set-path| Path to the image mirror set file.| .tekton/images-mirror-set.yaml| |
 |image-url| Image URL.| None| '$(tasks.build-image-index.results.IMAGE_URL)'|
+### fbc-inject-lifecycle-oci-ta:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|BUILD_ARGS| The array of --build-arg values ("arg=value" strings), passed to the check-lifecycle-eligibility, get-packages, and inject-lifecycle steps to resolve ARG references used in the Dockerfile's base image tag or in COPY/ADD source paths. Do not use for secrets, values are visible in TaskRun status, pod specs, and logs.| []| '['$(params.build-args[*])']'|
+|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
+|caTrustConfigMapKey| The key in the ConfigMap containing the CA bundle.| ca-bundle.crt| |
+|caTrustConfigMapName| The name of the ConfigMap containing the CA bundle for TLS verification.| trusted-ca| |
+|ociArtifactExpiresAfter| Expiration date for the trusted artifacts created in the OCI repository. An empty string means the artifacts do not expire.| ""| '$(params.image-expires-after)'|
+|ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).lifecycle'|
 ### fbc-target-index-pruning-check:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
@@ -190,12 +201,12 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |IDMS_PATH| Optional, path for ImageDigestMirrorSet file. It defaults to '.tekton/images-mirror-set.yaml'| .tekton/images-mirror-set.yaml| |
 |OPM_ARGS| The array of arguments to pass to the 'opm' command. (e.g., [ 'alpha', 'render-template', 'basic', 'v4.18/catalog-template.json']).| []| []|
 |OPM_OUTPUT_PATH| Relative path for the opm command's output file (e.g. 'v4.18/catalog/example-operator/catalog.json'). Relative to the root directory of given source code (Git repository).| None| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.clone-repository.results.SOURCE_ARTIFACT)'|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(tasks.fbc-inject-lifecycle.results.SOURCE_ARTIFACT)'|
 |caTrustConfigMapKey| The key in the ConfigMap containing the CA bundle.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap containing the CA bundle for TLS verification.| trusted-ca| |
 |ociArtifactExpiresAfter| Expiration date for the trusted artifacts. Empty string means no expiration.| None| '$(params.image-expires-after)'|
 |ociStorage| The OCI repository where the Trusted Artifacts are stored.| None| '$(params.output-image).opm'|
-### validate-fbc:0.1 task parameters
+### validate-fbc:0.2 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|
 |IMAGE_DIGEST| Image digest.| None| '$(tasks.build-image-index.results.IMAGE_DIGEST)'|
@@ -213,9 +224,9 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES| List of all referenced image manifests| |
-|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; apply-tags:0.3:IMAGE_DIGEST ; validate-fbc:0.1:IMAGE_DIGEST ; fbc-target-index-pruning-check:0.1:IMAGE_DIGEST ; fbc-fips-check-oci-ta:0.1:image-digest|
+|IMAGE_DIGEST| Digest of the image just built| deprecated-base-image-check:0.5:IMAGE_DIGEST ; apply-tags:0.3:IMAGE_DIGEST ; validate-fbc:0.2:IMAGE_DIGEST ; fbc-target-index-pruning-check:0.1:IMAGE_DIGEST ; fbc-fips-check-oci-ta:0.1:image-digest|
 |IMAGE_REF| Image reference of the built image containing both the repository and the digest| |
-|IMAGE_URL| Image repository and tag where the built image was pushed| deprecated-base-image-check:0.5:IMAGE_URL ; apply-tags:0.3:IMAGE_URL ; validate-fbc:0.1:IMAGE_URL ; fbc-target-index-pruning-check:0.1:IMAGE_URL ; fbc-fips-check-oci-ta:0.1:image-url|
+|IMAGE_URL| Image repository and tag where the built image was pushed| deprecated-base-image-check:0.5:IMAGE_URL ; apply-tags:0.3:IMAGE_URL ; validate-fbc:0.2:IMAGE_URL ; fbc-target-index-pruning-check:0.1:IMAGE_URL ; fbc-fips-check-oci-ta:0.1:image-url|
 |SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
 ### buildah-remote-oci-ta:0.10 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
@@ -234,6 +245,11 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |
 |TEST_OUTPUT| Tekton task test output.| |
+### fbc-inject-lifecycle-oci-ta:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| run-opm-command:0.1:SOURCE_ARTIFACT|
+|TEST_OUTPUT| Tekton task test output.| |
 ### fbc-target-index-pruning-check:0.1 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
@@ -244,7 +260,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |---|---|---|
 |CHAINS-GIT_COMMIT| The precise commit SHA that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
 |CHAINS-GIT_URL| The precise URL that was fetched by this Task. This result uses Chains type hinting to include in the provenance.| |
-|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| run-opm-command:0.1:SOURCE_ARTIFACT|
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| fbc-inject-lifecycle:0.1:SOURCE_ARTIFACT|
 |commit| The precise commit SHA that was fetched by this Task.| build-images:0.10:COMMIT_SHA|
 |commit-timestamp| The commit timestamp of the checkout| |
 |merged_sha| The SHA of the commit after merging the target branch (if the param mergeTargetBranch is true).| |
@@ -264,7 +280,7 @@ This pipeline is pushed as a Tekton bundle to [quay.io](https://quay.io/reposito
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code with generated file-based catalog from catalog-template.yml.| prefetch-dependencies:0.3:SOURCE_ARTIFACT|
-### validate-fbc:0.1 task results
+### validate-fbc:0.2 task results
 |name|description|used in params (taskname:taskrefversion:taskparam)
 |---|---|---|
 |IMAGES_PROCESSED| Images processed in the task.| |

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -136,10 +136,30 @@ spec:
     workspaces:
     - name: basic-auth
       workspace: git-auth
-  - name: run-opm-command
+  - name: fbc-inject-lifecycle
     params:
     - name: SOURCE_ARTIFACT
       value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+    - name: ociStorage
+      value: $(params.output-image).lifecycle
+    - name: ociArtifactExpiresAfter
+      value: $(params.image-expires-after)
+    - name: CONTEXT
+      value: $(params.path-context)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: BUILD_ARGS
+      value:
+      - $(params.build-args[*])
+    runAfter:
+    - clone-repository
+    taskRef:
+      name: fbc-inject-lifecycle-oci-ta
+      version: "0.1"
+  - name: run-opm-command
+    params:
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.fbc-inject-lifecycle.results.SOURCE_ARTIFACT)
     - name: ociStorage
       value: $(params.output-image).opm
     - name: ociArtifactExpiresAfter
@@ -151,7 +171,7 @@ spec:
     - name: IDMS_PATH
       value: ""
     runAfter:
-    - clone-repository
+    - fbc-inject-lifecycle
     taskRef:
       name: run-opm-command-oci-ta
       version: "0.1"
@@ -278,7 +298,7 @@ spec:
     - build-image-index
     taskRef:
       name: validate-fbc
-      version: "0.1"
+      version: "0.2"
     when:
     - input: $(params.skip-checks)
       operator: in

--- a/pipelines/fbc-builder/patch.yaml
+++ b/pipelines/fbc-builder/patch.yaml
@@ -118,15 +118,38 @@
 - op: add
   path: /spec/tasks/2
   value:
-    name: run-opm-command
+    name: fbc-inject-lifecycle
     runAfter:
       - clone-repository
+    taskRef:
+      name: fbc-inject-lifecycle-oci-ta
+      version: "0.1"
+    params:
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+      - name: ociStorage
+        value: $(params.output-image).lifecycle
+      - name: ociArtifactExpiresAfter
+        value: $(params.image-expires-after)
+      - name: CONTEXT
+        value: $(params.path-context)
+      - name: DOCKERFILE
+        value: $(params.dockerfile)
+      - name: BUILD_ARGS
+        value:
+          - $(params.build-args[*])
+- op: add
+  path: /spec/tasks/3
+  value:
+    name: run-opm-command
+    runAfter:
+      - fbc-inject-lifecycle
     taskRef:
       name: run-opm-command-oci-ta
       version: "0.1"
     params:
       - name: SOURCE_ARTIFACT
-        value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
+        value: $(tasks.fbc-inject-lifecycle.results.SOURCE_ARTIFACT)
       - name: ociStorage
         value: $(params.output-image).opm
       - name: ociArtifactExpiresAfter
@@ -138,13 +161,13 @@
       - name: IDMS_PATH
         value: ""
 - op: replace
-  path: /spec/tasks/3/runAfter/0
+  path: /spec/tasks/4/runAfter/0
   value: run-opm-command
 - op: replace
-  path: /spec/tasks/3/params/2/value
+  path: /spec/tasks/4/params/2/value
   value: $(tasks.run-opm-command.results.SOURCE_ARTIFACT)
 - op: replace
-  path: /spec/tasks/4/runAfter/0
+  path: /spec/tasks/5/runAfter/0
   value: clone-repository
 - op: add
   path: /spec/tasks/-
@@ -158,7 +181,7 @@
       - build-image-index
     taskRef:
       name: validate-fbc
-      version: "0.1"
+      version: "0.2"
     params:
     - name: IMAGE_URL
       value: $(tasks.build-image-index.results.IMAGE_URL)

--- a/renovate.json
+++ b/renovate.json
@@ -82,6 +82,7 @@
         "external-task/fbc-fips-check-oci-ta/**",
         "external-task/fbc-fips-check/**",
         "external-task/fbc-fips-prepare-oci-ta/**",
+        "external-task/fbc-inject-lifecycle-oci-ta/**",
         "external-task/fbc-target-index-pruning-check/**",
         "external-task/fips-operator-bundle-check-oci-ta/**",
         "external-task/fips-operator-bundle-check/**",


### PR DESCRIPTION
This PR adds a `fbc-inject-lifecycle` task to the fbc-builder pipeline. This is an external task that lives in the [konflux-operator-tasks repo](https://github.com/konflux-ci/konflux-operator-tasks/tree/main/task/fbc-inject-lifecycle-oci-ta/0.1).

It also bumps `validate-fbc` to 0.2, in order for the Renovate bot to open PRs against product teams' repos to update validate-fbc AND add the new task. There are no functional changes to validate-fbc - this is strictly for automated rollout purposes.

## Risk Assessment

Low

This task is added as a non-blocking task. Any failure of such task will not block the product teams' FBC releases.

