### PR TITLE
fix(modelcar-oci-ta): set name label for container-first security checks

### DIFF
--- a/task/modelcar-oci-ta/0.1/README.md
+++ b/task/modelcar-oci-ta/0.1/README.md
@@ -29,6 +29,8 @@ generated in the process.
 |IMAGE_EXPIRES_AFTER|Image tag expiration time for quay.expires-after label|""|false|
 |SOURCE_DATE_EPOCH|Timestamp in seconds since Unix epoch for reproducible builds. Sets org.opencontainers.image.created and build-date labels.|""|false|
 |CPE|CPE identifier label required for on-prem product releases|""|false|
+|IMAGE_NAME|Value for the image `name` label (must match the release destination path, e.g. `rhai/modelcar-foo`). When empty, defaults to `IMAGE_NAME_PREFIX`/`<IMAGE repository basename>`.|""|false|
+|IMAGE_NAME_PREFIX|Namespace prefix used when `IMAGE_NAME` is empty (e.g. `rhai` or `rhelai1`).|rhai|false|
 |caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
 |caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
 

--- a/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
+++ b/task/modelcar-oci-ta/0.1/modelcar-oci-ta.yaml
@@ -80,6 +80,20 @@ spec:
       description: CPE identifier label required for on-prem product releases
       type: string
       default: ""
+    - name: IMAGE_NAME
+      description: >-
+        Value for the image "name" label (must match the release destination
+        repository path, e.g. rhai/modelcar-foo). Required for rh-advisories
+        check-labels / container-first security label enforcement. When empty,
+        defaults to IMAGE_NAME_PREFIX/<repository-name> derived from IMAGE.
+      type: string
+      default: ""
+    - name: IMAGE_NAME_PREFIX
+      description: >-
+        Registry namespace prefix used when IMAGE_NAME is empty
+        (e.g. rhai or rhelai1). Combined with the IMAGE repository basename.
+      type: string
+      default: "rhai"
     - name: caTrustConfigMapKey
       description: The name of the key in the ConfigMap that contains the
         CA bundle data.
@@ -236,6 +250,10 @@ spec:
           value: $(params.SOURCE_DATE_EPOCH)
         - name: CPE
           value: $(params.CPE)
+        - name: IMAGE_NAME
+          value: $(params.IMAGE_NAME)
+        - name: IMAGE_NAME_PREFIX
+          value: $(params.IMAGE_NAME_PREFIX)
       script: |
         #!/bin/bash
         set -eu
@@ -416,6 +434,18 @@ spec:
         manifest_path="$BLOBS_DIR/${manifest_digest#sha256:}"
         config_path="$BLOBS_DIR/$(jq -r '.config.digest | sub("^sha256:"; "")' "$manifest_path")"
 
+        # Override inherited base "name" (e.g. ubi9/ubi-micro) so check-labels
+        # matches the catalog destination path (rhai/... or rhelai1/...).
+        if [ -n "${IMAGE_NAME}" ]; then
+          NAME_LABEL="${IMAGE_NAME}"
+        else
+          IMAGE_REPO="${IMAGE%%@*}"
+          IMAGE_REPO="${IMAGE_REPO%%:*}"
+          IMAGE_BASENAME="${IMAGE_REPO##*/}"
+          NAME_LABEL="${IMAGE_NAME_PREFIX}/${IMAGE_BASENAME}"
+        fi
+        echo "Setting image name label to: ${NAME_LABEL}"
+
         base_labels=$(jq -c '.config.Labels // {}' "$config_path")
         labels_json=$(jq -nc \
           --argjson base "$base_labels" \
@@ -423,10 +453,12 @@ spec:
           --arg commit "${COMMIT_SHA}" \
           --arg expires "${IMAGE_EXPIRES_AFTER}" \
           --arg cpe "${CPE}" \
+          --arg name "${NAME_LABEL}" \
           '$base * {
             "org.opencontainers.image.created": $created,
             "build-date": $created,
-            "vcs-type": "git"
+            "vcs-type": "git",
+            "name": $name
           }
           * (if $commit != "" then {"vcs-ref": $commit, "org.opencontainers.image.revision": $commit} else {} end)
           * (if $expires != "" then {"quay.expires-after": $expires} else {} end)


### PR DESCRIPTION
## Summary
- ModelCar images currently inherit `name=ubi9/ubi-micro` from the base image, which will fail `check-labels` in `rh-advisories` when `enforceContainerFirstSecurityLabels` defaults to true (Aug 23).
- Set the `name` label from `IMAGE_NAME`, or when unset to `IMAGE_NAME_PREFIX/<IMAGE repository basename>` (default prefix `rhai`).
- `cpe` was already set via the existing `CPE` param; this change addresses the mismatched `name` label.

## Test plan
- [ ] Task tests pass
- [ ] Build a ModelCar and confirm `name` is e.g. `rhai/modelcar-…` (not `ubi9/ubi-micro`)
- [ ] For components released to `rhelai1/…`, pass `IMAGE_NAME_PREFIX=rhelai1` or full `IMAGE_NAME=rhelai1/…`
- [ ] Confirm a release pipeline `check-labels` no longer warns/fails on `name`
