### PR TITLE
build-vm-image: resolve pushed manifest digest without --digestfile

### DIFF
--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -461,18 +461,41 @@ spec:
         fi
 
         buildah_retries=3
+        REPO=${OUTPUT_IMAGE%:*}
+
+        # Resolve the child (artifact) manifest digest from the LOCAL manifest
+        # list BEFORE pushing. We deliberately do NOT rely on
+        # `buildah manifest push --digestfile` to report the pushed index
+        # digest: against some registries (e.g. quay.io) a `manifest push --all`
+        # of a length-1 list writes only the child manifest and never the list
+        # itself, so the digestfile is left empty and the push still exits 0.
+        # That produced a bare "$REPO@" reference and crashed the task with
+        # "invalid reference format". See issue #3832.
+        #
+        # The list only ever contains a single artifact manifest, and we throw
+        # the index away anyway (we re-tag with the child below), so the child
+        # digest read locally is authoritative and registry-independent.
+        MANIFEST_DIGEST=$(buildah manifest inspect $OUTPUT_IMAGE | jq -r '.manifests[0].digest')
+        if [ -z "$MANIFEST_DIGEST" ] || [ "$MANIFEST_DIGEST" = "null" ]; then
+            echo "Failed to resolve child manifest digest from local manifest list ${OUTPUT_IMAGE}; refusing to build a bare reference" >&2
+            buildah manifest inspect $OUTPUT_IMAGE >&2 || true
+            exit 1
+        fi
+
         echo "Pushing image $OUTPUT_IMAGE to registry"
-        if ! retry buildah manifest push --digestfile image-digest --authfile /.docker/config.json --retry "$buildah_retries" --all $OUTPUT_IMAGE
+        if ! retry buildah manifest push --authfile /.docker/config.json --retry "$buildah_retries" --all $OUTPUT_IMAGE
         then
             echo "Failed to push image ${OUTPUT_IMAGE} to registry"
             exit 1
         fi
 
-        # At this point, we have pushed an image index of length 1 to the registry.
-        # Next, extract a reference to the image manifest and expose that, throwing away the image index.
-        IMAGE_INDEX_DIGEST=$(cat image-digest)
-        REPO=${OUTPUT_IMAGE%:*}
-        MANIFEST_DIGEST=$(buildah manifest inspect --authfile /.docker/config.json $REPO@$IMAGE_INDEX_DIGEST | jq -r '.manifests[0].digest')
+        # Confirm the child manifest is actually present on the registry before
+        # we re-tag with it (guards against a push that silently skipped it).
+        if ! retry skopeo inspect --authfile /.docker/config.json --raw docker://$REPO@$MANIFEST_DIGEST >/dev/null
+        then
+            echo "Child manifest ${REPO}@${MANIFEST_DIGEST} not found on registry after push" >&2
+            exit 1
+        fi
 
         # Overwrite the image index pullspec tag with the image manifest one
         echo "Overwriting image $OUTPUT_IMAGE in registry"

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -9,7 +9,19 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
-*Nothing yet.*
+### Fixed
+
+- Resolve the pushed artifact manifest digest from the local manifest list
+  (`buildah manifest inspect`) instead of relying on
+  `buildah manifest push --digestfile`. Against some registries (e.g. quay.io)
+  a `manifest push --all` of a length-1 list writes only the child manifest and
+  never the list itself, leaving the digestfile empty while the push still
+  exits 0. The empty digest produced a bare `$REPO@` reference and crashed the
+  task with `invalid reference format`. The list only ever holds a single
+  artifact manifest and the index is discarded (the tag is re-pointed at the
+  child), so the locally-read child digest is authoritative and
+  registry-independent. A post-push `skopeo inspect` guard confirms the child
+  manifest is present on the registry before re-tagging (issue #3832).
 
 ## 0.3
 


### PR DESCRIPTION
## Problem

The push step in `build-vm-image/0.3` read the pushed index digest from
`buildah manifest push --digestfile`. Against **quay.io**, a
`manifest push --all` of a length-1 manifest list writes only the **child**
manifest and never the list itself, so the digestfile is left **empty** while
the push still exits `0`. The empty digest yielded a bare `$REPO@` reference and
crashed the task with `invalid reference format` (exit 125) even though the
manifest push itself succeeded.

This was observed on **both** arch legs of a real RHEL AI disk-image build
([AIPCC-1307](https://redhat.atlassian.net/browse/AIPCC-1307)). Note: the earlier absolute-path / `WORKDIR` theory did **not**
hold — the digestfile was empty even with an absolute `mktemp` path, and the
push output confirmed the list was never written (`Writing manifest list to
image destination` / `Storing list signatures` lines absent).

## Fix

- Resolve the child (artifact) manifest digest from the **local** manifest list
  via `buildah manifest inspect` **before** pushing. The list only ever contains
  a single artifact manifest and the index is discarded (the tag is re-pointed
  at the child), so the locally-read child digest is authoritative and
  **registry-independent**.
- Drop `--digestfile` from the push entirely.
- Add a post-push `skopeo inspect` guard that fails loudly if the child manifest
  is not present on the registry, instead of constructing a bare reference.

## Verification

Replayed the exact `manifest create` → `manifest add --artifact` →
`manifest push --all` → `skopeo copy` sequence with buildah 1.43.2 against a
local registry: `MANIFEST_DIGEST` resolves, the child is confirmed present on
the registry, the final tag is the single artifact manifest carrying a real
config (`architecture`/`os`), and `IMAGE_URL` / `IMAGE_DIGEST` /
`IMAGE_REFERENCE` all populate — no bare `$REPO@`.

Fixes #3832

Signed-off-by: Victor M. Mugica <vmugicag@redhat.com>

[AIPCC-1307]: https://redhat.atlassian.net/browse/AIPCC-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ