### PR TITLE
build-vm-image: populate artifact manifest config with architecture/os

### DIFF
--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -387,6 +387,11 @@ spec:
 
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"
         export IMAGE_TYPE="$IMAGE_TYPE"
+        # ARCH is derived from the PLATFORM param (see above) and is already in
+        # OCI naming (amd64/arm64). Pass it into the remote push script so the
+        # artifact config uses OCI arch names, NOT the remote host's kernel arch
+        # ($(arch)/uname -m returns x86_64/aarch64). See AIPCC-1307.
+        export OCI_ARCH="$ARCH"
 
         REMOTESSHEOF
 
@@ -409,8 +414,20 @@ spec:
         # entry's platform from this config, and downstream release tasks
         # (get-image-architectures / apply_mapping) require platform.architecture.
         # See AIPCC-1307.
+        # Determine the OCI architecture name. Prefer OCI_ARCH (derived from the
+        # PLATFORM param on the pod, already in OCI naming). Fall back to the
+        # remote host's kernel arch only if OCI_ARCH is unset, and normalize it:
+        # the archs returned by uname (x86_64/aarch64) are not the names used by
+        # OCI manifests (amd64/arm64), and the --artifact-config blob is stored
+        # verbatim with no normalization (unlike buildah's --arch flag). See AIPCC-1307.
+        OCI_ARCH="${OCI_ARCH:-$(arch)}"
+        case "$OCI_ARCH" in
+          x86_64)  OCI_ARCH=amd64 ;;
+          aarch64) OCI_ARCH=arm64 ;;
+        esac
+
         ARTIFACT_CONFIG_FILE=$(mktemp)
-        jq -cn --arg arch "$(arch)" --arg os "linux" \
+        jq -cn --arg arch "$OCI_ARCH" --arg os "linux" \
           '{architecture: $arch, os: $os}' > "$ARTIFACT_CONFIG_FILE"
         ARTIFACT_CONFIG_ARGS=(--artifact-config "$ARTIFACT_CONFIG_FILE" \
           --artifact-config-type application/vnd.oci.image.config.v1+json)

--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -402,37 +402,50 @@ spec:
         # Build an image index of length 1 referring to an image manifest with the content
         buildah manifest create "$OUTPUT_IMAGE"
 
+        # Write a real OCI image config for the artifact manifest so it carries
+        # architecture/os. Without this, buildah uses the empty config
+        # (application/vnd.oci.empty.v1+json, i.e. "{}"), which leaves the child
+        # manifest with no platform data. build-image-index derives the index
+        # entry's platform from this config, and downstream release tasks
+        # (get-image-architectures / apply_mapping) require platform.architecture.
+        # See AIPCC-1307.
+        ARTIFACT_CONFIG_FILE=$(mktemp)
+        jq -cn --arg arch "$(arch)" --arg os "linux" \
+          '{architecture: $arch, os: $os}' > "$ARTIFACT_CONFIG_FILE"
+        ARTIFACT_CONFIG_ARGS=(--artifact-config "$ARTIFACT_CONFIG_FILE" \
+          --artifact-config-type application/vnd.oci.image.config.v1+json)
+
         # show contents of /output
         ls -alR /output
 
         if [ -f "/output/qcow2/disk.qcow2" ]; then
           echo -e "Found qcow2 image."
           # don't zip qcow2 images, it is already compressed.
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2 $OUTPUT_IMAGE /output/qcow2/disk.qcow2
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.qcow2 $OUTPUT_IMAGE /output/qcow2/disk.qcow2
         elif [ -f "/output/image/disk.raw" ]; then
           echo -e "Found raw image."
           pigz /output/image/disk.raw
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
         elif [ -f "/output/bootiso/install.iso" ]; then
           echo -e "Found iso image."
           pigz /output/bootiso/install.iso
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
         elif [ -f "/output/vpc/disk.vhd" ]; then
           echo -e "Found vhd image."
           pigz /output/vpc/disk.vhd
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.vhd.gzip $OUTPUT_IMAGE /output/vpc/disk.vhd.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.vhd.gzip $OUTPUT_IMAGE /output/vpc/disk.vhd.gz
         elif [ -f "/output/gce/image.tar.gz" ]; then
           echo -e "Found gce image."
           # already compressed.
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
         elif [ -f "/output/vmdk/disk.vmdk" ]; then
           echo -e "Found vmdk image."
           pigz /output/vmdk/disk.vmdk
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.vmdk.gzip $OUTPUT_IMAGE /output/vmdk/disk.vmdk.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.vmdk.gzip $OUTPUT_IMAGE /output/vmdk/disk.vmdk.gz
         elif [ -f "/output/archive/image.ova" ]; then
           echo -e "Found ova image."
           pigz /output/archive/image.ova
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.ova.gzip $OUTPUT_IMAGE /output/archive/image.ova.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.ova.gzip $OUTPUT_IMAGE /output/archive/image.ova.gz
         # NOTE: pxe-tar-xz handling covers two different bootc-image-builder versions:
         #
         # 1. New image-builder multicall binary (osbuild/image-builder):
@@ -449,11 +462,11 @@ spec:
         # the archive from the old raw tree.
         elif [ -f "/output/xz/pxe.tar.xz" ]; then
           echo -e "Found pxe-tar-xz image (new image-builder)."
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/xz/pxe.tar.xz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/xz/pxe.tar.xz
         elif [ -d "/output/bootc-pxe-tree" ]; then
           echo -e "Found pxe tree directory (old BIB), creating tar.xz archive."
           tar -cJf /output/bootc-pxe-tree.tar.xz -C /output/bootc-pxe-tree .
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/bootc-pxe-tree.tar.xz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/bootc-pxe-tree.tar.xz
         else
           echo "No output artifact found for IMAGE_TYPE=${IMAGE_TYPE}. Check BIB output in /output." >&2
           ls -alR /output >&2

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -17,6 +17,12 @@ If that's not something you ever plan to do, consider removing this section.
   index had `platform: null`, and downstream release tasks
   (`get-image-architectures` / `apply_mapping`) failed with
   `KeyError: 'platform'`.
+- Use OCI architecture names (`amd64`/`arm64`) in the artifact manifest config
+  instead of the kernel names returned by `$(arch)` on the remote builder VM
+  (`x86_64`/`aarch64`). The `--artifact-config` blob is stored verbatim with no
+  normalization (unlike buildah's `--arch` flag), so a non-standard value would
+  otherwise reach downstream release tasks that key on `platform.architecture`.
+  The architecture is now derived from the `PLATFORM` param.
 
 ## 0.3
 

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -9,7 +9,14 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
-*Nothing yet.*
+### Fixed
+
+- Populate the disk-image artifact manifest config with `architecture`/`os`
+  (via `--artifact-config`) instead of the empty OCI config (`{}`). Previously
+  the child artifact manifest carried no platform data, so the resulting image
+  index had `platform: null`, and downstream release tasks
+  (`get-image-architectures` / `apply_mapping`) failed with
+  `KeyError: 'platform'`.
 
 ## 0.3
 


### PR DESCRIPTION
## Problem

Disk-image artifact manifests produced by `build-vm-image` are built with buildah's **empty config** (`application/vnd.oci.empty.v1+json`, i.e. `{}`). Because of this, the child artifact manifest carries no platform data:

```
child manifest config:
  mediaType: application/vnd.oci.empty.v1+json
  digest:    sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
  size:      2
  data:      e30=   # base64 for "{}"
```

`build-image-index` derives the index entry's `platform` from this config, so the resulting image index ends up with `platform: null`. Downstream release-service tasks (`get-image-architectures` → `apply_mapping.py`) then fail with:

```
arch = arch_infos[0]["platform"]["architecture"]
KeyError: 'platform'
```

The `--arch`/`--os` flags on `buildah manifest add` only stamp platform onto the length-1 index entry, which the task subsequently discards when it overwrites the tag with the bare child manifest — so no platform metadata survives on the published artifact.

## Fix

Write a real OCI image config (`{architecture, os}`) to a temp file after `buildah manifest create`, and pass it via `--artifact-config` / `--artifact-config-type application/vnd.oci.image.config.v1+json` on every `buildah manifest add` call. The artifact manifest now carries platform metadata, and the final image index gets a populated `platform`, matching normal container images.

## Notes

- Applied to `0.3`. `0.2` has the same latent issue; happy to follow up there if desired.
- The existing tests mock the manifest and run the SBOM path locally; the `buildah manifest add` config path executes on the remote build VM, so this is best validated via the task's e2e.

Refs: [AIPCC-1307](https://redhat.atlassian.net/browse/AIPCC-1307)

Signed-off-by: Víctor M. Múgica <vmugicag@redhat.com>

[AIPCC-1307]: https://redhat.atlassian.net/browse/AIPCC-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ