### PR TITLE
modelcar-oci-ta: use olot's --root-dir flag to preserve subdirectory structure

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -297,7 +297,14 @@ spec:
 
           find "$BLOBS_DIR" -maxdepth 1 -type f -printf '%f\n' | sort > /tmp/blobs_before.txt
 
-          olot --verbose --remove-originals default \
+          # --root-dir preserves each file's subdirectory structure (relative
+          # to models/) in its resulting layer path, instead of flattening to
+          # just the basename. Without it, files with the same basename in
+          # different subdirectories (e.g. a root config.json and an
+          # inference/config.json) collide on the same in-image path and
+          # silently overwrite each other. Requires olot with
+          # https://github.com/containers/olot/pull/209.
+          olot --verbose --remove-originals default --root-dir models \
             "${MODELCARD_ARG[@]}" \
             "$TARGET_OCI" \
             "${BATCH_FILES[@]}"


### PR DESCRIPTION
## Summary

The `build-and-push` step in `modelcar-oci-ta` downloads and layers model files in batches, invoking the `olot` CLI separately per batch with each file's full on-disk path (e.g. `models/config.json`, `models/inference/config.json`).

Without `--root-dir`, `olot` derives each layer's in-image path from the file's **basename alone**, so files with the same basename in different subdirectories collide on the same in-image path and silently overwrite each other — e.g. both `models/config.json` and `models/inference/config.json` end up as `/models/config.json`, with whichever batch runs last winning.

This was the root cause of a real failure: a DeepSeek model with both a root `config.json` and a nested `inference/config.json` ended up with the wrong `config.json` in the final ModelCar image, causing vLLM to fail with `Unrecognized model in /mnt/models. Should have a model_type key in its config.json`.

- Adds `--root-dir models` to the existing `olot` CLI invocation so each file's layer path is derived relative to that root, preserving subdirectory structure.
- No other changes — this is the minimal, upstream-first fix (see dependency note below), replacing an earlier task-only Python-API workaround that was closed in favor of this.

## :warning: Blocked on a dependency

This depends on:
1. [containers/olot#209](https://github.com/containers/olot/pull/209) — adds the `--root-dir` CLI flag to `olot` (not yet merged).
2. A new `olot` release containing that flag.
3. The `task-runner` image (`quay.io/konflux-ci/task-runner`, currently pinned to `1.8.1` in this task) bundling that new `olot` release.

Opening this now as a draft so the change is ready to merge once the dependency chain above lands; marking as draft until then.

## Test plan

- [x] Verified the resolved step script parses as valid YAML and passes `bash -n`.
- [x] Built `olot` from the `containers/olot#209` branch locally and reproduced the fix end-to-end: ran the exact `olot --verbose --remove-originals default --root-dir models ...` invocation against a real OCI-layout fixture, simulating the task's two-batch flow (root `config.json` in batch 1, `inference/config.json` in batch 2). Confirmed the files land at `models/config.json` and `models/inference/config.json` respectively instead of colliding.
- [ ] Once `olot` with `--root-dir` is released and the `task-runner` image is bumped, re-run the existing `modelcar-oci-ta` integration tests (`task/modelcar-oci-ta/0.1/tests/`) in CI.

Made with [Cursor](https://cursor.com)