### PR TITLE
fix(ci): replace removed deploy-konflux.sh with deploy-local.sh

### DIFF
--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -102,9 +102,16 @@ jobs:
 
       - name: Deploying Konflux
         if: steps.tasks-to-be-tested.outputs.tasklist != ''
+        env:
+          # Kind cluster already created by kind-action above.
+          DEPLOY_LOCAL_SKIP_KIND: "1"
+          # Install operator + Konflux CR from the latest GitHub release.
+          OPERATOR_INSTALL_METHOD: release
+          # Task tests do not need GitHub App / Quay secrets.
+          SKIP_SECRETS: "true"
         run: |
           cd $GITHUB_WORKSPACE/konflux-ci
-          ./deploy-konflux.sh
+          ./scripts/deploy-local.sh
 
       - name: List namespaces
         if: steps.tasks-to-be-tested.outputs.tasklist != ''

--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -68,7 +68,8 @@ jobs:
         with:
           repository: 'konflux-ci/konflux-ci'
           path: konflux-ci
-          ref: f534315051ccafa8197ea6491a0fdc5ba88ec793
+          # Pin must include scripts/deploy-local.sh support for OPERATOR_RELEASE.
+          ref: d510887fc3f38a8f8f4f4d5540f5b7199d4c7f67
 
       - name: Create k8s Kind Cluster
         if: steps.changed-task-dirs.outputs.any_changed == 'true'
@@ -105,8 +106,10 @@ jobs:
         env:
           # Kind cluster already created by kind-action above.
           DEPLOY_LOCAL_SKIP_KIND: "1"
-          # Install operator + Konflux CR from the latest GitHub release.
+          # Install operator + Konflux CR from a pinned GitHub release (not
+          # floating "latest") so task-test CI stays reproducible.
           OPERATOR_INSTALL_METHOD: release
+          OPERATOR_RELEASE: v0.1.13
           # Task tests do not need GitHub App / Quay secrets.
           SKIP_SECRETS: "true"
         run: |


### PR DESCRIPTION
## Summary
- `run-task-tests` called `./deploy-konflux.sh`, which no longer exists in the pinned `konflux-ci` checkout
- Switch to `./scripts/deploy-local.sh` (operator-based install) with `DEPLOY_LOCAL_SKIP_KIND=1`, `OPERATOR_INSTALL_METHOD=release`, and `SKIP_SECRETS=true`
