### PR TITLE
modelcar-oci-ta: use olot --root-dir with task-runner 3.1.1

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -338,7 +338,14 @@ spec:
 
           find "$BLOBS_DIR" -maxdepth 1 -type f -printf '%f\n' | sort > /tmp/blobs_before.txt
 
-          olot --verbose --remove-originals default \
+          # --root-dir preserves each file's subdirectory structure (relative
+          # to models/) in its resulting layer path, instead of flattening to
+          # just the basename. Without it, files with the same basename in
+          # different subdirectories (e.g. a root config.json and an
+          # inference/config.json) collide on the same in-image path and
+          # silently overwrite each other. Requires olot >= 1.2.0 (task-runner
+          # >= 3.1.0; see https://github.com/containers/olot/pull/209).
+          olot --verbose --remove-originals default --root-dir models \
             "${MODELCARD_ARG[@]}" \
             "$TARGET_OCI" \
             "${BATCH_FILES[@]}"

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -209,7 +209,7 @@ spec:
         echo "$ARCHFUL_BASE_IMAGE" | tee "$(results.BASE_IMAGE_REF.path)"
 
     - name: build-and-push
-      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
       computeResources:
         requests:
           memory: 2Gi
@@ -519,7 +519,7 @@ spec:
           --sbom-type "$SBOM_TYPE"
 
     - name: upload-sbom
-      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
       computeResources:
         requests:
           memory: 64Mi
@@ -557,7 +557,7 @@ spec:
             exit 1
         fi
     - name: report-sbom-url
-      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
       computeResources:
         requests:
           memory: 64Mi

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -77,11 +77,14 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/model.bin);
-              # with --root-dir models, files land under /models/<title>.
-              mapfile -t files < <(find source -type f | sort)
-              oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
+              # Push from inside source/ so layer titles are paths relative to
+              # the model root (e.g. model.bin), not source/model.bin.
+              # With --root-dir models, files land under /models/<title>.
+              mapfile -t files < <(find source -type f -printf '%P\n' | sort)
+              (
+                cd source
+                oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
+              )
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
@@ -206,7 +209,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/model.bin; do
+              for filename in usr/bin/ls models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -79,7 +79,8 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles use basenames, so files land under /models/<basename>.
+              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest
@@ -206,7 +207,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/model.bin; do
+              for filename in usr/bin/ls models/source/models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -68,7 +68,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -83,7 +83,7 @@ spec:
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -180,7 +180,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -61,8 +61,7 @@ spec:
 
               # Create some additional test files
               echo "test content" > "$(workspaces.tests-workspace.path)/source/test.txt"
-              mkdir -p "$(workspaces.tests-workspace.path)/source/models"
-              echo "model data" > "$(workspaces.tests-workspace.path)/source/models/model.bin"
+              echo "model data" > "$(workspaces.tests-workspace.path)/source/model.bin"
 
               echo "Created source directory with test files:"
               ls -la "$(workspaces.tests-workspace.path)/source"
@@ -79,7 +78,7 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # oras titles keep relative paths (e.g. source/model.bin);
               # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
@@ -207,7 +206,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/models/model.bin; do
+              for filename in usr/bin/ls models/source/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -77,11 +77,14 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/model.bin);
-              # with --root-dir models, files land under /models/<title>.
-              mapfile -t files < <(find source -type f | sort)
-              oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
+              # Push from inside source/ so layer titles are paths relative to
+              # the model root (e.g. model.bin), not source/model.bin.
+              # With --root-dir models, files land under /models/<title>.
+              mapfile -t files < <(find source -type f -printf '%P\n' | sort)
+              (
+                cd source
+                oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
+              )
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -68,7 +68,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -83,7 +83,7 @@ spec:
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -178,7 +178,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -79,7 +79,8 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles use basenames, so files land under /models/<basename>.
+              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -61,8 +61,7 @@ spec:
 
               # Create some additional test files
               echo "test content" > "$(workspaces.tests-workspace.path)/source/test.txt"
-              mkdir -p "$(workspaces.tests-workspace.path)/source/models"
-              echo "model data" > "$(workspaces.tests-workspace.path)/source/models/model.bin"
+              echo "model data" > "$(workspaces.tests-workspace.path)/source/model.bin"
 
               echo "Created source directory with test files:"
               ls -la "$(workspaces.tests-workspace.path)/source"
@@ -79,7 +78,7 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # oras titles keep relative paths (e.g. source/model.bin);
               # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -77,11 +77,14 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/model.bin);
-              # with --root-dir models, files land under /models/<title>.
-              mapfile -t files < <(find source -type f | sort)
-              oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
+              # Push from inside source/ so layer titles are paths relative to
+              # the model root (e.g. model.bin), not source/model.bin.
+              # With --root-dir models, files land under /models/<title>.
+              mapfile -t files < <(find source -type f -printf '%P\n' | sort)
+              (
+                cd source
+                oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
+              )
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
@@ -205,7 +208,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/model.bin; do
+              for filename in usr/bin/ls models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -61,8 +61,7 @@ spec:
 
               # Create some additional test files
               echo "test content" > "$(workspaces.tests-workspace.path)/source/test.txt"
-              mkdir -p "$(workspaces.tests-workspace.path)/source/models"
-              echo "model data" > "$(workspaces.tests-workspace.path)/source/models/model.bin"
+              echo "model data" > "$(workspaces.tests-workspace.path)/source/model.bin"
 
               echo "Created source directory with test files:"
               ls -la "$(workspaces.tests-workspace.path)/source"
@@ -79,7 +78,7 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # oras titles keep relative paths (e.g. source/model.bin);
               # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
@@ -206,7 +205,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/models/model.bin; do
+              for filename in usr/bin/ls models/source/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -79,7 +79,8 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles use basenames, so files land under /models/<basename>.
+              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest
@@ -205,7 +206,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/model.bin; do
+              for filename in usr/bin/ls models/source/models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -68,7 +68,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -83,7 +83,7 @@ spec:
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -176,7 +176,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -61,8 +61,7 @@ spec:
 
               # Create some additional test files
               echo "test content" > "$(workspaces.tests-workspace.path)/source/test.txt"
-              mkdir -p "$(workspaces.tests-workspace.path)/source/models"
-              echo "model data" > "$(workspaces.tests-workspace.path)/source/models/model.bin"
+              echo "model data" > "$(workspaces.tests-workspace.path)/source/model.bin"
 
               echo "Created source directory with test files:"
               ls -la "$(workspaces.tests-workspace.path)/source"
@@ -79,7 +78,7 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # oras titles keep relative paths (e.g. source/model.bin);
               # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty \
@@ -183,7 +182,7 @@ spec:
               # The annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z"
               # is converted by the task to touch -t format: 202603131030.00
               # Expected: Mar 13 2026 10:30 UTC
-              mtime=$(stat -c '%Y' models/source/models/model.bin)
+              mtime=$(stat -c '%Y' models/source/model.bin)
               expected_epoch=1773397800
               if [ "$mtime" -ne "$expected_epoch" ]; then
                   echo "Expected mtime epoch $expected_epoch but got $mtime" && exit 1

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -79,7 +79,8 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles use basenames, so files land under /models/<basename>.
+              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty \
                 --annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z" \
@@ -182,7 +183,7 @@ spec:
               # The annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z"
               # is converted by the task to touch -t format: 202603131030.00
               # Expected: Mar 13 2026 10:30 UTC
-              mtime=$(stat -c '%Y' models/model.bin)
+              mtime=$(stat -c '%Y' models/source/models/model.bin)
               expected_epoch=1773397800
               if [ "$mtime" -ne "$expected_epoch" ]; then
                   echo "Expected mtime epoch $expected_epoch but got $mtime" && exit 1

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -68,7 +68,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -85,7 +85,7 @@ spec:
                 --annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z" \
                 "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -166,7 +166,7 @@ spec:
             env:
               - name: IMAGE_REF
                 value: $(params.IMAGE_REF)
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -77,13 +77,16 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/model.bin);
-              # with --root-dir models, files land under /models/<title>.
-              mapfile -t files < <(find source -type f | sort)
-              oras push --insecure --no-tty \
-                --annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z" \
-                "${MODEL_PATH}" "${files[@]}"
+              # Push from inside source/ so layer titles are paths relative to
+              # the model root (e.g. model.bin), not source/model.bin.
+              # With --root-dir models, files land under /models/<title>.
+              mapfile -t files < <(find source -type f -printf '%P\n' | sort)
+              (
+                cd source
+                oras push --insecure --no-tty \
+                  --annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z" \
+                  "${MODEL_PATH}" "${files[@]}"
+              )
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
@@ -182,7 +185,7 @@ spec:
               # The annotation "org.opencontainers.image.created=2026-03-13T10:30:00Z"
               # is converted by the task to touch -t format: 202603131030.00
               # Expected: Mar 13 2026 10:30 UTC
-              mtime=$(stat -c '%Y' models/source/model.bin)
+              mtime=$(stat -c '%Y' models/model.bin)
               expected_epoch=1773397800
               if [ "$mtime" -ne "$expected_epoch" ]; then
                   echo "Expected mtime epoch $expected_epoch but got $mtime" && exit 1

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -61,8 +61,7 @@ spec:
 
               # Create some additional test files
               echo "test content" > "$(workspaces.tests-workspace.path)/source/test.txt"
-              mkdir -p "$(workspaces.tests-workspace.path)/source/models"
-              echo "model data" > "$(workspaces.tests-workspace.path)/source/models/model.bin"
+              echo "model data" > "$(workspaces.tests-workspace.path)/source/model.bin"
 
               echo "Created source directory with test files:"
               ls -la "$(workspaces.tests-workspace.path)/source"
@@ -79,7 +78,7 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # oras titles keep relative paths (e.g. source/model.bin);
               # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
@@ -203,7 +202,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/models/model.bin; do
+              for filename in usr/bin/ls models/source/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -77,11 +77,14 @@ spec:
               set -euo pipefail
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
-              # Push files explicitly (directory push can collapse to one layer).
-              # oras titles keep relative paths (e.g. source/model.bin);
-              # with --root-dir models, files land under /models/<title>.
-              mapfile -t files < <(find source -type f | sort)
-              oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
+              # Push from inside source/ so layer titles are paths relative to
+              # the model root (e.g. model.bin), not source/model.bin.
+              # With --root-dir models, files land under /models/<title>.
+              mapfile -t files < <(find source -type f -printf '%P\n' | sort)
+              (
+                cd source
+                oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
+              )
           - name: record-model-digest
             image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
@@ -202,7 +205,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/source/model.bin; do
+              for filename in usr/bin/ls models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -79,7 +79,8 @@ spec:
               # Kind registry uses a cluster-local CA that is not reliably in
               # the task trust store under deploy-local CI; skip verify here.
               # Push files explicitly (directory push can collapse to one layer).
-              # oras titles use basenames, so files land under /models/<basename>.
+              # oras titles keep relative paths (e.g. source/models/model.bin);
+              # with --root-dir models, files land under /models/<title>.
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest
@@ -202,7 +203,7 @@ spec:
               echo "Confirm the contents of the filesystem"
               mkdir contents/ && pushd contents/
               oc image extract --insecure=true "$IMAGE_REF"
-              for filename in usr/bin/ls models/model.bin; do
+              for filename in usr/bin/ls models/source/models/model.bin; do
                 if [ -f "$filename" ]; then
                     echo "File $filename found as expected."
                 else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -68,7 +68,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -83,7 +83,7 @@ spec:
               mapfile -t files < <(find source -type f | sort)
               oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -176,7 +176,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
+            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
             securityContext:
               runAsUser: 0
               runAsNonRoot: false


### PR DESCRIPTION
## Summary
- Pass `--root-dir models` to `olot` so batch layering preserves subdirectory structure under `models/`
- Avoids silent overwrites when the same basename appears in different dirs (e.g. `config.json` vs `inference/config.json`)
- Bump modelcar-oci-ta task and tests to `quay.io/konflux-ci/task-runner:3.1.1` (olot 1.2.0), which provides the `--root-dir` CLI flag

Depends on [olot v1.2.0](https://github.com/containers/olot/releases/tag/v1.2.0) / [containers/olot#209](https://github.com/containers/olot/pull/209).
