### PR TITLE
show-sbom: Try to remove task from user pipelines again

### DIFF
--- a/task/show-sbom/0.3/README.md
+++ b/task/show-sbom/0.3/README.md
@@ -1,0 +1,18 @@
+# show-sbom task
+
+Shows the Software Bill of Materials (SBOM) generated for the built image.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|IMAGE_URL|Fully qualified image name to show SBOM for.||true|
+|PLATFORM|Specific architecture to display the SBOM for. An example arch would be "linux/amd64". If IMAGE_URL refers to a multi-arch image and this parameter is empty, the task will default to use "linux/amd64".|linux/amd64|false|
+|CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+
+
+## Additional info
+
+The parameter named PLATFORM can be used to specify the arch to display the sbom for in the case of a multi-arch image. 
+In the case of a single arch image, the parameter is ignored. 
+If PLATFORM is empty and the image is multi-arch, the task defaults to 'linux/amd64'

--- a/task/show-sbom/0.3/migrations/0.3.sh
+++ b/task/show-sbom/0.3/migrations/0.3.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+declare -r pipeline_file=${1:?missing pipeline file}
+
+TASKS_SELECTOR='(.spec.tasks[]?, .spec.pipelineSpec.tasks[]?, .spec.finally[]?, .spec.pipelineSpec.finally[]?)'
+
+if ! yq -e "${TASKS_SELECTOR} | select(.name == \"show-sbom\")" "$pipeline_file" >/dev/null 2>&1; then 
+  echo "show-sbom not found, skipping"
+  exit 0
+fi
+
+pmt_path=$(yq -o=json "${TASKS_SELECTOR} | select(.name == \"show-sbom\") | path" "$pipeline_file") 
+pmt modify -f "$pipeline_file" generic remove "$pmt_path"

--- a/task/show-sbom/0.3/show-sbom.yaml
+++ b/task/show-sbom/0.3/show-sbom.yaml
@@ -1,0 +1,97 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: show-sbom
+  labels:
+    app.kubernetes.io/version: "0.3"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "konflux"
+    build.appstudio.redhat.com/expires-on: "2026-08-08T00:00:00Z"
+spec:
+  description: >-
+    Shows the Software Bill of Materials (SBOM) generated for the built image.
+  params:
+    - name: IMAGE_URL
+      description: Fully qualified image name to show SBOM for.
+      type: string
+    - name: PLATFORM
+      description: Specific architecture to display the SBOM for. An example arch would be "linux/amd64". If IMAGE_URL
+        refers to a multi-arch image and this parameter is empty, the task will default to use "linux/amd64".
+      type: string
+      default: "linux/amd64"
+    - name: CA_TRUST_CONFIG_MAP_NAME
+      type: string
+      description: The name of the ConfigMap to read CA bundle data from.
+      default: trusted-ca
+    - name: CA_TRUST_CONFIG_MAP_KEY
+      type: string
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      default: ca-bundle.crt
+  steps:
+  - name: show-sbom
+    image: quay.io/konflux-ci/task-runner:2.0.0@sha256:4b01fbf98fa7155f5c21443c285f88853864ae7cc66981cf6b543fc6ba16b81b
+    computeResources:
+      limits:
+        memory: 256Mi
+        cpu: 100m
+      requests:
+        memory: 256Mi
+        cpu: 100m
+    # per https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting
+    # the cluster will set imagePullPolicy to IfNotPresent
+    env:
+    - name: IMAGE_URL
+      value: $(params.IMAGE_URL)
+    - name: PLATFORM
+      value: $(params.PLATFORM)
+    script: |
+      #!/bin/bash
+      set -euo pipefail
+      download_sbom_with_retry() {
+        local extra_args=("$@")
+
+        # Pre-select the correct credentials to work around cosign not supporting the containers-auth.json spec
+        mkdir -p /tmp/auth
+        if ! select-oci-auth "$IMAGE_URL" 2>/tmp/stderr >/tmp/auth/config.json; then
+          # Print stderr only in case of failure. This task is supposed to output *only* the SBOM on success.
+          cat /tmp/stderr
+          exit 1
+        fi
+
+        export DOCKER_CONFIG=/tmp/auth
+        if ! retry cosign download sbom "${extra_args[@]}" "$IMAGE_URL" 2>>err
+        then
+          echo "Failed to get SBOM" >&2
+          cat err >&2
+        fi
+      }
+
+      RAW_OUTPUT=$(skopeo inspect --no-tags --raw "docker://${IMAGE_URL}")
+      if [[ "$(jq 'has("manifests")' <<< "$RAW_OUTPUT")" == "true" ]] ; then
+        # Multi arch
+        ARCHES=$(jq -r '.manifests[].platform.architecture' <<< "$RAW_OUTPUT")
+      else
+        ARCHES=""
+      fi
+
+      if [ -z "${ARCHES}" ] ; then
+        # single arch image
+        download_sbom_with_retry
+      else
+        download_sbom_with_retry --platform="$PLATFORM"
+      fi
+    volumeMounts:
+    - name: trusted-ca
+      mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+      subPath: ca-bundle.crt
+      readOnly: true
+  volumes:
+  - name: trusted-ca
+    configMap:
+      name: $(params.CA_TRUST_CONFIG_MAP_NAME)
+      items:
+        - key: $(params.CA_TRUST_CONFIG_MAP_KEY)
+          path: ca-bundle.crt
+      optional: true

--- a/task/show-sbom/CHANGELOG.md
+++ b/task/show-sbom/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 0.3
 
+### Fixed
+
+The migration script wasn't attached to the task bundle.
+
+## 0.2
+
 ### Removed
 
 The task `show-sbom` is deprecated. The migration script deletes it from the pipeline.


### PR DESCRIPTION
The previous migration scrip wasn't attached to the task bundle. It seems, it was because of unfortunate commit splitting and the way the buid-and-push.sh script works [1]. Let's try to bake everything in one commit and bump the task version one more time.

```
diff -r task/show-sbom/0.2 task/show-sbom/0.3
```

Version 0.3 has the same expires-on annotation.

--
[1]: https://github.com/konflux-ci/build-definitions/blob/main/hack/build-and-push.sh#L696

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
