### PR TITLE
Mark enterprise-contract pipeline as deprecated

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -1,3 +1,9 @@
+# DEPRECATED: The source of truth for this pipeline has moved to:
+#   https://github.com/conforma/cli/blob/main/pipelines/enterprise-contract/0.1/enterprise-contract.yaml
+# It is also published to:
+#   https://github.com/conforma/tekton-catalog/blob/main/pipelines/enterprise-contract/0.1/enterprise-contract.yaml
+# This copy is retained for backward compatibility but will not receive updates.
+#
 # The purpose of this pipeline is to execute the verify-enterprise-contract-v2 task for container
 # images that are built but not automatically released in order to provide early feedback to users.
 # When auto release is enabled, the task is executed by the release pipeline immediately after the


### PR DESCRIPTION
The source of truth for this pipeline has moved to conforma/cli and is published to conforma/tekton-catalog. This copy is retained for backward compatibility.

Ref: https://issues.redhat.com/browse/EC-1942
