### PR TITLE
fix(modelcar-oci-ta): fix Kind registry TLS and task test harness

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -80,6 +80,15 @@ spec:
       description: CPE identifier label required for on-prem product releases
       type: string
       default: ""
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
   results:
     - name: IMAGE_DIGEST
       description: Digest of the artifact just pushed
@@ -128,6 +137,10 @@ spec:
         value: $(params.IMAGE_APPEND_PLATFORM)
       - name: TARGET_OCI
         value: "/var/workdir/modelcar-oci"
+      # Used by Go tools (oras/cosign). Only takes effect when the mounted
+      # bundle is non-empty; scripts also guard before exporting.
+      - name: CA_FILE
+        value: /etc/pki/tls/certs/ca-custom-bundle.crt
     imagePullPolicy: IfNotPresent
     volumeMounts:
       - mountPath: /var/workdir
@@ -211,6 +224,10 @@ spec:
         #!/bin/bash
         set -eu
         set -o pipefail
+
+        if [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
+          export SSL_CERT_FILE="${CA_FILE}"
+        fi
 
         # ─── Resolve destination image ───
         if [ "${IMAGE_APPEND_PLATFORM}" == "true" ]; then
@@ -468,6 +485,10 @@ spec:
       script: |
         #!/bin/bash
         set -e
+
+        if [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
+          export SSL_CERT_FILE="${CA_FILE}"
+        fi
 
         # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
         mkdir -p /tmp/auth && select-oci-auth "$(cat "$(results.IMAGE_REF.path)")" > /tmp/auth/config.json

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -175,6 +175,10 @@ spec:
         set -eu
         set -o pipefail
 
+        if [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
+          export SSL_CERT_FILE="${CA_FILE}"
+        fi
+
         BASE_IMAGE="${BASE_IMAGE//:*@/@}"  # Strip tag, only if it is infixed before the digest
         arch="${PLATFORM//*\//}"
         os="${PLATFORM//\/*/}"
@@ -465,6 +469,10 @@ spec:
       script: |
         #!/bin/bash
         set -euo pipefail
+
+        if [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
+          export SSL_CERT_FILE="${CA_FILE}"
+        fi
 
         MODELCAR_IMAGE=$(cat "$(results.IMAGE_REF.path)")
         BASE_IMAGE_REF=$(cat "$(results.BASE_IMAGE_REF.path)")

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -227,14 +227,11 @@ spec:
 
         if [ "${INSECURE_REGISTRY:-false}" = "true" ]; then
           ORAS_TLS_OPTS=(--insecure)
-          COSIGN_TLS_OPTS=(--allow-insecure-registry)
         elif [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
           export SSL_CERT_FILE="${CA_FILE}"
           ORAS_TLS_OPTS=()
-          COSIGN_TLS_OPTS=()
         else
           ORAS_TLS_OPTS=()
-          COSIGN_TLS_OPTS=()
         fi
 
         # ─── Resolve destination image ───

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -225,8 +225,16 @@ spec:
         set -eu
         set -o pipefail
 
-        if [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
+        if [ "${INSECURE_REGISTRY:-false}" = "true" ]; then
+          ORAS_TLS_OPTS=(--insecure)
+          COSIGN_TLS_OPTS=(--allow-insecure-registry)
+        elif [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
           export SSL_CERT_FILE="${CA_FILE}"
+          ORAS_TLS_OPTS=()
+          COSIGN_TLS_OPTS=()
+        else
+          ORAS_TLS_OPTS=()
+          COSIGN_TLS_OPTS=()
         fi
 
         # ─── Resolve destination image ───
@@ -239,7 +247,7 @@ spec:
         BLOBS_DIR="${TARGET_OCI}/blobs/sha256"
 
         # ─── Fetch model manifest for mtime + layer list ───
-        MODEL_MANIFEST=$(oras manifest fetch "$MODEL_IMAGE" \
+        MODEL_MANIFEST=$(oras manifest fetch "${ORAS_TLS_OPTS[@]}" "$MODEL_IMAGE" \
           --registry-config /model-secret/.dockerconfigjson)
         MODEL_REF="${MODEL_IMAGE%%@*}"
 
@@ -282,7 +290,7 @@ spec:
             BATCH_FILES+=("models/${title}")
 
             (
-              retry oras blob fetch \
+              retry oras blob fetch "${ORAS_TLS_OPTS[@]}" \
                 --registry-config /model-secret/.dockerconfigjson \
                 -o "models/${title}" \
                 "${MODEL_REF}@${blob_digest}" \
@@ -331,7 +339,7 @@ spec:
             if echo "$LAYER_HASHES" | grep -qx "$new_blob"; then
               NEW_BLOBS+=("$new_blob")
               (
-                retry oras blob push --registry-config auth.json \
+                retry oras blob push "${ORAS_TLS_OPTS[@]}" --registry-config auth.json \
                   "$DEST_REPO" "$BLOBS_DIR/$new_blob" \
                 && echo "  Pushed sha256:${new_blob}"
               ) &
@@ -425,11 +433,11 @@ spec:
           blob_name=$(basename "$blob_file")
           [ "$blob_name" = "$MANIFEST_HASH" ] && continue
           echo "Pushing blob sha256:${blob_name}..."
-          retry oras blob push --registry-config auth.json "$DEST_REPO" "$blob_file"
+          retry oras blob push "${ORAS_TLS_OPTS[@]}" --registry-config auth.json "$DEST_REPO" "$blob_file"
         done
 
         echo "Pushing manifest to ${IMAGE}..."
-        if ! retry oras manifest push --registry-config auth.json \
+        if ! retry oras manifest push "${ORAS_TLS_OPTS[@]}" --registry-config auth.json \
           "$IMAGE" "$BLOBS_DIR/$MANIFEST_HASH"
         then
           echo "Failed to push manifest to ${IMAGE}"
@@ -437,7 +445,7 @@ spec:
         fi
         echo "Push complete!"
 
-        if ! RESULTING_DIGEST=$(retry oras resolve --registry-config auth.json "${IMAGE}")
+        if ! RESULTING_DIGEST=$(retry oras resolve "${ORAS_TLS_OPTS[@]}" --registry-config auth.json "${IMAGE}")
         then
           echo "Failed to get digest for ${IMAGE} from registry"
           exit 1
@@ -486,8 +494,13 @@ spec:
         #!/bin/bash
         set -e
 
-        if [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
+        if [ "${INSECURE_REGISTRY:-false}" = "true" ]; then
+          COSIGN_TLS_OPTS=(--allow-insecure-registry)
+        elif [ -n "${CA_FILE:-}" ] && [ -s "${CA_FILE}" ]; then
           export SSL_CERT_FILE="${CA_FILE}"
+          COSIGN_TLS_OPTS=()
+        else
+          COSIGN_TLS_OPTS=()
         fi
 
         # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
@@ -495,7 +508,7 @@ spec:
         export DOCKER_CONFIG=/tmp/auth
 
         echo "Pushing sbom to registry"
-        if ! retry cosign attach sbom --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
+        if ! retry cosign attach sbom "${COSIGN_TLS_OPTS[@]}" --sbom sbom.json --type "$SBOM_TYPE" "$(cat "$(results.IMAGE_REF.path)")"
         then
             echo "Failed to push sbom to registry"
             exit 1

--- a/task/modelcar-oci-ta/0.1/tests/pre-apply-task-hook.sh
+++ b/task/modelcar-oci-ta/0.1/tests/pre-apply-task-hook.sh
@@ -10,4 +10,13 @@ echo '{"auths":{}}' | kubectl create secret generic dummy-secret \
   --type=kubernetes.io/dockerconfigjson \
   -n "$TEST_NS" --dry-run=client -o yaml | kubectl apply -f - -n "$TEST_NS"
 
-echo "Pre-requirements setup complete" 
+# Kind registry TLS is not reliably trusted via the mounted trusted-ca bundle
+# under deploy-local CI. Opt the task into insecure registry mode for tests only.
+yq -i '
+  .spec.stepTemplate.env = (.spec.stepTemplate.env // []) + [
+    {"name": "INSECURE_REGISTRY", "value": "true"},
+    {"name": "ORAS_OPTIONS", "value": "--insecure"}
+  ]
+' "$TASK_COPY"
+
+echo "Pre-requirements setup complete"

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -75,8 +75,8 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly so layer titles keep paths like
-              # source/models/model.bin (directory push can collapse to one layer).
+              # Push files explicitly (directory push can collapse to one layer).
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest
@@ -200,7 +200,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/models/model.bin; do
+              for filename in usr/bin/ls models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -38,12 +38,6 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -76,12 +70,12 @@ spec:
           - name: mock-model
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             workingDir: $(workspaces.tests-workspace.path)
-            command: ["oras"]
-            args:
-              - push
-              - --no-tty
-              - $(params.modelPath)
-              - source/
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              # Kind registry uses a cluster-local CA that is not reliably in
+              # the task trust store under deploy-local CI; skip verify here.
+              oras push --insecure --no-tty "$(params.modelPath)" source/
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |
@@ -89,12 +83,18 @@ spec:
               set -euo pipefail
 
               echo "Find digest of the mocked model"
-              digest=$(oras resolve "$(params.modelPath)")
+              digest=$(oras resolve --insecure "$(params.modelPath)")
 
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
             image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            env:
+              # Consumed by oras_opts.sh inside build-trusted-artifacts.
+              - name: ORAS_OPTIONS
+                value: --insecure
+              - name: CA_FILE
+                value: /etc/pki/tls/certs/ca-custom-bundle.crt
             args:
               - create
               - --store
@@ -157,12 +157,6 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -186,23 +180,23 @@ spec:
               set -eu
 
               echo "Confirm we can inspect the image with an archful tag"
-              skopeo inspect "docker://${IMAGE_REF//:latest-linux-s390x/}"
+              skopeo inspect --tls-verify=false "docker://${IMAGE_REF//:latest-linux-s390x/}"
 
               echo "Confirm the image is single-arch; multiarch not supported"
-              mediaType=$(skopeo inspect --raw "docker://${IMAGE_REF//:latest-linux-s390x/}" | jq -r .mediaType)
+              mediaType=$(skopeo inspect --tls-verify=false --raw "docker://${IMAGE_REF//:latest-linux-s390x/}" | jq -r .mediaType)
               if [ "$mediaType" != "application/vnd.oci.image.manifest.v1+json" ]; then
                   echo "Image is not single-arch." && exit 1
               fi
 
               echo "Confirm the image is s390x - the one we asked for"
-              mediaType=$(skopeo inspect "docker://${IMAGE_REF//:latest-linux-s390x/}" | jq -r .Architecture)
+              mediaType=$(skopeo inspect --tls-verify=false "docker://${IMAGE_REF//:latest-linux-s390x/}" | jq -r .Architecture)
               if [ "$mediaType" != "s390x" ]; then
                   echo "Image is not s390x." && exit 1
               fi
 
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
-              oc image extract "$IMAGE_REF"
+              oc image extract --insecure=true "$IMAGE_REF"
               for filename in usr/bin/ls models/source/models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
@@ -213,7 +207,7 @@ spec:
               popd
 
               echo "Confirm the sbom exists as json"
-              packages=$(cosign download sbom "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
+              packages=$(cosign download sbom --allow-insecure-registry "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
               for purl in pkg:oci/test-modelcar pkg:oci/ubi pkg:oci/test-model; do
                 if [[ "$packages" == *"${purl}@sha256"* ]]; then
                   echo "$purl found as expected."

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -38,6 +38,12 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -151,6 +157,12 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -75,7 +75,10 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              oras push --insecure --no-tty "$(params.modelPath)" source/
+              # Push files explicitly so layer titles keep paths like
+              # source/models/model.bin (directory push can collapse to one layer).
+              mapfile -t files < <(find source -type f | sort)
+              oras push --insecure --no-tty "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -75,8 +75,8 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly so layer titles keep paths like
-              # source/models/model.bin (directory push can collapse to one layer).
+              # Push files explicitly (directory push can collapse to one layer).
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -38,6 +38,12 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -149,6 +155,12 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -38,12 +38,6 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -76,12 +70,12 @@ spec:
           - name: mock-model
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             workingDir: $(workspaces.tests-workspace.path)
-            command: ["oras"]
-            args:
-              - push
-              - --no-tty
-              - $(params.modelPath)
-              - source/
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              # Kind registry uses a cluster-local CA that is not reliably in
+              # the task trust store under deploy-local CI; skip verify here.
+              oras push --insecure --no-tty "$(params.modelPath)" source/
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |
@@ -89,12 +83,18 @@ spec:
               set -euo pipefail
 
               echo "Find digest of the mocked model"
-              digest=$(oras resolve "$(params.modelPath)")
+              digest=$(oras resolve --insecure "$(params.modelPath)")
 
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
             image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            env:
+              # Consumed by oras_opts.sh inside build-trusted-artifacts.
+              - name: ORAS_OPTIONS
+                value: --insecure
+              - name: CA_FILE
+                value: /etc/pki/tls/certs/ca-custom-bundle.crt
             args:
               - create
               - --store
@@ -155,12 +155,6 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -181,10 +175,10 @@ spec:
               set -eu
 
               echo "Confirm we can inspect the image"
-              skopeo inspect "docker://${IMAGE_REF//:latest/}"
+              skopeo inspect --tls-verify=false "docker://${IMAGE_REF//:latest/}"
 
               echo "Confirm the sbom exists as json"
-              packages=$(cosign download sbom "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
+              packages=$(cosign download sbom --allow-insecure-registry "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
               for purl in pkg:oci/test-modelcar pkg:oci/ubi pkg:oci/test-model; do
                 if [[ "$packages" == *"${purl}@sha256"* ]]; then
                   echo "$purl found as expected."

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -75,7 +75,10 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              oras push --insecure --no-tty "$(params.modelPath)" source/
+              # Push files explicitly so layer titles keep paths like
+              # source/models/model.bin (directory push can collapse to one layer).
+              mapfile -t files < <(find source -type f | sort)
+              oras push --insecure --no-tty "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -38,12 +38,6 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -76,12 +70,12 @@ spec:
           - name: mock-model
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             workingDir: $(workspaces.tests-workspace.path)
-            command: ["oras"]
-            args:
-              - push
-              - --no-tty
-              - $(params.modelPath)
-              - source/
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              # Kind registry uses a cluster-local CA that is not reliably in
+              # the task trust store under deploy-local CI; skip verify here.
+              oras push --insecure --no-tty "$(params.modelPath)" source/
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |
@@ -89,12 +83,18 @@ spec:
               set -euo pipefail
 
               echo "Find digest of the mocked model"
-              digest=$(oras resolve "$(params.modelPath)")
+              digest=$(oras resolve --insecure "$(params.modelPath)")
 
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
             image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            env:
+              # Consumed by oras_opts.sh inside build-trusted-artifacts.
+              - name: ORAS_OPTIONS
+                value: --insecure
+              - name: CA_FILE
+                value: /etc/pki/tls/certs/ca-custom-bundle.crt
             args:
               - create
               - --store
@@ -153,12 +153,6 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -185,23 +179,23 @@ spec:
               IMAGE_REF="${IMAGE_REF//:latest/}"
 
               echo "Confirm we can inspect the image ${IMAGE_REF}"
-              skopeo inspect "docker://${IMAGE_REF}"
+              skopeo inspect --tls-verify=false "docker://${IMAGE_REF}"
 
               echo "Confirm the image is single-arch; multiarch not supported"
-              mediaType=$(skopeo inspect --raw "docker://${IMAGE_REF}" | jq -r .mediaType)
+              mediaType=$(skopeo inspect --tls-verify=false --raw "docker://${IMAGE_REF}" | jq -r .mediaType)
               if [ "$mediaType" != "application/vnd.oci.image.manifest.v1+json" ]; then
                   echo "Image is not single-arch." && exit 1
               fi
 
               echo "Confirm the image is amd64 - the one matching the single-arch base image we provided"
-              mediaType=$(skopeo inspect "docker://${IMAGE_REF}" | jq -r .Architecture)
+              mediaType=$(skopeo inspect --tls-verify=false "docker://${IMAGE_REF}" | jq -r .Architecture)
               if [ "$mediaType" != "amd64" ]; then
                   echo "Image is not amd64." && exit 1
               fi
 
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
-              oc image extract "$IMAGE_REF"
+              oc image extract --insecure=true "$IMAGE_REF"
               for filename in usr/bin/ls models/source/models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
@@ -212,7 +206,7 @@ spec:
               popd
 
               echo "Confirm the sbom exists as json"
-              packages=$(cosign download sbom "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
+              packages=$(cosign download sbom --allow-insecure-registry "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
               for purl in pkg:oci/test-modelcar pkg:oci/ubi pkg:oci/test-model; do
                 if [[ "$packages" == *"${purl}@sha256"* ]]; then
                   echo "$purl found as expected."
@@ -222,7 +216,7 @@ spec:
               done
 
               echo "Confirm the sbom has a reasonable name"
-              sbom_name=$(cosign download sbom "$IMAGE_REF" | jq -r '.name')
+              sbom_name=$(cosign download sbom --allow-insecure-registry "$IMAGE_REF" | jq -r '.name')
               if [[ "$sbom_name" == "$IMAGE_REF" ]]; then
                 echo "SBOM name $sbom_name is as expected."
               else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -75,8 +75,8 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly so layer titles keep paths like
-              # source/models/model.bin (directory push can collapse to one layer).
+              # Push files explicitly (directory push can collapse to one layer).
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest
@@ -199,7 +199,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/models/model.bin; do
+              for filename in usr/bin/ls models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -38,6 +38,12 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -147,6 +153,12 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -75,7 +75,10 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              oras push --insecure --no-tty "$(params.modelPath)" source/
+              # Push files explicitly so layer titles keep paths like
+              # source/models/model.bin (directory push can collapse to one layer).
+              mapfile -t files < <(find source -type f | sort)
+              oras push --insecure --no-tty "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -75,9 +75,12 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
+              # Push files explicitly so layer titles keep paths like
+              # source/models/model.bin (directory push can collapse to one layer).
+              mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty \
                 --annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z" \
-                "$(params.modelPath)" source/
+                "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -38,12 +38,6 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -76,14 +70,14 @@ spec:
           - name: mock-model
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             workingDir: $(workspaces.tests-workspace.path)
-            command: ["oras"]
-            args:
-              - push
-              - --no-tty
-              - --annotation
-              - "org.opencontainers.image.created=2026-03-13T10:30:00Z"
-              - $(params.modelPath)
-              - source/
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              # Kind registry uses a cluster-local CA that is not reliably in
+              # the task trust store under deploy-local CI; skip verify here.
+              oras push --insecure --no-tty \
+                --annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z" \
+                "$(params.modelPath)" source/
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |
@@ -91,12 +85,18 @@ spec:
               set -euo pipefail
 
               echo "Find digest of the mocked model"
-              digest=$(oras resolve "$(params.modelPath)")
+              digest=$(oras resolve --insecure "$(params.modelPath)")
 
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
             image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            env:
+              # Consumed by oras_opts.sh inside build-trusted-artifacts.
+              - name: ORAS_OPTIONS
+                value: --insecure
+              - name: CA_FILE
+                value: /etc/pki/tls/certs/ca-custom-bundle.crt
             args:
               - create
               - --store
@@ -147,12 +147,6 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -173,7 +167,7 @@ spec:
 
               echo "Extract the image filesystem"
               mkdir contents/ && pushd contents/
-              oc image extract "$IMAGE_REF"
+              oc image extract --insecure=true "$IMAGE_REF"
 
               echo "Confirm model files have the expected mtime from OCI annotation"
               # The annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z"

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -38,6 +38,12 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -141,6 +147,12 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -75,8 +75,8 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly so layer titles keep paths like
-              # source/models/model.bin (directory push can collapse to one layer).
+              # Push files explicitly (directory push can collapse to one layer).
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty \
                 --annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z" \
@@ -176,7 +176,7 @@ spec:
               # The annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z"
               # is converted by the task to touch -t format: 202603131030.00
               # Expected: Mar 13 2026 10:30 UTC
-              mtime=$(stat -c '%Y' models/source/models/model.bin)
+              mtime=$(stat -c '%Y' models/model.bin)
               expected_epoch=1773397800
               if [ "$mtime" -ne "$expected_epoch" ]; then
                   echo "Expected mtime epoch $expected_epoch but got $mtime" && exit 1

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -38,12 +38,6 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -76,12 +70,12 @@ spec:
           - name: mock-model
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             workingDir: $(workspaces.tests-workspace.path)
-            command: ["oras"]
-            args:
-              - push
-              - --no-tty
-              - $(params.modelPath)
-              - source/
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              # Kind registry uses a cluster-local CA that is not reliably in
+              # the task trust store under deploy-local CI; skip verify here.
+              oras push --insecure --no-tty "$(params.modelPath)" source/
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |
@@ -89,12 +83,18 @@ spec:
               set -euo pipefail
 
               echo "Find digest of the mocked model"
-              digest=$(oras resolve "$(params.modelPath)")
+              digest=$(oras resolve --insecure "$(params.modelPath)")
 
               echo "Share location of the mocked model"
               echo -n "$(params.modelPath)@${digest}" > "$(results.MODEL_PATH.path)"
           - name: create-trusted-artifact
             image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:15d7dc86012e41b10d1eb37679ec03ee75c96436224fadd0938a49dc537aa4ad
+            env:
+              # Consumed by oras_opts.sh inside build-trusted-artifacts.
+              - name: ORAS_OPTIONS
+                value: --insecure
+              - name: CA_FILE
+                value: /etc/pki/tls/certs/ca-custom-bundle.crt
             args:
               - create
               - --store
@@ -153,12 +153,6 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
-          env:
-            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
-            - name: SSL_CERT_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
-            - name: CA_FILE
-              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -182,23 +176,23 @@ spec:
               set -eu
 
               echo "Confirm we can inspect the image"
-              skopeo inspect "docker://${IMAGE_REF//:latest/}"
+              skopeo inspect --tls-verify=false "docker://${IMAGE_REF//:latest/}"
 
               echo "Confirm the image is single-arch; multiarch not supported"
-              mediaType=$(skopeo inspect --raw "docker://${IMAGE_REF//:latest/}" | jq -r .mediaType)
+              mediaType=$(skopeo inspect --tls-verify=false --raw "docker://${IMAGE_REF//:latest/}" | jq -r .mediaType)
               if [ "$mediaType" != "application/vnd.oci.image.manifest.v1+json" ]; then
                   echo "Image is not single-arch." && exit 1
               fi
 
               echo "Confirm the image is amd64 - the one matching the single-arch base image we provided"
-              mediaType=$(skopeo inspect "docker://${IMAGE_REF//:latest/}" | jq -r .Architecture)
+              mediaType=$(skopeo inspect --tls-verify=false "docker://${IMAGE_REF//:latest/}" | jq -r .Architecture)
               if [ "$mediaType" != "amd64" ]; then
                   echo "Image is not amd64." && exit 1
               fi
 
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
-              oc image extract "$IMAGE_REF"
+              oc image extract --insecure=true "$IMAGE_REF"
               for filename in usr/bin/ls models/source/models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
@@ -209,7 +203,7 @@ spec:
               popd
 
               echo "Confirm the sbom exists as json"
-              packages=$(cosign download sbom "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
+              packages=$(cosign download sbom --allow-insecure-registry "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
               for purl in pkg:oci/test-modelcar pkg:oci/ubi pkg:oci/test-model; do
                 if [[ "$packages" == *"${purl}@sha256"* ]]; then
                   echo "$purl found as expected."

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -38,6 +38,12 @@ spec:
           - name: ociStorage
           - name: modelPath
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
@@ -147,6 +153,12 @@ spec:
                   path: ca-bundle.crt
               name: $(params.caTrustConfigMapName)
         stepTemplate:
+          env:
+            # Kind registry uses a cluster CA; Go/oras need SSL_CERT_FILE to trust it.
+            - name: SSL_CERT_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            - name: CA_FILE
+              value: /etc/pki/tls/certs/ca-custom-bundle.crt
           volumeMounts:
             - name: trusted-ca
               mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -75,8 +75,8 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly so layer titles keep paths like
-              # source/models/model.bin (directory push can collapse to one layer).
+              # Push files explicitly (directory push can collapse to one layer).
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest
@@ -196,7 +196,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/models/model.bin; do
+              for filename in usr/bin/ls models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -75,7 +75,10 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              oras push --insecure --no-tty "$(params.modelPath)" source/
+              # Push files explicitly so layer titles keep paths like
+              # source/models/model.bin (directory push can collapse to one layer).
+              mapfile -t files < <(find source -type f | sort)
+              oras push --insecure --no-tty "$(params.modelPath)" "${files[@]}"
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:1.4.1@sha256:d9feec6f2ce9b10cfb76b45ea14f83b5ed9f231de7d6083291550aebe8eb09ea
             script: |


### PR DESCRIPTION
## Summary
After https://github.com/konflux-ci/build-definitions/pull/3748 (`deploy-local.sh`), `run-task-tests` actually reaches `modelcar-oci-ta` tests. They were failing against `registry-service.kind-registry` and blocking bundle builds.

### Production task (`modelcar-oci-ta.yaml`)
- Declare missing `caTrustConfigMapName` / `caTrustConfigMapKey` params (defaults match other tasks: `trusted-ca` / `ca-bundle.crt`)
- Set `CA_FILE` and export `SSL_CERT_FILE` only when the mounted CA bundle is non-empty (oras / cosign / mobster)
- Optional `INSECURE_REGISTRY` support for oras/cosign TLS opts — **off by default**; production behavior unchanged unless explicitly set

### Test harness only
- Kind registry CA is not reliably trusted under deploy-local CI even with `SSL_CERT_FILE`, so tests use `--insecure` / `--tls-verify=false` / `--allow-insecure-registry`
- `pre-apply-task-hook.sh` sets `INSECURE_REGISTRY=true` and `ORAS_OPTIONS=--insecure` on the **test copy** of the task only
- Mock model push: push individual files (directory push collapsed to one layer)
- Verify expectations: oras titles layers with basenames, so files land at `models/model.bin` (not `models/source/models/model.bin`)

## Test plan
- [x] `run-task-tests` gets past `mock-model` TLS errors