### PR TITLE
tkn-bundle: don't require version label for non-Tasks

### DIFF
--- a/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
+++ b/task/tkn-bundle-oci-ta/0.2/tkn-bundle-oci-ta.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: image-build, konflux
   labels:
-    app.kubernetes.io/version: 0.2.4
+    app.kubernetes.io/version: 0.2.5
     build.appstudio.redhat.com/build_type: tkn-bundle
 spec:
   description: Creates and pushes a Tekton bundle containing the specified
@@ -283,7 +283,7 @@ spec:
 
         actual_task_version=$(get_actual_task_version "${FILES[0]}")
 
-        if [[ -z "$actual_task_version" ]]; then
+        if [[ "$(yq .kind "${FILES[0]}")" == Task && -z "$actual_task_version" ]]; then
           printf "Label %s is not set in task file %s\n" "$LABEL_ACTUAL_TASK_VERSION" "${FILES[0]}" >&2
           exit 1
         fi
@@ -292,7 +292,7 @@ spec:
         migration_image_digest=
         migration_image_tag=
         migration_file_path="${task_dir}/migrations/${actual_task_version}.sh"
-        if [[ -f "$migration_file_path" ]]; then
+        if [[ -n "$actual_task_version" && -f "$migration_file_path" ]]; then
           sha256_checksum=$(sha256sum "$migration_file_path" | cut -d' ' -f1)
           # Migration image tag is in form: migration-<actual task version>-<sha256sum>-<timestamp>
           image_repo=${IMAGE%:*}      # remove tag
@@ -342,7 +342,10 @@ spec:
         ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
         ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
         ANNOTATIONS+=("org.opencontainers.image.url=${URL}/tree/${REVISION}/${CONTEXT}")
-        ANNOTATIONS+=("org.opencontainers.image.version=${actual_task_version}")
+
+        if [[ -n "$actual_task_version" ]]; then
+          ANNOTATIONS+=("org.opencontainers.image.version=${actual_task_version}")
+        fi
 
         if [ -f "${task_dir}/README.md" ]; then
           ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")

--- a/task/tkn-bundle-oci-ta/CHANGELOG.md
+++ b/task/tkn-bundle-oci-ta/CHANGELOG.md
@@ -9,6 +9,14 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
+## 0.2.5
+
+### Changed
+
+- No longer requires the `app.kubernetes.io/version` label if the input file
+  doesn't have `kind: Task`. This allows the tkn-bundle task to build `Pipeline`
+  bundles (pipeline files do not tend to have a version label).
+
 ## 0.2.4
 
 ### Removed

--- a/task/tkn-bundle/0.2/tkn-bundle.yaml
+++ b/task/tkn-bundle/0.2/tkn-bundle.yaml
@@ -2,7 +2,7 @@ apiVersion: tekton.dev/v1
 kind: Task
 metadata:
   labels:
-    app.kubernetes.io/version: "0.2.4"
+    app.kubernetes.io/version: "0.2.5"
     build.appstudio.redhat.com/build_type: "tkn-bundle"
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
@@ -272,7 +272,7 @@ spec:
 
       actual_task_version=$(get_actual_task_version "${FILES[0]}")
 
-      if [[ -z "$actual_task_version" ]]; then
+      if [[ "$(yq .kind "${FILES[0]}")" == Task && -z "$actual_task_version" ]]; then
         printf "Label %s is not set in task file %s\n" "$LABEL_ACTUAL_TASK_VERSION" "${FILES[0]}" >&2
         exit 1
       fi
@@ -281,7 +281,7 @@ spec:
       migration_image_digest=
       migration_image_tag=
       migration_file_path="${task_dir}/migrations/${actual_task_version}.sh"
-      if [[ -f "$migration_file_path" ]]; then
+      if [[ -n "$actual_task_version" && -f "$migration_file_path" ]]; then
         sha256_checksum=$(sha256sum "$migration_file_path" | cut -d' ' -f1)
         # Migration image tag is in form: migration-<actual task version>-<sha256sum>-<timestamp>
         image_repo=${IMAGE%:*}  # remove tag
@@ -331,7 +331,10 @@ spec:
       ANNOTATIONS+=("org.opencontainers.image.source=${URL}")
       ANNOTATIONS+=("org.opencontainers.image.revision=${REVISION}")
       ANNOTATIONS+=("org.opencontainers.image.url=${URL}/tree/${REVISION}/${CONTEXT}")
-      ANNOTATIONS+=("org.opencontainers.image.version=${actual_task_version}")
+
+      if [[ -n "$actual_task_version" ]]; then
+        ANNOTATIONS+=("org.opencontainers.image.version=${actual_task_version}")
+      fi
 
       if [ -f "${task_dir}/README.md" ]; then
         ANNOTATIONS+=("org.opencontainers.image.documentation=${URL}/tree/${REVISION}/${CONTEXT}/README.md")

--- a/task/tkn-bundle/CHANGELOG.md
+++ b/task/tkn-bundle/CHANGELOG.md
@@ -9,6 +9,14 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
+## 0.2.5
+
+### Changed
+
+- No longer requires the `app.kubernetes.io/version` label if the input file
+  doesn't have `kind: Task`. This allows the tkn-bundle task to build `Pipeline`
+  bundles (pipeline files do not tend to have a version label).
+
 ## 0.2.4
 
 ### Removed


### PR DESCRIPTION
As part of the build-definitions decomissioning, we need to move pipeline files out and build them in Konflux. The pipeline most suitable for that is tekton-bundle-builder.

However, the tkn-bundle task currently assumes it's operating on a Task. Make the minimal changes to make tkn-bundle work with Pipelines.

Specifically, require the app.kubernetes.io/version label only for Tasks, and make the related behaviors conditional on the existence of the label.

---

Going forward, this task would deserve a rework to make it clearer that it can handle Tekton objects other than Tasks as well. But that's not the intended scope here.