### PR TITLE
feat: add extract-titled-layers-oci-ta for ModelCar SAST

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -126,7 +126,8 @@
 /task/oci-copy-oci-ta   @konflux-ci/secure-ai-sig @Allda @jedinym
 
 # renovate groupName=modelcar-oci
-/task/modelcar-oci-ta   @konflux-ci/secure-ai-sig @Allda @jedinym
+/task/modelcar-oci-ta                 @konflux-ci/secure-ai-sig @Allda @jedinym
+/task/extract-titled-layers-oci-ta    @konflux-ci/secure-ai-sig @Allda @jedinym
 
 # renovate groupName=buildpack
 /task/build-paketo-builder-oci-ta @cmoulliard @Allda @jedinym

--- a/renovate.json
+++ b/renovate.json
@@ -167,7 +167,8 @@
     {
       "groupName": "modelcar-oci",
       "matchFileNames": [
-        "task/modelcar-oci-ta/**"
+        "task/modelcar-oci-ta/**",
+        "task/extract-titled-layers-oci-ta/**"
       ]
     },
     {

--- a/task/extract-titled-layers-oci-ta/0.1/README.md
+++ b/task/extract-titled-layers-oci-ta/0.1/README.md
@@ -1,0 +1,36 @@
+# extract-titled-layers-oci-ta task
+
+Restore SOURCE_ARTIFACT, then fetch titled container-image layers matching
+EXTRA_ARTIFACT_FILTER from image-url@image-digest into that tree and emit a
+new SOURCE_ARTIFACT.
+
+Intended for ModelCar/olot images: untitled base-image layers and
+non-matching blobs (e.g. weights) are not pulled. Image indexes are
+resolved to linux/amd64. SAST tasks stay unchanged and just scan the
+resulting artifact.
+
+## Parameters
+|name|description|default value|required|
+|---|---|---|---|
+|SOURCE_ARTIFACT|Trusted Artifact URI of the git source to restore first.||true|
+|image-url|Container image repository (no digest).||true|
+|image-digest|Digest of the image or image index to extract from.||true|
+|EXTRA_ARTIFACT_FILTER|Extended regex matched against org.opencontainers.image.title.|(^|/)(Dockerfile|Containerfile|[^/]+\.(json|jinja|py|rb|pl|js|mjs|cjs|ts|ps1|sh|bash|zsh|ksh|md|yaml|yml|txt|model))$|false|
+|ociStorage|OCI repository where the output Trusted Artifact is stored.||true|
+|ociArtifactExpiresAfter|Expiration for the created trusted artifact. Empty means no expiry.|""|false|
+|caTrustConfigMapKey|The name of the key in the ConfigMap that contains the CA bundle data.|ca-bundle.crt|false|
+|caTrustConfigMapName|The name of the ConfigMap to read CA bundle data from.|trusted-ca|false|
+
+## Results
+|name|description|
+|---|---|
+|SOURCE_ARTIFACT|Trusted Artifact URI with git source plus extracted titled layers.|
+
+
+## Additional info
+
+Use this before `sast-snyk-check-oci-ta` in ModelCar pipelines so Snyk scans
+titled olot layers without growing the SAST Task YAML ([PSSECAUT-1601](https://redhat.atlassian.net/browse/PSSECAUT-1601)).
+Untitled layers and filter misses (weights) are not pulled.
+
+Pass the result `SOURCE_ARTIFACT` into Snyk instead of the git clone artifact.

--- a/task/extract-titled-layers-oci-ta/0.1/extract-titled-layers-oci-ta.yaml
+++ b/task/extract-titled-layers-oci-ta/0.1/extract-titled-layers-oci-ta.yaml
@@ -1,0 +1,179 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: extract-titled-layers-oci-ta
+  annotations:
+    tekton.dev/pipelines.minVersion: 0.12.1
+    tekton.dev/tags: image-build, konflux
+  labels:
+    app.kubernetes.io/version: "0.1"
+spec:
+  description: |-
+    Restore SOURCE_ARTIFACT, then fetch titled container-image layers matching
+    EXTRA_ARTIFACT_FILTER from image-url@image-digest into that tree and emit a
+    new SOURCE_ARTIFACT.
+
+    Intended for ModelCar/olot images: untitled base-image layers and
+    non-matching blobs (e.g. weights) are not pulled. Image indexes are
+    resolved to linux/amd64. SAST tasks stay unchanged and just scan the
+    resulting artifact.
+  params:
+    - name: SOURCE_ARTIFACT
+      description: Trusted Artifact URI of the git source to restore first.
+      type: string
+    - name: image-url
+      description: Container image repository (no digest).
+      type: string
+    - name: image-digest
+      description: Digest of the image or image index to extract from.
+      type: string
+    - name: EXTRA_ARTIFACT_FILTER
+      description: Extended regex matched against org.opencontainers.image.title.
+      type: string
+      default: '(^|/)(Dockerfile|Containerfile|[^/]+\.(json|jinja|py|rb|pl|js|mjs|cjs|ts|ps1|sh|bash|zsh|ksh|md|yaml|yml|txt|model))$'
+    - name: ociStorage
+      description: OCI repository where the output Trusted Artifact is stored.
+      type: string
+    - name: ociArtifactExpiresAfter
+      description: Expiration for the created trusted artifact. Empty means no expiry.
+      type: string
+      default: ""
+    - name: caTrustConfigMapKey
+      description: The name of the key in the ConfigMap that contains the CA bundle data.
+      type: string
+      default: ca-bundle.crt
+    - name: caTrustConfigMapName
+      description: The name of the ConfigMap to read CA bundle data from.
+      type: string
+      default: trusted-ca
+  results:
+    - name: SOURCE_ARTIFACT
+      description: Trusted Artifact URI with git source plus extracted titled layers.
+  volumes:
+    - name: workdir
+      emptyDir: {}
+    - name: trusted-ca
+      configMap:
+        items:
+          - key: $(params.caTrustConfigMapKey)
+            path: ca-bundle.crt
+        name: $(params.caTrustConfigMapName)
+        optional: true
+  stepTemplate:
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+      - mountPath: /var/workdir
+        name: workdir
+      - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+        name: trusted-ca
+        readOnly: true
+        subPath: ca-bundle.crt
+    env:
+      - name: CA_FILE
+        value: /etc/pki/tls/certs/ca-custom-bundle.crt
+  steps:
+    - name: use-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7b4f5bbf8b8aa663beaf18bfef4fd16ba1cb5ce846d1fc776a64b312c52ee28c
+      args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+      computeResources:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          memory: 512Mi
+    - name: extract-titled-layers
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7b4f5bbf8b8aa663beaf18bfef4fd16ba1cb5ce846d1fc776a64b312c52ee28c
+      workingDir: /var/workdir
+      env:
+        - name: IMAGE_URL
+          value: $(params.image-url)
+        - name: IMAGE_DIGEST
+          value: $(params.image-digest)
+        - name: EXTRA_ARTIFACT_FILTER
+          value: $(params.EXTRA_ARTIFACT_FILTER)
+      computeResources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          memory: 1Gi
+      script: |
+        #!/usr/bin/env bash
+        set -euo pipefail
+        SOURCE_ROOT=/var/workdir/source
+        mkdir -p "${SOURCE_ROOT}"
+
+        if [[ -z "${IMAGE_URL}" || -z "${IMAGE_DIGEST}" ]]; then
+          echo "INFO: image-url/image-digest missing, skipping titled-layer extract"
+          exit 0
+        fi
+
+        declare -a oras_opts=()
+        # shellcheck source=/dev/null
+        source /usr/local/bin/oras_opts.sh
+
+        authfile="$(mktemp)"
+        trap 'rm -f "${authfile}"' EXIT
+        /usr/local/bin/select-oci-auth.sh "${IMAGE_URL}" >"${authfile}"
+
+        retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" \
+          "${IMAGE_URL}@${IMAGE_DIGEST}" > /tmp/manifest.json
+
+        if jq -e '.manifests? | length > 0' /tmp/manifest.json >/dev/null; then
+          child="$(jq -r '
+            (.manifests // []) as $m
+            | ($m | map(select(.platform.architecture == "amd64" and ((.platform.os // "linux") == "linux"))) | .[0].digest)
+              // ($m[0].digest) // empty
+          ' /tmp/manifest.json)"
+          if [[ -z "${child}" || "${child}" == "null" ]]; then
+            echo "ERROR: image index has no manifests to resolve"
+            exit 1
+          fi
+          echo "INFO: Resolving image index to ${child}"
+          retry oras manifest fetch "${oras_opts[@]}" --registry-config "${authfile}" \
+            "${IMAGE_URL}@${child}" > /tmp/manifest.json
+        fi
+
+        fetched=0
+        while IFS=$'\t' read -r digest media_type title; do
+          [[ -n "${title}" ]] || continue
+          [[ "${title}" != *..* ]] || { echo "WARN: skipping ${title}"; continue; }
+          printf '%s\n' "${title}" | grep -Eq "${EXTRA_ARTIFACT_FILTER}" || continue
+
+          tmp="$(mktemp)"
+          echo "INFO: Fetching layer ${digest} (${title})"
+          retry oras blob fetch "${oras_opts[@]}" --registry-config "${authfile}" \
+            "${IMAGE_URL}@${digest}" --output "${tmp}"
+          if [[ "${media_type}" == *gzip* ]]; then
+            tar -xzf "${tmp}" -C "${SOURCE_ROOT}"
+          else
+            tar -xf "${tmp}" -C "${SOURCE_ROOT}"
+          fi
+          rm -f "${tmp}"
+          fetched=$((fetched + 1))
+        done < <(jq -r '
+          (.layers // [])[]
+          | [.digest, (.mediaType // ""), (.annotations["org.opencontainers.image.title"] // "")]
+          | @tsv
+        ' /tmp/manifest.json)
+
+        echo "INFO: Extracted ${fetched} titled layer(s) into SOURCE_ARTIFACT"
+    - name: create-trusted-artifact
+      image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7b4f5bbf8b8aa663beaf18bfef4fd16ba1cb5ce846d1fc776a64b312c52ee28c
+      args:
+        - create
+        - --store
+        - $(params.ociStorage)
+        - $(results.SOURCE_ARTIFACT.path)=/var/workdir/source
+      env:
+        - name: IMAGE_EXPIRES_AFTER
+          value: $(params.ociArtifactExpiresAfter)
+      computeResources:
+        requests:
+          cpu: 50m
+          memory: 256Mi
+        limits:
+          memory: 1Gi

--- a/task/extract-titled-layers-oci-ta/0.1/tests/pre-apply-task-hook.sh
+++ b/task/extract-titled-layers-oci-ta/0.1/tests/pre-apply-task-hook.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# Kind registry TLS is not reliably trusted via the mounted trusted-ca bundle
+# under deploy-local CI. Opt the task into insecure registry mode for tests only.
+TASK_COPY="$1"
+
+yq -i '
+  .spec.stepTemplate.env = (.spec.stepTemplate.env // []) + [
+    {"name": "ORAS_OPTIONS", "value": "--insecure"}
+  ]
+' "$TASK_COPY"
+
+echo "Pre-requirements setup complete"

--- a/task/extract-titled-layers-oci-ta/0.1/tests/test-extract-titled-layers-oci-ta.yaml
+++ b/task/extract-titled-layers-oci-ta/0.1/tests/test-extract-titled-layers-oci-ta.yaml
@@ -1,0 +1,190 @@
+---
+apiVersion: tekton.dev/v1
+kind: Pipeline
+metadata:
+  name: test-extract-titled-layers-oci-ta
+spec:
+  description: |
+    Push a fake ModelCar-style image (titled tar layers), run extract-titled-layers-oci-ta,
+    and check matching files land in the output artifact while weights do not.
+  workspaces:
+    - name: tests-workspace
+  tasks:
+    - name: mock-inputs
+      params:
+        - name: ociStorage
+          value: registry-service.kind-registry/extract-titled-layers:source
+        - name: image
+          value: registry-service.kind-registry/extract-titled-layers:image
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+      taskSpec:
+        results:
+          - name: SOURCE_ARTIFACT
+            type: string
+          - name: IMAGE_URL
+            type: string
+          - name: IMAGE_DIGEST
+            type: string
+        workspaces:
+          - name: tests-workspace
+        volumes:
+          - name: trusted-ca
+            configMap:
+              items:
+                - key: $(params.caTrustConfigMapKey)
+                  path: ca-bundle.crt
+              name: $(params.caTrustConfigMapName)
+        params:
+          - name: ociStorage
+          - name: image
+        stepTemplate:
+          volumeMounts:
+            - name: trusted-ca
+              mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+              subPath: ca-bundle.crt
+              readOnly: true
+        steps:
+          - name: mock-source-and-image
+            image: quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35
+            workingDir: $(workspaces.tests-workspace.path)
+            env:
+              - name: IMAGE
+                value: $(params.image)
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              mkdir -p source layers/keep/models layers/skip/models
+              echo "from git" > source/README.md
+              echo '{"ok":true}' > layers/keep/models/config.json
+              echo 'WEIGHTS' > layers/skip/models/model.safetensors
+
+              tar -cf /tmp/keep.tar -C layers/keep models/config.json
+              tar -cf /tmp/skip.tar -C layers/skip models/model.safetensors
+              printf '{"architecture":"amd64","os":"linux","rootfs":{"type":"layers","diff_ids":[]}}' > /tmp/config.json
+
+              push_blob() {
+                local file="$1"
+                oras blob push --insecure --no-tty --descriptor "${IMAGE}" "${file}" | jq -r .digest
+              }
+              keep_digest="$(push_blob /tmp/keep.tar)"
+              skip_digest="$(push_blob /tmp/skip.tar)"
+              config_digest="$(push_blob /tmp/config.json)"
+              keep_size="$(wc -c < /tmp/keep.tar | tr -d ' ')"
+              skip_size="$(wc -c < /tmp/skip.tar | tr -d ' ')"
+              config_size="$(wc -c < /tmp/config.json | tr -d ' ')"
+
+              cat > /tmp/manifest.json <<EOF
+              {
+                "schemaVersion": 2,
+                "mediaType": "application/vnd.oci.image.manifest.v1+json",
+                "config": {
+                  "mediaType": "application/vnd.oci.image.config.v1+json",
+                  "digest": "${config_digest}",
+                  "size": ${config_size}
+                },
+                "layers": [
+                  {
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                    "digest": "${keep_digest}",
+                    "size": ${keep_size},
+                    "annotations": {"org.opencontainers.image.title": "models/config.json"}
+                  },
+                  {
+                    "mediaType": "application/vnd.oci.image.layer.v1.tar",
+                    "digest": "${skip_digest}",
+                    "size": ${skip_size},
+                    "annotations": {"org.opencontainers.image.title": "models/model.safetensors"}
+                  }
+                ]
+              }
+              EOF
+              digest="$(oras manifest push --insecure --no-tty --descriptor "${IMAGE}" /tmp/manifest.json | jq -r .digest)"
+              echo -n "${IMAGE%:*}" > "$(results.IMAGE_URL.path)"
+              echo -n "${digest}" > "$(results.IMAGE_DIGEST.path)"
+          - name: create-trusted-artifact
+            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7b4f5bbf8b8aa663beaf18bfef4fd16ba1cb5ce846d1fc776a64b312c52ee28c
+            env:
+              - name: ORAS_OPTIONS
+                value: --insecure
+              - name: CA_FILE
+                value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            args:
+              - create
+              - --store
+              - $(params.ociStorage)
+              - $(results.SOURCE_ARTIFACT.path)=$(workspaces.tests-workspace.path)/source
+    - name: run-extract
+      runAfter:
+        - mock-inputs
+      taskRef:
+        name: extract-titled-layers-oci-ta
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.mock-inputs.results.SOURCE_ARTIFACT)
+        - name: image-url
+          value: $(tasks.mock-inputs.results.IMAGE_URL)
+        - name: image-digest
+          value: $(tasks.mock-inputs.results.IMAGE_DIGEST)
+        - name: ociStorage
+          value: registry-service.kind-registry/extract-titled-layers:out
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+    - name: verify
+      runAfter:
+        - run-extract
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.run-extract.results.SOURCE_ARTIFACT)
+        - name: caTrustConfigMapName
+          value: trusted-ca
+        - name: caTrustConfigMapKey
+          value: ca-bundle.crt
+      taskSpec:
+        params:
+          - name: SOURCE_ARTIFACT
+        volumes:
+          - name: workdir
+            emptyDir: {}
+          - name: trusted-ca
+            configMap:
+              items:
+                - key: $(params.caTrustConfigMapKey)
+                  path: ca-bundle.crt
+              name: $(params.caTrustConfigMapName)
+        stepTemplate:
+          volumeMounts:
+            - mountPath: /var/workdir
+              name: workdir
+            - mountPath: /etc/pki/tls/certs/ca-custom-bundle.crt
+              name: trusted-ca
+              readOnly: true
+              subPath: ca-bundle.crt
+        steps:
+          - name: use-trusted-artifact
+            image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:7b4f5bbf8b8aa663beaf18bfef4fd16ba1cb5ce846d1fc776a64b312c52ee28c
+            env:
+              - name: ORAS_OPTIONS
+                value: --insecure
+              - name: CA_FILE
+                value: /etc/pki/tls/certs/ca-custom-bundle.crt
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+          - name: check-files
+            image: quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+              test -f /var/workdir/source/README.md
+              test -f /var/workdir/source/models/config.json
+              if [[ -e /var/workdir/source/models/model.safetensors ]]; then
+                echo "weights must not be extracted" >&2
+                exit 1
+              fi
+              echo "ok"

--- a/task/extract-titled-layers-oci-ta/CHANGELOG.md
+++ b/task/extract-titled-layers-oci-ta/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1
+
+### Added
+
+- New task: restore git `SOURCE_ARTIFACT`, fetch matching titled container-image
+  layers (ModelCar/olot) into that tree, and emit a new `SOURCE_ARTIFACT` for
+  SAST to scan. Untitled layers and filter misses (e.g. weights) are skipped.
+  Image indexes resolve to linux/amd64.


### PR DESCRIPTION
## Summary
- New catalog task `extract-titled-layers-oci-ta`: restore git `SOURCE_ARTIFACT`, fetch titled ModelCar/olot layers matching `EXTRA_ARTIFACT_FILTER` (skip untitled layers and weights), emit a new `SOURCE_ARTIFACT`.
- Lets ModelCar pipelines feed those files to stock `sast-snyk-check-oci-ta` instead of growing SAST Task YAML ([PSSECAUT-1601](https://redhat.atlassian.net/browse/PSSECAUT-1601), alternative to [konflux-sast-tasks#161](https://github.com/konflux-ci/konflux-sast-tasks/pull/161)).

## Test plan
- [ ] `task/extract-titled-layers-oci-ta/0.1/tests/test-extract-titled-layers-oci-ta.yaml` in task CI
- [ ] After catalog publish, ModelCar pipeline switches Snyk `SOURCE_ARTIFACT` to this task's result


Made with [Cursor](https://cursor.com)

[PSSECAUT-1601]: https://redhat.atlassian.net/browse/PSSECAUT-1601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ