### PR TITLE
Update digest of task-fbc-inject-lifecycle-oci-ta image

### DIFF
--- a/external-task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
+++ b/external-task/fbc-inject-lifecycle-oci-ta/0.1/fbc-inject-lifecycle-oci-ta.yaml
@@ -1,1 +1,1 @@
-task_bundle: quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:a636970f2f7ff1c8156ad92e3c6bde96ce532a3195b24cc3ed4025d7d609e6eb
+task_bundle: quay.io/konflux-ci/tekton-catalog/task-fbc-inject-lifecycle-oci-ta:0.1@sha256:da1217be1dcec3d5b5140ea351466607005481397b31f2b81108c4fd3012fbde


### PR DESCRIPTION
Update digest of task-fbc-inject-lifecycle-oci-ta to pin the latest v0.1 image

The pipeline is failing on:

> "pmt add-task: error: argument bundle_ref: Mismatch digest. Tag 0.1 points to a different digest sha256:da1217be1dcec3d5b5140ea351466607005481397b31f2b81108c4fd3012fbde"

This is fix to pin the correct digest of task-fbc-inject-lifecycle-oci-ta task.

Related issues: KFLUXSPRT-8578, [KFLUXSPRT-8605](https://redhat.atlassian.net/browse/KFLUXSPRT-8605)


[KFLUXSPRT-8605]: https://redhat.atlassian.net/browse/KFLUXSPRT-8605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ