### PR TITLE
Konflux e2e tests image update

### DIFF
--- a/.tekton/tasks/e2e-test.yaml
+++ b/.tekton/tasks/e2e-test.yaml
@@ -38,7 +38,7 @@ spec:
         secretName: konflux-test-infra
   steps:
     - name: e2e-test
-      image: quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests:eca3dcc01e3c8a9a66396704eef68d4ad83728b4
+      image: quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests@sha256:ef02de0447e56d98425765524fe9cd9734d45316d87864332bca1be58be53997
       workingDir: $(workspaces.source.path)/source/e2e-tests
       script: |
         #!/bin/bash

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,15 @@
       ]
     },
     {
+      "groupName": "e2e-tests",
+      "matchPackageNames": [
+        "quay.io/redhat-user-workloads/konflux-qe-team-tenant/konflux-e2e/konflux-e2e-tests"
+      ],
+      "matchFileNames": [
+        ".tekton/tasks/e2e-test.yaml"
+      ]
+    },
+    {
       "groupName": "build",
       "matchFileNames": [
         "external-task/apply-tags/**",


### PR DESCRIPTION
This change will allow us to get rid of:
- https://github.com/konflux-ci/e2e-tests/blob/eca3dcc01e3c8a9a66396704eef68d4ad83728b4/.tekton/konflux-e2e-tests-push.yaml#L473-L520
- update-infra-deployments task