### PR TITLE
chore(deps): bump modelcar-oci-ta task-runner to 3.0.0

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -180,7 +180,7 @@ spec:
         echo "$ARCHFUL_BASE_IMAGE" | tee "$(results.BASE_IMAGE_REF.path)"
 
     - name: build-and-push
-      image: quay.io/konflux-ci/task-runner:1.8.1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 2Gi
@@ -457,7 +457,7 @@ spec:
           --sbom-type "$SBOM_TYPE"
 
     - name: upload-sbom
-      image: quay.io/konflux-ci/task-runner:1.8.1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 64Mi
@@ -480,7 +480,7 @@ spec:
             exit 1
         fi
     - name: report-sbom-url
-      image: quay.io/konflux-ci/task-runner:1.8.1@sha256:b9ef0479b57a494368a12a02886c650314c9ac7391c6228f21065865aab71c9e
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 64Mi


### PR DESCRIPTION
## Summary
- Bump `task-runner` image in `modelcar-oci-ta` from `1.8.1` to `3.0.0` (`sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05`)
