### PR TITLE
pnc-prebuild-git-clone-oci-ta/0.2: Set expires-on annotation

### DIFF
--- a/task/pnc-prebuild-git-clone-oci-ta/0.2/pnc-prebuild-git-clone-oci-ta.yaml
+++ b/task/pnc-prebuild-git-clone-oci-ta/0.2/pnc-prebuild-git-clone-oci-ta.yaml
@@ -2,6 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   annotations:
+    build.appstudio.redhat.com/expires-on: "2026-08-20T00:00:00Z"
     tekton.dev/categories: Git
     tekton.dev/displayName: pnc prebuild git clone oci trusted artifacts
     tekton.dev/pipelines.minVersion: 0.21.0


### PR DESCRIPTION
The task is not used anymore. Add the same expires-on annotations as for version 0.1 which is 08.08. 2026. Afterwards both versions can be deleted.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
