### PR TITLE
feat: add compression-format param to docker-build pipelines

### DIFF
--- a/pipelines/core-services/core-services.yaml
+++ b/pipelines/core-services/core-services.yaml
@@ -167,6 +167,13 @@ spec:
     name: omit-history
     type: string
   - default: ""
+    description: Compression format to use when pushing the image (gzip, zstd:chunked
+      or dual). Empty means buildah's default (gzip). dual is a tech preview that
+      pushes both gzip and zstd:chunked variants bundled in a per-arch OCI index;
+      it requires buildah-format=oci. See ADR 0070 in konflux-ci/architecture.
+    name: compression-format
+    type: string
+  - default: ""
     name: infra-deployment-update-script
   - default: ""
     name: update-repo-script
@@ -261,6 +268,8 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: COMPRESSION_FORMAT
+      value: $(params.compression-format)
     - name: HTTP_PROXY
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
@@ -277,7 +286,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah-remote
-      version: "0.10"
+      version: "0.13"
     workspaces:
     - name: source
       workspace: workspace

--- a/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+++ b/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
@@ -105,6 +105,13 @@ spec:
       etc.) from the resulting image.
     name: omit-history
     type: string
+  - default: ""
+    description: Compression format to use when pushing the image (gzip, zstd:chunked
+      or dual). Empty means buildah's default (gzip). dual is a tech preview that
+      pushes both gzip and zstd:chunked variants bundled in a per-arch OCI index;
+      it requires buildah-format=oci. See ADR 0070 in konflux-ci/architecture.
+    name: compression-format
+    type: string
   - default:
     - linux/x86_64
     description: List of platforms to build the container images on. The available
@@ -200,6 +207,8 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: COMPRESSION_FORMAT
+      value: $(params.compression-format)
     - name: HTTP_PROXY
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
@@ -220,7 +229,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah-remote-oci-ta
-      version: "0.10"
+      version: "0.13"
     workspaces: []
   - name: build-image-index
     params:

--- a/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
+++ b/pipelines/docker-build-oci-ta-min/docker-build-oci-ta-min.yaml
@@ -103,6 +103,13 @@ spec:
       etc.) from the resulting image.
     name: omit-history
     type: string
+  - default: ""
+    description: Compression format to use when pushing the image (gzip, zstd:chunked
+      or dual). Empty means buildah's default (gzip). dual is a tech preview that
+      pushes both gzip and zstd:chunked variants bundled in a per-arch OCI index;
+      it requires buildah-format=oci. See ADR 0070 in konflux-ci/architecture.
+    name: compression-format
+    type: string
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -187,6 +194,8 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: COMPRESSION_FORMAT
+      value: $(params.compression-format)
     - name: HTTP_PROXY
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
@@ -205,7 +214,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah-oci-ta-min
-      version: "0.10"
+      version: "0.13"
     workspaces: []
   - name: build-image-index
     params:

--- a/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
+++ b/pipelines/docker-build-oci-ta/docker-build-oci-ta.yaml
@@ -105,6 +105,13 @@ spec:
       etc.) from the resulting image.
     name: omit-history
     type: string
+  - default: ""
+    description: Compression format to use when pushing the image (gzip, zstd:chunked
+      or dual). Empty means buildah's default (gzip). dual is a tech preview that
+      pushes both gzip and zstd:chunked variants bundled in a per-arch OCI index;
+      it requires buildah-format=oci. See ADR 0070 in konflux-ci/architecture.
+    name: compression-format
+    type: string
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -189,6 +196,8 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: COMPRESSION_FORMAT
+      value: $(params.compression-format)
     - name: HTTP_PROXY
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
@@ -207,7 +216,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah-oci-ta
-      version: "0.10"
+      version: "0.13"
     workspaces: []
   - name: build-image-index
     params:

--- a/pipelines/docker-build/docker-build.yaml
+++ b/pipelines/docker-build/docker-build.yaml
@@ -105,6 +105,13 @@ spec:
       etc.) from the resulting image.
     name: omit-history
     type: string
+  - default: ""
+    description: Compression format to use when pushing the image (gzip, zstd:chunked
+      or dual). Empty means buildah's default (gzip). dual is a tech preview that
+      pushes both gzip and zstd:chunked variants bundled in a per-arch OCI index;
+      it requires buildah-format=oci. See ADR 0070 in konflux-ci/architecture.
+    name: compression-format
+    type: string
   results:
   - name: IMAGE_URL
     value: $(tasks.build-image-index.results.IMAGE_URL)
@@ -183,6 +190,8 @@ spec:
       value: $(tasks.clone-repository.results.url)
     - name: BUILDAH_FORMAT
       value: $(params.buildah-format)
+    - name: COMPRESSION_FORMAT
+      value: $(params.compression-format)
     - name: HTTP_PROXY
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
@@ -197,7 +206,7 @@ spec:
     - prefetch-dependencies
     taskRef:
       name: buildah
-      version: "0.10"
+      version: "0.13"
     workspaces:
     - name: source
       workspace: workspace

--- a/pipelines/docker-build/patch.yaml
+++ b/pipelines/docker-build/patch.yaml
@@ -41,7 +41,7 @@
   path: /spec/tasks/3/taskRef
   value:
     name: buildah
-    version: "0.10"
+    version: "0.13"
 - op: add
   path: /spec/params/-
   value:
@@ -85,6 +85,13 @@
     type: string
     default: "false"
 - op: add
+  path: /spec/params/-
+  value:
+    name: compression-format
+    description: Compression format to use when pushing the image (gzip, zstd:chunked or dual). Empty means buildah's default (gzip). dual is a tech preview that pushes both gzip and zstd:chunked variants bundled in a per-arch OCI index; it requires buildah-format=oci. See ADR 0070 in konflux-ci/architecture.
+    type: string
+    default: ""
+- op: add
   path: /spec/tasks/3/params
   value:
   - name: IMAGE
@@ -112,6 +119,8 @@
     value: "$(tasks.clone-repository.results.url)"
   - name: BUILDAH_FORMAT
     value: "$(params.buildah-format)"
+  - name: COMPRESSION_FORMAT
+    value: "$(params.compression-format)"
   - name: HTTP_PROXY
     value: "$(tasks.init.results.http-proxy)"
   - name: NO_PROXY

--- a/pipelines/fbc-builder/fbc-builder.yaml
+++ b/pipelines/fbc-builder/fbc-builder.yaml
@@ -95,6 +95,13 @@ spec:
       etc.) from the resulting image.
     name: omit-history
     type: string
+  - default: ""
+    description: Compression format to use when pushing the image (gzip, zstd:chunked
+      or dual). Empty means buildah's default (gzip). dual is a tech preview that
+      pushes both gzip and zstd:chunked variants bundled in a per-arch OCI index;
+      it requires buildah-format=oci. See ADR 0070 in konflux-ci/architecture.
+    name: compression-format
+    type: string
   - default:
     - linux/x86_64
     description: List of platforms to build the container images on. The available
@@ -225,6 +232,8 @@ spec:
       value: $(params.build-args-file)
     - name: SOURCE_URL
       value: $(tasks.clone-repository.results.url)
+    - name: COMPRESSION_FORMAT
+      value: $(params.compression-format)
     - name: HTTP_PROXY
       value: $(tasks.init.results.http-proxy)
     - name: NO_PROXY
@@ -245,7 +254,7 @@ spec:
     - clone-repository
     taskRef:
       name: buildah-remote-oci-ta
-      version: "0.10"
+      version: "0.13"
     workspaces: []
   - name: build-image-index
     params:


### PR DESCRIPTION
Wire the buildah task's new COMPRESSION_FORMAT parameter (0.13) into the docker-build pipeline family: docker-build, docker-build-oci-ta, docker-build-oci-ta-min, docker-build-multi-platform-oci-ta, and the derived core-services and fbc-builder pipelines.

Empty by default, which keeps buildah's current behavior. dual is a tech preview per ADR 0070 and requires buildah-format=oci.

Pipeline READMEs are intentionally not regenerated: the generator reads task metadata from the quay bundle, and the buildah 0.13 bundle only exists once the task PR merges


