### PR TITLE
test(modelcar-oci-ta): roll back to task-runner 3.0.0 without --root-dir

### DIFF
--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -209,7 +209,7 @@ spec:
         echo "$ARCHFUL_BASE_IMAGE" | tee "$(results.BASE_IMAGE_REF.path)"
 
     - name: build-and-push
-      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 2Gi
@@ -338,14 +338,9 @@ spec:
 
           find "$BLOBS_DIR" -maxdepth 1 -type f -printf '%f\n' | sort > /tmp/blobs_before.txt
 
-          # --root-dir preserves each file's subdirectory structure (relative
-          # to models/) in its resulting layer path, instead of flattening to
-          # just the basename. Without it, files with the same basename in
-          # different subdirectories (e.g. a root config.json and an
-          # inference/config.json) collide on the same in-image path and
-          # silently overwrite each other. Requires olot >= 1.2.0 (task-runner
-          # >= 3.1.0; see https://github.com/containers/olot/pull/209).
-          olot --verbose --remove-originals default --root-dir models \
+          # TEMP: task-runner 3.0.0 / olot without --root-dir (avoids olot 1.2.0
+          # Docker→OCI multi-batch KeyError). Nested titles flatten to basename.
+          olot --verbose --remove-originals default \
             "${MODELCARD_ARG[@]}" \
             "$TARGET_OCI" \
             "${BATCH_FILES[@]}"
@@ -519,7 +514,7 @@ spec:
           --sbom-type "$SBOM_TYPE"
 
     - name: upload-sbom
-      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 64Mi
@@ -557,7 +552,7 @@ spec:
             exit 1
         fi
     - name: report-sbom-url
-      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 64Mi

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,14 +79,14 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
                 oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -183,7 +183,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,14 +79,14 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
                 oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -181,7 +181,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,14 +79,14 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
                 oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -179,7 +179,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,7 +79,7 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
@@ -88,7 +88,7 @@ spec:
                   "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -169,7 +169,7 @@ spec:
             env:
               - name: IMAGE_REF
                 value: $(params.IMAGE_REF)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,14 +79,14 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
                 oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -179,7 +179,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             securityContext:
               runAsUser: 0
               runAsNonRoot: false


### PR DESCRIPTION
## Summary
- Temporary rollback for testing: pin `task-runner` to **3.0.0** (olot without 1.2.0) and remove `--root-dir`.
- Avoids the olot 1.2.0 Docker→OCI multi-batch `KeyError` while validating ModelCar builds on the older stack.
- **Do not merge** as a permanent change — re-enable `--root-dir` + task-runner 3.1.1 after olot #216 (or equivalent) lands.
