### PR TITLE
Bump conforma version to latest

### DIFF
--- a/e2e-tests/tests/build/build_templates.go
+++ b/e2e-tests/tests/build/build_templates.go
@@ -44,7 +44,7 @@ var (
 )
 
 const pipelineCompletionRetries = 2
-const verifyECTaskBundle = "quay.io/conforma/tekton-task:konflux@sha256:e86e0c7c0dfec6aad4b40ff8a4eac3c023cdb2ccbd8e5709800ebbfd5579afb2"
+const verifyECTaskBundle = "quay.io/conforma/tekton-task:konflux@sha256:775cbfaa5361bd39d7cf8816c1c31b85c862609fb70ee76afa7d5a8b7d839517"
 
 type TestBranches struct {
 	RepoName       string

--- a/pipelines/enterprise-contract.yaml
+++ b/pipelines/enterprise-contract.yaml
@@ -100,7 +100,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: quay.io/conforma/tekton-task:konflux@sha256:e86e0c7c0dfec6aad4b40ff8a4eac3c023cdb2ccbd8e5709800ebbfd5579afb2
+            value: quay.io/conforma/tekton-task:konflux@sha256:775cbfaa5361bd39d7cf8816c1c31b85c862609fb70ee76afa7d5a8b7d839517
           - name: name
             value: collect-keyless-params
           - name: kind
@@ -154,7 +154,7 @@ spec:
         resolver: bundles
         params:
           - name: bundle
-            value: quay.io/conforma/tekton-task:konflux@sha256:e86e0c7c0dfec6aad4b40ff8a4eac3c023cdb2ccbd8e5709800ebbfd5579afb2
+            value: quay.io/conforma/tekton-task:konflux@sha256:775cbfaa5361bd39d7cf8816c1c31b85c862609fb70ee76afa7d5a8b7d839517
           - name: name
             value: verify-enterprise-contract
           - name: kind


### PR DESCRIPTION
Release changelog: [Conforma changelog]( https://github.com/conforma/infra-deployments-ci/blob/main/releases/2026-08-11T17%3A36%3A11/changelog.md
)

**This should be merged on August 17th alongside the `konflux-ci/release-service-catalog` production promotion.**