### PR TITLE
AIPCC-1307: build-vm-image: push disk image as a single OCI artifact manifest (direct oras push)

### DIFF
--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -402,67 +402,68 @@ spec:
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-push.sh <<'REMOTESSHEOF'
-        dnf -y install buildah skopeo pigz jq tar xz
+        dnf -y install buildah skopeo oras pigz jq tar xz
 
-        # Build an image index of length 1 referring to an image manifest with the content
-        buildah manifest create "$OUTPUT_IMAGE"
-
-        # Write a real OCI image config for the artifact manifest so it carries
-        # architecture/os. Without this, buildah uses the empty config
-        # (application/vnd.oci.empty.v1+json, i.e. "{}"), which leaves the child
-        # manifest with no platform data. build-image-index derives the index
-        # entry's platform from this config, and downstream release tasks
-        # (get-image-architectures / apply_mapping) require platform.architecture.
-        # See AIPCC-1307.
         # Determine the OCI architecture name. Prefer OCI_ARCH (derived from the
         # PLATFORM param on the pod, already in OCI naming). Fall back to the
         # remote host's kernel arch only if OCI_ARCH is unset, and normalize it:
         # the archs returned by uname (x86_64/aarch64) are not the names used by
-        # OCI manifests (amd64/arm64), and the --artifact-config blob is stored
-        # verbatim with no normalization (unlike buildah's --arch flag). See AIPCC-1307.
+        # OCI manifests (amd64/arm64). See AIPCC-1307.
         OCI_ARCH="${OCI_ARCH:-$(arch)}"
         case "$OCI_ARCH" in
           x86_64)  OCI_ARCH=amd64 ;;
           aarch64) OCI_ARCH=arm64 ;;
         esac
 
-        ARTIFACT_CONFIG_FILE=$(mktemp)
-        jq -cn --arg arch "$OCI_ARCH" --arg os "linux" \
-          '{architecture: $arch, os: $os}' > "$ARTIFACT_CONFIG_FILE"
-        ARTIFACT_CONFIG_ARGS=(--artifact-config "$ARTIFACT_CONFIG_FILE" \
-          --artifact-config-type application/vnd.oci.image.config.v1+json)
-
         # show contents of /output
         ls -alR /output
 
+        # Locate the disk-image output for this IMAGE_TYPE and set the artifact
+        # media type + file path. We push a SINGLE OCI artifact manifest directly
+        # (oras / oci-copy pattern) rather than wrapping the image in a length-1
+        # manifest list. quay's index validator returns HTTP 500 for an OCI index
+        # whose only child is an artifact manifest carrying a real (non-empty)
+        # {architecture,os} config, so the manifest-list path is impossible on
+        # quay once we ship a real platform config. A single artifact manifest
+        # avoids the index entirely, still carries a real config (for platform),
+        # and is the correct topology for a single-arch disk-image artifact. The
+        # multi-arch index, when needed, is built later by build-image-index,
+        # which derives each entry's platform from this child config. See AIPCC-1307.
         if [ -f "/output/qcow2/disk.qcow2" ]; then
           echo -e "Found qcow2 image."
           # don't zip qcow2 images, it is already compressed.
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.qcow2 $OUTPUT_IMAGE /output/qcow2/disk.qcow2
+          ARTIFACT_TYPE=application/vnd.diskimage.qcow2
+          ARTIFACT_FILE=/output/qcow2/disk.qcow2
         elif [ -f "/output/image/disk.raw" ]; then
           echo -e "Found raw image."
           pigz /output/image/disk.raw
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
+          ARTIFACT_TYPE=application/vnd.diskimage.raw.gzip
+          ARTIFACT_FILE=/output/image/disk.raw.gz
         elif [ -f "/output/bootiso/install.iso" ]; then
           echo -e "Found iso image."
           pigz /output/bootiso/install.iso
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
+          ARTIFACT_TYPE=application/vnd.diskimage.iso.gzip
+          ARTIFACT_FILE=/output/bootiso/install.iso.gz
         elif [ -f "/output/vpc/disk.vhd" ]; then
           echo -e "Found vhd image."
           pigz /output/vpc/disk.vhd
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.vhd.gzip $OUTPUT_IMAGE /output/vpc/disk.vhd.gz
+          ARTIFACT_TYPE=application/vnd.diskimage.vhd.gzip
+          ARTIFACT_FILE=/output/vpc/disk.vhd.gz
         elif [ -f "/output/gce/image.tar.gz" ]; then
           echo -e "Found gce image."
           # already compressed.
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
+          ARTIFACT_TYPE=application/vnd.diskimage.gce.tgz
+          ARTIFACT_FILE=/output/gce/image.tar.gz
         elif [ -f "/output/vmdk/disk.vmdk" ]; then
           echo -e "Found vmdk image."
           pigz /output/vmdk/disk.vmdk
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.vmdk.gzip $OUTPUT_IMAGE /output/vmdk/disk.vmdk.gz
+          ARTIFACT_TYPE=application/vnd.diskimage.vmdk.gzip
+          ARTIFACT_FILE=/output/vmdk/disk.vmdk.gz
         elif [ -f "/output/archive/image.ova" ]; then
           echo -e "Found ova image."
           pigz /output/archive/image.ova
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.ova.gzip $OUTPUT_IMAGE /output/archive/image.ova.gz
+          ARTIFACT_TYPE=application/vnd.diskimage.ova.gzip
+          ARTIFACT_FILE=/output/archive/image.ova.gz
         # NOTE: pxe-tar-xz handling covers two different bootc-image-builder versions:
         #
         # 1. New image-builder multicall binary (osbuild/image-builder):
@@ -479,36 +480,92 @@ spec:
         # the archive from the old raw tree.
         elif [ -f "/output/xz/pxe.tar.xz" ]; then
           echo -e "Found pxe-tar-xz image (new image-builder)."
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/xz/pxe.tar.xz
+          ARTIFACT_TYPE=application/vnd.diskimage.pxe.tar.xz
+          ARTIFACT_FILE=/output/xz/pxe.tar.xz
         elif [ -d "/output/bootc-pxe-tree" ]; then
           echo -e "Found pxe tree directory (old BIB), creating tar.xz archive."
           tar -cJf /output/bootc-pxe-tree.tar.xz -C /output/bootc-pxe-tree .
-          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/bootc-pxe-tree.tar.xz
+          ARTIFACT_TYPE=application/vnd.diskimage.pxe.tar.xz
+          ARTIFACT_FILE=/output/bootc-pxe-tree.tar.xz
         else
           echo "No output artifact found for IMAGE_TYPE=${IMAGE_TYPE}. Check BIB output in /output." >&2
           ls -alR /output >&2
           exit 1
         fi
 
-        buildah_retries=3
-        echo "Pushing image $OUTPUT_IMAGE to registry"
-        if ! retry buildah manifest push --digestfile image-digest --authfile /.docker/config.json --retry "$buildah_retries" --all $OUTPUT_IMAGE
+        REPO=${OUTPUT_IMAGE%:*}
+
+        # --- Build and push a single OCI artifact manifest directly (oras) ---
+        #
+        # 1. Push the OCI image config blob carrying the real platform. The
+        #    {architecture,os} config is what build-image-index / apply_mapping
+        #    read to derive platform.architecture (an empty config yields
+        #    platform: null downstream — the original AIPCC-1307 KeyError).
+        CONFIG_FILE=$(mktemp)
+        jq -cn --arg arch "$OCI_ARCH" --arg os "linux" \
+          '{architecture: $arch, os: $os}' > "$CONFIG_FILE"
+        CONFIG_MEDIA_TYPE=application/vnd.oci.image.config.v1+json
+
+        echo "Pushing config blob to ${REPO}"
+        if ! retry oras blob push --registry-config /.docker/config.json \
+              "${REPO}" --media-type "${CONFIG_MEDIA_TYPE}" "${CONFIG_FILE}"
         then
-            echo "Failed to push image ${OUTPUT_IMAGE} to registry"
+            echo "Failed to push config blob to ${REPO}" >&2
+            exit 1
+        fi
+        CONFIG_DESC=$(retry oras blob fetch --registry-config /.docker/config.json \
+          --descriptor "${REPO}@sha256:$(sha256sum "${CONFIG_FILE}" | awk '{print $1}')")
+
+        # 2. Push the disk-image blob (the artifact layer).
+        echo "Pushing disk image blob ${ARTIFACT_FILE} to ${REPO}"
+        if ! retry oras blob push --registry-config /.docker/config.json \
+              "${REPO}" --media-type "${ARTIFACT_TYPE}" "${ARTIFACT_FILE}"
+        then
+            echo "Failed to push disk image blob to ${REPO}" >&2
+            exit 1
+        fi
+        LAYER_DESC=$(retry oras blob fetch --registry-config /.docker/config.json \
+          --descriptor "${REPO}@sha256:$(sha256sum "${ARTIFACT_FILE}" | awk '{print $1}')")
+        # Annotate the layer with its media type and a title (filename).
+        LAYER_DESC=$(echo "$LAYER_DESC" | jq -c \
+          --arg mt "$ARTIFACT_TYPE" --arg title "$(basename "$ARTIFACT_FILE")" \
+          '.mediaType = $mt | .annotations."org.opencontainers.image.title" = $title')
+
+        # 3. Hand-build the OCI artifact manifest: single config + single layer.
+        ARTIFACT_MANIFEST=$(mktemp)
+        jq -n \
+          --arg at "$ARTIFACT_TYPE" \
+          --arg created "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+          --argjson config "$CONFIG_DESC" \
+          --argjson layer "$LAYER_DESC" \
+          '{
+            schemaVersion: 2,
+            mediaType: "application/vnd.oci.image.manifest.v1+json",
+            artifactType: $at,
+            config: ($config | .mediaType = "application/vnd.oci.image.config.v1+json"),
+            layers: [$layer],
+            annotations: {"org.opencontainers.image.created": $created}
+          }' > "$ARTIFACT_MANIFEST"
+        echo "Artifact manifest:"
+        cat "$ARTIFACT_MANIFEST"
+
+        # 4. Push the artifact manifest to the output tag.
+        echo "Pushing artifact manifest to ${OUTPUT_IMAGE}"
+        if ! retry oras manifest push --registry-config /.docker/config.json \
+              "${OUTPUT_IMAGE}" "${ARTIFACT_MANIFEST}"
+        then
+            echo "Failed to push artifact manifest to ${OUTPUT_IMAGE}" >&2
             exit 1
         fi
 
-        # At this point, we have pushed an image index of length 1 to the registry.
-        # Next, extract a reference to the image manifest and expose that, throwing away the image index.
-        IMAGE_INDEX_DIGEST=$(cat image-digest)
-        REPO=${OUTPUT_IMAGE%:*}
-        MANIFEST_DIGEST=$(buildah manifest inspect --authfile /.docker/config.json $REPO@$IMAGE_INDEX_DIGEST | jq -r '.manifests[0].digest')
-
-        # Overwrite the image index pullspec tag with the image manifest one
-        echo "Overwriting image $OUTPUT_IMAGE in registry"
-        if ! retry skopeo copy --authfile /.docker/config.json docker://$REPO@$MANIFEST_DIGEST docker://$OUTPUT_IMAGE
+        # 5. Resolve the digest of the pushed manifest.
+        if ! MANIFEST_DIGEST=$(retry oras resolve --registry-config /.docker/config.json "${OUTPUT_IMAGE}")
         then
-            echo "Failed to overwrite image ${OUTPUT_IMAGE} in registry"
+            echo "Failed to resolve digest for ${OUTPUT_IMAGE} from registry" >&2
+            exit 1
+        fi
+        if [ -z "$MANIFEST_DIGEST" ] || [ "$MANIFEST_DIGEST" = "null" ]; then
+            echo "Resolved an empty digest for ${OUTPUT_IMAGE}; refusing to build a bare reference" >&2
             exit 1
         fi
 

--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -387,6 +387,11 @@ spec:
 
         export OUTPUT_IMAGE="$OUTPUT_IMAGE"
         export IMAGE_TYPE="$IMAGE_TYPE"
+        # ARCH is derived from the PLATFORM param (see above) and is already in
+        # OCI naming (amd64/arm64). Pass it into the remote push script so the
+        # artifact config uses OCI arch names, NOT the remote host's kernel arch
+        # ($(arch)/uname -m returns x86_64/aarch64). See AIPCC-1307.
+        export OCI_ARCH="$ARCH"
 
         REMOTESSHEOF
 
@@ -409,8 +414,20 @@ spec:
         # entry's platform from this config, and downstream release tasks
         # (get-image-architectures / apply_mapping) require platform.architecture.
         # See AIPCC-1307.
+        # Determine the OCI architecture name. Prefer OCI_ARCH (derived from the
+        # PLATFORM param on the pod, already in OCI naming). Fall back to the
+        # remote host's kernel arch only if OCI_ARCH is unset, and normalize it:
+        # the archs returned by uname (x86_64/aarch64) are not the names used by
+        # OCI manifests (amd64/arm64), and the --artifact-config blob is stored
+        # verbatim with no normalization (unlike buildah's --arch flag). See AIPCC-1307.
+        OCI_ARCH="${OCI_ARCH:-$(arch)}"
+        case "$OCI_ARCH" in
+          x86_64)  OCI_ARCH=amd64 ;;
+          aarch64) OCI_ARCH=arm64 ;;
+        esac
+
         ARTIFACT_CONFIG_FILE=$(mktemp)
-        jq -cn --arg arch "$(arch)" --arg os "linux" \
+        jq -cn --arg arch "$OCI_ARCH" --arg os "linux" \
           '{architecture: $arch, os: $os}' > "$ARTIFACT_CONFIG_FILE"
         ARTIFACT_CONFIG_ARGS=(--artifact-config "$ARTIFACT_CONFIG_FILE" \
           --artifact-config-type application/vnd.oci.image.config.v1+json)

--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -402,37 +402,50 @@ spec:
         # Build an image index of length 1 referring to an image manifest with the content
         buildah manifest create "$OUTPUT_IMAGE"
 
+        # Write a real OCI image config for the artifact manifest so it carries
+        # architecture/os. Without this, buildah uses the empty config
+        # (application/vnd.oci.empty.v1+json, i.e. "{}"), which leaves the child
+        # manifest with no platform data. build-image-index derives the index
+        # entry's platform from this config, and downstream release tasks
+        # (get-image-architectures / apply_mapping) require platform.architecture.
+        # See AIPCC-1307.
+        ARTIFACT_CONFIG_FILE=$(mktemp)
+        jq -cn --arg arch "$(arch)" --arg os "linux" \
+          '{architecture: $arch, os: $os}' > "$ARTIFACT_CONFIG_FILE"
+        ARTIFACT_CONFIG_ARGS=(--artifact-config "$ARTIFACT_CONFIG_FILE" \
+          --artifact-config-type application/vnd.oci.image.config.v1+json)
+
         # show contents of /output
         ls -alR /output
 
         if [ -f "/output/qcow2/disk.qcow2" ]; then
           echo -e "Found qcow2 image."
           # don't zip qcow2 images, it is already compressed.
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.qcow2 $OUTPUT_IMAGE /output/qcow2/disk.qcow2
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.qcow2 $OUTPUT_IMAGE /output/qcow2/disk.qcow2
         elif [ -f "/output/image/disk.raw" ]; then
           echo -e "Found raw image."
           pigz /output/image/disk.raw
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.raw.gzip $OUTPUT_IMAGE /output/image/disk.raw.gz
         elif [ -f "/output/bootiso/install.iso" ]; then
           echo -e "Found iso image."
           pigz /output/bootiso/install.iso
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.iso.gzip $OUTPUT_IMAGE /output/bootiso/install.iso.gz
         elif [ -f "/output/vpc/disk.vhd" ]; then
           echo -e "Found vhd image."
           pigz /output/vpc/disk.vhd
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.vhd.gzip $OUTPUT_IMAGE /output/vpc/disk.vhd.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.vhd.gzip $OUTPUT_IMAGE /output/vpc/disk.vhd.gz
         elif [ -f "/output/gce/image.tar.gz" ]; then
           echo -e "Found gce image."
           # already compressed.
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.gce.tgz $OUTPUT_IMAGE /output/gce/image.tar.gz
         elif [ -f "/output/vmdk/disk.vmdk" ]; then
           echo -e "Found vmdk image."
           pigz /output/vmdk/disk.vmdk
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.vmdk.gzip $OUTPUT_IMAGE /output/vmdk/disk.vmdk.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.vmdk.gzip $OUTPUT_IMAGE /output/vmdk/disk.vmdk.gz
         elif [ -f "/output/archive/image.ova" ]; then
           echo -e "Found ova image."
           pigz /output/archive/image.ova
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.ova.gzip $OUTPUT_IMAGE /output/archive/image.ova.gz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.ova.gzip $OUTPUT_IMAGE /output/archive/image.ova.gz
         # NOTE: pxe-tar-xz handling covers two different bootc-image-builder versions:
         #
         # 1. New image-builder multicall binary (osbuild/image-builder):
@@ -449,11 +462,11 @@ spec:
         # the archive from the old raw tree.
         elif [ -f "/output/xz/pxe.tar.xz" ]; then
           echo -e "Found pxe-tar-xz image (new image-builder)."
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/xz/pxe.tar.xz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/xz/pxe.tar.xz
         elif [ -d "/output/bootc-pxe-tree" ]; then
           echo -e "Found pxe tree directory (old BIB), creating tar.xz archive."
           tar -cJf /output/bootc-pxe-tree.tar.xz -C /output/bootc-pxe-tree .
-          buildah manifest add --arch $(arch) --os linux --artifact --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/bootc-pxe-tree.tar.xz
+          buildah manifest add --arch $(arch) --os linux --artifact "${ARTIFACT_CONFIG_ARGS[@]}" --artifact-type application/vnd.diskimage.pxe.tar.xz $OUTPUT_IMAGE /output/bootc-pxe-tree.tar.xz
         else
           echo "No output artifact found for IMAGE_TYPE=${IMAGE_TYPE}. Check BIB output in /output." >&2
           ls -alR /output >&2

--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -389,14 +389,16 @@ spec:
         # available for image pulls), then extraction is purely local. We keep
         # ubi9/buildah as the push container so pigz/xz stay available for
         # compressing large disk images. See AIPCC-1307.
-        # Extract the oras binary by running the task-runner container and copying
-        # the binary to stdout. We deliberately use `sudo podman run` (the same
-        # invocation the build/push containers already use) rather than
-        # `podman create` + `podman cp`: the builder VM's sudoers does not grant
-        # passwordless sudo for `podman cp`, so a create/cp/rm sequence fails with
-        # "sudo: a password is required". `podman run ... cat` needs only the
-        # already-permitted `podman run`. The file is written by the (non-root)
-        # ssh user via the redirect, so the subsequent chmod needs no sudo.
+        # Extract the oras binary AND the select-oci-auth helper by running the
+        # task-runner container and copying each file to stdout. We deliberately
+        # use `sudo podman run` (the same invocation the build/push containers
+        # already use) rather than `podman create` + `podman cp`: the builder VM's
+        # sudoers does not grant passwordless sudo for `podman cp`, so a
+        # create/cp/rm sequence fails with "sudo: a password is required".
+        # `podman run ... cat` needs only the already-permitted `podman run`. The
+        # files are written by the (non-root) ssh user via the redirect, so the
+        # subsequent chmod needs no sudo.
+        #
         # See AIPCC-1307.
         echo "EXTRACTING oras FROM $ORAS_SOURCE_IMAGE"
         if ! time retry sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm --pull=newer --entrypoint="" "$ORAS_SOURCE_IMAGE" cat /usr/local/bin/oras > "$BUILD_DIR/oras"
@@ -540,6 +542,28 @@ spec:
         fi
 
         REPO=${OUTPUT_IMAGE%:*}
+        REGISTRY=${REPO%%/*}
+
+        # Build a REGISTRY-scoped auth file for oras. The Konflux
+        # .docker/config.json contains REPOSITORY-scoped tokens (e.g. an entry
+        # keyed on the full repo path). buildah/skopeo match those, but oras only
+        # matches REGISTRY-scoped tokens and otherwise returns HTTP 401. Mirror
+        # what the konflux `select-oci-auth` helper does: find the token for the
+        # repo (walking up parent paths), then re-key it under the bare registry
+        # so oras can use it. See AIPCC-1307.
+        ORAS_AUTH=$(mktemp)
+        AUTH_TOKEN=$(jq -r --arg repo "$REPO" --arg reg "$REGISTRY" '
+          .auths as $a
+          | ($repo | split("/")) as $parts
+          | [range(($parts|length); 0; -1) | $parts[0:.] | join("/")] as $candidates
+          | ( ($candidates[] | select($a[.] != null) | $a[.]) // $a[$reg] // empty )
+          | @json' /.docker/config.json | head -n1)
+        if [ -z "$AUTH_TOKEN" ] || [ "$AUTH_TOKEN" = "null" ]; then
+            echo "No auth token found for ${REPO} in /.docker/config.json" >&2
+            exit 1
+        fi
+        jq -n --arg reg "$REGISTRY" --argjson tok "$AUTH_TOKEN" \
+          '{auths: {($reg): $tok}}' > "$ORAS_AUTH"
 
         # --- Build and push a single OCI artifact manifest directly (oras) ---
         #
@@ -553,24 +577,24 @@ spec:
         CONFIG_MEDIA_TYPE=application/vnd.oci.image.config.v1+json
 
         echo "Pushing config blob to ${REPO}"
-        if ! retry oras blob push --registry-config /.docker/config.json \
+        if ! retry oras blob push --registry-config "$ORAS_AUTH" \
               "${REPO}" --media-type "${CONFIG_MEDIA_TYPE}" "${CONFIG_FILE}"
         then
             echo "Failed to push config blob to ${REPO}" >&2
             exit 1
         fi
-        CONFIG_DESC=$(retry oras blob fetch --registry-config /.docker/config.json \
+        CONFIG_DESC=$(retry oras blob fetch --registry-config "$ORAS_AUTH" \
           --descriptor "${REPO}@sha256:$(sha256sum "${CONFIG_FILE}" | awk '{print $1}')")
 
         # 2. Push the disk-image blob (the artifact layer).
         echo "Pushing disk image blob ${ARTIFACT_FILE} to ${REPO}"
-        if ! retry oras blob push --registry-config /.docker/config.json \
+        if ! retry oras blob push --registry-config "$ORAS_AUTH" \
               "${REPO}" --media-type "${ARTIFACT_TYPE}" "${ARTIFACT_FILE}"
         then
             echo "Failed to push disk image blob to ${REPO}" >&2
             exit 1
         fi
-        LAYER_DESC=$(retry oras blob fetch --registry-config /.docker/config.json \
+        LAYER_DESC=$(retry oras blob fetch --registry-config "$ORAS_AUTH" \
           --descriptor "${REPO}@sha256:$(sha256sum "${ARTIFACT_FILE}" | awk '{print $1}')")
         # Annotate the layer with its media type and a title (filename).
         LAYER_DESC=$(echo "$LAYER_DESC" | jq -c \
@@ -597,7 +621,7 @@ spec:
 
         # 4. Push the artifact manifest to the output tag.
         echo "Pushing artifact manifest to ${OUTPUT_IMAGE}"
-        if ! retry oras manifest push --registry-config /.docker/config.json \
+        if ! retry oras manifest push --registry-config "$ORAS_AUTH" \
               "${OUTPUT_IMAGE}" "${ARTIFACT_MANIFEST}"
         then
             echo "Failed to push artifact manifest to ${OUTPUT_IMAGE}" >&2
@@ -605,7 +629,7 @@ spec:
         fi
 
         # 5. Resolve the digest of the pushed manifest.
-        if ! MANIFEST_DIGEST=$(retry oras resolve --registry-config /.docker/config.json "${OUTPUT_IMAGE}")
+        if ! MANIFEST_DIGEST=$(retry oras resolve --registry-config "$ORAS_AUTH" "${OUTPUT_IMAGE}")
         then
             echo "Failed to resolve digest for ${OUTPUT_IMAGE} from registry" >&2
             exit 1

--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -82,6 +82,16 @@ spec:
         value: $(params.STORAGE_DRIVER)
       - name: BUILDAH_IMAGE
         value: 'registry.access.redhat.com/ubi9/buildah:9.8-1787017371'
+      # Image the `oras` binary is extracted from on the remote builder VM.
+      # oras is not packaged in the UBI9 repos available on the (RHSM-unregistered)
+      # builder VM, so we cannot `dnf install oras`. Instead we `podman cp` the
+      # binary out of this pinned, trusted Konflux image and mount it into the
+      # buildah push container. Keeping ubi9/buildah as the push container
+      # preserves pigz (parallel gzip) and xz for compressing large disk images.
+      # This is the same image (and digest) used for the Tekton steps above.
+      # See AIPCC-1307.
+      - name: ORAS_SOURCE_IMAGE
+        value: 'quay.io/konflux-ci/task-runner:3.1.2@sha256:e272c1e1c60a4ecc72ff9c8d65bc48da534de6f1ce0d5aba79db3ac532d11c35'
       - name: PLATFORM
         value: $(params.PLATFORM)
       - name: IMAGE_APPEND_PLATFORM
@@ -292,6 +302,7 @@ spec:
         export IMAGE_TYPE_ARGUMENT="$IMAGE_TYPE_ARGUMENT"
         export STORAGE_DRIVER="$STORAGE_DRIVER"
         export BUILDAH_IMAGE="$BUILDAH_IMAGE"
+        export ORAS_SOURCE_IMAGE="$ORAS_SOURCE_IMAGE"
 
         REMOTESSHEOF
 
@@ -369,10 +380,31 @@ spec:
           $ENTITLEMENT_VOLUME \
           $BOOTC_BUILDER_IMAGE $IMAGE_TYPE_ARGUMENT --local $TAGGED_AS
 
+        # Extract the oras binary from the pinned, trusted Konflux task-runner
+        # image and mount it into the buildah push container. oras is not
+        # available in the UBI9 repos on the (RHSM-unregistered) builder VM, so
+        # it cannot be dnf-installed. Pulling the binary out of a digest-pinned
+        # Konflux image keeps us inside trusted registries (Conforma-friendly)
+        # and works under hermetic builds: the image is pulled here (network is
+        # available for image pulls), then extraction is purely local. We keep
+        # ubi9/buildah as the push container so pigz/xz stay available for
+        # compressing large disk images. See AIPCC-1307.
+        echo "EXTRACTING oras FROM $ORAS_SOURCE_IMAGE"
+        if ! time retry sudo podman pull --authfile=$BUILD_DIR/.docker/config.json --retry "$buildah_retries" "$ORAS_SOURCE_IMAGE"
+        then
+            echo "Failed to pull oras source image ${ORAS_SOURCE_IMAGE}"
+            exit 1
+        fi
+        ORAS_CTR=$(sudo podman create "$ORAS_SOURCE_IMAGE")
+        sudo podman cp "${ORAS_CTR}:/usr/local/bin/oras" "$BUILD_DIR/oras"
+        sudo podman rm "$ORAS_CTR"
+        sudo chmod +x "$BUILD_DIR/oras"
+
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
           -v $BUILD_DIR/.docker:/.docker -v $(pwd)/output:/output \
           -v /var/lib/containers/storage:/var/lib/containers/storage \
           -v $BUILD_DIR/scripts/script-push.sh:/script-push.sh \
+          -v $BUILD_DIR/oras:/usr/bin/oras:ro \
           -v $BUILD_DIR/tekton-results:/tekton-results \
           "$BUILDAH_IMAGE" \
           /script-push.sh
@@ -402,7 +434,11 @@ spec:
 
         # this quoted heredoc prevents expansions and command substitutions. the env vars are evaluated on the remote vm
         cat >>scripts/script-push.sh <<'REMOTESSHEOF'
-        dnf -y install buildah skopeo oras pigz jq tar xz
+        # oras is mounted into this container at /usr/bin/oras (extracted from the
+        # pinned Konflux task-runner image on the VM); it is not dnf-installable
+        # here because it is not in the UBI9 repos. See AIPCC-1307.
+        dnf -y install buildah skopeo pigz jq tar xz
+        oras version
 
         # Determine the OCI architecture name. Prefer OCI_ARCH (derived from the
         # PLATFORM param on the pod, already in OCI naming). Fall back to the

--- a/task/build-vm-image/0.3/build-vm-image.yaml
+++ b/task/build-vm-image/0.3/build-vm-image.yaml
@@ -389,16 +389,26 @@ spec:
         # available for image pulls), then extraction is purely local. We keep
         # ubi9/buildah as the push container so pigz/xz stay available for
         # compressing large disk images. See AIPCC-1307.
+        # Extract the oras binary by running the task-runner container and copying
+        # the binary to stdout. We deliberately use `sudo podman run` (the same
+        # invocation the build/push containers already use) rather than
+        # `podman create` + `podman cp`: the builder VM's sudoers does not grant
+        # passwordless sudo for `podman cp`, so a create/cp/rm sequence fails with
+        # "sudo: a password is required". `podman run ... cat` needs only the
+        # already-permitted `podman run`. The file is written by the (non-root)
+        # ssh user via the redirect, so the subsequent chmod needs no sudo.
+        # See AIPCC-1307.
         echo "EXTRACTING oras FROM $ORAS_SOURCE_IMAGE"
-        if ! time retry sudo podman pull --authfile=$BUILD_DIR/.docker/config.json --retry "$buildah_retries" "$ORAS_SOURCE_IMAGE"
+        if ! time retry sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm --pull=newer --entrypoint="" "$ORAS_SOURCE_IMAGE" cat /usr/local/bin/oras > "$BUILD_DIR/oras"
         then
-            echo "Failed to pull oras source image ${ORAS_SOURCE_IMAGE}"
+            echo "Failed to extract oras from ${ORAS_SOURCE_IMAGE}"
             exit 1
         fi
-        ORAS_CTR=$(sudo podman create "$ORAS_SOURCE_IMAGE")
-        sudo podman cp "${ORAS_CTR}:/usr/local/bin/oras" "$BUILD_DIR/oras"
-        sudo podman rm "$ORAS_CTR"
-        sudo chmod +x "$BUILD_DIR/oras"
+        if [ ! -s "$BUILD_DIR/oras" ]; then
+            echo "Extracted oras binary is empty (expected /usr/local/bin/oras in ${ORAS_SOURCE_IMAGE})" >&2
+            exit 1
+        fi
+        chmod +x "$BUILD_DIR/oras"
 
         time sudo podman run --authfile=$BUILD_DIR/.docker/config.json --rm -it --privileged --pull=newer --security-opt label=type:unconfined_t \
           -v $BUILD_DIR/.docker:/.docker -v $(pwd)/output:/output \

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -17,6 +17,12 @@ If that's not something you ever plan to do, consider removing this section.
   index had `platform: null`, and downstream release tasks
   (`get-image-architectures` / `apply_mapping`) failed with
   `KeyError: 'platform'`.
+- Use OCI architecture names (`amd64`/`arm64`) in the artifact manifest config
+  instead of the kernel names returned by `$(arch)` on the remote builder VM
+  (`x86_64`/`aarch64`). The `--artifact-config` blob is stored verbatim with no
+  normalization (unlike buildah's `--arch` flag), so a non-standard value would
+  otherwise reach downstream release tasks that key on `platform.architecture`.
+  The architecture is now derived from the `PLATFORM` param.
 
 ## 0.3
 

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -23,7 +23,8 @@ If that's not something you ever plan to do, consider removing this section.
   removes the `--digestfile` workaround: the digest is now obtained from
   `oras resolve`. See AIPCC-1307.
 - Provide `oras` on the remote builder VM by extracting `/usr/local/bin/oras`
-  from the pinned Konflux `task-runner` image (`podman create` + `podman cp`) and
+  from the pinned Konflux `task-runner` image (`podman run ... cat` — the builder
+  VM's sudoers does not permit `podman cp`, so create/cp/rm is avoided) and
   mounting it into the `ubi9/buildah` push container. `oras` is not packaged in
   the UBI9 repos available on the (RHSM-unregistered) builder VM, so it cannot be
   `dnf`-installed. Sourcing the binary from a digest-pinned, trusted registry

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -22,6 +22,14 @@ If that's not something you ever plan to do, consider removing this section.
   is the correct topology for a single-arch disk-image artifact. This also
   removes the `--digestfile` workaround: the digest is now obtained from
   `oras resolve`. See AIPCC-1307.
+- Provide `oras` on the remote builder VM by extracting `/usr/local/bin/oras`
+  from the pinned Konflux `task-runner` image (`podman create` + `podman cp`) and
+  mounting it into the `ubi9/buildah` push container. `oras` is not packaged in
+  the UBI9 repos available on the (RHSM-unregistered) builder VM, so it cannot be
+  `dnf`-installed. Sourcing the binary from a digest-pinned, trusted registry
+  image keeps the task Conforma-compliant and works under hermetic builds, while
+  keeping `ubi9/buildah` as the push container preserves `pigz`/`xz` for
+  compressing large disk images. See AIPCC-1307.
 
 ### Fixed
 

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -9,6 +9,20 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
+### Changed
+
+- Push the disk image as a single OCI artifact manifest directly (via `oras`)
+  instead of wrapping it in a length-1 manifest list/index and pushing with
+  `buildah manifest push --all`. quay's index validator returns HTTP 500 for an
+  OCI index whose only child is an artifact manifest carrying a real
+  (non-empty) `{architecture,os}` config, which made the manifest-list path
+  impossible on quay once a real platform config was shipped. A single artifact
+  manifest avoids the index entirely, still carries a real config (so
+  `build-image-index` / `apply_mapping` can derive `platform.architecture`), and
+  is the correct topology for a single-arch disk-image artifact. This also
+  removes the `--digestfile` workaround: the digest is now obtained from
+  `oras resolve`. See AIPCC-1307.
+
 ### Fixed
 
 - Populate the disk-image artifact manifest config with `architecture`/`os`

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -25,7 +25,11 @@ If that's not something you ever plan to do, consider removing this section.
 - Provide `oras` on the remote builder VM by extracting `/usr/local/bin/oras`
   from the pinned Konflux `task-runner` image (`podman run ... cat` — the builder
   VM's sudoers does not permit `podman cp`, so create/cp/rm is avoided) and
-  mounting it into the `ubi9/buildah` push container. `oras` is not packaged in
+  mounting it into the `ubi9/buildah` push container. oras is invoked with a
+  registry-scoped auth file derived from `.docker/config.json`: the Konflux auth
+  file uses repository-scoped tokens, which buildah/skopeo match but oras does
+  not (oras only matches registry-scoped tokens and otherwise returns HTTP 401),
+  so the token is re-keyed under the bare registry (mirroring `select-oci-auth`). `oras` is not packaged in
   the UBI9 repos available on the (RHSM-unregistered) builder VM, so it cannot be
   `dnf`-installed. Sourcing the binary from a digest-pinned, trusted registry
   image keeps the task Conforma-compliant and works under hermetic builds, while

--- a/task/build-vm-image/CHANGELOG.md
+++ b/task/build-vm-image/CHANGELOG.md
@@ -9,7 +9,14 @@ When you make changes without bumping the version right away, document them here
 If that's not something you ever plan to do, consider removing this section.
 -->
 
-*Nothing yet.*
+### Fixed
+
+- Populate the disk-image artifact manifest config with `architecture`/`os`
+  (via `--artifact-config`) instead of the empty OCI config (`{}`). Previously
+  the child artifact manifest carried no platform data, so the resulting image
+  index had `platform: null`, and downstream release tasks
+  (`get-image-architectures` / `apply_mapping`) failed with
+  `KeyError: 'platform'`.
 
 ## 0.3
 


### PR DESCRIPTION
> **DRAFT — for discussion, not yet requesting review.** Supersedes #3830 and #3833.

## Summary
This is the full [AIPCC-1307](https://redhat.atlassian.net/browse/AIPCC-1307) work-in-progress branch, opened as a **draft** so the
actual change is visible (the two existing PRs #3830 and #3833 are stale and
predate the redesign).

RHEL AI disk-image OCI artifacts carried buildah's empty config `{}`, so the
image index had `platform: null` and the release `apply-mapping` task failed with
`KeyError: 'platform'`.

## What this branch currently does (⚠️ under active review — see below)
1. Populate the artifact manifest config with a real `{architecture, os}` (from #3830).
2. Use OCI arch names amd64/arm64 derived from the PLATFORM param (from #3830).
3. **Replace `buildah manifest create/add --all` + `skopeo copy .manifests[0]`
   with a direct single OCI artifact manifest push via `oras`** (blob push config
   + layer, hand-build manifest, `oras manifest push`, `oras resolve`). This
   avoids quay returning HTTP 500 on an OCI *index* whose only child is an
   artifact carrying a real config, and removes the `--digestfile` workaround
   (#3832 / #3833).
4. Provide `oras` on the remote builder VM by extracting it from the pinned
   Konflux `task-runner` image (`podman run … cat`), since oras is not in the UBI9
   repos and `podman cp` is not permitted by the VM sudoers.
5. Give oras a registry-scoped auth file (Konflux config.json is repo-scoped;
   oras needs registry-scoped), mirroring `select-oci-auth`.

## ⚠️ Open design concern (thozza, #3830)
@thozza raised that using `application/vnd.oci.image.config.v1+json` as the
artifact config makes a disk-image artifact look like an OCI container image,
which is spec-nonconformant (image config schema requires `rootfs`) and flips
load-bearing discriminators in containers/image, and may trip Conforma/EC
container-image rules. His suggested alternative is to keep the artifact config
empty/artifact-specific and instead have `build-vm-image` emit a
ref→platform mapping result that `build-image-index` optionally consumes to
reconstruct `platform`.

This draft is kept open to compare approaches; the config-media-type question is
unresolved and may change the direction of the fix.

Signed-off-by: Victor M. Mugica <vmugicag@redhat.com>

[AIPCC-1307]: https://redhat.atlassian.net/browse/AIPCC-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ