### PR TITLE
chore: update shared CI for deploy-local task tests

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/konflux-ci/task-repo-shared-ci",
-  "commit": "e3e90232ccd9e98c922ec2285ca89f53909aa73d",
+  "commit": "e7f81e61a9d2e593b1c7dbda83039aff25b967d1",
   "skip": [
     "hack/build-manifests.sh",
     ".github/scripts/check_tekton_tasks.sh"
@@ -13,7 +13,7 @@
         "*"
       ],
       "_template": "https://github.com/konflux-ci/task-repo-shared-ci",
-      "_commit": "e3e90232ccd9e98c922ec2285ca89f53909aa73d"
+      "_commit": "e7f81e61a9d2e593b1c7dbda83039aff25b967d1"
     }
   },
   "directory": null

--- a/.github/workflows/run-task-tests.yaml
+++ b/.github/workflows/run-task-tests.yaml
@@ -68,7 +68,7 @@ jobs:
         with:
           repository: 'konflux-ci/konflux-ci'
           path: konflux-ci
-          ref: f534315051ccafa8197ea6491a0fdc5ba88ec793
+          ref: d510887fc3f38a8f8f4f4d5540f5b7199d4c7f67
 
       - name: Create k8s Kind Cluster
         if: steps.changed-task-dirs.outputs.any_changed == 'true'
@@ -102,9 +102,18 @@ jobs:
 
       - name: Deploying Konflux
         if: steps.tasks-to-be-tested.outputs.tasklist != ''
+        env:
+          # Kind cluster already created by kind-action above.
+          DEPLOY_LOCAL_SKIP_KIND: "1"
+          # Install operator + Konflux CR from a pinned GitHub release (not
+          # floating "latest") so task-test CI stays reproducible.
+          OPERATOR_INSTALL_METHOD: release
+          OPERATOR_RELEASE: v0.1.13
+          # Task tests do not need GitHub App / Quay secrets.
+          SKIP_SECRETS: "true"
         run: |
           cd $GITHUB_WORKSPACE/konflux-ci
-          ./deploy-konflux.sh
+          ./scripts/deploy-local.sh
 
       - name: List namespaces
         if: steps.tasks-to-be-tested.outputs.tasklist != ''

--- a/hack/checkton-local.sh
+++ b/hack/checkton-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 
 # <TEMPLATED FILE!>

--- a/hack/renovate-ignore-shared-ci.sh
+++ b/hack/renovate-ignore-shared-ci.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -o errexit -o nounset -o pipefail
 
 # <TEMPLATED FILE!>

--- a/hack/verify-manifests.sh
+++ b/hack/verify-manifests.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+set -e
 
 # <TEMPLATED FILE!>
 # This file comes from the templates at https://github.com/konflux-ci/task-repo-shared-ci.


### PR DESCRIPTION
## Summary
- `cruft update` to task-repo-shared-ci `e7f81e61` (https://github.com/konflux-ci/task-repo-shared-ci/pull/73)
- `run-task-tests` now uses `scripts/deploy-local.sh` with a pinned operator release instead of the removed `deploy-konflux.sh`
- Includes incidental shared-CI script shebang updates from the same template bump

Supersedes https://github.com/konflux-ci/build-definitions/pull/3747 (local patch; this is the template-delivered fix).
