### PR TITLE
[STONEBLD-4315]Remove parameter build-source-image from tekton bundle builder pipeline

### DIFF
--- a/pipelines/tekton-bundle-builder-oci-ta/README.md
+++ b/pipelines/tekton-bundle-builder-oci-ta/README.md
@@ -4,7 +4,6 @@
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.3:ALWAYS_BUILD_INDEX|
-|build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|

--- a/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
+++ b/pipelines/tekton-bundle-builder-oci-ta/tekton-bundle-builder-oci-ta.yaml
@@ -48,10 +48,6 @@ spec:
     name: image-expires-after
     type: string
   - default: "false"
-    description: Build a source image.
-    name: build-source-image
-    type: string
-  - default: "false"
     description: Add built image into an OCI image index
     name: build-image-index
     type: string

--- a/pipelines/tekton-bundle-builder/README.md
+++ b/pipelines/tekton-bundle-builder/README.md
@@ -4,7 +4,6 @@
 |name|description|default value|used in (taskname:taskrefversion:taskparam)|
 |---|---|---|---|
 |build-image-index| Add built image into an OCI image index| false| build-image-index:0.3:ALWAYS_BUILD_INDEX|
-|build-source-image| Build a source image.| false| |
 |dockerfile| Path to the Dockerfile inside the context specified by parameter path-context| Dockerfile| |
 |enable-cache-proxy| Enable cache proxy configuration| false| init:0.4:enable-cache-proxy|
 |enable-package-registry-proxy| Use the package registry proxy when prefetching dependencies| true| prefetch-dependencies:0.3:enable-package-registry-proxy|

--- a/pipelines/tekton-bundle-builder/patch.yaml
+++ b/pipelines/tekton-bundle-builder/patch.yaml
@@ -74,6 +74,8 @@
 # 13	enable-package-registry-proxy
 - op: remove
   path: /spec/params/11  # buildah-format
+- op: remove
+  path: /spec/params/9  # build-source-image
 # Remove build-index-image task params
 # $ yq ".spec.tasks.4.params.[].name" pipelines/template-build/template-build.yaml | nl -v 0
 #      0	IMAGE
@@ -82,5 +84,3 @@
 #      3	BUILDAH_FORMAT
 - op: remove
   path: /spec/tasks/4/params/3  # BUILDAH_FORMAT
-- op: remove
-  path: /spec/params/9  # remove build-source-image param

--- a/pipelines/tekton-bundle-builder/patch.yaml
+++ b/pipelines/tekton-bundle-builder/patch.yaml
@@ -82,3 +82,5 @@
 #      3	BUILDAH_FORMAT
 - op: remove
   path: /spec/tasks/4/params/3  # BUILDAH_FORMAT
+- op: remove
+  path: /spec/params/9  # remove build-source-image param

--- a/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
+++ b/pipelines/tekton-bundle-builder/tekton-bundle-builder.yaml
@@ -48,10 +48,6 @@ spec:
     name: image-expires-after
     type: string
   - default: "false"
-    description: Build a source image.
-    name: build-source-image
-    type: string
-  - default: "false"
     description: Add built image into an OCI image index
     name: build-image-index
     type: string

--- a/task/tkn-bundle-oci-ta/0.2/migrations/0.2.4.sh
+++ b/task/tkn-bundle-oci-ta/0.2/migrations/0.2.4.sh
@@ -15,11 +15,11 @@ if ! yq -e "${PARAMS_SELECTOR} | select(.name == \"build-source-image\")" "$pipe
   exit 0
 fi
 
-# restrict to only run if pipeline uses task with name tkn-bundle or tkn-bundle-oci-ta
+# Match catalog taskRef.name and real PipelineRun bundles-resolver taskRef.params
 if ! yq -e "${TASKS_SELECTOR} | select(
   .taskRef.name == \"tkn-bundle\" or
   .taskRef.name == \"tkn-bundle-oci-ta\" or
-  (.taskRef.params[]? | .name == \"name\" and (.value == \"tkn-bundle\" or .value == \"tkn-bundle-oci-ta\"))
+  (.taskRef.params[] | select(.name == \"name\" and (.value == \"tkn-bundle\" or .value == \"tkn-bundle-oci-ta\")))
 )" "$pipeline_file" >/dev/null 2>&1; then
   echo "not a tekton-bundle-builder pipeline, skipping"
   exit 0

--- a/task/tkn-bundle-oci-ta/0.2/migrations/0.2.4.sh
+++ b/task/tkn-bundle-oci-ta/0.2/migrations/0.2.4.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Migration for tkn-bundle-oci-ta 0.2.4
+# Removes the build-source-image parameter from the tkn-bundle builder pipeline
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+PARAMS_SELECTOR='(.spec.params[]?, .spec.pipelineSpec.params[]?)'
+
+if ! yq -e "${PARAMS_SELECTOR} | select(.name == \"build-source-image\")" "$pipeline_file" >/dev/null 2>&1; then
+  echo "build-source-image parameter not found, skipping"
+  exit 0
+fi
+
+param_path=$(yq -o=json "${PARAMS_SELECTOR} | select(.name == \"build-source-image\") | path" "$pipeline_file")
+
+pmt modify -f "$pipeline_file" \
+    generic remove "$param_path"

--- a/task/tkn-bundle-oci-ta/0.2/migrations/0.2.4.sh
+++ b/task/tkn-bundle-oci-ta/0.2/migrations/0.2.4.sh
@@ -8,9 +8,20 @@ set -euo pipefail
 declare -r pipeline_file=${1:?missing pipeline file}
 
 PARAMS_SELECTOR='(.spec.params[]?, .spec.pipelineSpec.params[]?)'
+TASKS_SELECTOR='(.spec.tasks[]?, .spec.pipelineSpec.tasks[]?)'
 
 if ! yq -e "${PARAMS_SELECTOR} | select(.name == \"build-source-image\")" "$pipeline_file" >/dev/null 2>&1; then
   echo "build-source-image parameter not found, skipping"
+  exit 0
+fi
+
+# restrict to only run if pipeline uses task with name tkn-bundle or tkn-bundle-oci-ta
+if ! yq -e "${TASKS_SELECTOR} | select(
+  .taskRef.name == \"tkn-bundle\" or
+  .taskRef.name == \"tkn-bundle-oci-ta\" or
+  (.taskRef.params[]? | .name == \"name\" and (.value == \"tkn-bundle\" or .value == \"tkn-bundle-oci-ta\"))
+)" "$pipeline_file" >/dev/null 2>&1; then
+  echo "not a tekton-bundle-builder pipeline, skipping"
   exit 0
 fi
 

--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.2.3
+    app.kubernetes.io/version: 0.2.4
     build.appstudio.redhat.com/build_type: tkn-bundle
 spec:
   description: Creates and pushes a Tekton bundle containing the specified

--- a/task/tkn-bundle-oci-ta/CHANGELOG.md
+++ b/task/tkn-bundle-oci-ta/CHANGELOG.md
@@ -9,6 +9,14 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
+## 0.2.4
+
+### Removed
+
+- Unused `build-source-image` pipeline parameter from tekton-bundle-builder
+  pipelines via migration. Source image builds are not applicable to tekton
+  bundle builds.
+
 ## 0.2.3
 
 ### Removed

--- a/task/tkn-bundle/0.2/migrations/0.2.4.sh
+++ b/task/tkn-bundle/0.2/migrations/0.2.4.sh
@@ -15,18 +15,17 @@ if ! yq -e "${PARAMS_SELECTOR} | select(.name == \"build-source-image\")" "$pipe
   exit 0
 fi
 
-# restrict to only run if pipeline uses task with name tkn-bundle or tkn-bundle-oci-ta
+# Match catalog taskRef.name and real PipelineRun bundles-resolver taskRef.params
 if ! yq -e "${TASKS_SELECTOR} | select(
   .taskRef.name == \"tkn-bundle\" or
   .taskRef.name == \"tkn-bundle-oci-ta\" or
-  (.taskRef.params[]? | .name == \"name\" and (.value == \"tkn-bundle\" or .value == \"tkn-bundle-oci-ta\"))
+  (.taskRef.params[] | select(.name == \"name\" and (.value == \"tkn-bundle\" or .value == \"tkn-bundle-oci-ta\")))
 )" "$pipeline_file" >/dev/null 2>&1; then
   echo "not a tekton-bundle-builder pipeline, skipping"
   exit 0
 fi
 
-param_path=$(yq -o=json "${PARAMS_SELECTOR} | select(.name == \"build-source-image\") | path " "$pipeline_file")
-
+param_path=$(yq -o=json "${PARAMS_SELECTOR} | select(.name == \"build-source-image\") | path" "$pipeline_file")
 
 pmt modify -f "$pipeline_file" \
     generic remove "$param_path"

--- a/task/tkn-bundle/0.2/migrations/0.2.4.sh
+++ b/task/tkn-bundle/0.2/migrations/0.2.4.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Migration for tkn-bundle 0.2.4
+#Removes the build-source-image parameter from the tkn-bundle builder pipeline
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+PARAMS_SELECTOR='(.spec.params[]?, .spec.pipelineSpec.params[]?)'
+
+if ! yq -e "${PARAMS_SELECTOR} | select(.name == \"build-source-image\")" "$pipeline_file" >/dev/null 2>&1; then
+  echo "build-source-image parameter not found, skipping"
+  exit 0
+fi
+
+param_path=$(yq -o=json "${PARAMS_SELECTOR} | select(.name == \"build-source-image\") | path " "$pipeline_file")
+
+
+pmt modify -f "$pipeline_file" \
+    generic remove "$param_path"

--- a/task/tkn-bundle/0.2/migrations/0.2.4.sh
+++ b/task/tkn-bundle/0.2/migrations/0.2.4.sh
@@ -8,9 +8,20 @@ set -euo pipefail
 declare -r pipeline_file=${1:?missing pipeline file}
 
 PARAMS_SELECTOR='(.spec.params[]?, .spec.pipelineSpec.params[]?)'
+TASKS_SELECTOR='(.spec.tasks[]?, .spec.pipelineSpec.tasks[]?)'
 
 if ! yq -e "${PARAMS_SELECTOR} | select(.name == \"build-source-image\")" "$pipeline_file" >/dev/null 2>&1; then
   echo "build-source-image parameter not found, skipping"
+  exit 0
+fi
+
+# restrict to only run if pipeline uses task with name tkn-bundle or tkn-bundle-oci-ta
+if ! yq -e "${TASKS_SELECTOR} | select(
+  .taskRef.name == \"tkn-bundle\" or
+  .taskRef.name == \"tkn-bundle-oci-ta\" or
+  (.taskRef.params[]? | .name == \"name\" and (.value == \"tkn-bundle\" or .value == \"tkn-bundle-oci-ta\"))
+)" "$pipeline_file" >/dev/null 2>&1; then
+  echo "not a tekton-bundle-builder pipeline, skipping"
   exit 0
 fi
 

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.3"
+    app.kubernetes.io/version: "0.2.4"
     build.appstudio.redhat.com/build_type: "tkn-bundle"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"

--- a/task/tkn-bundle/CHANGELOG.md
+++ b/task/tkn-bundle/CHANGELOG.md
@@ -9,6 +9,14 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
+## 0.2.4
+
+### Removed
+
+- Unused `build-source-image` pipeline parameter from tekton-bundle-builder
+  pipelines via migration. Source image builds are not applicable to tekton
+  bundle builds.
+
 ## 0.2.3
 
 ### Removed


### PR DESCRIPTION
Remove unused `build-source-image` param from tekton-bundle-builder pipelines, and add tkn-bundle/tkn-bundle-oci-ta `0.2.4` migrations to clean it up on existing user pipelines

Closes: [STONEBLD-4315](https://redhat.atlassian.net/browse/STONEBLD-4315)
How is this tested?

- [x] Regenerated manifests/READMEs; confirmed param removed from both bundle-builder pipelines
- [x] Ran migration on a copy of the old pipeline YAML - param removed; second run skipped
- [x] Confirmed any other pipeline is skipped by the migration gate
- [x] `./hack/validate-migration.sh` passed locally


[STONEBLD-4315]: https://redhat.atlassian.net/browse/STONEBLD-4315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ