### PR TITLE
chore(renovate): group sast tasks into separate PR group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -62,7 +62,7 @@
 /external-task/github-sarif-upload                       @konflux-ci/operator-foundry
 /stepactions/fips-operator-check-step-action              @konflux-ci/operator-foundry
 
-# renovate groupName=integration
+# renovate groupName=sast
 /external-task/coverity-availability-check           @sfowl @swillis0221
 /external-task/sast-coverity-check                   @konflux-ci/build-maintainers @sfowl @swillis0221
 /external-task/sast-coverity-check-oci-ta            @konflux-ci/build-maintainers @sfowl @swillis0221

--- a/renovate.json
+++ b/renovate.json
@@ -76,7 +76,6 @@
         "external-task/clair-scan/**",
         "external-task/clamav-scan-min/**",
         "external-task/clamav-scan/**",
-        "external-task/coverity-availability-check/**",
         "external-task/deprecated-image-check/**",
         "external-task/fbc-fips-check-matrix-based-oci-ta/**",
         "external-task/fbc-fips-check-oci-ta/**",
@@ -89,16 +88,6 @@
         "external-task/github-sarif-upload/**",
         "external-task/roxctl-scan/**",
         "external-task/run-opm-command-oci-ta/**",
-        "external-task/sast-coverity-check-oci-ta/**",
-        "external-task/sast-coverity-check/**",
-        "external-task/sast-shell-check-oci-ta-min/**",
-        "external-task/sast-shell-check-oci-ta/**",
-        "external-task/sast-shell-check/**",
-        "external-task/sast-snyk-check-oci-ta/**",
-        "external-task/sast-snyk-check/**",
-        "external-task/sast-unicode-check-oci-ta-min/**",
-        "external-task/sast-unicode-check-oci-ta/**",
-        "external-task/sast-unicode-check/**",
         "external-task/tpa-scan/**",
         "external-task/validate-fbc/**",
         "stepactions/fips-operator-check-step-action/**",
@@ -270,6 +259,22 @@
         "pipelines/package-operator-package/**",
         "task/package-operator-package-oci-ta/**",
         "task/package-operator-package/**"
+      ]
+    },
+    {
+      "groupName": "sast",
+      "matchFileNames": [
+        "external-task/coverity-availability-check/**",
+        "external-task/sast-coverity-check-oci-ta/**",
+        "external-task/sast-coverity-check/**",
+        "external-task/sast-shell-check-oci-ta-min/**",
+        "external-task/sast-shell-check-oci-ta/**",
+        "external-task/sast-shell-check/**",
+        "external-task/sast-snyk-check-oci-ta/**",
+        "external-task/sast-snyk-check/**",
+        "external-task/sast-unicode-check-oci-ta-min/**",
+        "external-task/sast-unicode-check-oci-ta/**",
+        "external-task/sast-unicode-check/**"
       ]
     }
   ],


### PR DESCRIPTION
Move sast-related external-task paths out of the integration group into a dedicated sast group so renovate/mintmaker creates separate PRs for sast task updates, aligning with CODEOWNERS approvers.
