### PR TITLE
Deprecate build-maven-zip tasks

### DIFF
--- a/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
+++ b/task/build-maven-zip-oci-ta/0.1/build-maven-zip-oci-ta.yaml
@@ -4,6 +4,9 @@ kind: Task
 metadata:
   name: build-maven-zip-oci-ta
   annotations:
+    build.appstudio.redhat.com/expires-on: "2026-10-10T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: The build-maven-zip task (and
+      the pipeline that uses it) is discontinued.
     tekton.dev/pipelines.minVersion: 0.12.1
     tekton.dev/tags: maven-build, konflux
   labels:

--- a/task/build-maven-zip/0.1/build-maven-zip.yaml
+++ b/task/build-maven-zip/0.1/build-maven-zip.yaml
@@ -5,6 +5,9 @@ metadata:
   annotations:
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "maven-build, konflux"
+    build.appstudio.redhat.com/expires-on: "2026-10-10T00:00:00Z"
+    build.appstudio.redhat.com/expiry-message: >-
+      The build-maven-zip task (and the pipeline that uses it) is discontinued.
   labels:
     app.kubernetes.io/version: "0.1"
     build.appstudio.redhat.com/build_type: "maven-zip"


### PR DESCRIPTION
These tasks have no maintainers. The original maintainers were removed from Red Hat and the tasks have been orphaned since then.

We found no evidence that the tasks have ever been used for production purposes. Deprecate them.
