### PR TITLE
modelcar-oci-ta: fix path collision when batching olot invocations

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -289,18 +289,38 @@ spec:
           done
 
           # ── olot: add all files in batch as layers ──
-          MODELCARD_ARG=()
+          MODELCARD_ARG=""
           if [ "$FIRST_BATCH" = true ]; then
-            MODELCARD_ARG+=(-m "$MODELCARD_PATH")
+            MODELCARD_ARG="$MODELCARD_PATH"
             FIRST_BATCH=false
           fi
 
           find "$BLOBS_DIR" -maxdepth 1 -type f -printf '%f\n' | sort > /tmp/blobs_before.txt
 
-          olot --verbose --remove-originals default \
-            "${MODELCARD_ARG[@]}" \
-            "$TARGET_OCI" \
-            "${BATCH_FILES[@]}"
+          # Call olot's Python API directly instead of its CLI so we can pass
+          # root_dir="models". Without it, olot derives each layer's in-image
+          # path from the file's basename only, so files that share a
+          # basename in different subdirectories (e.g. "config.json" at the
+          # model root and "inference/config.json") both collapse to
+          # "/models/config.json" and silently overwrite each other. Passing
+          # root_dir="models" makes olot preserve each file's path relative
+          # to that root instead.
+          TARGET_OCI="$TARGET_OCI" MODELCARD_ARG="$MODELCARD_ARG" \
+          python3 - "${BATCH_FILES[@]}" <<'PYEOF'
+        import os
+        import sys
+
+        from olot.basics import oci_layers_on_top
+        from olot.enums import RemoveOriginals
+
+        oci_layers_on_top(
+            os.environ["TARGET_OCI"],
+            sys.argv[1:],
+            os.environ.get("MODELCARD_ARG") or None,
+            root_dir="models",
+            remove_originals=RemoveOriginals.DEFAULT,
+        )
+        PYEOF
 
           rm -f "${BATCH_FILES[@]}"
 


### PR DESCRIPTION
## Summary

The `build-and-push` step in `modelcar-oci-ta` downloads and layers model files in batches, invoking the `olot` CLI separately per batch with each file's full on-disk path (e.g. `models/config.json`, `models/inference/config.json`).

The `olot` CLI has no way to preserve subdirectory structure for individual file arguments — it derives each layer's in-image path from the file's **basename alone**. So files that share a basename in different subdirectories collapse onto the same in-image path: both `models/config.json` and `models/inference/config.json` become `/models/config.json` in their respective layers, and whichever batch is processed last silently overwrites the other's content.

This was the root cause of a real failure: a DeepSeek model with both a root `config.json` and a nested `inference/config.json` ended up with the wrong `config.json` in the final ModelCar image, causing vLLM to fail with `Unrecognized model in /mnt/models. Should have a model_type key in its config.json`.

- Calls `olot`'s Python API (`oci_layers_on_top`) directly instead of shelling out to its CLI, passing `root_dir="models"` so each file's layer path is derived relative to that root and subdirectory structure is preserved.
- No parameters or task interface changes — this is a same-version bug fix.

## Root cause verification

- Traced `olot`'s CLI (`olot/cli.py`) and confirmed it has no `--root-dir` flag; individual file inputs use `Path(file).name` to build the in-layer archive path (`olot/utils/files.py`), which strips all parent directories.
- Confirmed `oci_layers_on_top`'s `root_dir` parameter (added in `olot` for exactly this use case, see `olot/tests/basic_test.py::test_oci_layers_on_top_nested_files`) preserves relative subdirectory structure instead.
- Reproduced the collision locally end-to-end using an olot test OCI-layout fixture, simulating the task's two-batch download flow (root `config.json` in batch 1, `inference/config.json` in batch 2):
  - **Before the fix**: both files land at `/models/config.json`.
  - **After the fix**: they land at `/models/config.json` and `/models/inference/config.json` respectively, as expected.
