### PR TITLE
feat!: respect Chart.yaml version with timestamp (0.4.0)

### DIFF
--- a/task/build-helm-chart-oci-ta/0.4/MIGRATION.md
+++ b/task/build-helm-chart-oci-ta/0.4/MIGRATION.md
@@ -1,0 +1,14 @@
+# Migration from 0.2 to 0.3
+
+## Parameter Changes
+
+### Modified Parameters
+- `VALUES_FILE`: renamed to `VALUES_FILES`. Now represents an array
+  (default: `["values.yaml"]`)
+
+### Removed Parameters
+- None
+
+## Action from users
+
+The task is assumed to have no active users.

--- a/task/build-helm-chart-oci-ta/0.4/README.md
+++ b/task/build-helm-chart-oci-ta/0.4/README.md
@@ -1,0 +1,271 @@
+# build-helm-chart-oci-ta task
+
+The task packages and pushes a Helm chart to an OCI repository.
+As Helm charts require to have a semver-compatible version to be packaged, the
+task relies on git tags in order to determine the chart version during runtime.
+
+The task computes the version based on the git commit SHA distance from the latest
+tag prefixed with the value of TAG_PREFIX. The value of that tag will be used as
+the version's X.Y values, and the Z value will be computed by the commit's distance
+from the tag, followed by an abbreviated SHA as build metadata.
+
+The task also supports image substitution in the chart templates. Use the IMAGE_MAPPINGS
+parameter to specify source images to be replaced with target images and tags.
+
+Version 0.2 includes improved digest extraction from skopeo copy operations.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|CA_TRUST_CONFIG_MAP_KEY|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|CA_TRUST_CONFIG_MAP_NAME|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+|CHART_CONTEXT|Path relative to SOURCE_CODE_DIR where the chart is located|dist/chart/|false|
+|COMMIT_SHA|Git commit sha to build chart for||true|
+|IMAGE_MAPPINGS|JSON array of image mappings to substitute in chart templates. Format: [{"source": "localhost/my/repo", "target": "quay.io/myorg/myapp"}] Source images will be replaced with target images in all YAML files in templates/. The task automatically appends the tag format: VERSION_SUFFIX-COMMIT_SHA (or just COMMIT_SHA if VERSION_SUFFIX is empty).|[]|false|
+|IMAGE|Full image reference with tag (e.g., quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid:on-pr-{{revision}})||true|
+|SOURCE_ARTIFACT|The Trusted Artifact URI pointing to the artifact with the application source code.||true|
+|SOURCE_CODE_DIR|Path relative to the workingDir where the code was pulled into|source|false|
+|TAG_PREFIX|An identifying prefix on which the version tag is to be matched|helm-|false|
+|VALUES_FILES|Array of values file names to process for image substitution (e.g., ["values.yaml", "values-prod.yaml", "values-dev.yaml"])|["values.yaml"]|false|
+|VERSION_SUFFIX|A suffix to be added to the version string|""|false|
+
+## Results
+|name|description|
+|---|---|
+|IMAGE_DIGEST|Digest of the OCI-Artifact just built|
+|IMAGE_URL|OCI-Artifact repository and tag where the built OCI-Artifact was pushed|
+
+
+## Additional info
+
+## Features
+
+- **Chart Packaging**: Packages Helm charts with semver-compatible versioning
+- **OCI Push**: Pushes packaged charts to OCI registries
+- **Image Substitution**: Replaces source images with target images in chart templates
+- **Git-based Versioning**: Uses git tags to determine chart versions
+- **Trusted Artifacts**: Uses trusted artifacts for source code access
+
+## Image Substitution
+
+The task supports replacing source images with target images in chart templates before packaging. This is useful when you have placeholder images in your chart templates that need to be replaced with actual built images.
+
+### Image Mappings Format
+
+The `IMAGE_MAPPINGS` parameter accepts a JSON array of mapping objects:
+
+```json
+[
+  {
+    "source": "localhost/my/repo",
+    "target": "quay.io/myorg/myapp:on-pr-{{revision}}"
+  },
+  {
+    "source": "localhost/another/repo",
+    "target": "quay.io/myorg/another-app:on-pr-{{revision}}"
+  }
+]
+```
+
+### How It Works
+
+1. **Source Images**: These are the placeholder images in your chart templates
+   (e.g., `localhost/my/repo`)
+2. **Target Images**: These are the registry/repository names without tags
+   (e.g., `quay.io/myorg/myapp`)
+3. **Substitution**: The task finds all YAML files in the `templates/` directory and
+   all specified values files, then replaces source images with target images (with
+   standardized tags)
+
+### Supported Image Formats
+
+The substitution handles various YAML image formats in both templates and values files:
+
+```yaml
+# In templates/ files:
+image: localhost/my/repo
+image: "localhost/my/repo"
+image: 'localhost/my/repo'
+image: localhost/my/repo:latest
+
+# In values files:
+repository: localhost/my/repo
+repository: "localhost/my/repo"
+repository: 'localhost/my/repo'
+```
+
+## Usage Examples
+
+### Basic Usage
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: build-helm-chart-oci-ta
+spec:
+  taskRef:
+    name: build-helm-chart-oci-ta
+  params:
+  - name: IMAGE
+    value: "quay.io/myorg/mychart:latest"
+  - name: COMMIT_SHA
+    value: "abc123"
+  - name: SOURCE_ARTIFACT
+    value: "oci://quay.io/myorg/source:abc123"
+```
+
+### With Image Substitution
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: build-helm-chart-oci-ta-with-images
+spec:
+  taskRef:
+    name: build-helm-chart-oci-ta
+  params:
+  - name: IMAGE
+    value: "quay.io/myorg/mychart:latest"
+  - name: COMMIT_SHA
+    value: "abc123"
+  - name: SOURCE_ARTIFACT
+    value: "oci://quay.io/myorg/source:abc123"
+  - name: IMAGE_MAPPINGS
+    value: |
+      [
+        {
+          "source": "localhost/myapp",
+          "target": "quay.io/myorg/myapp:on-pr-{{revision}}"
+        },
+        {
+          "source": "localhost/sidecar",
+          "target": "quay.io/myorg/sidecar:on-pr-{{revision}}"
+        }
+      ]
+```
+
+### With Custom Values Files
+
+```yaml
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: build-helm-chart-oci-ta-with-custom-values
+spec:
+  taskRef:
+    name: build-helm-chart-oci-ta
+  params:
+  - name: IMAGE
+    value: "quay.io/myorg/mychart:latest"
+  - name: COMMIT_SHA
+    value: "abc123"
+  - name: SOURCE_ARTIFACT
+    value: "oci://quay.io/myorg/source:abc123"
+  - name: VALUES_FILES
+    value:
+      - "values.yaml"
+      - "values-prod.yaml"
+      - "values-dev.yaml"
+  - name: IMAGE_MAPPINGS
+    value: |
+      [
+        {
+          "source": "localhost/myapp",
+          "target": "quay.io/myorg/myapp:on-pr-{{revision}}"
+        }
+      ]
+```
+
+### Chart Template and Values Example
+
+**Before substitution:**
+
+`templates/deployment.yaml`:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: localhost/myapp
+      - name: sidecar
+        image: localhost/sidecar
+```
+
+`values.yaml`:
+
+```yaml
+image:
+  repository: localhost/myapp
+  pullPolicy: IfNotPresent
+  tag: ""
+
+sidecar:
+  image:
+    repository: localhost/sidecar
+    pullPolicy: IfNotPresent
+    tag: ""
+```
+
+**After substitution** (assuming VERSION_SUFFIX="v1.2.3" and COMMIT_SHA="abc123"):
+
+`templates/deployment.yaml`:
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: myapp
+spec:
+  template:
+    spec:
+      containers:
+      - name: app
+        image: "quay.io/myorg/myapp:on-pr-eae88d147b23236dd3007ddfbf669356edf0028a"
+      - name: sidecar
+        image: "quay.io/myorg/sidecar:on-pr-eae88d147b23236dd3007ddfbf669356edf0028a"
+```
+
+`values.yaml`:
+```yaml
+image:
+  repository: "quay.io/myorg/myapp"
+  pullPolicy: IfNotPresent
+  tag: "on-pr-eae88d147b23236dd3007ddfbf669356edf0028a"
+
+sidecar:
+  image:
+    repository: "quay.io/myorg/sidecar"
+    pullPolicy: IfNotPresent
+    tag: "on-pr-eae88d147b23236dd3007ddfbf669356edf0028a"
+```
+
+## Version Calculation
+
+The task calculates chart versions based on git tags:
+
+1. **Tagged Version**: If a tag like `helm-1.2` exists, version becomes `1.2.0+<sha>`
+2. **Distance from Tag**: If commits exist after tag, version becomes `1.2.<distance>+<sha>`
+3. **Fallback**: If no matching tag exists, version becomes `0.1.<commit-count>+<sha>`
+
+## Requirements
+
+- Git repository with tags (for version calculation)
+- Helm chart in the specified directory
+- Access to the target OCI registry
+- `yq` and `jq` tools (included in the container image)
+- Trusted artifacts setup for source code access
+
+## Notes
+
+- Image substitution affects files in the `templates/` directory and all specified
+  values files
+- The task preserves YAML formatting and quotes target images consistently
+- Source images are matched exactly (no partial matching)
+- The task is idempotent - running it multiple times with the same mappings is safe

--- a/task/build-helm-chart-oci-ta/0.4/build-helm-chart-oci-ta.yaml
+++ b/task/build-helm-chart-oci-ta/0.4/build-helm-chart-oci-ta.yaml
@@ -1,0 +1,383 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: build-helm-chart-oci-ta
+  labels:
+    app.kubernetes.io/version: "0.4.0"
+spec:
+  description: |-
+    The task packages and pushes a Helm chart to an OCI repository.
+    As Helm charts require to have a semver-compatible version to be packaged, the
+    task relies on git tags in order to determine the chart version during runtime.
+
+    The task computes the version based on the git commit SHA distance from the latest
+    tag prefixed with the value of TAG_PREFIX. The value of that tag will be used as
+    the version's X.Y values, and the Z value will be computed by the commit's distance
+    from the tag, followed by an abbreviated SHA as build metadata.
+    If the CHART_VERSION parameter is provided, that value is used as-is and version calculation is skipped.
+
+    The task also supports image substitution in the chart templates. Use the IMAGE_MAPPINGS
+    parameter to specify source images to be replaced with target images and tags.
+
+    Version 0.2 includes improved digest extraction from skopeo copy operations.
+  params:
+    - name: CA_TRUST_CONFIG_MAP_KEY
+      description: The name of the key in the ConfigMap that contains the
+        CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: CA_TRUST_CONFIG_MAP_NAME
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+    - name: CHART_CONTEXT
+      description: Path relative to SOURCE_CODE_DIR where the chart is located
+      default: dist/chart/
+    - name: COMMIT_SHA
+      description: Git commit sha to build chart for
+    - name: IMAGE_MAPPINGS
+      description: |-
+        JSON array of image mappings to substitute in chart templates.
+        Format: [{"source": "localhost/my/repo", "target": "quay.io/myorg/myapp"}]
+        Source images will be replaced with target images in all YAML files in templates/.
+        The task automatically appends the tag format: VERSION_SUFFIX-COMMIT_SHA (or just COMMIT_SHA if VERSION_SUFFIX is empty).
+      default: "[]"
+    - name: IMAGE
+      description: Full image reference with tag (e.g., quay.io/redhat-user-workloads/konflux-vanguard-tenant/caching/squid:on-pr-{{revision}})
+    - name: SOURCE_ARTIFACT
+      description: The Trusted Artifact URI pointing to the artifact with
+        the application source code.
+      type: string
+    - name: SOURCE_CODE_DIR
+      description: Path relative to the workingDir where the code was pulled
+        into
+      default: source
+    - name: TAG_PREFIX
+      description: An identifying prefix on which the version tag is to be
+        matched
+      default: helm-
+    - name: VALUES_FILES
+      description: Array of values file names to process for image substitution
+        (e.g., ["values.yaml", "values-prod.yaml", "values-dev.yaml"])
+      type: array
+      default:
+        - values.yaml
+    - name: VERSION_SUFFIX
+      description: A suffix to be added to the version string
+      default: ""
+    - name: CHART_VERSION
+      description: >-
+        Optional chart version string. When set, this value is used directly
+        instead of computing a version from git metadata.
+      type: string
+      default: ""
+    - name: APP_VERSION
+      description: >-
+        Optional appVersion override. When set, this value is used directly
+        instead of defaulting to COMMIT_SHA.
+      type: string
+      default: ""
+  results:
+    - name: IMAGE_DIGEST
+      description: Digest of the OCI-Artifact just built
+    - name: IMAGE_URL
+      description: OCI-Artifact repository and tag where the built OCI-Artifact
+        was pushed
+  volumes:
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.CA_TRUST_CONFIG_MAP_KEY)
+            path: ca-bundle.crt
+        name: $(params.CA_TRUST_CONFIG_MAP_NAME)
+        optional: true
+    - name: workdir
+      emptyDir: {}
+  stepTemplate:
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:9b180776a41d9a22a1c51539f1647c60defbbd55b44bbebdd4130e33512d8b0d
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      volumeMounts:
+        - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+          name: trusted-ca
+          readOnly: true
+          subPath: ca-bundle.crt
+      resources:
+        limits:
+          memory: 64Mi
+        requests:
+          cpu: 50m
+          memory: 64Mi
+    - name: package-and-push
+      image: quay.io/konflux-ci/tools@sha256:2112b51ba80d1041c120c32b67b871d371fde4e5775b32a3c7bf01a2f9ec0964
+      workingDir: /var/workdir
+      env:
+        - name: IMAGE
+          value: $(params.IMAGE)
+        - name: COMMIT_SHA
+          value: $(params.COMMIT_SHA)
+        - name: SOURCE_CODE_DIR
+          value: $(params.SOURCE_CODE_DIR)
+        - name: CHART_CONTEXT
+          value: $(params.CHART_CONTEXT)
+        - name: VERSION_SUFFIX
+          value: $(params.VERSION_SUFFIX)
+        - name: TAG_PREFIX
+          value: $(params.TAG_PREFIX)
+        - name: IMAGE_MAPPINGS
+          value: $(params.IMAGE_MAPPINGS)
+        - name: CHART_VERSION
+          value: $(params.CHART_VERSION)
+        - name: APP_VERSION
+          value: $(params.APP_VERSION)
+      resources:
+        limits:
+          memory: 256Mi
+        requests:
+          cpu: 50m
+          memory: 256Mi
+      args:
+        - "$(params.VALUES_FILES[*])"
+      script: |
+        #!/bin/bash
+        set -ex
+
+        # The values files are passed as arguments
+        VALUES_FILES_ARGS="$*"
+
+        cd "$SOURCE_CODE_DIR"/"$CHART_CONTEXT"
+
+        # Extract repo from IMAGE (remove tag part)
+        REPO="${IMAGE%:*}"
+
+        # Rename the chart according to the output registry
+        export chart_name="${REPO##*/}"
+        yq -i '.name = strenv(chart_name)' Chart.yaml
+
+        # Process image mappings if provided
+        if [ "$IMAGE_MAPPINGS" != "[]" ]; then
+          echo "Processing image mappings..."
+
+          # Parse the JSON array and perform substitutions
+          # Sort by source image length (longest first) to avoid partial matches
+          # Use bash string length and sort to process longer images first
+          echo "$IMAGE_MAPPINGS" | jq -c '.[]' | while read -r mapping; do
+            source_image=$(echo "$mapping" | jq -r '.source')
+            echo "${#source_image}:$mapping"
+          done | sort -t: -k1,1nr | cut -d: -f2- | while read -r mapping; do
+            source_image=$(echo "$mapping" | jq -r '.source')
+            target_image=$(echo "$mapping" | jq -r '.target')
+
+            echo "Replacing '$source_image' with '$target_image' in templates and values files..."
+
+            # Find all YAML files in templates directory and substitute images
+            if [ -d "templates" ]; then
+              find templates -name "*.yaml" -o -name "*.yml" | while read -r template_file; do
+                sed -i -re "s|image: *[\"']?${source_image}[\"']?|image: \"${target_image}\"|g" "$template_file"
+              done
+            fi
+
+            # Process the specified values files if they exist
+            # Use arguments passed to the script
+            for values_file in $VALUES_FILES_ARGS; do
+
+              if [ -f "$values_file" ]; then
+                echo "Processing $values_file..."
+
+                # Extract repository and tag from target_image using bash syntax
+                if [[ "$target_image" == *:* ]]; then
+                  # Image has a tag
+                  target_repo="${target_image%:*}"
+                  target_tag="${target_image#*:}"
+                else
+                  # Image has no tag, default to latest
+                  target_repo="$target_image"
+                  target_tag="latest"
+                fi
+
+                # Extract repository and tag from source_image for comparison
+                if [[ "$source_image" == *:* ]]; then
+                  # Image has a tag
+                  source_repo="${source_image%:*}"
+                  source_tag="${source_image#*:}"
+                else
+                  # Image has no tag, default to latest
+                  source_repo="$source_image"
+                  source_tag="latest"
+                fi
+
+                # Use yq to replace simple image fields (not repository/tag pairs)
+                # Find all image fields that match the source_image exactly and replace with target_image
+                # Handle nested image fields at any level in the YAML structure, including arrays
+                yq -i "
+                  with(.. | select(type == \"!!map\" and has(\"image\") and .image == \"$source_image\");
+                    .image = \"$target_image\"
+                  )
+                " "$values_file"
+
+                # Use yq to properly handle YAML structure with repository/tag pairs
+                # Find all image objects that have repository/tag fields matching source_image
+                # Handle nested image structures at any level in the YAML, including arrays
+                yq -i "
+                  with(.. | select(type == \"!!map\" and has(\"image\") and .image.repository? == \"$source_repo\" and (.image.tag? // \"latest\") == \"$source_tag\");
+                    .image.repository = \"$target_repo\" |
+                    .image.tag = \"$target_tag\"
+                  )
+                " "$values_file"
+              else
+                echo "Warning: Values file '$values_file' not found, skipping..."
+              fi
+            done
+          done
+
+          echo "Image substitution completed."
+        fi
+
+        # Create a chart version
+        # Priority order:
+        # 1. CHART_VERSION parameter if provided (full override)
+        # 2. Chart.yaml version field + timestamp (respects user input, ensures uniqueness)
+        # 3. Git-based calculation (fallback for repos without Chart.yaml version)
+        if [ -n "$CHART_VERSION" ]; then
+          echo "Using provided chart version: $CHART_VERSION"
+          chart_version="$CHART_VERSION"
+        elif [ -f "Chart.yaml" ] && yq -e '.version' Chart.yaml >/dev/null 2>&1; then
+          base_version=$(yq -r '.version' Chart.yaml)
+          timestamp=$(date +%s)
+          chart_version="${base_version}-${timestamp}"
+          echo "Using Chart.yaml version (${base_version}) with timestamp: ${chart_version}"
+        else
+          # We need git tags and history to be able to compute the chart version
+          git fetch --unshallow --tags origin "$COMMIT_SHA"
+
+          # Create a semver compliant chart version:
+          # We assume the existence of a git tag of the format "${TAG_PREFIX}X.Y"
+          # Suppose that TAG_PREFIX=helm- and the tag is helm-1.2,
+          # `git describe --tags` will return helm-1.2-z-W (if the tag is not on the
+          # current commit) where z is the number of commits since the appearance of
+          # the matching tag and W is an abbreviated SHA.
+          # The command below will convert that output to be semver-compatible: 1.2.z+W
+          chart_version=$(
+            git describe --tags --match="${TAG_PREFIX}*" |
+              sed -e "s/^${TAG_PREFIX}//" |
+              sed -e "0,/-/s//\./" |
+              sed -e "0,/-/s//+/"
+          )
+
+          # If the tag is on the current commit, the command will just return the
+          # tagged version (e.g. 1.2). In that case, we'll set z to be 0: 1.2.0+<abbrev sha>
+          if [[ "$chart_version" =~ ^[^.]*\.[^.]*$ ]]; then
+            chart_version=$chart_version.0+$(git rev-parse --short HEAD)
+          fi
+
+          # If such tag does not exist, 0.1 will be used and z will be the commits count
+          # on the current branch since the dawn of time: 0.1.z+<abbrev sha>
+          if [ -z "${chart_version}" ]; then
+            chart_version=0.1.$(git rev-list HEAD --count)+$(git rev-parse --short HEAD)
+          fi
+
+          chart_version="$chart_version$VERSION_SUFFIX"
+        fi
+
+        # Build Helm dependencies if Chart.yaml has dependencies
+        if [ -f "Chart.yaml" ] && yq -e '.dependencies' Chart.yaml >/dev/null 2>&1; then
+          echo "Building Helm dependencies from Chart.lock..."
+
+          # Add required repositories from Chart.yaml dependencies
+          http_repo_used=false
+          while read -r repo_url; do
+            if [ -n "$repo_url" ]; then
+              proto=$(echo "$repo_url" | cut -d: -f1)
+              if [ "$proto" = "oci" ] || [ "$proto" = "file" ]; then
+                echo "Skipping adding helm repository for $proto dependency: $repo_url"
+              else
+                http_repo_used=true
+                repo_name=$(echo "$repo_url" | sed 's|https://||' | sed 's|http://||' | sed 's|/.*$||' | sed 's|\.|_|g')
+                echo "Adding repository: $repo_name ($repo_url)"
+                helm repo add "$repo_name" "$repo_url" || true
+              fi
+            fi
+          done < <(yq -r '.dependencies[].repository' Chart.yaml | sort -u)
+
+          # Update repository index
+          if [ "$http_repo_used" = "true" ]; then
+            helm repo update
+          fi
+
+          # Build dependencies
+          helm dependency build .
+        fi
+
+        # Determine appVersion
+        if [ -n "$APP_VERSION" ]; then
+          echo "Using provided appVersion: $APP_VERSION"
+          app_version="$APP_VERSION"
+        else
+          app_version="$COMMIT_SHA"
+        fi
+
+        helm package . --version "$chart_version" --app-version "$app_version"
+
+        # Helm (ORAS) doesn't do a good job with selecting the correct auth, so
+        # need to provide it with just one option
+        jq --arg registry "$REPO" '.auths[$registry]' ~/.docker/config.json |
+          jq -n --arg registry "$REPO" '{auths:{($registry):inputs}}' \
+            >scoped_authfile.json
+
+        dest="oci://${REPO%/*}"
+
+        echo "Pushing image to registry"
+        echo "Pushing file: $chart_name-$chart_version.tgz"
+        echo "Destination: $dest"
+        if ! output="$(retry helm push "$chart_name"-"$chart_version".tgz "$dest" \
+          --registry-config ./scoped_authfile.json 2>&1)"; then
+          echo "Failed to push image to registry"
+          echo "Output: $output"
+          exit 1
+        fi
+        echo "Push command completed successfully"
+        echo "Push output: $output"
+
+        # Construct the pushed URL and digest from known values
+        # Since we know exactly what was pushed, we can construct the URL
+        # Helm automatically replaces + with _ when pushing to OCI registries
+        docker_tag="${chart_version//+/_}"
+        pushed="${REPO}:${docker_tag}"
+        echo "Constructed pushed URL: $pushed"
+
+        # Tag the pushed chart with the full IMAGE reference using Skopeo
+        echo "Tagging chart with additional tag: $IMAGE"
+        if ! skopeo_output="$(skopeo copy --src-tls-verify=false --dest-tls-verify=false \
+          "docker://$pushed" "docker://$IMAGE" 2>&1)"; then
+          echo "Failed to tag chart with $IMAGE"
+          echo "Source: docker://$pushed"
+          echo "Destination: docker://$IMAGE"
+          echo "Skopeo output: $skopeo_output"
+          exit 1
+        fi
+
+        # Get the manifest digest of the pushed chart
+        # The manifest digest is the SHA256 of the entire manifest JSON
+        if ! manifest_digest=$(skopeo inspect --raw "docker://$pushed" | sha256sum | awk '{print "sha256:" $1}' 2>/dev/null); then
+          echo "Could not retrieve manifest digest from pushed image"
+          echo "This does not affect the main functionality"
+          digest=""
+        else
+          echo "Successfully retrieved manifest digest: $manifest_digest"
+          digest="$manifest_digest"
+        fi
+
+        # Set IMAGE_URL result to the URL with sanitized semver tag (what was actually pushed)
+        semver_url="${REPO}:${docker_tag}"
+        echo -n "$semver_url" | tee "$(results.IMAGE_URL.path)"
+        echo -n "$digest" | tee "$(results.IMAGE_DIGEST.path)"
+      securityContext:
+        runAsUser: 0

--- a/task/build-helm-chart-oci-ta/CHANGELOG.md
+++ b/task/build-helm-chart-oci-ta/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Changelog
 
+## 0.4.0
+
+### Changed
+
+**BREAKING CHANGE**: Respect the version field in Chart.yaml when present.
+
+The task now prioritizes version sources in this order:
+1. CHART_VERSION parameter (full override)
+2. Chart.yaml version field with timestamp as pre-release identifier (NEW)
+3. Git-based calculation (fallback for repos without Chart.yaml version)
+
+This ensures each build has a unique, semantically ordered version while
+respecting user input. The timestamp prevents race conditions from concurrent
+builds with the same Chart.yaml version, and enables dynamic tagging via
+`{{ oci_version }}` in ReleasePlanAdmissions.
+
+**Migration Required**: Users who currently have placeholder versions in
+Chart.yaml (e.g., `version: 0.1.0`) that rely on git-based calculation must
+REMOVE the version field from Chart.yaml to continue using git-based versioning.
+Alternatively, set the version field to your actual product version to use the
+new timestamp-based versioning.
+
+Example: Chart.yaml `version: 1.0.0` becomes `1.0.0-1724684400` in the built
+chart, which Helm stores in the `org.opencontainers.image.version` annotation.
+
 ## 0.3.1
 
 ### Fixed


### PR DESCRIPTION
BREAKING CHANGE: The task now respects the version field in Chart.yaml when present, appending a timestamp as a pre-release identifier to ensure uniqueness.

Version priority order:
1. CHART_VERSION parameter (full override)
2. Chart.yaml version field with timestamp (NEW)
3. Git-based calculation (fallback)

This prevents race conditions from concurrent builds with the same Chart.yaml version and enables dynamic tagging via {{ oci_version }} in ReleasePlanAdmissions.

Migration required: Users with placeholder versions in Chart.yaml (e.g., version: 0.1.0) that rely on git-based calculation must remove the version field from Chart.yaml or update it to their actual product version.

Example: Chart.yaml version 1.0.0 becomes 1.0.0-1724684400, which Helm stores in org.opencontainers.image.version annotation.

Related: [KONFLUX-15549](https://redhat.atlassian.net/browse/KONFLUX-15549)

Assisted-by: Claude



[KONFLUX-15549]: https://redhat.atlassian.net/browse/KONFLUX-15549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ