### PR TITLE
fix(build-helm-chart-oci-ta): skip file:// deps in repo add

### DIFF
--- a/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.3/build-helm-chart-oci-ta.yaml
@@ -4,7 +4,7 @@ kind: Task
 metadata:
   name: build-helm-chart-oci-ta
   labels:
-    app.kubernetes.io/version: "0.3"
+    app.kubernetes.io/version: "0.3.1"
 spec:
   description: |-
     The task packages and pushes a Helm chart to an OCI repository.
@@ -288,8 +288,8 @@ spec:
           while read -r repo_url; do
             if [ -n "$repo_url" ]; then
               proto=$(echo "$repo_url" | cut -d: -f1)
-              if [ "$proto" = "oci" ]; then
-                echo "Skipping adding helm repository for OCI dependency: $repo_url"
+              if [ "$proto" = "oci" ] || [ "$proto" = "file" ]; then
+                echo "Skipping adding helm repository for $proto dependency: $repo_url"
               else
                 http_repo_used=true
                 repo_name=$(echo "$repo_url" | sed 's|https://||' | sed 's|http://||' | sed 's|/.*$||' | sed 's|\.|_|g')

--- a/task/build-helm-chart-oci-ta/CHANGELOG.md
+++ b/task/build-helm-chart-oci-ta/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## 0.3.1
+
+### Fixed
+
+Skip adding helm repositories for `file://` protocol dependencies.
+Helm cannot register local filesystem paths as remote repositories, causing
+`helm repo add` to fail with "could not find protocol handler for: file".
+Local dependencies are resolved by `helm dependency build` directly from the
+filesystem without requiring a repository entry.


### PR DESCRIPTION
The dependency-handling loop only skipped oci:// dependencies from the helm repo add path. For file:// dependencies (valid Helm local path deps), the code fell into the else branch, set http_repo_used=true, and then helm repo update failed because no real HTTP repos were added — aborting before helm dependency build was ever called.

Add file:// to the protocol skip condition alongside oci://. Both protocol types are natively handled by helm dependency build and should not go through the helm repo add path.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
