### PR TITLE
Add optional ADDITIONAL_SECRET param to run-script-oci-ta

### DIFF
--- a/task/run-script-oci-ta/0.1/README.md
+++ b/task/run-script-oci-ta/0.1/README.md
@@ -17,6 +17,7 @@ to use it later.
 |STORAGE_DRIVER|Storage driver to configure for buildah|vfs|false|
 |HERMETIC|Determines if build will be executed without network access.|false|false|
 |SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|ADDITIONAL_SECRET|Name of a Kubernetes secret to mount into the script container at /var/run/secrets/additional-secret. The script is responsible for reading the secret keys.|does-not-exist|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 

--- a/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
+++ b/task/run-script-oci-ta/0.1/run-script-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: "0.1.2"
+    app.kubernetes.io/version: "0.1.3"
 spec:
   description: |-
     This task allows to run an script stored on the git repository and stores the resultant directory
@@ -57,6 +57,15 @@ spec:
       description: The Trusted Artifact URI pointing to the artifact with
         the application source code.
       type: string
+    - name: ADDITIONAL_SECRET
+      description: >
+        Name of a Kubernetes secret to mount into the script container.
+        The secret is mounted at /mnt/additional-secret in the Tekton step
+        and forwarded to /var/run/secrets/additional-secret inside the
+        buildah script container. The script is responsible for reading
+        the secret keys. Leave default to skip.
+      type: string
+      default: does-not-exist
     - name: caTrustConfigMapKey
       description: The name of the key in the ConfigMap that contains the
         CA bundle data.
@@ -91,6 +100,10 @@ spec:
       emptyDir: {}
     - name: varlibcontainers
       emptyDir: {}
+    - name: additional-secret
+      secret:
+        secretName: $(params.ADDITIONAL_SECRET)
+        optional: true
   stepTemplate:
     env:
       - name: SCRIPT
@@ -134,6 +147,9 @@ spec:
           readOnly: true
         - mountPath: /var/lib/containers
           name: varlibcontainers
+        - mountPath: /mnt/additional-secret
+          name: additional-secret
+          readOnly: true
       env:
         - name: HOME
           value: /root
@@ -181,6 +197,12 @@ spec:
           UNSHARE_ARGS+=("--net")
         fi
 
+        SECRET_MOUNT=""
+        if [ -d "/mnt/additional-secret" ] && [ -n "$(ls -A /mnt/additional-secret 2>/dev/null)" ]; then
+          echo "Mounting additional secret into script container"
+          SECRET_MOUNT="--volume /mnt/additional-secret:/var/run/secrets/additional-secret:ro"
+        fi
+
         PREFETCH_MOUNT=""
         PREFETCH_SOURCE=""
         if [ -d "/var/workdir/prefetch" ]; then
@@ -206,7 +228,7 @@ spec:
         # TODO remove the option once all hosts were updated
         buildah from --name script-container --security-opt=unmask=/proc/interrupts "$SCRIPT_RUNNER_IMAGE"
 
-        BUILDAH_CMD="buildah run ${PREFETCH_MOUNT} --volume /tmp/script.sh:/tmp/script.sh --volume /var/workdir/source:/var/workdir/source --volume /var/workdir/output:/var/workdir/output --workingdir ${SCRIPT_WORKDIR} --user root:root -- script-container /bin/sh -c '${PREFETCH_SOURCE} SCRIPT_OUTPUT=/var/workdir/output/output SCRIPT_OUTPUT_ARRAY=/var/workdir/output/array exec /tmp/script.sh'"
+        BUILDAH_CMD="buildah run ${PREFETCH_MOUNT} ${SECRET_MOUNT} --volume /tmp/script.sh:/tmp/script.sh --volume /var/workdir/source:/var/workdir/source --volume /var/workdir/output:/var/workdir/output --workingdir ${SCRIPT_WORKDIR} --user root:root -- script-container /bin/sh -c '${PREFETCH_SOURCE} SCRIPT_OUTPUT=/var/workdir/output/output SCRIPT_OUTPUT_ARRAY=/var/workdir/output/array exec /tmp/script.sh'"
         unshare -Uf "${UNSHARE_ARGS[@]}" --keep-caps -r --map-users 1,1,65536 --map-groups 1,1,65536 -w /var/workdir sh -c "${BUILDAH_CMD}"
 
         IMAGE_REFERENCE=$(buildah inspect script-container | jq -r '.FromImage')

--- a/task/run-script-oci-ta/CHANGELOG.md
+++ b/task/run-script-oci-ta/CHANGELOG.md
@@ -4,12 +4,15 @@
 
 ## Unreleased
 
-<!--
-When you make changes without bumping the version right away, document them here.
-If that's not something you ever plan to do, consider removing this section.
--->
-
 *Nothing yet.*
+
+## 0.1.3
+
+### Added
+
+- New optional `ADDITIONAL_SECRET` parameter to mount a Kubernetes secret into the
+  script container at `/var/run/secrets/additional-secret`. Useful for passing
+  registry credentials, AWS keys, or other tokens the script needs at runtime.
 
 ## 0.1.2
 


### PR DESCRIPTION
## Summary
- Adds an optional `ADDITIONAL_SECRET` param to `run-script-oci-ta` that mounts a Kubernetes secret into the script container
- The secret is available at `/var/run/secrets/additional-secret` inside the buildah container, so scripts can read whatever keys they need (registry auth, AWS creds, tokens, etc.)
- Fully backwards-compatible: param defaults to empty, volume is optional, existing users are unaffected

## Motivation
Scripts running inside `run-script-oci-ta` currently have no way to access secrets. This makes it impossible to authenticate to private registries (e.g. `skopeo copy --authfile`), cloud services (AWS keys), or any other credentialed endpoint. This change mounts an optional secret into the buildah container so scripts can access credentials when needed. The script author is responsible for knowing the format of the secret they pass.

## Test plan
- [ ] Verify existing tests still pass (no secret provided)
- [x] Test with a secret to confirm it is accessible from inside the script container at `/var/run/secrets/additional-secret`