### PR TITLE
Add verify-reproducibility pipeline and task

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -138,6 +138,10 @@
 # renovate groupName=verify-source
 /task/verify-source @arewm @ralphbean
 
+# renovate groupName=verify-reproducibility
+/task/verify-reproducibility @chmeliik @Allda @jedinym
+/pipelines/verify-reproducibility @chmeliik @Allda @jedinym
+
 # renovate groupName=ko-builder
 /task/ko-oci-ta @ggallen @vdemeester @arewm @skoved @rh-hemartin @maruiz93
 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -140,6 +140,7 @@
 
 # renovate groupName=verify-reproducibility
 /task/verify-reproducibility @chmeliik @Allda @jedinym
+/task/verify-distinct-repositories @chmeliik @Allda @jedinym
 /pipelines/verify-reproducibility @chmeliik @Allda @jedinym
 
 # renovate groupName=ko-builder

--- a/pipelines/kustomization.yaml
+++ b/pipelines/kustomization.yaml
@@ -13,3 +13,4 @@ resources:
 - maven-zip-build
 - maven-zip-build-oci-ta
 - package-operator-package
+- verify-reproducibility

--- a/pipelines/verify-reproducibility/README.md
+++ b/pipelines/verify-reproducibility/README.md
@@ -1,0 +1,143 @@
+# "verify-reproducibility pipeline"
+Rebuilds an image from the source it claims to have been built from,
+using the same reproducibility params, and checks whether the two
+digests match. Run it on demand against an image you want to verify -
+it isn't part of the automatic build flow. The rebuild pushes to a
+separate, caller-supplied scratch repository, never to the repo of the
+image being verified, so running this never changes that image.
+
+Single-arch images only, for now: this pipeline rebuilds through one
+buildah-oci-ta run, so its digest can never match a multi-platform
+image index digest (from docker-build-multi-platform-oci-ta /
+build-image-index). Multi-arch manifest ordering is still open work
+(see ADR-0069).
+
+A matching digest proves the same source, params, and task version
+produce the same bytes on this platform - it does not prove an
+independent platform would agree. If the platform running this
+pipeline is the same one that built the original image, and that
+platform were tampered with in a way that doesn't break its own
+determinism, both builds would agree with each other while still
+being wrong. Catching that needs an independent platform rebuilding
+from the provenance recipe, which ADR-0069 calls out as a stronger
+property this pipeline's shape could grow into, but isn't what it
+does today.
+
+This can only be as faithful as the params it's given: if the original
+build used a non-default value for something this pipeline exposes
+(source-date-epoch, image-expires-after, hermetic, ...), pass the same
+value here, or you'll get a false "not reproducible" result that has
+nothing to do with real non-determinism.
+
+## Parameters
+|name|description|default value|used in (taskname:taskrefversion:taskparam)|
+|---|---|---|---|
+|build-args| --build-arg values the original build used. Must match the original build.| []| rebuild:0.10:BUILD_ARGS|
+|build-args-file| Path to a build-args file, if the original build used one. Must match the original build.| | rebuild:0.10:BUILD_ARGS_FILE|
+|buildah-format| Image mediaType the original build used (oci or docker). Must match the original build.| docker| rebuild:0.10:BUILDAH_FORMAT|
+|cachi2-artifact| Trusted Artifact URI for prefetched hermetic dependencies (CACHI2_ARTIFACT result). Set alongside hermetic=true for a faithful hermetic rebuild.| | rebuild:0.10:CACHI2_ARTIFACT|
+|dockerfile| Path to the Dockerfile inside path-context. Must match the original build.| Dockerfile| rebuild:0.10:DOCKERFILE|
+|git-url| Source repository URL the original image was built from. Must match the original build's git URL exactly - it's baked into a digest-affecting label, so a mismatch here alone causes a false "not reproducible" result. | None| rebuild:0.10:SOURCE_URL|
+|hermetic| Whether the original build ran with network access disabled. Must match the original build.| false| rebuild:0.10:HERMETIC|
+|image-digest| Digest (sha256:...) of the image being verified.| None| |
+|image-expires-after| The image-expires-after value the original build used (leave empty if it didn't set one). Echoed straight through to the rebuild - buildah bakes this into a quay.expires-after label in the image config, so a mismatch here alone causes a false "not reproducible" result. This is not a cleanup knob for the verify-* tag this pipeline pushes - use a registry-side auto-prune policy scoped to that tag pattern for that instead. | | rebuild:0.10:IMAGE_EXPIRES_AFTER|
+|image-repository| Repository (no tag or digest) of the image being verified.| None| compare:0.1:ORIGINAL_IMAGE_REF|
+|omit-history| The omit-history value the original build used. Must match the original build.| false| rebuild:0.10:OMIT_HISTORY|
+|path-context| Path to the source code to build. Must match the original build.| .| rebuild:0.10:CONTEXT|
+|prefetch-input| Prefetch config the original build used, if hermetic. Must match the original build.| | rebuild:0.10:PREFETCH_INPUT|
+|privileged-nested| Whether the original build ran in privileged mode. Must match the original build.| false| rebuild:0.10:PRIVILEGED_NESTED|
+|revision| Resolved commit SHA (not a branch name) the original image was built from. Must match the original build exactly, same reason as git-url above. | None| rebuild:0.10:COMMIT_SHA|
+|rewrite-timestamp| The rewrite-timestamp value the original build used. Must match the original build.| false| rebuild:0.10:REWRITE_TIMESTAMP|
+|skip-sbom-generation| Skips SBOM generation, SBOM upload, and SBOM attestation signing on the rebuild. Doesn't affect the digest comparison - the rebuild's IMAGE_DIGEST is set before any SBOM step runs. Defaults on since the rebuild's SBOM has nowhere useful to go. Set to "false" if you're using this pipeline to check whether syft produces byte-identical SBOMs across rebuilds (ADR-0069's open question on that). | true| rebuild:0.10:SKIP_SBOM_GENERATION|
+|source-artifact| Trusted Artifact URI for the exact source the original image was built from (the SOURCE_ARTIFACT result from that build's clone-repository or prefetch-dependencies task). This expires on the same schedule as the original build's image-expires-after, so verification generally needs to run before that window closes. | None| rebuild:0.10:SOURCE_ARTIFACT|
+|source-date-epoch| The source-date-epoch value the original build used. Must match the original build.| | rebuild:0.10:SOURCE_DATE_EPOCH|
+|verify-repository| Scratch repository the rebuild pushes to, tagged verify-<pipelineRun-uid>. Must be a different repository than image-repository: buildah-oci-ta signs every push whenever the cluster has keyless signing configured, and cosign's signature tag is repo-scoped, so pushing the rebuild into the same repo as the image being verified would overwrite that image's own signature (and SBOM/attestation tags) just by inspecting it. | None| rebuild:0.10:IMAGE|
+
+## Available params from tasks
+### buildah-oci-ta:0.10 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ACTIVATION_KEY| Name of secret which contains subscription activation key| activation-key| |
+|ADDITIONAL_BASE_IMAGES| Additional base image references to include to the SBOM. Array of image_reference_with_digest strings| []| |
+|ADDITIONAL_SECRET| Name of a secret which will be made available to the build with 'buildah build --secret' at /run/secrets/$ADDITIONAL_SECRET| does-not-exist| |
+|ADD_CAPABILITIES| Comma separated list of extra capabilities to add when running 'buildah build'| ""| |
+|ALLOW_CROSS_PLATFORM_IMAGES| Allows to use parent images that don't match the build host architecture. This option must be used with caution as it may create incompatible images.| false| |
+|ANNOTATIONS| Additional key=value annotations that should be applied to the image| []| |
+|ANNOTATIONS_FILE| Path to a file with additional key=value annotations that should be applied to the image| ""| |
+|BUILDAH_FORMAT| The format for the resulting image's mediaType. Valid values are oci (default) or docker.| oci| '$(params.buildah-format)'|
+|BUILD_ARGS| Array of --build-arg values ("arg=value" strings)| []| '['$(params.build-args[*])']'|
+|BUILD_ARGS_FILE| Path to a file with build arguments, see https://www.mankier.com/1/buildah-build#--build-arg-file| ""| '$(params.build-args-file)'|
+|BUILD_TIMESTAMP| Defines the single build time for all buildah builds in seconds since UNIX epoch. Conflicts with SOURCE_DATE_EPOCH.| ""| |
+|CACHI2_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the prefetched dependencies.| ""| '$(params.cachi2-artifact)'|
+|COMMIT_SHA| The image is built from this commit.| ""| '$(params.revision)'|
+|CONTEXT| Path to the directory to use as context.| .| '$(params.path-context)'|
+|CONTEXTUALIZE_SBOM| Determines if SBOM will be contextualized.| true| |
+|DOCKERFILE| Path to the Dockerfile to build.| ./Dockerfile| '$(params.dockerfile)'|
+|ENTITLEMENT_SECRET| Name of secret which contains the entitlement certificates| etc-pki-entitlement| |
+|ENV_VARS| Array of --env values ("env=value" strings)| []| |
+|HERMETIC| Determines if build will be executed without network access.| false| '$(params.hermetic)'|
+|HTTP_PROXY| HTTP/HTTPS proxy to use for the buildah pull and build operations. Will not be passed through to the container during the build process.| ""| |
+|ICM_KEEP_COMPAT_LOCATION| Whether to keep compatibility location at /root/buildinfo/ for ICM injection| true| |
+|IMAGE| Reference of the image buildah will produce.| None| '$(params.verify-repository):verify-$(context.pipelineRun.uid)'|
+|IMAGE_EXPIRES_AFTER| Delete image tag after specified time. Empty means to keep the image tag. Time values could be something like 1h, 2d, 3w for hours, days, and weeks, respectively.| ""| '$(params.image-expires-after)'|
+|INHERIT_BASE_IMAGE_LABELS| Determines if the image inherits the base image labels.| true| |
+|LABELS| Additional key=value labels that should be applied to the image| []| |
+|LOG_LEVEL| Log level for the build command.| info| |
+|NO_PROXY| Comma separated list of hosts or domains which should bypass the HTTP/HTTPS proxy.| ""| |
+|OMIT_HISTORY| Omit build history information from the resulting image. Improves reproducibility by excluding timestamps and layer metadata.| false| '$(params.omit-history)'|
+|PREFETCH_INPUT| In case it is not empty, the prefetched content should be made available to the build.| ""| '$(params.prefetch-input)'|
+|PRIVILEGED_NESTED| Whether to enable privileged mode, should be used only with remote VMs| false| '$(params.privileged-nested)'|
+|PROXY_CA_TRUST_CONFIG_MAP_KEY| The name of the key in the ConfigMap that contains the proxy CA bundle data.| ca-bundle.crt| |
+|PROXY_CA_TRUST_CONFIG_MAP_NAME| The name of the ConfigMap to read proxy CA bundle data from.| caching-ca-bundle| |
+|REWRITE_TIMESTAMP| Clamp mtime of all files to at most SOURCE_DATE_EPOCH. Does nothing if SOURCE_DATE_EPOCH is not defined.| false| '$(params.rewrite-timestamp)'|
+|RHSM_MOUNT_CA_CERTS| Mount /etc/rhsm/ca from the host machine into the build. Valid values are 'always', 'auto' (default), 'never'. Only effective if HERMETIC=false and ACTIVATION_KEY or ENTITLEMENT_SECRET is set.| auto| |
+|SBOM_SKIP_VALIDATION| Flag to enable or disable SBOM validation before save. Validation is optional - use this if you are experiencing performance issues.| true| |
+|SBOM_SOURCE_SCAN_ENABLED| Flag to enable or disable SBOM generation from source code. The scanner of the source code is enabled only for non-hermetic builds and can be disabled if the SBOM_SYFT_SELECT_CATALOGERS can't turn off catalogers that cause false positives on source code scanning.| true| |
+|SBOM_SYFT_SELECT_CATALOGERS| Extra option to customize Syft's default catalogers when generating SBOMs. The value corresponds to Syft's CLI flag --select-catalogers. The details about available catalogers can be found here: https://github.com/anchore/syft/wiki/Package-Cataloger-Selection| ""| |
+|SBOM_TYPE| Select the SBOM format to generate. Valid values: spdx, cyclonedx. Note: the SBOM from the prefetch task - if there is one - must be in the same format.| spdx| |
+|SKIP_INJECTIONS| Don't inject a content-sets.json or a labels.json file. This requires that the canonical Containerfile takes care of this itself.| false| |
+|SKIP_SBOM_GENERATION| Skip SBOM-related operations. This will likely cause EC policies to fail if enabled| false| '$(params.skip-sbom-generation)'|
+|SKIP_UNUSED_STAGES| Whether to skip stages in Containerfile that seem unused by subsequent stages| true| |
+|SOURCE_ARTIFACT| The Trusted Artifact URI pointing to the artifact with the application source code.| None| '$(params.source-artifact)'|
+|SOURCE_DATE_EPOCH| Timestamp in seconds since Unix epoch for reproducible builds. Sets image created time and SOURCE_DATE_EPOCH build arg. Conflicts with BUILD_TIMESTAMP.| ""| '$(params.source-date-epoch)'|
+|SOURCE_URL| The image is built from this URL.| ""| '$(params.git-url)'|
+|SQUASH| Squash all new and previous layers added as a part of this build, as per --squash| false| |
+|STORAGE_DRIVER| Storage driver to configure for buildah| overlay| |
+|TARGET_STAGE| Target stage in Dockerfile to build. If not specified, the Dockerfile is processed entirely to (and including) its last stage.| ""| |
+|TLSVERIFY| Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)| true| |
+|WORKINGDIR_MOUNT| Mount the current working directory into the build using --volume $PWD:/$WORKINGDIR_MOUNT. Note that the $PWD will be the context directory for the build (see the CONTEXT param).| ""| |
+|YUM_REPOS_D_FETCHED| Path in source workspace where dynamically-fetched repos are present| fetched.repos.d| |
+|YUM_REPOS_D_SRC| Path in the git repository in which yum repository files are stored| repos.d| |
+|YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
+|caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
+|caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+### verify-reproducibility:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|ORIGINAL_IMAGE_REF| Reference (repo@sha256:...) of the original image being verified.| None| '$(params.image-repository)@$(params.image-digest)'|
+|REBUILT_IMAGE_REF| Reference (repo@sha256:...) of the freshly rebuilt image to compare against.| None| '$(tasks.rebuild.results.IMAGE_REF)'|
+
+## Results
+|name|description|value|
+|---|---|---|
+|REBUILT_IMAGE_REF| |$(tasks.rebuild.results.IMAGE_REF)|
+|REPRODUCIBLE| |$(tasks.compare.results.REPRODUCIBLE)|
+|TEST_OUTPUT| |$(tasks.compare.results.TEST_OUTPUT)|
+## Available results from tasks
+### buildah-oci-ta:0.10 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|IMAGE_DIGEST| Digest of the image just built| |
+|IMAGE_REF| Image reference of the built image| compare:0.1:REBUILT_IMAGE_REF|
+|IMAGE_URL| Image repository and tag where the built image was pushed| |
+|SBOM_BLOB_URL| Reference of SBOM blob digest to enable digest-based verification from provenance| |
+### verify-reproducibility:0.1 task results
+|name|description|used in params (taskname:taskrefversion:taskparam)
+|---|---|---|
+|REPRODUCIBLE| true if the rebuilt image's digest matches the original image's digest, false otherwise| |
+|TEST_OUTPUT| JSON formatted test results for the reproducibility comparison| |
+
+## Workspaces
+|name|description|optional|used in tasks
+|---|---|---|---|
+## Available workspaces from tasks

--- a/pipelines/verify-reproducibility/README.md
+++ b/pipelines/verify-reproducibility/README.md
@@ -41,7 +41,7 @@ nothing to do with real non-determinism.
 |hermetic| Whether the original build ran with network access disabled. Must match the original build.| false| rebuild:0.10:HERMETIC|
 |image-digest| Digest (sha256:...) of the image being verified.| None| |
 |image-expires-after| The image-expires-after value the original build used (leave empty if it didn't set one). Echoed straight through to the rebuild - buildah bakes this into a quay.expires-after label in the image config, so a mismatch here alone causes a false "not reproducible" result. This is not a cleanup knob for the verify-* tag this pipeline pushes - use a registry-side auto-prune policy scoped to that tag pattern for that instead. | | rebuild:0.10:IMAGE_EXPIRES_AFTER|
-|image-repository| Repository (no tag or digest) of the image being verified.| None| compare:0.1:ORIGINAL_IMAGE_REF|
+|image-repository| Repository (no tag or digest) of the image being verified.| None| validate-params:0.1:REPOSITORY_A ; compare:0.1:ORIGINAL_IMAGE_REF|
 |omit-history| The omit-history value the original build used. Must match the original build.| false| rebuild:0.10:OMIT_HISTORY|
 |path-context| Path to the source code to build. Must match the original build.| .| rebuild:0.10:CONTEXT|
 |prefetch-input| Prefetch config the original build used, if hermetic. Must match the original build.| | rebuild:0.10:PREFETCH_INPUT|
@@ -51,7 +51,7 @@ nothing to do with real non-determinism.
 |skip-sbom-generation| Skips SBOM generation, SBOM upload, and SBOM attestation signing on the rebuild. Doesn't affect the digest comparison - the rebuild's IMAGE_DIGEST is set before any SBOM step runs. Defaults on since the rebuild's SBOM has nowhere useful to go. Set to "false" if you're using this pipeline to check whether syft produces byte-identical SBOMs across rebuilds (ADR-0069's open question on that). | true| rebuild:0.10:SKIP_SBOM_GENERATION|
 |source-artifact| Trusted Artifact URI for the exact source the original image was built from (the SOURCE_ARTIFACT result from that build's clone-repository or prefetch-dependencies task). This expires on the same schedule as the original build's image-expires-after, so verification generally needs to run before that window closes. | None| rebuild:0.10:SOURCE_ARTIFACT|
 |source-date-epoch| The source-date-epoch value the original build used. Must match the original build.| | rebuild:0.10:SOURCE_DATE_EPOCH|
-|verify-repository| Scratch repository the rebuild pushes to, tagged verify-<pipelineRun-uid>. Must be a different repository than image-repository: buildah-oci-ta signs every push whenever the cluster has keyless signing configured, and cosign's signature tag is repo-scoped, so pushing the rebuild into the same repo as the image being verified would overwrite that image's own signature (and SBOM/attestation tags) just by inspecting it. | None| rebuild:0.10:IMAGE|
+|verify-repository| Scratch repository the rebuild pushes to, tagged verify-<pipelineRun-uid>. Must be a different repository than image-repository: buildah-oci-ta signs every push whenever the cluster has keyless signing configured, and cosign's signature tag is repo-scoped, so pushing the rebuild into the same repo as the image being verified would overwrite that image's own signature (and SBOM/attestation tags) just by inspecting it. | None| validate-params:0.1:REPOSITORY_B ; rebuild:0.10:IMAGE|
 
 ## Available params from tasks
 ### buildah-oci-ta:0.10 task parameters
@@ -111,6 +111,11 @@ nothing to do with real non-determinism.
 |YUM_REPOS_D_TARGET| Target path on the container in which yum repository files should be made available| /etc/yum.repos.d| |
 |caTrustConfigMapKey| The name of the key in the ConfigMap that contains the CA bundle data.| ca-bundle.crt| |
 |caTrustConfigMapName| The name of the ConfigMap to read CA bundle data from.| trusted-ca| |
+### verify-distinct-repositories:0.1 task parameters
+|name|description|default value|already set by|
+|---|---|---|---|
+|REPOSITORY_A| First repository to compare.| None| '$(params.image-repository)'|
+|REPOSITORY_B| Second repository to compare.| None| '$(params.verify-repository)'|
 ### verify-reproducibility:0.1 task parameters
 |name|description|default value|already set by|
 |---|---|---|---|

--- a/pipelines/verify-reproducibility/kustomization.yaml
+++ b/pipelines/verify-reproducibility/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- verify-reproducibility.yaml

--- a/pipelines/verify-reproducibility/verify-reproducibility.yaml
+++ b/pipelines/verify-reproducibility/verify-reproducibility.yaml
@@ -150,7 +150,40 @@ spec:
     - name: REBUILT_IMAGE_REF
       value: $(tasks.rebuild.results.IMAGE_REF)
   tasks:
+    - name: validate-params
+      params:
+        - name: IMAGE_REPOSITORY
+          value: $(params.image-repository)
+        - name: VERIFY_REPOSITORY
+          value: $(params.verify-repository)
+      taskSpec:
+        params:
+          - name: IMAGE_REPOSITORY
+          - name: VERIFY_REPOSITORY
+        steps:
+          - name: validate
+            image: quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35
+            env:
+              - name: IMAGE_REPOSITORY
+                value: $(params.IMAGE_REPOSITORY)
+              - name: VERIFY_REPOSITORY
+                value: $(params.VERIFY_REPOSITORY)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              # if these match, the rebuild would overwrite the verified
+              # image's own signature and SBOM/attestation tags. fail here,
+              # before the rebuild runs, so that never happens.
+              if [ "$IMAGE_REPOSITORY" = "$VERIFY_REPOSITORY" ]; then
+                echo "ERROR: verify-repository must be different from image-repository (both are '${IMAGE_REPOSITORY}')." >&2
+                echo "Pushing the rebuild into the same repo as the image being verified would" >&2
+                echo "overwrite that image's own signature and SBOM/attestation tags." >&2
+                exit 1
+              fi
     - name: rebuild
+      runAfter:
+        - validate-params
       params:
         - name: IMAGE
           value: $(params.verify-repository):verify-$(context.pipelineRun.uid)

--- a/pipelines/verify-reproducibility/verify-reproducibility.yaml
+++ b/pipelines/verify-reproducibility/verify-reproducibility.yaml
@@ -152,35 +152,13 @@ spec:
   tasks:
     - name: validate-params
       params:
-        - name: IMAGE_REPOSITORY
+        - name: REPOSITORY_A
           value: $(params.image-repository)
-        - name: VERIFY_REPOSITORY
+        - name: REPOSITORY_B
           value: $(params.verify-repository)
-      taskSpec:
-        params:
-          - name: IMAGE_REPOSITORY
-          - name: VERIFY_REPOSITORY
-        steps:
-          - name: validate
-            image: quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35
-            env:
-              - name: IMAGE_REPOSITORY
-                value: $(params.IMAGE_REPOSITORY)
-              - name: VERIFY_REPOSITORY
-                value: $(params.VERIFY_REPOSITORY)
-            script: |
-              #!/usr/bin/env bash
-              set -euo pipefail
-
-              # if these match, the rebuild would overwrite the verified
-              # image's own signature and SBOM/attestation tags. fail here,
-              # before the rebuild runs, so that never happens.
-              if [ "$IMAGE_REPOSITORY" = "$VERIFY_REPOSITORY" ]; then
-                echo "ERROR: verify-repository must be different from image-repository (both are '${IMAGE_REPOSITORY}')." >&2
-                echo "Pushing the rebuild into the same repo as the image being verified would" >&2
-                echo "overwrite that image's own signature and SBOM/attestation tags." >&2
-                exit 1
-              fi
+      taskRef:
+        name: verify-distinct-repositories
+        version: "0.1"
     - name: rebuild
       runAfter:
         - validate-params

--- a/pipelines/verify-reproducibility/verify-reproducibility.yaml
+++ b/pipelines/verify-reproducibility/verify-reproducibility.yaml
@@ -1,0 +1,206 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: verify-reproducibility
+spec:
+  description: |
+    Rebuilds an image from the source it claims to have been built from,
+    using the same reproducibility params, and checks whether the two
+    digests match. Run it on demand against an image you want to verify -
+    it isn't part of the automatic build flow. The rebuild pushes to a
+    separate, caller-supplied scratch repository, never to the repo of the
+    image being verified, so running this never changes that image.
+
+    Single-arch images only, for now: this pipeline rebuilds through one
+    buildah-oci-ta run, so its digest can never match a multi-platform
+    image index digest (from docker-build-multi-platform-oci-ta /
+    build-image-index). Multi-arch manifest ordering is still open work
+    (see ADR-0069).
+
+    A matching digest proves the same source, params, and task version
+    produce the same bytes on this platform - it does not prove an
+    independent platform would agree. If the platform running this
+    pipeline is the same one that built the original image, and that
+    platform were tampered with in a way that doesn't break its own
+    determinism, both builds would agree with each other while still
+    being wrong. Catching that needs an independent platform rebuilding
+    from the provenance recipe, which ADR-0069 calls out as a stronger
+    property this pipeline's shape could grow into, but isn't what it
+    does today.
+
+    This can only be as faithful as the params it's given: if the original
+    build used a non-default value for something this pipeline exposes
+    (source-date-epoch, image-expires-after, hermetic, ...), pass the same
+    value here, or you'll get a false "not reproducible" result that has
+    nothing to do with real non-determinism.
+  params:
+    - name: image-repository
+      type: string
+      description: Repository (no tag or digest) of the image being verified.
+    - name: image-digest
+      type: string
+      description: Digest (sha256:...) of the image being verified.
+    - name: verify-repository
+      type: string
+      description: |
+        Scratch repository the rebuild pushes to, tagged
+        verify-<pipelineRun-uid>. Must be a different repository than
+        image-repository: buildah-oci-ta signs every push whenever the
+        cluster has keyless signing configured, and cosign's signature tag
+        is repo-scoped, so pushing the rebuild into the same repo as the
+        image being verified would overwrite that image's own signature
+        (and SBOM/attestation tags) just by inspecting it.
+    - name: source-artifact
+      type: string
+      description: |
+        Trusted Artifact URI for the exact source the original image was
+        built from (the SOURCE_ARTIFACT result from that build's
+        clone-repository or prefetch-dependencies task). This expires on
+        the same schedule as the original build's image-expires-after, so
+        verification generally needs to run before that window closes.
+    - name: cachi2-artifact
+      type: string
+      default: ""
+      description: Trusted Artifact URI for prefetched hermetic dependencies (CACHI2_ARTIFACT result). Set alongside hermetic=true for a faithful hermetic rebuild.
+    - name: git-url
+      type: string
+      description: |
+        Source repository URL the original image was built from. Must
+        match the original build's git URL exactly - it's baked into a
+        digest-affecting label, so a mismatch here alone causes a false
+        "not reproducible" result.
+    - name: revision
+      type: string
+      description: |
+        Resolved commit SHA (not a branch name) the original image was
+        built from. Must match the original build exactly, same reason as
+        git-url above.
+    - name: dockerfile
+      type: string
+      default: Dockerfile
+      description: Path to the Dockerfile inside path-context. Must match the original build.
+    - name: path-context
+      type: string
+      default: "."
+      description: Path to the source code to build. Must match the original build.
+    - name: hermetic
+      type: string
+      default: "false"
+      description: Whether the original build ran with network access disabled. Must match the original build.
+    - name: prefetch-input
+      type: string
+      default: ""
+      description: Prefetch config the original build used, if hermetic. Must match the original build.
+    - name: build-args
+      type: array
+      default: []
+      description: --build-arg values the original build used. Must match the original build.
+    - name: build-args-file
+      type: string
+      default: ""
+      description: Path to a build-args file, if the original build used one. Must match the original build.
+    - name: privileged-nested
+      type: string
+      default: "false"
+      description: Whether the original build ran in privileged mode. Must match the original build.
+    - name: buildah-format
+      type: string
+      default: docker
+      description: Image mediaType the original build used (oci or docker). Must match the original build.
+    - name: image-expires-after
+      type: string
+      default: ""
+      description: |
+        The image-expires-after value the original build used (leave
+        empty if it didn't set one). Echoed straight through to the
+        rebuild - buildah bakes this into a quay.expires-after label in
+        the image config, so a mismatch here alone causes a false "not
+        reproducible" result. This is not a cleanup knob for the verify-*
+        tag this pipeline pushes - use a registry-side auto-prune policy
+        scoped to that tag pattern for that instead.
+    - name: source-date-epoch
+      type: string
+      default: ""
+      description: The source-date-epoch value the original build used. Must match the original build.
+    - name: rewrite-timestamp
+      type: string
+      default: "false"
+      description: The rewrite-timestamp value the original build used. Must match the original build.
+    - name: omit-history
+      type: string
+      default: "false"
+      description: The omit-history value the original build used. Must match the original build.
+    - name: skip-sbom-generation
+      type: string
+      default: "true"
+      description: |
+        Skips SBOM generation, SBOM upload, and SBOM attestation signing
+        on the rebuild. Doesn't affect the digest comparison - the
+        rebuild's IMAGE_DIGEST is set before any SBOM step runs. Defaults
+        on since the rebuild's SBOM has nowhere useful to go. Set to
+        "false" if you're using this pipeline to check whether syft
+        produces byte-identical SBOMs across rebuilds (ADR-0069's open
+        question on that).
+  results:
+    - name: REPRODUCIBLE
+      value: $(tasks.compare.results.REPRODUCIBLE)
+    - name: TEST_OUTPUT
+      value: $(tasks.compare.results.TEST_OUTPUT)
+    - name: REBUILT_IMAGE_REF
+      value: $(tasks.rebuild.results.IMAGE_REF)
+  tasks:
+    - name: rebuild
+      params:
+        - name: IMAGE
+          value: $(params.verify-repository):verify-$(context.pipelineRun.uid)
+        - name: DOCKERFILE
+          value: $(params.dockerfile)
+        - name: CONTEXT
+          value: $(params.path-context)
+        - name: HERMETIC
+          value: $(params.hermetic)
+        - name: PREFETCH_INPUT
+          value: $(params.prefetch-input)
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.image-expires-after)
+        - name: COMMIT_SHA
+          value: $(params.revision)
+        - name: BUILD_ARGS
+          value:
+            - $(params.build-args[*])
+        - name: BUILD_ARGS_FILE
+          value: $(params.build-args-file)
+        - name: PRIVILEGED_NESTED
+          value: $(params.privileged-nested)
+        - name: SOURCE_URL
+          value: $(params.git-url)
+        - name: BUILDAH_FORMAT
+          value: $(params.buildah-format)
+        - name: SOURCE_DATE_EPOCH
+          value: $(params.source-date-epoch)
+        - name: REWRITE_TIMESTAMP
+          value: $(params.rewrite-timestamp)
+        - name: OMIT_HISTORY
+          value: $(params.omit-history)
+        - name: SOURCE_ARTIFACT
+          value: $(params.source-artifact)
+        - name: CACHI2_ARTIFACT
+          value: $(params.cachi2-artifact)
+        - name: SKIP_SBOM_GENERATION
+          value: $(params.skip-sbom-generation)
+      taskRef:
+        name: buildah-oci-ta
+        version: "0.10"
+      workspaces: []
+    - name: compare
+      runAfter:
+        - rebuild
+      params:
+        - name: ORIGINAL_IMAGE_REF
+          value: $(params.image-repository)@$(params.image-digest)
+        - name: REBUILT_IMAGE_REF
+          value: $(tasks.rebuild.results.IMAGE_REF)
+      taskRef:
+        name: verify-reproducibility
+        version: "0.1"

--- a/renovate.json
+++ b/renovate.json
@@ -295,6 +295,7 @@
       "groupName": "verify-reproducibility",
       "matchFileNames": [
         "pipelines/verify-reproducibility/**",
+        "task/verify-distinct-repositories/**",
         "task/verify-reproducibility/**"
       ]
     }

--- a/renovate.json
+++ b/renovate.json
@@ -290,6 +290,13 @@
         "external-task/validate-fbc/**",
         "stepactions/fips-operator-check-step-action/**"
       ]
+    },
+    {
+      "groupName": "verify-reproducibility",
+      "matchFileNames": [
+        "pipelines/verify-reproducibility/**",
+        "task/verify-reproducibility/**"
+      ]
     }
   ],
   "postUpdateOptions": [

--- a/task/verify-distinct-repositories/0.1/README.md
+++ b/task/verify-distinct-repositories/0.1/README.md
@@ -1,0 +1,17 @@
+# verify-distinct-repositories task
+
+Fails if REPOSITORY_A and REPOSITORY_B are the same string. Meant to
+run before a rebuild that pushes to REPOSITORY_B, to catch the case
+where it was accidentally set to the same repository as the image
+being verified in REPOSITORY_A (see the verify-reproducibility
+pipeline, ADR-0069).
+
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|REPOSITORY_A|First repository to compare.||true|
+|REPOSITORY_B|Second repository to compare.||true|
+
+
+## Additional info

--- a/task/verify-distinct-repositories/0.1/tests/test-verify-distinct-repositories-fail.yaml
+++ b/task/verify-distinct-repositories/0.1/tests/test-verify-distinct-repositories-fail.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-verify-distinct-repositories-fail
+  annotations:
+    test/assert-task-failure: run-task
+spec:
+  description: |
+    Test verify-distinct-repositories with the same repository given
+    twice: expect the TaskRun to fail.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: verify-distinct-repositories
+      params:
+        - name: REPOSITORY_A
+          value: quay.io/example/repo-a
+        - name: REPOSITORY_B
+          value: quay.io/example/repo-a

--- a/task/verify-distinct-repositories/0.1/tests/test-verify-distinct-repositories-pass.yaml
+++ b/task/verify-distinct-repositories/0.1/tests/test-verify-distinct-repositories-pass.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-verify-distinct-repositories-pass
+spec:
+  description: |
+    Test verify-distinct-repositories with two different repositories:
+    expect the TaskRun to succeed.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: verify-distinct-repositories
+      params:
+        - name: REPOSITORY_A
+          value: quay.io/example/repo-a
+        - name: REPOSITORY_B
+          value: quay.io/example/repo-b

--- a/task/verify-distinct-repositories/0.1/verify-distinct-repositories.yaml
+++ b/task/verify-distinct-repositories/0.1/verify-distinct-repositories.yaml
@@ -1,0 +1,42 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: verify-distinct-repositories
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/tags: security, reproducibility
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: |
+    Fails if REPOSITORY_A and REPOSITORY_B are the same string. Meant to
+    run before a rebuild that pushes to REPOSITORY_B, to catch the case
+    where it was accidentally set to the same repository as the image
+    being verified in REPOSITORY_A (see the verify-reproducibility
+    pipeline, ADR-0069).
+  params:
+    - name: REPOSITORY_A
+      description: First repository to compare.
+      type: string
+    - name: REPOSITORY_B
+      description: Second repository to compare.
+      type: string
+  steps:
+    - name: verify
+      image: quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35
+      env:
+        - name: PARAM_REPOSITORY_A
+          value: $(params.REPOSITORY_A)
+        - name: PARAM_REPOSITORY_B
+          value: $(params.REPOSITORY_B)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        if [ "$PARAM_REPOSITORY_A" = "$PARAM_REPOSITORY_B" ]; then
+          echo "ERROR: REPOSITORY_A and REPOSITORY_B must be different (both are '${PARAM_REPOSITORY_A}')." >&2
+          exit 1
+        fi
+
+        echo "OK: '${PARAM_REPOSITORY_A}' and '${PARAM_REPOSITORY_B}' are different repositories."

--- a/task/verify-distinct-repositories/CHANGELOG.md
+++ b/task/verify-distinct-repositories/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
+
+## Unreleased
+
+<!--
+When you make changes without bumping the version right away, document them here.
+If that's not something you ever plan to do, consider removing this section.
+-->
+
+*Nothing yet.*
+
+## 0.1
+
+### Added
+
+- The initial version of the `verify-distinct-repositories` task!

--- a/task/verify-reproducibility/0.1/README.md
+++ b/task/verify-reproducibility/0.1/README.md
@@ -1,0 +1,23 @@
+# verify-reproducibility task
+
+Compares the digest of a freshly rebuilt image against the digest of
+the original image it's supposed to match, and reports the outcome as
+a REPRODUCIBLE result plus a TEST_OUTPUT summary. Meant to run right
+after a rebuild task, as the last step of the verify-reproducibility
+pipeline (see ADR-0069).
+
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|ORIGINAL_IMAGE_REF|Reference (repo@sha256:...) of the original image being verified.||true|
+|REBUILT_IMAGE_REF|Reference (repo@sha256:...) of the freshly rebuilt image to compare against.||true|
+
+## Results
+|name|description|
+|---|---|
+|REPRODUCIBLE|true if the rebuilt image's digest matches the original image's digest, false otherwise|
+|TEST_OUTPUT|JSON formatted test results for the reproducibility comparison|
+
+
+## Additional info

--- a/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-malformed.yaml
+++ b/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-malformed.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-verify-reproducibility-malformed
+  annotations:
+    test/assert-task-failure: run-task
+spec:
+  description: |
+    Test verify-reproducibility with a ref that has no digest: expect the
+    TaskRun itself to fail. Unlike a mismatch, a ref we can't even parse
+    is a real error, not a verification result.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: verify-reproducibility
+      params:
+        - name: ORIGINAL_IMAGE_REF
+          value: quay.io/example/repo:latest
+        - name: REBUILT_IMAGE_REF
+          value: quay.io/example/scratch:verify-abc123@sha256:1111111111111111111111111111111111111111111111111111111111111111

--- a/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-match.yaml
+++ b/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-match.yaml
@@ -1,0 +1,52 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-verify-reproducibility-match
+spec:
+  description: |
+    Test verify-reproducibility with matching digests: expect REPRODUCIBLE=true.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: verify-reproducibility
+      params:
+        - name: ORIGINAL_IMAGE_REF
+          value: quay.io/example/repo@sha256:1111111111111111111111111111111111111111111111111111111111111111
+        - name: REBUILT_IMAGE_REF
+          value: quay.io/example/scratch:verify-abc123@sha256:1111111111111111111111111111111111111111111111111111111111111111
+    - name: check-result
+      params:
+        - name: REPRODUCIBLE
+          value: $(tasks.run-task.results.REPRODUCIBLE)
+        - name: TEST_OUTPUT
+          value: $(tasks.run-task.results.TEST_OUTPUT)
+      taskSpec:
+        params:
+          - name: REPRODUCIBLE
+          - name: TEST_OUTPUT
+        steps:
+          - name: check-result
+            env:
+              - name: REPRODUCIBLE
+                value: $(params.REPRODUCIBLE)
+              - name: TEST_OUTPUT
+                value: $(params.TEST_OUTPUT)
+            image: quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$REPRODUCIBLE" != "true" ]; then
+                echo "ERROR: expected REPRODUCIBLE=true, got: $REPRODUCIBLE"
+                exit 1
+              fi
+
+              if ! echo "$TEST_OUTPUT" | grep -q '"result": "SUCCESS"'; then
+                echo "ERROR: expected TEST_OUTPUT to report SUCCESS, got: $TEST_OUTPUT"
+                exit 1
+              fi
+
+              echo "SUCCESS: matching-digest test passed"
+      runAfter:
+        - run-task

--- a/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-match.yaml
+++ b/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-match.yaml
@@ -42,8 +42,9 @@ spec:
                 exit 1
               fi
 
-              if ! echo "$TEST_OUTPUT" | grep -q '"result": "SUCCESS"'; then
-                echo "ERROR: expected TEST_OUTPUT to report SUCCESS, got: $TEST_OUTPUT"
+              actual_result=$(echo "$TEST_OUTPUT" | jq -r '.result')
+              if [ "$actual_result" != "SUCCESS" ]; then
+                echo "ERROR: expected TEST_OUTPUT.result=SUCCESS, got: $actual_result"
                 exit 1
               fi
 

--- a/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-mismatch.yaml
+++ b/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-mismatch.yaml
@@ -1,0 +1,54 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-verify-reproducibility-mismatch
+spec:
+  description: |
+    Test verify-reproducibility with mismatched digests: expect
+    REPRODUCIBLE=false, and the TaskRun itself still succeeding - a
+    mismatch is a real answer, not a task failure.
+  tasks:
+    - name: run-task
+      taskRef:
+        name: verify-reproducibility
+      params:
+        - name: ORIGINAL_IMAGE_REF
+          value: quay.io/example/repo@sha256:1111111111111111111111111111111111111111111111111111111111111111
+        - name: REBUILT_IMAGE_REF
+          value: quay.io/example/scratch:verify-abc123@sha256:2222222222222222222222222222222222222222222222222222222222222222
+    - name: check-result
+      params:
+        - name: REPRODUCIBLE
+          value: $(tasks.run-task.results.REPRODUCIBLE)
+        - name: TEST_OUTPUT
+          value: $(tasks.run-task.results.TEST_OUTPUT)
+      taskSpec:
+        params:
+          - name: REPRODUCIBLE
+          - name: TEST_OUTPUT
+        steps:
+          - name: check-result
+            env:
+              - name: REPRODUCIBLE
+                value: $(params.REPRODUCIBLE)
+              - name: TEST_OUTPUT
+                value: $(params.TEST_OUTPUT)
+            image: quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35
+            script: |
+              #!/usr/bin/env sh
+              set -eux
+
+              if [ "$REPRODUCIBLE" != "false" ]; then
+                echo "ERROR: expected REPRODUCIBLE=false, got: $REPRODUCIBLE"
+                exit 1
+              fi
+
+              if ! echo "$TEST_OUTPUT" | grep -q '"result": "FAILURE"'; then
+                echo "ERROR: expected TEST_OUTPUT to report FAILURE, got: $TEST_OUTPUT"
+                exit 1
+              fi
+
+              echo "SUCCESS: mismatched-digest test passed (run-task correctly did not fail)"
+      runAfter:
+        - run-task

--- a/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-mismatch.yaml
+++ b/task/verify-reproducibility/0.1/tests/test-verify-reproducibility-mismatch.yaml
@@ -44,8 +44,9 @@ spec:
                 exit 1
               fi
 
-              if ! echo "$TEST_OUTPUT" | grep -q '"result": "FAILURE"'; then
-                echo "ERROR: expected TEST_OUTPUT to report FAILURE, got: $TEST_OUTPUT"
+              actual_result=$(echo "$TEST_OUTPUT" | jq -r '.result')
+              if [ "$actual_result" != "FAILURE" ]; then
+                echo "ERROR: expected TEST_OUTPUT.result=FAILURE, got: $actual_result"
                 exit 1
               fi
 

--- a/task/verify-reproducibility/0.1/verify-reproducibility.yaml
+++ b/task/verify-reproducibility/0.1/verify-reproducibility.yaml
@@ -1,0 +1,93 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: verify-reproducibility
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.21.0
+    tekton.dev/tags: security, reproducibility
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: |
+    Compares the digest of a freshly rebuilt image against the digest of
+    the original image it's supposed to match, and reports the outcome as
+    a REPRODUCIBLE result plus a TEST_OUTPUT summary. Meant to run right
+    after a rebuild task, as the last step of the verify-reproducibility
+    pipeline (see ADR-0069).
+  params:
+    - name: ORIGINAL_IMAGE_REF
+      description: Reference (repo@sha256:...) of the original image being verified.
+      type: string
+    - name: REBUILT_IMAGE_REF
+      description: Reference (repo@sha256:...) of the freshly rebuilt image to compare against.
+      type: string
+  results:
+    - name: REPRODUCIBLE
+      description: 'true if the rebuilt image''s digest matches the original image''s digest, false otherwise'
+    - name: TEST_OUTPUT
+      description: JSON formatted test results for the reproducibility comparison
+  steps:
+    - name: compare-digests
+      image: quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35
+      env:
+        - name: PARAM_ORIGINAL_IMAGE_REF
+          value: $(params.ORIGINAL_IMAGE_REF)
+        - name: PARAM_REBUILT_IMAGE_REF
+          value: $(params.REBUILT_IMAGE_REF)
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+
+        # the digest is just whatever comes after the last '@' in the ref
+        original_digest="${PARAM_ORIGINAL_IMAGE_REF##*@}"
+        rebuilt_digest="${PARAM_REBUILT_IMAGE_REF##*@}"
+
+        digest_re='^sha256:[0-9a-f]{64}$'
+        if ! [[ "$original_digest" =~ $digest_re ]]; then
+          echo "ERROR: ORIGINAL_IMAGE_REF has no valid digest: ${PARAM_ORIGINAL_IMAGE_REF}" >&2
+          exit 1
+        fi
+        if ! [[ "$rebuilt_digest" =~ $digest_re ]]; then
+          echo "ERROR: REBUILT_IMAGE_REF has no valid digest: ${PARAM_REBUILT_IMAGE_REF}" >&2
+          exit 1
+        fi
+
+        if [ "$original_digest" = "$rebuilt_digest" ]; then
+          reproducible="true"
+          result="SUCCESS"
+          successes=1
+          failures=0
+        else
+          reproducible="false"
+          result="FAILURE"
+          successes=0
+          failures=1
+        fi
+
+        note="original=${PARAM_ORIGINAL_IMAGE_REF} rebuilt=${PARAM_REBUILT_IMAGE_REF}"
+        test_entry=$(printf '{"name":"digest-comparison","result":"%s","note":"%s"}' "$result" "$note")
+
+        test_output=$(cat <<EOF
+        {
+          "result": "$result",
+          "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+          "namespace": "reproducibility",
+          "successes": $successes,
+          "failures": $failures,
+          "warnings": 0,
+          "tests": [$test_entry]
+        }
+        EOF
+        )
+
+        # A mismatch is a real, useful answer, not a task failure - so we
+        # don't exit non-zero for it. We only bail out above when a ref
+        # can't even be read as a digest, since that's a real error.
+        printf '%s' "$reproducible" >"$(results.REPRODUCIBLE.path)"
+        printf '%s' "$test_output" >"$(results.TEST_OUTPUT.path)"
+
+        echo "=== Reproducibility check ==="
+        echo "original digest: $original_digest"
+        echo "rebuilt digest:  $rebuilt_digest"
+        echo "REPRODUCIBLE: $reproducible"

--- a/task/verify-reproducibility/0.1/verify-reproducibility.yaml
+++ b/task/verify-reproducibility/0.1/verify-reproducibility.yaml
@@ -66,20 +66,24 @@ spec:
         fi
 
         note="original=${PARAM_ORIGINAL_IMAGE_REF} rebuilt=${PARAM_REBUILT_IMAGE_REF}"
-        test_entry=$(printf '{"name":"digest-comparison","result":"%s","note":"%s"}' "$result" "$note")
 
-        test_output=$(cat <<EOF
-        {
-          "result": "$result",
-          "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-          "namespace": "reproducibility",
-          "successes": $successes,
-          "failures": $failures,
-          "warnings": 0,
-          "tests": [$test_entry]
-        }
-        EOF
-        )
+        # build the JSON with jq instead of hand-quoting it, so we never have
+        # to think about escaping whatever ends up in the image refs
+        test_output=$(jq -n \
+          --arg result "$result" \
+          --arg timestamp "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          --argjson successes "$successes" \
+          --argjson failures "$failures" \
+          --arg note "$note" \
+          '{
+            result: $result,
+            timestamp: $timestamp,
+            namespace: "reproducibility",
+            successes: $successes,
+            failures: $failures,
+            warnings: 0,
+            tests: [{name: "digest-comparison", result: $result, note: $note}]
+          }')
 
         # A mismatch is a real, useful answer, not a task failure - so we
         # don't exit non-zero for it. We only bail out above when a ref

--- a/task/verify-reproducibility/CHANGELOG.md
+++ b/task/verify-reproducibility/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+<!-- Format guidelines: https://keepachangelog.com/en/1.1.0/#how -->
+
+## Unreleased
+
+<!--
+When you make changes without bumping the version right away, document them here.
+If that's not something you ever plan to do, consider removing this section.
+-->
+
+*Nothing yet.*
+
+## 0.1
+
+### Added
+
+- The initial version of the `verify-reproducibility` task!


### PR DESCRIPTION
## Summary

Implements the standalone verification pipeline from ADR-0069. It's a pipeline rather than a task since a task can't invoke another task to trigger the rebuild.

The rebuild pushes to a caller-supplied scratch repository, not the repo of the image being verified. buildah-oci-ta signs every push unconditionally whenever the cluster has keyless signing configured, with no param to skip it, and cosign's signature tag is repo-scoped. A same-repo rebuild would overwrite the verified image's own signature and SBOM/attestation tags as a side effect of inspecting it.

A matching digest proves the same source, params, and task version produce the same bytes on this platform, not that an independent platform would agree. Verifying on the same build platform that produced the original image can't catch that platform itself being compromised in a way that's still internally deterministic. The ADR names this limitation and points to independent-platform rebuilding from provenance as the stronger property to grow into later.

Single-arch images only for now. This pipeline rebuilds through one buildah-oci-ta run, so it can't produce a matching digest for a multi-platform image index. Multi-arch manifest ordering is still open work per the ADR.

diffoci integration for layer-by-layer diffs on mismatch is left for a follow-up. It isn't vendored anywhere in this repo today, and bringing in the first non-konflux-ci step image is its own conversation.

## Testing

Task-level tests (matching digest, mismatched digest, malformed ref) run automatically in CI. YAML structure, kustomize builds, CODEOWNERS, and shellcheck were all validated locally.