### PR TITLE
fix(modelcar-oci-ta): merge base-image Syft packages into SBOM

### DIFF
--- a/task/modelcar-oci-ta/0.1/README.md
+++ b/task/modelcar-oci-ta/0.1/README.md
@@ -12,7 +12,8 @@ OCI image layout directory. Then all files included in the OCI artifact specifie
 MODEL_IMAGE parameter are copied on top.
 
 An SBOM report defining the Model and Base Images as descendants of the ModelCar image is also
-generated in the process.
+generated in the process. Packages discovered in the base image with Syft are merged into that
+SBOM so release can populate the package database.
 
 ## Parameters
 |name|description|default value|required|

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -283,49 +283,6 @@ spec:
 
         echo "[$(date -Ins)] Model artifact has ${TOTAL} named layer(s), processing in batches of ${BATCH_SIZE}"
 
-        # oras copy --to-oci-layout can leave Docker-distribution manifests in the
-        # OCI layout. olot converts those on first use but keeps the old Docker
-        # blobs on disk; the next batch then re-enters conversion and KeyErrors
-        # because index.json already points at OCI digests. Convert once and
-        # delete leftover Docker manifest blobs before batching.
-        python3 - "$TARGET_OCI" <<'PY'
-        import json
-        import sys
-        from pathlib import Path
-
-        from olot.dockerdist.convert import (
-            DOCKER_LIST_V2,
-            DOCKER_MANIFEST_V2,
-            check_if_oci_layout_contains_docker_manifests,
-            convert_docker_manifests_to_oci,
-        )
-
-        oci = Path(sys.argv[1])
-        if not check_if_oci_layout_contains_docker_manifests(oci):
-            print("Base OCI layout has no Docker manifests; skipping conversion")
-            raise SystemExit(0)
-
-        converted = convert_docker_manifests_to_oci(oci)
-        blobs = oci / "blobs" / "sha256"
-        for old_hash, new_hash in converted.items():
-            if old_hash != new_hash:
-                (blobs / old_hash).unlink(missing_ok=True)
-                print(f"Removed leftover Docker manifest blob {old_hash} (now {new_hash})")
-
-        # Belt-and-suspenders: drop any remaining Docker manifest/list blobs.
-        for blob in blobs.iterdir():
-            if not blob.is_file():
-                continue
-            try:
-                media_type = json.loads(blob.read_text()).get("mediaType")
-            except Exception:
-                continue
-            if media_type in (DOCKER_MANIFEST_V2, DOCKER_LIST_V2):
-                blob.unlink(missing_ok=True)
-                print(f"Removed leftover Docker blob {blob.name} ({media_type})")
-        print("Docker→OCI conversion complete")
-        PY
-
         # ─── Download, layer, and push model files in batches ───
         mkdir -p models
         FIRST_BATCH=true

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -22,7 +22,8 @@ spec:
     MODEL_IMAGE parameter are copied on top.
 
     An SBOM report defining the Model and Base Images as descendants of the ModelCar image is also
-    generated in the process.
+    generated in the process. Packages from the base image (via Syft) are merged into that SBOM so
+    release can populate the package database.
   params:
     - name: MODEL_IMAGE_AUTH
       description: Name of secret required to pull the model OCI artifact
@@ -483,10 +484,10 @@ spec:
       image: quay.io/konflux-ci/mobster:1.2.1-1782136886@sha256:1374bc35c71781987cce00ef5efe2be42923f83def19b60a570e947189b90d15
       computeResources:
         requests:
-          memory: 64Mi
-          cpu: 50m
+          memory: 512Mi
+          cpu: 100m
         limits:
-          memory: 64Mi
+          memory: 1Gi
       securityContext:
         runAsUser: 0
         runAsNonRoot: false
@@ -509,14 +510,114 @@ spec:
         MODELCAR_IMAGE=$(cat "$(results.IMAGE_REF.path)")
         BASE_IMAGE_REF=$(cat "$(results.BASE_IMAGE_REF.path)")
 
-        echo "manifest_data.json does not exist. $MODELCAR_IMAGE is a single-arch image";
+        case "$SBOM_TYPE" in
+          cyclonedx) SYFT_OUTPUT=cyclonedx-json ;;
+          spdx) SYFT_OUTPUT=spdx-json@2.3 ;;
+          *)
+            echo "Unsupported SBOM_TYPE: $SBOM_TYPE" >&2
+            exit 1
+            ;;
+        esac
+
+        # Scan the base image only — model layers are huge weight blobs, not RPM/Python inventory.
+        echo "Scanning base image with syft: $BASE_IMAGE_REF"
+        syft scan "$BASE_IMAGE_REF" -o "$SYFT_OUTPUT" > sbom-base-syft.json
+
+        echo "Generating modelcar composition SBOM for $MODELCAR_IMAGE"
         mobster generate  \
-          --output sbom.json \
+          --output sbom-modelcar.json \
           modelcar \
           --modelcar-image "$MODELCAR_IMAGE" \
           --base-image "$BASE_IMAGE_REF" \
           --model-image "$MODEL_IMAGE" \
           --sbom-type "$SBOM_TYPE"
+
+        echo "Merging base-image Syft packages into modelcar SBOM"
+        python3 - "$SBOM_TYPE" sbom-modelcar.json sbom-base-syft.json sbom.json <<'PY'
+        import json
+        import sys
+
+        sbom_type, modelcar_path, syft_path, out_path = sys.argv[1:5]
+        with open(modelcar_path, encoding="utf-8") as f:
+            modelcar = json.load(f)
+        with open(syft_path, encoding="utf-8") as f:
+            syft = json.load(f)
+
+        def spdx_purls(pkg):
+            return [
+                ref["referenceLocator"]
+                for ref in pkg.get("externalRefs", [])
+                if ref.get("referenceType") == "purl"
+            ]
+
+        if sbom_type == "spdx":
+            existing_ids = {p["SPDXID"] for p in modelcar.get("packages", [])}
+            existing_purls = {
+                purl for p in modelcar.get("packages", []) for purl in spdx_purls(p)
+            }
+            root_id = next(
+                (
+                    r["relatedSpdxElement"]
+                    for r in modelcar.get("relationships", [])
+                    if r.get("relationshipType") == "DESCRIBES"
+                ),
+                None,
+            )
+            for pkg in syft.get("packages", []):
+                purls = spdx_purls(pkg)
+                if purls and any(p in existing_purls for p in purls):
+                    continue
+                pkg = dict(pkg)
+                spdx_id = pkg["SPDXID"]
+                if spdx_id in existing_ids:
+                    spdx_id = f"{spdx_id}-from-syft"
+                    pkg["SPDXID"] = spdx_id
+                modelcar.setdefault("packages", []).append(pkg)
+                existing_ids.add(spdx_id)
+                existing_purls.update(purls)
+                if root_id:
+                    modelcar.setdefault("relationships", []).append(
+                        {
+                            "spdxElementId": root_id,
+                            "relationshipType": "CONTAINS",
+                            "relatedSpdxElement": spdx_id,
+                        }
+                    )
+        else:
+            existing_refs = {
+                c.get("bom-ref") for c in modelcar.get("components", []) if c.get("bom-ref")
+            }
+            existing_purls = {
+                c["purl"] for c in modelcar.get("components", []) if c.get("purl")
+            }
+            root_ref = (modelcar.get("metadata") or {}).get("component", {}).get("bom-ref")
+            deps = modelcar.setdefault("dependencies", [])
+            root_dep = next((d for d in deps if d.get("ref") == root_ref), None)
+            if root_ref and root_dep is None:
+                root_dep = {"ref": root_ref, "dependsOn": []}
+                deps.append(root_dep)
+            if root_dep is not None:
+                root_dep.setdefault("dependsOn", [])
+
+            for comp in syft.get("components", []):
+                purl = comp.get("purl")
+                if purl and purl in existing_purls:
+                    continue
+                comp = dict(comp)
+                ref = comp.get("bom-ref") or f"syft-{comp.get('name', 'component')}"
+                if ref in existing_refs:
+                    ref = f"{ref}-from-syft"
+                comp["bom-ref"] = ref
+                modelcar.setdefault("components", []).append(comp)
+                existing_refs.add(ref)
+                if purl:
+                    existing_purls.add(purl)
+                if root_dep is not None and ref not in root_dep["dependsOn"]:
+                    root_dep["dependsOn"].append(ref)
+
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(modelcar, f)
+        PY
 
     - name: upload-sbom
       image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -283,6 +283,49 @@ spec:
 
         echo "[$(date -Ins)] Model artifact has ${TOTAL} named layer(s), processing in batches of ${BATCH_SIZE}"
 
+        # oras copy --to-oci-layout can leave Docker-distribution manifests in the
+        # OCI layout. olot converts those on first use but keeps the old Docker
+        # blobs on disk; the next batch then re-enters conversion and KeyErrors
+        # because index.json already points at OCI digests. Convert once and
+        # delete leftover Docker manifest blobs before batching.
+        python3 - "$TARGET_OCI" <<'PY'
+        import json
+        import sys
+        from pathlib import Path
+
+        from olot.dockerdist.convert import (
+            DOCKER_LIST_V2,
+            DOCKER_MANIFEST_V2,
+            check_if_oci_layout_contains_docker_manifests,
+            convert_docker_manifests_to_oci,
+        )
+
+        oci = Path(sys.argv[1])
+        if not check_if_oci_layout_contains_docker_manifests(oci):
+            print("Base OCI layout has no Docker manifests; skipping conversion")
+            raise SystemExit(0)
+
+        converted = convert_docker_manifests_to_oci(oci)
+        blobs = oci / "blobs" / "sha256"
+        for old_hash, new_hash in converted.items():
+            if old_hash != new_hash:
+                (blobs / old_hash).unlink(missing_ok=True)
+                print(f"Removed leftover Docker manifest blob {old_hash} (now {new_hash})")
+
+        # Belt-and-suspenders: drop any remaining Docker manifest/list blobs.
+        for blob in blobs.iterdir():
+            if not blob.is_file():
+                continue
+            try:
+                media_type = json.loads(blob.read_text()).get("mediaType")
+            except Exception:
+                continue
+            if media_type in (DOCKER_MANIFEST_V2, DOCKER_LIST_V2):
+                blob.unlink(missing_ok=True)
+                print(f"Removed leftover Docker blob {blob.name} ({media_type})")
+        print("Docker→OCI conversion complete")
+        PY
+
         # ─── Download, layer, and push model files in batches ───
         mkdir -p models
         FIRST_BATCH=true

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -210,7 +210,7 @@ spec:
         echo "$ARCHFUL_BASE_IMAGE" | tee "$(results.BASE_IMAGE_REF.path)"
 
     - name: build-and-push
-      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 2Gi
@@ -339,14 +339,9 @@ spec:
 
           find "$BLOBS_DIR" -maxdepth 1 -type f -printf '%f\n' | sort > /tmp/blobs_before.txt
 
-          # --root-dir preserves each file's subdirectory structure (relative
-          # to models/) in its resulting layer path, instead of flattening to
-          # just the basename. Without it, files with the same basename in
-          # different subdirectories (e.g. a root config.json and an
-          # inference/config.json) collide on the same in-image path and
-          # silently overwrite each other. Requires olot >= 1.2.0 (task-runner
-          # >= 3.1.0; see https://github.com/containers/olot/pull/209).
-          olot --verbose --remove-originals default --root-dir models \
+          # TEMP: task-runner 3.0.0 / olot without --root-dir (avoids olot 1.2.0
+          # Docker→OCI multi-batch KeyError). Nested titles flatten to basename.
+          olot --verbose --remove-originals default \
             "${MODELCARD_ARG[@]}" \
             "$TARGET_OCI" \
             "${BATCH_FILES[@]}"
@@ -620,7 +615,7 @@ spec:
         PY
 
     - name: upload-sbom
-      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 64Mi
@@ -658,7 +653,7 @@ spec:
             exit 1
         fi
     - name: report-sbom-url
-      image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+      image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
       computeResources:
         requests:
           memory: 64Mi

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-alternative-arch.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,14 +79,14 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
                 oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -183,7 +183,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-floating-tag.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,14 +79,14 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
                 oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -181,7 +181,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -218,7 +218,8 @@ spec:
               popd
 
               echo "Confirm the sbom exists as json"
-              packages=$(cosign download sbom --allow-insecure-registry "$IMAGE_REF" | jq -r '.packages[].externalRefs[].referenceLocator')
+              sbom=$(cosign download sbom --allow-insecure-registry "$IMAGE_REF")
+              packages=$(echo "$sbom" | jq -r '.packages[].externalRefs[]?.referenceLocator // empty')
               for purl in pkg:oci/test-modelcar pkg:oci/ubi pkg:oci/test-model; do
                 if [[ "$packages" == *"${purl}@sha256"* ]]; then
                   echo "$purl found as expected."
@@ -227,8 +228,16 @@ spec:
                 fi
               done
 
+              echo "Confirm base-image RPM packages were merged from Syft"
+              rpm_count=$(echo "$sbom" | jq '[.packages[].externalRefs[]? | select(.referenceType=="purl" and (.referenceLocator|startswith("pkg:rpm")))] | length')
+              if [[ "$rpm_count" -gt 0 ]]; then
+                echo "Found ${rpm_count} RPM purls in SBOM as expected."
+              else
+                echo "Expected RPM packages from Syft base scan, found none." && exit 1
+              fi
+
               echo "Confirm the sbom has a reasonable name"
-              sbom_name=$(cosign download sbom --allow-insecure-registry "$IMAGE_REF" | jq -r '.name')
+              sbom_name=$(echo "$sbom" | jq -r '.name')
               if [[ "$sbom_name" == "$IMAGE_REF" ]]; then
                 echo "SBOM name $sbom_name is as expected."
               else

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-happy-path.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,14 +79,14 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
                 oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -179,7 +179,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-mtime.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,7 +79,7 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
@@ -88,7 +88,7 @@ spec:
                   "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -169,7 +169,7 @@ spec:
             env:
               - name: IMAGE_REF
                 value: $(params.IMAGE_REF)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             securityContext:
               runAsUser: 0
               runAsNonRoot: false

--- a/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
+++ b/task/modelcar-oci-ta/0.1/tests/test-modelcar-oci-ta-without-remove-originals.yaml
@@ -45,7 +45,7 @@ spec:
               readOnly: true
         steps:
           - name: mock-source
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             script: |
               #!/usr/bin/env bash
               set -euo pipefail
@@ -67,7 +67,7 @@ spec:
               ls -la "$(workspaces.tests-workspace.path)/source"
               find "$(workspaces.tests-workspace.path)/source" -type f -exec echo "  {}" \;
           - name: mock-model
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             workingDir: $(workspaces.tests-workspace.path)
             env:
               - name: MODEL_PATH
@@ -79,14 +79,14 @@ spec:
               # the task trust store under deploy-local CI; skip verify here.
               # Push from inside source/ so layer titles are paths relative to
               # the model root (e.g. model.bin), not source/model.bin.
-              # With --root-dir models, files land under /models/<title>.
+              # oras titles use basenames, so files land under /models/<basename>.
               mapfile -t files < <(find source -type f -printf '%P\n' | sort)
               (
                 cd source
                 oras push --insecure --no-tty "${MODEL_PATH}" "${files[@]}"
               )
           - name: record-model-digest
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             env:
               - name: MODEL_PATH
                 value: $(params.modelPath)
@@ -179,7 +179,7 @@ spec:
                 value: $(params.IMAGE_URL)
               - name: SBOM_BLOB_URL
                 value: $(params.SBOM_BLOB_URL)
-            image: quay.io/konflux-ci/task-runner:3.1.1@sha256:790df1bb5ea7a9ce4c1717ff341398ff72c99faed1c2e939a3b4a15ff8f4a493
+            image: quay.io/konflux-ci/task-runner:3.0.0@sha256:9f4151ff21f4c14b9151582c91a5542140bbbb6dca7861cd42081006840bec05
             securityContext:
               runAsUser: 0
               runAsNonRoot: false


### PR DESCRIPTION
## Summary
- Modelcar SBOMs currently only contain the composition graph (modelcar + base + model), so release has no RPM inventory to load into the package DB.
- Scan the **base image** with Syft during `sbom-generate` and merge those packages into the Mobster modelcar SBOM (keep existing descendant relationships).
- Extend the happy-path test to assert `pkg:rpm/...` purls are present.

## Test plan
- [x] `run-task-tests` / modelcar-oci-ta happy-path passes (composition purls + RPM purls)
- [x] Rebuild a Modelcar with the new task bundle and confirm `cosign download sbom … | jq '.packages[].name'` includes base RPMs (e.g. bash/glibc) in addition to the three composition nodes


Made with [Cursor](https://cursor.com)