### PR TITLE
fix(EC-1994): bump WORKERS default from 1 to 2

### DIFF
--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -56,7 +56,7 @@ spec:
     - name: WORKERS
       type: string
       description: Number of parallel workers to use for policy evaluation.
-      default: "1"
+      default: "2"
     - name: CA_TRUST_CONFIGMAP_NAME
       type: string
       description: The name of the ConfigMap to read CA bundle data from.


### PR DESCRIPTION
## Summary
- Bump `WORKERS` default in `pipelines/enterprise-contract.yaml` from 1 to 2
- An off-by-one fix in conforma/cli ([conforma/cli#3425](https://github.com/conforma/cli/pull/3425)) corrected the worker loop from `<=` to `<`, reducing actual worker count by 1. This bumps the default to preserve the effective concurrency users had before the fix.

## Test plan
- [x] Verified the change is a single default value update

Resolves: https://redhat.atlassian.net/browse/EC-1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)