### PR TITLE
chore(STONEINTG-1727): move operator tasks to own renovate group

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -48,6 +48,9 @@
 /external-task/roxctl-scan                      @konflux-ci/integration-service-maintainers
 /external-task/tpa-scan                         @konflux-ci/integration-service-maintainers
 /external-task/deprecated-image-check           @konflux-ci/integration-service-maintainers
+/task/sbom-json-check                                    @Allda @jedinym
+
+# renovate groupName=operator
 /external-task/fbc-fips-check                            @konflux-ci/operator-foundry
 /external-task/fbc-fips-check-matrix-based-oci-ta        @konflux-ci/operator-foundry
 /external-task/fbc-fips-check-oci-ta                     @konflux-ci/operator-foundry
@@ -55,7 +58,6 @@
 /external-task/fbc-inject-lifecycle-oci-ta               @konflux-ci/operator-foundry
 /external-task/fbc-target-index-pruning-check            @konflux-ci/operator-foundry
 /external-task/run-opm-command-oci-ta                    @konflux-ci/operator-foundry
-/task/sbom-json-check                                    @Allda @jedinym
 /external-task/validate-fbc                              @konflux-ci/operator-foundry
 /external-task/fips-operator-bundle-check                @konflux-ci/operator-foundry
 /external-task/fips-operator-bundle-check-oci-ta         @konflux-ci/operator-foundry

--- a/renovate.json
+++ b/renovate.json
@@ -274,21 +274,20 @@
         "external-task/sast-unicode-check/**"
       ]
     },
-
     {
       "groupName": "operator",
       "matchFileNames": [
-        "external-task/fbc-fips-check/**",
         "external-task/fbc-fips-check-matrix-based-oci-ta/**",
         "external-task/fbc-fips-check-oci-ta/**",
+        "external-task/fbc-fips-check/**",
         "external-task/fbc-fips-prepare-oci-ta/**",
         "external-task/fbc-inject-lifecycle-oci-ta/**",
         "external-task/fbc-target-index-pruning-check/**",
+        "external-task/fips-operator-bundle-check-oci-ta/**",
+        "external-task/fips-operator-bundle-check/**",
+        "external-task/github-sarif-upload/**",
         "external-task/run-opm-command-oci-ta/**",
         "external-task/validate-fbc/**",
-        "external-task/fips-operator-bundle-check/**",
-        "external-task/fips-operator-bundle-check-oci-ta/**",
-        "external-task/github-sarif-upload/**",
         "stepactions/fips-operator-check-step-action/**"
       ]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -86,20 +86,8 @@
         "external-task/clamav-scan-min/**",
         "external-task/clamav-scan/**",
         "external-task/deprecated-image-check/**",
-        "external-task/fbc-fips-check-matrix-based-oci-ta/**",
-        "external-task/fbc-fips-check-oci-ta/**",
-        "external-task/fbc-fips-check/**",
-        "external-task/fbc-fips-prepare-oci-ta/**",
-        "external-task/fbc-inject-lifecycle-oci-ta/**",
-        "external-task/fbc-target-index-pruning-check/**",
-        "external-task/fips-operator-bundle-check-oci-ta/**",
-        "external-task/fips-operator-bundle-check/**",
-        "external-task/github-sarif-upload/**",
         "external-task/roxctl-scan/**",
-        "external-task/run-opm-command-oci-ta/**",
         "external-task/tpa-scan/**",
-        "external-task/validate-fbc/**",
-        "stepactions/fips-operator-check-step-action/**",
         "task/sbom-json-check/**"
       ]
     },
@@ -284,6 +272,24 @@
         "external-task/sast-unicode-check-oci-ta-min/**",
         "external-task/sast-unicode-check-oci-ta/**",
         "external-task/sast-unicode-check/**"
+      ]
+    },
+
+    {
+      "groupName": "operator",
+      "matchFileNames": [
+        "external-task/fbc-fips-check/**",
+        "external-task/fbc-fips-check-matrix-based-oci-ta/**",
+        "external-task/fbc-fips-check-oci-ta/**",
+        "external-task/fbc-fips-prepare-oci-ta/**",
+        "external-task/fbc-inject-lifecycle-oci-ta/**",
+        "external-task/fbc-target-index-pruning-check/**",
+        "external-task/run-opm-command-oci-ta/**",
+        "external-task/validate-fbc/**",
+        "external-task/fips-operator-bundle-check/**",
+        "external-task/fips-operator-bundle-check-oci-ta/**",
+        "external-task/github-sarif-upload/**",
+        "stepactions/fips-operator-check-step-action/**"
       ]
     }
   ],


### PR DESCRIPTION

Move operator-related external-task paths out of the **integration group** into a dedicated **operator group** so **renovate/mintmaker** creates separate PRs for operator task updates, aligning with **CODEOWNERS** approvers.

This PR is the follow-up to [#3729](https://github.com/konflux-ci/build-definitions/pull/3729) (SAST group).

Resolves the issue raised in   [STONEINTG-1727](https://redhat.atlassian.net/jira/software/c/projects/BMPTEMP/boards/9424?selectedIssue=[STONEINTG-1727](https://redhat.atlassian.net/browse/STONEINTG-1727)). 

[STONEINTG-1727]: https://redhat.atlassian.net/browse/STONEINTG-1727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ