### PR TITLE
Set expires-on annotation on update-infra-deployments task

### DIFF
--- a/task/update-infra-deployments/0.1/update-infra-deployments.yaml
+++ b/task/update-infra-deployments/0.1/update-infra-deployments.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/version: "0.1"
   annotations:
+    build.appstudio.redhat.com/expires-on: "2026-09-12T00:00:00Z"
     tekton.dev/pipelines.minVersion: "0.12.1"
     tekton.dev/tags: "konflux"
   name: update-infra-deployments


### PR DESCRIPTION
This task is not used anywhere anymore. The last usage was in the `core-services` pipeline that was deleted in
c70647eef6067b2ffa00a613e52c673c472bced8.

The original cleanup and investigation has been done as part of: https://redhat.atlassian.net/browse/STONEBLD-4928

The expires-on annotation is set on Saturday. It will be deleted afterwards.

# Before you complete this pull request ...

Look for any open pull requests in the repository with the title "e2e-tests update" and 
see if there are recent e2e-tests updates that will be applicable to your change.
